### PR TITLE
IMB enhancement + suggested value support 

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -106,9 +106,16 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                         var_str = '\t\tDescription: ' + \
                             workload_vars[var]['description'] + '\n'
                         out_str.append(var_str)
+
                         var_str = '\t\tDefault: ' + \
                             workload_vars[var]['default'] + '\n'
                         out_str.append(var_str)
+
+                        if 'values' in workload_vars[var].keys():
+                            var_str = '\t\tSuggested Values: ' + \
+                                str(workload_vars[var]['values']) + '\n'
+                            out_str.append(var_str)
+
                     out_str.append('\n')
 
         return out_str

--- a/lib/ramble/ramble/language/application_language.py
+++ b/lib/ramble/ramble/language/application_language.py
@@ -197,7 +197,7 @@ def input_file(name, url, description, target_dir='{workload_name}', **kwargs):
 
 
 @application_directive('workload_variables')
-def workload_variable(name, default, description, workload=None,
+def workload_variable(name, default, description, values=None, workload=None,
                       workloads=None, **kwargs):
     """Define a new variable to be used in experiments
 
@@ -230,6 +230,9 @@ def workload_variable(name, default, description, workload=None,
                 'default': default,
                 'description': description
             }
+            if values:
+                app.workload_variables[wl_name][name]['values'] = values
+
 
     return _execute_workload_variable
 

--- a/var/ramble/repos/builtin/applications/intel-mpi-benchmarks/application.py
+++ b/var/ramble/repos/builtin/applications/intel-mpi-benchmarks/application.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 # https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -8,50 +8,133 @@
 
 from ramble.appkit import *
 
+# Genral Guidance:
+# - Use compact placement policy
+# - Check the compute nodes in a single rack using the network topology API
 
 class IntelMpiBenchmarks(SpackApplication):
-    '''Intel MPI Benchmark applicaiton.
+    '''Intel MPI Benchmark application.
 
     https://www.intel.com/content/www/us/en/developer/articles/technical/intel-mpi-benchmarks.html
     https://github.com/intel/mpi-benchmarks
     https://www.intel.com/content/www/us/en/develop/documentation/imb-user-guide/top.html
     '''
+
     name = 'IntelMpiBenchmarks'
 
-    tags = ['micro-benchmark', 'mpi']
+    tags = ['micro-benchmark', 'benchmark', 'mpi']
 
     default_compiler('gcc9', base='gcc', version='9.3.0')
     mpi_library('impi2018', base='intel-mpi', version='2018.4.274')
-    software_spec('imb', base='intel-mpi-benchmarks', version='2019.6',
-                  compiler='gcc9', mpi='impi2018')
+    software_spec('intel-mpi-benchmarks', base='intel-mpi-benchmarks', version='2019.6',
+                  compiler='gcc9', mpi='impi2018', required=True)
 
-    executable('MPI1', 'IMB-MPI1 {benchmark} {flags}', use_mpi=True)
+    executable('pingpong',
+               '-genv I_MPI_FABRICS=shm:tcp ' \
+               '-genv I_MPI_PIN_PROCESSOR_LIST=0 ' \
+               'IMB-MPI1 {pingpong_type} -msglog {msglog_min}:{msglog_max} ' \
+               '-iter {num_iterations} -show_tail on -dumpfile {output_file}',
+               use_mpi=True)
 
-    workload('MPI1', executable='MPI1')
+    # FIXME: how best to deal with the desirded behavior of <2*num_cores> -ppn <num_cores>
+    executable('multi-pingpong',
+               '-genv I_MPI_FABRICS=shm:tcp ' \
+               'IMB-MPI1 Pingpong -msglog {msglog_min}:{msglog_max} ' \
+               '-iter {num_iteration} -multi 0 -map 2*{num_cores} -show_tail on',
+               use_mpi=True)
 
-    workload_variable('benchmark', default='PingPong',
-                      description='Benchmark name for IMB-MPI1',
-                      workloads=['MPI1'])
+    executable('collective',
+               '-genv I_MPI_FABRICS=shm:tcp ' \
+               'IMB-MPI1 {collective_type} -msglog {msglog_min}:{msglog_max} ' \
+	       '-iter {num_iterations} -npmin {min_collective_ranks}',
+               use_mpi=True)
 
-    workload_variable('flags', default='',
-                      description='Flags for running the IMB-MPI1 benchmark',
-                      workloads=['MPI1'])
+    workload('pingpong', executable='pingpong')
+    workload('multi-pingpong', executable='multi-pingpong')
+    workload('collective', executable='collective')
 
-    figure_of_merit('Latency-0-Byte', log_file='{experiment_run_dir}/{experiment_name}.out',
-                    fom_regex=r'\s+0\s+[0-9]+\s+(?P<latency>[0-9]+\.[0-9]+).*',
-                    group_name='latency', units='usec')
+    workload_variable('output_path', default='./output',
+                      description='Dumpfile Output Path',
+                      workloads=['pingpong'])
 
-    figure_of_merit('Bandwidth-0-Byte', log_file='{experiment_run_dir}/{experiment_name}.out',
-                    fom_regex=r'\s+0\s+[0-9]+\s+[0-9]+\.[0-9]+\s+(?P<bandwidth>[0-9]+\.[0-9]+).*',
-                    group_name='bandwidth', units='Mbytes/sec')
+    workload_variable('pingpong_type',
+                      default='Pingpong',
+                      values=['Pingpong', 'Unirandom', 'Multi-Pingpong', 'Birandom', 'Corandom'],
+                      description='Pingpong Algorithm to Use',
+                      workloads=['pingpong'])
 
-    max_exponent = 25
-    for exp in range(0, max_exponent):
-        size = 2**exp
-        figure_of_merit('Latency-%s-Byte' % size, log_file='{experiment_run_dir}/{experiment_name}.out',
-                        fom_regex=r'\s+%s\s+[0-9]+\s+(?P<latency>[0-9]+\.[0-9]+).*' % size,
-                        group_name='latency', units='usec')
 
-        figure_of_merit('Bandwidth-%s-Byte' % size, log_file='{experiment_run_dir}/{experiment_name}.out',
-                        fom_regex=r'\s+%s\s+[0-9]+\s+[0-9]+\.[0-9]+\s+(?P<bandwidth>[0-9]+\.[0-9]+).*' % size,
-                        group_name='bandwidth', units='Mbytes/sec')
+    workload_variable('num_cores',
+                      default='{n_ranks}/2',
+                      description='Number of cores',
+                      workloads=['multi-pingpong'])
+
+    workload_variable('collective_type',
+                      default='Allgather', # FIXME: should default just be denoted by the first value in the values list?
+                      values=['Allgather', 'Allgatherv', 'Alltoall',
+                              'Alltoallv', 'Bcast', 'Scatter', 'Scatterv',
+                              'Gather', 'Gatherv', 'Reduce', 'Reduce_scatter',
+                              'Allreduce', 'Barrier'],
+                      description='Collective type to test',
+                      workloads=['collective'])
+
+    workload_variable('min_collective_ranks', default='{n_ranks}',
+                      description='Minimum number of ranks to use in a collective operation',
+                      workloads=['collective'])
+
+    workload_variable('num_iterations', default='1000',
+                      description='Number of iterations to test over',
+                      workloads=['pingpong', 'multi-pingpong', 'collective'])
+
+    workload_variable('msglog_min', default='1',
+                      description='Min Message Size (power of 2)',
+                      workloads=['pingpong', 'multi-pingpong', 'collective'])
+
+    workload_variable('msglog_max', default='30',
+                      description='Max Message Size (power of 2)',
+                      workloads=['pingpong', 'multi-pingpong', 'collective'])
+
+
+    # Matches tables like:
+          #bytes #repetitions  t_min[usec]  t_max[usec]  t_avg[usec]
+    latency_regex = '^\s+(?P<bytes>\d+)\s+(?P<repetitions>\d+)\s+(?P<t_min>\d+\.\d+)\s+(?P<t_avg>\d+\.\d+)\s+(?P<t_max>\d+\.\d+)$'
+
+    figure_of_merit('Latency min', log_file='{experiment_run_dir}/{experiment_name}.out',
+            fom_regex=latency_regex,
+            group_name='t_min', units='usec', contexts=['latency-bytes'])
+
+    figure_of_merit('Latency avg', log_file='{experiment_run_dir}/{experiment_name}.out',
+            fom_regex=latency_regex,
+            group_name='t_avg', units='usec', contexts=['latency-bytes'])
+
+    figure_of_merit('Latency max', log_file='{experiment_run_dir}/{experiment_name}.out',
+            fom_regex=latency_regex,
+            group_name='t_max', units='usec', contexts=['latency-bytes'])
+
+    # Matches tables like:
+       #bytes #repetitions      t[usec]   Mbytes/sec
+    bw_regex = '^\s+(?P<bytes>\d+)\s+(?P<repetitions>\d+)\s+(?P<t_avg>\d+\.\d+)\s+(?P<bw>\d+\.\d+)$'
+    figure_of_merit('Bandwidth', log_file='{experiment_run_dir}/{experiment_name}.out',
+            fom_regex=bw_regex,
+            group_name='bw', units='Mbytes/sec', contexts=['bw-bytes'])
+
+    # Combiend tables like:
+       #bytes #repetitions  t_min[usec]  t_max[usec]  t_avg[usec]   Mbytes/sec
+       # (happens in sendrecv and exchange)
+    combined_regex = '^\s+(?P<bytes>\d+)\s+(?P<repetitions>\d+)\s+(?P<t_min>\d+\.\d+)\s+(?P<t_avg>\d+\.\d+)\s+(?P<t_max>\d+\.\d+)\s+(?P<bw>\d+\.\d+)$'
+    figure_of_merit('Combo', log_file='{experiment_run_dir}/{experiment_name}.out',
+            fom_regex=combined_regex,
+            group_name='bw', units='Mbytes/sec', contexts=['combo-bytes'])
+
+
+    figure_of_merit_context('latency-bytes',
+            regex=latency_regex,
+            output_format='Bytes: {bytes} (Latency)')
+
+    figure_of_merit_context('bw-bytes',
+            regex=bw_regex,
+            output_format='Bytes: {bytes} (BW)')
+
+    figure_of_merit_context('combo-bytes',
+            regex=combined_regex,
+            output_format='Bytes: {bytes} (Combo)')

--- a/var/ramble/repos/builtin/applications/intel-mpi-benchmarks/application.py
+++ b/var/ramble/repos/builtin/applications/intel-mpi-benchmarks/application.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2022-2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 # https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -97,7 +97,7 @@ class IntelMpiBenchmarks(SpackApplication):
 
     # Matches tables like:
           #bytes #repetitions  t_min[usec]  t_max[usec]  t_avg[usec]
-    latency_regex = '^\s+(?P<bytes>\d+)\s+(?P<repetitions>\d+)\s+(?P<t_min>\d+\.\d+)\s+(?P<t_avg>\d+\.\d+)\s+(?P<t_max>\d+\.\d+)$'
+    latency_regex = r'^\s+(?P<bytes>\d+)\s+(?P<repetitions>\d+)\s+(?P<t_min>\d+\.\d+)\s+(?P<t_avg>\d+\.\d+)\s+(?P<t_max>\d+\.\d+)$'
 
     figure_of_merit('Latency min', log_file='{experiment_run_dir}/{experiment_name}.out',
             fom_regex=latency_regex,
@@ -113,7 +113,7 @@ class IntelMpiBenchmarks(SpackApplication):
 
     # Matches tables like:
        #bytes #repetitions      t[usec]   Mbytes/sec
-    bw_regex = '^\s+(?P<bytes>\d+)\s+(?P<repetitions>\d+)\s+(?P<t_avg>\d+\.\d+)\s+(?P<bw>\d+\.\d+)$'
+    bw_regex = r'^\s+(?P<bytes>\d+)\s+(?P<repetitions>\d+)\s+(?P<t_avg>\d+\.\d+)\s+(?P<bw>\d+\.\d+)$'
     figure_of_merit('Bandwidth', log_file='{experiment_run_dir}/{experiment_name}.out',
             fom_regex=bw_regex,
             group_name='bw', units='Mbytes/sec', contexts=['bw-bytes'])
@@ -121,7 +121,7 @@ class IntelMpiBenchmarks(SpackApplication):
     # Combiend tables like:
        #bytes #repetitions  t_min[usec]  t_max[usec]  t_avg[usec]   Mbytes/sec
        # (happens in sendrecv and exchange)
-    combined_regex = '^\s+(?P<bytes>\d+)\s+(?P<repetitions>\d+)\s+(?P<t_min>\d+\.\d+)\s+(?P<t_avg>\d+\.\d+)\s+(?P<t_max>\d+\.\d+)\s+(?P<bw>\d+\.\d+)$'
+    combined_regex = r'^\s+(?P<bytes>\d+)\s+(?P<repetitions>\d+)\s+(?P<t_min>\d+\.\d+)\s+(?P<t_avg>\d+\.\d+)\s+(?P<t_max>\d+\.\d+)\s+(?P<bw>\d+\.\d+)$'
     figure_of_merit('Combo', log_file='{experiment_run_dir}/{experiment_name}.out',
             fom_regex=combined_regex,
             group_name='bw', units='Mbytes/sec', contexts=['combo-bytes'])

--- a/var/ramble/repos/builtin/applications/intel-mpi-benchmarks/examples/slurm/execute_experiment.tpl
+++ b/var/ramble/repos/builtin/applications/intel-mpi-benchmarks/examples/slurm/execute_experiment.tpl
@@ -19,7 +19,6 @@ cd "{experiment_run_dir}"
 
 {spack_setup}
 
-#scontrol show hostnames ${SLURM_JOB_NODELIST} > hostfile
-echo 'localhost' > hostfile
+scontrol show hostnames ${SLURM_JOB_NODELIST} > hostfile
 
 {command}

--- a/var/ramble/repos/builtin/applications/intel-mpi-benchmarks/examples/slurm/execute_experiment.tpl
+++ b/var/ramble/repos/builtin/applications/intel-mpi-benchmarks/examples/slurm/execute_experiment.tpl
@@ -1,0 +1,25 @@
+# This is a template execution script for
+# running the execute pipeline.
+#
+# Variables surrounded by curly braces will be expanded
+# when generating a specific execution script.
+# Some example variables are:
+#   - experiment_run_dir (Will be replaced with the experiment directory)
+#   - command (Will be replaced with the command to run the experiment)
+#   - spack_setup (Will be replaced with the commands needed to setup
+#                  and load a spack environment for a given experiment)
+#   - log_dir (Will be replaced with the logs directory)
+#   - experiment_name (Will be replaced with the name of the experiment)
+#   - workload_run_dir (Will be replaced with the directory of the workload
+#   - application_name (Will be repalced with the name of the application)
+#   - n_nodes (Will be replaced with the required number of nodes)
+#   Any experiment parameters will be available as variables as well.
+
+cd "{experiment_run_dir}"
+
+{spack_setup}
+
+#scontrol show hostnames ${SLURM_JOB_NODELIST} > hostfile
+echo 'localhost' > hostfile
+
+{command}

--- a/var/ramble/repos/builtin/applications/intel-mpi-benchmarks/examples/slurm/ramble.yaml
+++ b/var/ramble/repos/builtin/applications/intel-mpi-benchmarks/examples/slurm/ramble.yaml
@@ -1,0 +1,49 @@
+ramble:
+  mpi:
+    command: mpirun
+    args:
+    - -n
+    - '{n_ranks}'
+    - -ppn
+    - '{processes_per_node}'
+    - -hostfile
+    - hostfile
+  batch:
+    #submit: sbatch '{execute_experiment}'
+    submit: '{execute_experiment}'
+  variables:
+    processes_per_node: 56
+  applications:
+    intel-mpi-benchmarks:
+      workloads:
+        pingpong:
+          experiments:
+            full_node_{pingpong_type}:
+              variables:
+                pingpong_type: ['Pingpong', 'Unirandom', 'Multi-Pingpong', 'Birandom', 'Corandom']
+                n_ranks: '56'
+        multi-pingpong:
+          experiments:
+            full_node:
+              variables:
+                n_ranks: '128'
+        collective:
+          experiments:
+            full_node_{collective_type}:
+              variables:
+                collective_type: ['Bcast', 'Allgather', 'Allgatherv', 'Alltoall', 'Alltoallv', 'Scatter', 'Scatterv', 'Gather', 'Gatherv', 'Reduce', 'Reduce_scatter', 'Allreduce', 'Barrier']
+                n_ranks: '128'
+spack:
+  concretized: true
+  compilers: {}
+  mpi_libraries:
+    impi2018:
+      base: intel-mpi
+      version: 2018.4.274
+      target: x86_64
+  applications:
+    intel-mpi-benchmarks:
+      intel-mpi-benchmarks:
+        base: intel-mpi
+        version: 2018.4.274
+        required: true

--- a/var/ramble/repos/builtin/applications/intel-mpi-benchmarks/examples/slurm/ramble.yaml
+++ b/var/ramble/repos/builtin/applications/intel-mpi-benchmarks/examples/slurm/ramble.yaml
@@ -9,8 +9,7 @@ ramble:
     - -hostfile
     - hostfile
   batch:
-    #submit: sbatch '{execute_experiment}'
-    submit: '{execute_experiment}'
+    submit: sbatch '{execute_experiment}'
   variables:
     processes_per_node: 56
   applications:
@@ -44,6 +43,6 @@ spack:
   applications:
     intel-mpi-benchmarks:
       intel-mpi-benchmarks:
-        base: intel-mpi
-        version: 2018.4.274
+        base: intel-mpi-benchmarks
+        version: 2019.6
         required: true


### PR DESCRIPTION
General improvements to IMB application to add better FOMs and bring it inline with what the requesting user wanted 

Example use: 

```
 applications:
    intel-mpi-benchmarks:
      workloads:
        pingpong:
          experiments:
            full_node_{pingpong_type}:
              variables:
                pingpong_type: ['Pingpong', 'Unirandom', 'Multi-Pingpong', 'Birandom', 'Corandom']
                n_ranks: '56'
```


Also adds support for suggested values in the application definition, eg: 

```
    workload_variable('pingpong_type',
                      default='Pingpong',
                      values=['Pingpong', 'Unirandom', 'Multi-Pingpong', 'Birandom', 'Corandom'],
```

This now shows up in `ramble info <app_name>` but does not enforce it 