### PR TITLE
Change cache to use spec_namespace

### DIFF
--- a/lib/ramble/ramble/application_types/spack.py
+++ b/lib/ramble/ramble/application_types/spack.py
@@ -8,7 +8,7 @@
 
 import llnl.util.tty as tty
 
-from ramble.application import ApplicationBase
+from ramble.application import ApplicationBase, ApplicationError
 import ramble.spack_runner
 
 header_color = '@*b'
@@ -87,7 +87,11 @@ class SpackApplication(ApplicationBase):
     def _install_software(self, workspace, expander):
 
         # See if we cached this already, and if so return
-        cache_tupl = ('spack', expander.workload_namespace)
+        namespace = expander.spec_namespace
+        if not namespace:
+            raise ApplicationError('Ramble spec_namespace is set to None.')
+
+        cache_tupl = ('spack', namespace)
         if workspace.check_cache(cache_tupl):
             tty.debug('{} already in cache.'.format(cache_tupl))
             return

--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -239,6 +239,14 @@ class Expander(object):
             return '%s.%s' % (app_name, wl_name)
         return None
 
+    @property
+    def spec_namespace(self):
+        app_name = self.expand_var('{spec_name}')
+        wl_name = self.workload_name
+        if app_name and wl_name:
+            return '%s.%s' % (app_name, wl_name)
+        return None
+
     def set_experiment(self, exp_name):
         tty.debug('Expander: Setting exp name %s' % exp_name)
         if not self.workload_name:


### PR DESCRIPTION
This merge adds spec_namespace as a property for the expander. This namespace is defined as: `'{spec_name}.workload_name'`

Fixes #15 