### PR TITLE
Add iperf2 app

### DIFF
--- a/var/ramble/repos/builtin/applications/iperf2/application.py
+++ b/var/ramble/repos/builtin/applications/iperf2/application.py
@@ -1,0 +1,89 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.appkit import *
+
+
+class Iperf2(SpackApplication):
+    '''Define the iperf2 application'''
+    name = 'iperf2'
+
+    tags = []
+
+    default_compiler('gcc9', base='gcc', version='9.3.0')
+
+    #software_spec('iperf2', base='iperf2', version='2.0.12',
+           #compiler='gcc9', required=True)
+
+    # Need to support these use cases:
+    # iperf -s // set up server
+    # iperf -t 600 -i 10 -c server_dns_or_internal_ip -P 16 // connect from another vm
+    workload('iperf2_server', executable='iperf2')
+    workload('iperf2_client', executable='iperf2')
+    workload('iperf2_custom', executable='iperf2')
+
+    workload_variable('input_flags',
+        default='-s',
+        description='Input flags to start iperf2 in server mode',
+        workload='iperf2_server'
+    )
+
+    workload_variable('input_flags',
+        default='-t {time} -i {interval} -c {host} -P {num_threads}',
+        description='Input flags to start iperf2 in server mode',
+        workload='iperf2_client'
+    )
+    workload_variable('input_flags',
+        default='',
+        description='Input flags in custom mode',
+        workload='iperf2_custom'
+    )
+
+    workload_variable('time',
+        default='600',
+        description='time in seconds to listen for new connections as well as to receive traffic (default not set)',
+        workload='iperf2_client'
+    )
+
+    workload_variable('interval',
+        default='10',
+        description='seconds between periodic bandwidth reports',
+        workload='iperf2_client'
+    )
+
+    workload_variable('host',
+        default='<host>',
+        description='run in client mode, connecting to <host>',
+        workload='iperf2_client'
+    )
+
+    workload_variable('num_threads',
+        default='16',
+        description='number of parallel client threads to run',
+        workload='iperf2_client'
+    )
+
+    workload_variable('additional_flags',
+        default='',
+        description='Allow users to pass additional flags',
+        workloads=['iperf2_client', 'iperf2_server', 'iperf2_custom']
+    )
+
+    executable('iperf2',
+        template='iperf {input_flags} {additional_flags}',
+        use_mpi=False
+    )
+
+    # TODO: addsuccess_criteria(..
+    figure_of_merit(
+        'Total BW',
+        log_file='{experiment_run_dir}/{experiment_name}.out',
+        fom_regex=r'\[SUM\]\s.*sec\s.*GBytes\s(?P<bw>.*)\sGbits/sec.*',
+        group_name='bw',
+        units='Gbits/sec'
+    )

--- a/var/ramble/repos/builtin/applications/iperf2/examples/manual_run/execute_experiment.tpl
+++ b/var/ramble/repos/builtin/applications/iperf2/examples/manual_run/execute_experiment.tpl
@@ -1,0 +1,23 @@
+#!/bin/sh
+# This is a template execution script for
+# running the execute pipeline.
+#
+# Variables surrounded by curly braces will be expanded
+# when generating a specific execution script.
+# Some example variables are:
+#   - experiment_run_dir (Will be replaced with the experiment directory)
+#   - command (Will be replaced with the command to run the experiment)
+#   - spack_setup (Will be replaced with the commands needed to setup
+#                  and load a spack environment for a given experiment)
+#   - log_dir (Will be replaced with the logs directory)
+#   - experiment_name (Will be replaced with the name of the experiment)
+#   - workload_run_dir (Will be replaced with the directory of the workload
+#   - application_name (Will be repalced with the name of the application)
+#   - n_nodes (Will be replaced with the required number of nodes)
+#   Any experiment parameters will be available as variables as well.
+
+cd "{experiment_run_dir}"
+
+{spack_setup}
+
+{command}

--- a/var/ramble/repos/builtin/applications/iperf2/examples/manual_run/ramble.yaml
+++ b/var/ramble/repos/builtin/applications/iperf2/examples/manual_run/ramble.yaml
@@ -1,0 +1,56 @@
+# This is a ramble workspace config file.
+#
+# It describes the experiments, the software stack
+# and all variables required for ramble to configure
+# experiments.
+# As an example, experiments can be defined as follows.
+# applications:
+#   variables:
+#     processes_per_node: '30'
+#   hostname:
+#     variables:
+#       iterations: '5'
+#     workloads:
+#       serial:
+#         variables:
+#           type: 'test'
+#         experiments:
+#           single_node:
+#             variables:
+#               n_ranks: '{processes_per_node}'
+
+ramble:
+  mpi: {}
+  batch:
+    submit: '{execute_experiment}'
+  variables:
+    processes_per_node: -1
+  applications:
+    iperf2:
+      workloads:
+        iperf2_client:
+          experiments:
+            test_client:
+              variables:
+                time: 10
+                interval: 10
+                host: "my_hostname"
+                num_threads: 2
+        iperf2_server:
+          experiments:
+            test_server:
+                variables:
+                    additional_flags: "-t 120"
+spack:
+  concretized: true
+  compilers:
+    gcc9:
+      base: gcc
+      version: 9.3.0
+  mpi_libraries: {}
+  applications:
+    iperf2:
+      iperf2:
+        base: iperf2
+        version: 2.0.12
+        required: true


### PR DESCRIPTION
Supports both client and server as two different workloads

The expectation is that a user will run server on one VM/node and client on another