### PR TITLE
Add simple install cache to spack applications

### DIFF
--- a/lib/ramble/ramble/cache.py
+++ b/lib/ramble/ramble/cache.py
@@ -1,9 +1,0 @@
-class SetCache:
-    def __init__(self):
-        self.store = set()
-
-    def add(self, tupl):
-        self.store.add(tupl)
-
-    def contains(self, tupl):
-        return (tupl in self.store)

--- a/lib/ramble/ramble/util/install_cache.py
+++ b/lib/ramble/ramble/util/install_cache.py
@@ -1,0 +1,19 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+"""Provide data structures to assist with cacheing operations"""
+
+class SetCache:
+    def __init__(self):
+        self.store = set()
+
+    def add(self, tupl):
+        self.store.add(tupl)
+
+    def contains(self, tupl):
+        return (tupl in self.store)

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -28,7 +28,7 @@ import ramble.spack_runner
 import ramble.expander
 import ramble.util.web
 import ramble.fetch_strategy
-import ramble.cache
+import ramble.util.install_cache
 
 import spack.util.spack_yaml as syaml
 import spack.util.spack_json as sjson
@@ -428,7 +428,7 @@ class Workspace(object):
 
         self.config_sections = {}
 
-        self.install_cache = ramble.cache.SetCache()
+        self.install_cache = ramble.util.install_cache.SetCache()
 
         self.results = None
 


### PR DESCRIPTION
Currently each expierment tries to install spack packages and regenerate modules. This is fine, but we can guarntee this work will already be done, and thus we spend a lot of time in needless operations.

This PR is a first attempt at resolving that, and speeds things up significantly. In my workspace with ~20 experiments it takes install time from ~3mins to ~20s  (saves ~6-7s per repeated experiment)