### PR TITLE
Add success criteria and tests

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -398,7 +398,8 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                 shutil.copy(src, archive_experiment_dir)
 
         # Copy all figure of merit files
-        analysis_files, _, _ = self._analysis_dicts(expander)
+        criteria_list = workspace.success_list
+        analysis_files, _, _ = self._analysis_dicts(expander, criteria_list)
         for file, file_conf in analysis_files.items():
             if os.path.exists(file):
                 shutil.copy(file, archive_experiment_dir)
@@ -416,7 +417,17 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
 
         fom_values[context][fom]
 
-        A fom can show up in multiple contexts, but
+        A fom can show up in any number of explicit contexts (including zero).
+        If the number of explicit contexts is zero, the fom is associated with
+        the default '(null)' context.
+
+        Success is determined at analysis time as well. This happens by checking if:
+         - At least one FOM is extracted
+         AND
+         - Any defined success criteria pass
+
+        Success criteria are defined within the application.py, but can also be
+        injected in a workspace config.
         """
 
         def format_context(context_match, context_format):
@@ -433,7 +444,10 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
 
         fom_values = {}
 
-        files, contexts, foms = self._analysis_dicts(expander)
+        criteria_list = workspace.success_list
+
+        files, contexts, foms = self._analysis_dicts(expander, criteria_list)
+
         # Iterate over files. We already know they exist
         for file, file_conf in files.items():
 
@@ -443,6 +457,13 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
 
             with open(file, 'r') as f:
                 for line in f.readlines():
+
+                    for criteria in file_conf['success_criteria']:
+                        tty.debug('Looking for criteria %s' % criteria)
+                        criteria_obj = criteria_list.find_criteria(criteria)
+                        if criteria_obj.matches(line):
+                            criteria_obj.mark_found()
+
                     for context in file_conf['contexts']:
                         context_conf = contexts[context]
                         context_match = context_conf['regex'].match(line)
@@ -489,8 +510,11 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         exp_ns = expander.experiment_namespace
         results[exp_ns] = {}
 
+        success = True if fom_values else False
+        success = success and criteria_list.passed()
+
         tty.debug('fom_vals = %s' % fom_values)
-        if fom_values:
+        if success:
             results[exp_ns]['RAMBLE_STATUS'] = 'SUCCESS'
             results[exp_ns]['RAMBLE_VARIABLES'] = expander.all_vars()
             results[exp_ns]['CONTEXTS'] = {}
@@ -503,11 +527,20 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
 
         workspace.append_result(results)
 
-    def _analysis_dicts(self, expander):
+    def _new_file_dict(self):
+        return {
+            'success_criteria': [],
+            'contexts': [],
+            'foms': []
+        }
+
+    def _analysis_dicts(self, expander, criteria_list):
         """Extract files that need to be analyzed.
 
         Process figures_of_merit, and return the manipulated dictionaries
         to allow them to be extracted.
+
+        Additionally, ensure the success criteria list is complete.
 
         Returns:
            - files (dict): All files that need to be processed
@@ -519,12 +552,29 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         contexts = {}
         foms = {}
 
+        # Add the application defined criteria
+        criteria_list.flush_scope('application_definition')
+        for criteria, conf in self.success_criteria.items():
+            if conf['mode'] == 'string':
+                criteria_list.add_criteria('application_definition', criteria,
+                                           conf['mode'], re.compile(conf['match']),
+                                           conf['file'])
+
+        # Extract file paths for all criteria
+        for criteria in criteria_list.all_criteria():
+            log_path = expander.expand_var(criteria.file)
+            if log_path not in files and os.path.exists(log_path):
+                files[log_path] = self._new_file_dict()
+
+            if log_path in files:
+                files[log_path]['success_criteria'].append(criteria.name)
+
         # Remap fom / context / file data
         # Could push this into the language features in the future
         for fom, conf in self.figures_of_merit.items():
             log_path = expander.expand_var(conf['log_file'])
             if log_path not in files and os.path.exists(log_path):
-                files[log_path] = {'contexts': [], 'foms': []}
+                files[log_path] = self._new_file_dict()
 
             if log_path in files:
                 tty.debug('Log = %s' % log_path)

--- a/lib/ramble/ramble/language/application_language.py
+++ b/lib/ramble/ramble/language/application_language.py
@@ -6,6 +6,8 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+import llnl.util.tty as tty
+
 import ramble.language.language_base
 from ramble.language.language_base import DirectiveError
 
@@ -325,3 +327,33 @@ def software_spec(name, base, version=None, variants=None,
             }
 
     return _execute_software_spec
+
+
+@application_directive('success_criteria')
+def success_criteria(name, mode, match, file):
+    """Defines a success criteria used by experiments of this application
+
+    Adds a new success criteria to this application definition.
+
+    These will be checked during the analyze step to see if a job exited properly.
+
+    Arguments:
+      - name: The name of this success criteria
+      - mode: The type of success criteria that will be validated
+              Valid values are: 'string'
+      - match: The value to check indicate success (if found, it would mark success)
+      - file: Which file the success criteria should be located in
+    """
+
+    def _execute_success_criteria(app):
+        valid_modes = ['string']
+        if mode not in valid_modes:
+            tty.die(f'Mode {mode} is not valid. Valid values are {valid_modes}')
+
+        app.success_criteria[name] = {
+            'mode': mode,
+            'match': match,
+            'file': file
+        }
+
+    return _execute_success_criteria

--- a/lib/ramble/ramble/success_criteria.py
+++ b/lib/ramble/ramble/success_criteria.py
@@ -1,0 +1,130 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import re
+
+import llnl.util.tty as tty
+
+
+class ScopedCriteriaList(object):
+    """A scoped list of success criteria
+
+    This object represents a list of success criteria. The criteria are scoped
+    based on which portion of a workspace they are defined in.
+
+    Possible scopes are:
+     - application_definition
+     - application
+     - workload
+     - experiment
+
+    To see if success was met, all criteria will be checked and are ANDed together.
+    """
+
+    _valid_scopes = [
+        'application_definition',
+        'workspace',
+        'application',
+        'workload',
+        'experiment'
+    ]
+    _flush_scopes = {
+        'experiment': ['experiment'],
+        'workload': ['workload', 'experiment'],
+        'application': ['application', 'workload', 'experiment'],
+        'workspace': ['workspace', 'application', 'workload', 'experiment'],
+        'application_definition': ['application_definition']
+    }
+
+    def __init__(self):
+        self.criteria = {}
+        for scope in self._valid_scopes:
+            self.criteria[scope] = []
+
+    def validate_scope(self, scope):
+        if scope not in self._valid_scopes:
+            tty.die('Success scope %s is not valid. Possible scopes are: %s'
+                    % (scope, self._valid_scopes))
+
+    def add_criteria(self, scope, name, mode, match, file):
+        self.validate_scope(scope)
+        exists = self.find_criteria(name)
+        if exists:
+            tty.die(f'Criteria {name} is not unique.')
+
+        self.criteria[scope].append(SuccessCriteria(name, mode, match, file))
+
+    def flush_scope(self, scope):
+        """Remove criteria within a scope, and lower level scopes
+
+        Scope to be purged are defined in self._flush_scopes.
+        """
+        self.validate_scope(scope)
+
+        for scope in self._flush_scopes[scope]:
+            tty.debug(' Flushing scope: %s' % scope)
+            tty.debug('    It contained:')
+            for crit in self.criteria[scope]:
+                tty.debug('      %s' % crit.name)
+            del self.criteria[scope]
+            self.criteria[scope] = []
+
+    def passed(self):
+        succeed = True
+        for scope in self._valid_scopes:
+            for criteria in self.criteria[scope]:
+                succeed = succeed and criteria.found
+        return succeed
+
+    def all_criteria(self):
+        for scope in self._valid_scopes:
+            for criteria in self.criteria[scope]:
+                yield criteria
+
+    def find_criteria(self, name):
+        for scope in self._valid_scopes:
+            for criteria in self.criteria[scope]:
+                if criteria.name == name:
+                    return criteria
+        return None
+
+
+class SuccessCriteria(object):
+    """A single success criteria object
+
+    This object represents a single criteria for success for a Ramble
+    experiment.
+    """
+
+    _valid_modes = ['string']
+
+    def __init__(self, name, mode, match, file):
+        self.name = name
+        if mode not in self._valid_modes:
+            tty.die(f'{mode} is not valid. Possible modes are: {self._valid_modes}')
+
+        self.mode = mode
+        self.match = re.compile(match)
+        self.file = file
+        self.found = False
+
+    def matches(self, test):
+        tty.debug(f'Testing criteria {self.name}')
+        if self.mode == 'string':
+            match_obj = self.match.match(test)
+            if match_obj:
+                return True
+
+        return False
+
+    def mark_found(self):
+        tty.debug(f'   {self.name} was matched!')
+        self.found = True
+
+    def reset_found(self):
+        self.found = False

--- a/lib/ramble/ramble/test/end_to_end.py
+++ b/lib/ramble/ramble/test/end_to_end.py
@@ -48,6 +48,11 @@ ramble:
         CONUS_12km:
           experiments:
             scaling_{n_nodes}_{partition}_{spec_name}:
+              success_criteria:
+              - name: 'timing'
+                mode: 'string'
+                match: '.*Timing for main.*'
+                file: '{experiment_run_dir}/rsl.out.0000'
               env-vars:
                 set:
                   OMP_NUM_THREADS: '{n_threads}'

--- a/lib/ramble/ramble/test/spack_runner.py
+++ b/lib/ramble/ramble/test/spack_runner.py
@@ -121,7 +121,6 @@ def test_config_concretize_flags(tmpdir, capsys, mutable_config):
 
 
 def test_default_install_flags(tmpdir, capsys):
-    import sys
     try:
         env_path = tmpdir.join('spack-env')
         sr = ramble.spack_runner.SpackRunner(dry_run=True)

--- a/lib/ramble/ramble/test/success_criteria.py
+++ b/lib/ramble/ramble/test/success_criteria.py
@@ -1,0 +1,85 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import ramble.success_criteria
+
+
+def generate_file(path):
+    file_contents = """
+Some output
+Into a log file
+From
+An
+Experiment
+Success string
+Or maybe an exit code: 0
+    """
+
+    with open(path, 'w+') as f:
+        f.write(file_contents)
+
+
+def test_single_criteria(tmpdir):
+    log_path = tmpdir.join('log.out')
+    generate_file(log_path)
+
+    new_criteria = ramble.success_criteria.SuccessCriteria('test', 'string',
+                                                           r'.*Success string.*',
+                                                           log_path)
+
+    with open(log_path, 'r') as f:
+        for line in f.readlines():
+            if new_criteria.matches(line):
+                new_criteria.mark_found()
+
+    assert new_criteria.found
+
+
+def test_criteria_list(tmpdir):
+    log_path = tmpdir.join('log.out')
+    generate_file(log_path)
+
+    criteria_list = ramble.success_criteria.ScopedCriteriaList()
+
+    criteria_list.add_criteria('application_definition',
+                               'test-success',
+                               'string',
+                               r'.*Success string.*',
+                               log_path)
+
+    criteria_list.add_criteria('experiment',
+                               'test-exp',
+                               'string',
+                               r'.*Experiment.*',
+                               log_path)
+
+    criteria_list.add_criteria('workload',
+                               'test-wl',
+                               'string',
+                               r'.*Some output.*',
+                               log_path)
+
+    criteria_list.add_criteria('application',
+                               'test-app',
+                               'string',
+                               r'.*exit code.*',
+                               log_path)
+
+    criteria_list.add_criteria('workspace',
+                               'test-ws',
+                               'string',
+                               r'.*Into a log file.*',
+                               log_path)
+
+    with open(log_path, 'r') as f:
+        for line in f.readlines():
+            for criteria in criteria_list.all_criteria():
+                if criteria.matches(line):
+                    criteria.mark_found()
+
+    assert criteria_list.passed()

--- a/var/ramble/repos/builtin/applications/hostname/application.py
+++ b/var/ramble/repos/builtin/applications/hostname/application.py
@@ -25,3 +25,5 @@ class Hostname(ExecutableApplication):
     figure_of_merit('user time', log_file='{experiment_run_dir}/{experiment_name}.out',
                     fom_regex=r'(?P<user_time>[0-9]+\.[0-9]+)user.*',
                     group_name='user_time', units='s')
+
+    success_criteria('has_user_time', mode='string', match=r'[0-9]+\.[0-9]+user.*', file='{experiment_run_dir}/{experiment_name}.out')

--- a/var/ramble/repos/builtin/applications/streamc/application.py
+++ b/var/ramble/repos/builtin/applications/streamc/application.py
@@ -30,6 +30,10 @@ class Streamc(SpackApplication):
 
     log_file = '{experiment_run_dir}/{experiment_name}.out'
 
+    success_criteria('valid', mode='string',
+                     match=r'Solution Validates: avg error less than 1.000000e-13 on all three arrays',
+                     file=log_file)
+
     figure_of_merit("Array size",
                     log_file=log_file,
                     fom_regex=r'Array size\s+\=\s+(?P<array_size>[0-9]+)',


### PR DESCRIPTION
This merge adds syntax for defining success criteria in both application.py files, and ramble.yaml workspace files.

Within an application definition file, this looks like:

`success_criteria(name, mode, match, file)`

Within a ramble.yaml, this looks like:
```
success_criteria:
- name: <name>
  mode: <mode>
  match: <match>
  file: <file>
```

This can be defined at any level where a variables dictionary can exist.