### PR TITLE
Add a getting started guide, and updated READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,20 @@
-Ramble is a multi-platform experimentation framework that is capable of driving
-software installation, acquire input files, configure experiments, and extract
-results. It works on Linux, macOS, and many supercomputers.
+Ramble is a multi-platform experimentation framework to increase exploration
+productivity and improve reproducibility. Ramble is capable of driving software
+installation, acquire input files, configure experiments, and extract results.
+It works on Linux, macOS, and many supercomputers.
+
+Ramble can be used to configure a variety of experiments for applications.
+These can include anything from:
+ - Scientific parameter sweeps
+ - Performance focused scalaing studies
+ - Compiler flag sweeps
 
 To install ramble and configure your experiment workspace, make sure you have Python.
 Then:
 
     $ git clone -c feature.manyFiles=true https://github.com/GoogleCloudPlatform/ramble.git
     $ cd ramble/bin
-    $ ./ramble workspace create -d test_workspace -c ../examples/basic_workspace.yaml
+    $ ./ramble workspace create -d test_workspace -c ../examples/basic_hostname_config.yaml
 
 Dependencies
 ------------
@@ -26,6 +33,12 @@ Documentation
 ----------------
 
 For help with Ramble’s commands, run `ramble help` or `ramble help --all`.
+
+For more information on concepts in Ramble, see Ramble’s
+[Getting Started](./docs/Getting_Started.md) guide.
+
+Example configuration files are also contained in the
+[examples](./examples) directory.
 
 Community
 ------------------------
@@ -52,7 +65,7 @@ please use the test runners:
  - share/ramble/qa/run-unit-tests
  - share/ramble/qa/run-flake8-tests
 
- For additional requirements about contributing, see our
+ For additional requirements about contributing, including Google’s CLA, see our
  [Contribution Guide](.github/CONTRIBUTING.md).
 
 

--- a/docs/Getting_Started.md
+++ b/docs/Getting_Started.md
@@ -1,0 +1,249 @@
+# Getting Started
+-----------------
+
+# System Requirements:
+------------------------
+
+Ramble's dependencies are listed within the top level
+requirements.txt file.
+
+In addition to the listed python dependencies, Ramble depends on
+spack for some application definition files.
+
+Please see [Spack's documentation](https://spack.readthedocs.io/en/latest/getting_started.html)
+for getting spack installed.
+
+
+# Installation:
+-----------------
+
+Installing ramble is easy. You can clone it from the
+[github repository](https://github.com/GoogleCloudPlatform/ramble) using this command:
+
+```
+   $ git clone -c feature.manyFiles=true https://github.com/GoogleCloudPlatform/ramble.git
+```
+
+This will create a directory called ``ramble``.
+
+# Shell Support:
+------------------
+
+Once you have cloned Ramble, we recommend sourcing the appropriate script for your shell:
+
+```
+   # For bash/zsh/sh
+   $ . ramble/share/ramble/setup-env.sh
+
+   # For tcsh/csh
+   $ source ramble/share/ramble/setup-env.csh
+
+   # For fish
+   $ . ramble/share/ramble/setup-env.fish
+```
+
+That's it! You're ready to use Ramble.
+
+Sourcing these files will put the ``ramble`` command in your ``PATH``.
+
+If you do not want to use Ramble's shell support, you can always just run the
+``ramble`` command directly from ``ramble/bin/ramble``.
+
+When the ``ramble`` command is executed, it searches for an appropriate Python
+interpreter to use, which can be explicitly overriden by setting the
+``RAMBLE_PYTHON`` environment variable. When sourcing the appropriate shell
+setup script, ``RAMBLE_PYTHON`` will be set to the interpreter found at
+sourcing time, ensuring future invocations of the ``ramble`` command will
+continue to use the same consistent python version regardless of changes in the
+environment.
+
+
+# Command Help:
+-----------------
+To get information on the available commands, you can execute:
+
+```
+    $ ramble help --all
+```
+
+For help with sub-commands, the ``-h`` flag can be used:
+
+```
+   $ ramble <subcommand> -h
+```
+
+# Defined Applications:
+-------------------------
+
+In order to get information about the available applications defined within
+``ramble``, you can use the command:
+
+```
+   $ ramble list
+```
+
+This command uses filtering to search the defined applications, e.g.:
+
+```
+   $ ramble list wrf
+```
+
+will list both ``wrfv3`` and ``wrfv4``.
+
+# Ramble Workspaces:
+----------------------
+
+To configure experiments, you need to use a Ramble workspace. A workspace is a
+self contained directory that contains configuration files, template files, and
+eventually will contain spack environments, input files, and experiment
+execution directories.
+
+Workspaces fall into one of two categories:
+
+Named Workspaces (created with ``ramble workspace create <name>``) are located
+in ``$ramble/var/workspaces/<workspace_name>``. These workspaces can be managed
+with other ramble commands directly (e.g. ``ramble workspace remove <name>``).
+
+Anonymous Workspaces (created with ``ramble workspace create -d <path>``) are
+located in the provided path, and need to be managed independently of ramble
+commands.
+
+A workspace can be selected when executing ``ramble`` through the use of the
+``-w`` and ``-D`` flags.
+
+## Creating Workspaces:
+-------------------------
+
+To create a new Ramble workspace, you can use:
+
+```
+    $ ramble workspace create [<name>] [-d <path>]
+```
+
+Once a workspace is created, you can activate the workspace. This allows some
+subsequent commands to work without explicitly passing in a workspace. This
+is done through:
+
+```
+    $ ramble workspace activate [<name>/<path>]
+```
+
+With an activated workspace, you can get information about the workspace with:
+
+```
+    $ ramble workspace info
+```
+
+## Configuring A Workspace:
+-----------------------------
+
+Within the created workspace, a ``configs`` directory is created to house the
+configuration files.
+
+A newly created workspace will contain:
+
+```
+   - configs
+     | - ramble.yaml
+     | - execute_experiment.tpl
+```
+
+The ``ramble.yaml`` file contains the configuration of the workspace. Any file
+placed in this ``configs`` directory with the extension ``.tpl`` will generate
+a "rendered" version within every experiment directory.
+
+These files can be edited with your favorite editor, or though the command:
+
+```
+    $ ramble workspace edit
+```
+
+Flags exist to control whether you want to edit a template file, or the
+configuration file.
+
+Variables are defined of the format ``{file_prefix}``, that contain the path to
+the rendered version within every experiment. As an example:
+
+```
+    configs/execute_experiment.tpl
+```
+
+Will define ``{execute_experiment}``
+
+## Concretizing A Workspace:
+------------------------------
+
+After configuring a workspace with applications, workloads, and experiments,
+Ramble can be used to inject default software configurations for the requested
+experiments. To do this, you can use the:
+
+```
+    $ ramble workspace concretize
+```
+
+This will fill out the ``spack`` dictionary within the ``ramble.yaml`` file
+with defaults. The defaults can be configured however you want before
+installing the actual software.
+
+## Setting Up A Workspace:
+----------------------------
+
+Once a workspace is concretized, it can be set up. This process is executed through:
+
+```
+    $ ramble workspace setup
+```
+
+The setup action will:
+ - Install required / requested software
+ - Download required input files
+ - Create and configure experiment directories
+ - Create the ``all_experiments`` script
+
+## Executing Experiments:
+---------------------------
+
+After the workspace is set up, its experiments can be executed. The two methods
+to run the experiments are:
+
+```
+    $ ramble on
+    $ ./all_experiments
+```
+
+
+## Analyzing Experiments:
+---------------------------
+
+Once the experiments within a workspace are complete, the experiments can be
+analyzed. This is done through:
+
+```
+    $ ramble workspace analyze
+```
+
+This creates a ``results`` file in the root of the workspace that contains
+extracted figures of merit.
+
+
+## Archiving A Workspace:
+---------------------------
+
+Ramble can create an archive of a workspace. This is a self contained copy of various important aspects of the workspace, including:
+ - All files in the ``configs`` directory
+ - Rendered templates in the experiments directories
+ - Files that would have figures of merit extracted
+ - Auxiliary files that an application lists for archival
+ - All genreated spack.yaml files
+
+You can archive a workspace with:
+
+```
+    $ ramble workspace archive
+```
+
+And you can create a tar-ball with:
+
+```
+    $ ramble workspace archive -t
+```

--- a/examples/README.md
+++ b/examples/README.md
@@ -47,7 +47,7 @@ math expressions using variable definitions.
 
 A description of the configuration files available is below:
 
-### [basic_hostname_config.yaml]
+### [Basic Hostname Config](./basic_hostname_config.yaml)
 The basic hostname config is the simplest of the configuration files. This file
 uses a pre-existing binary (hostname) to generate experiments.
 
@@ -64,14 +64,14 @@ And for information on what workloads are available within an application, one c
 ramble info <app_name>
 ```
 
-### [basic_gromacs_config.yaml]
+### [Basic Gromacs Config](basic_gromacs_config.yaml)
 The basic gromacs configuration file is a good next step in get started using
 ramble. It is overly verbose, but this is to show how configurable experiments
 can be.
 
 This configuration changes from a pre-existing binary to using spack to build gromacs.
 
-### [basic_expansion_config.yaml]
+### [Basic Expansion Config](basic_expansion_config.yaml)
 The basic expansion configuration file shows some examples of the experiment generation syntax.
 
 It changes from using groamcs to using OpenFoam and WRF.
@@ -79,7 +79,7 @@ It changes from using groamcs to using OpenFoam and WRF.
 Additionally, it shows how a configuration file can contain experiments for
 multiple applications and / or workloads at the same time.
 
-### [full_expansion_config.yaml]
+### [Full Config](full_expansion_config.yaml)
 
 The full expansion configuration file shows a more complete example of
 experiment generation. It extends the basic expansion config file by showing two main aspects:


### PR DESCRIPTION
This merge adds a getting started guide to Ramble. Additionally, it updates the top level README to refer to the CLA, and have a bit more decsription about why one might use Ramble.

It also fixes some issues in the examples/README.md file.