### PR TITLE
Fix empty expvars

### DIFF
--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -657,7 +657,7 @@ class Expander(object):
                 expansions.update(self.package_paths)
             if self.workspace_vars:
                 expansions.update(self.workspace_vars)
-            if self.application_vars:
+            if self.application_vars is not None:
                 expansions.update(self.application_vars)
             if self.workload_vars:
                 expansions.update(self.workload_vars)

--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -504,7 +504,7 @@ class Expander(object):
 
     def set_experiment_vars(self, experiment_vars):
         self._expansion_dict = None
-        if experiment_vars:
+        if experiment_vars is not None:
             self.experiment_vars = experiment_vars.copy()
         else:
             self.experiment_vars = None

--- a/lib/ramble/ramble/schema/applications.py
+++ b/lib/ramble/ramble/schema/applications.py
@@ -14,6 +14,8 @@
 
 import ramble.schema.licenses
 
+
+# FIXME: should this use the vector notation which type natively supports?
 string_or_num = {
     'anyOf': [
         {'type': 'string'},
@@ -33,7 +35,7 @@ array_or_scalar_of_strings_or_nums = {
 }
 
 variables_def = {
-    'type': 'object',
+    'type': ['object', 'null'],
     'default': {},
     'properties': {},
     'additionalProperties': array_or_scalar_of_strings_or_nums
@@ -93,9 +95,10 @@ applications_schema = {
                                 'default': {},
                                 'properties': {},
                                 'additionalProperties': {
-                                    'type': 'object',
+                                    'type': ['object'],
                                     'default': {},
                                     'additionalProperties': {
+                                        'type': ['object'],
                                         'variables': variables_def,
                                         'matrix': matrix_def,
                                         'matrices': matrices_def,

--- a/lib/ramble/ramble/schema/applications.py
+++ b/lib/ramble/ramble/schema/applications.py
@@ -95,10 +95,9 @@ applications_schema = {
                                 'default': {},
                                 'properties': {},
                                 'additionalProperties': {
-                                    'type': ['object'],
+                                    'type': 'object',
                                     'default': {},
                                     'additionalProperties': {
-                                        'type': ['object'],
                                         'variables': variables_def,
                                         'matrix': matrix_def,
                                         'matrices': matrices_def,

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -1238,3 +1238,49 @@ spack:
     assert os.path.exists(ws1.latest_archive_path + '.tar.gz')
 
     assert os.path.exists(os.path.join(remote_archive_path, ws1.latest_archive + '.tar.gz'))
+
+def test_dryrun_noexpvars_setup():
+    test_config = """
+ramble:
+  mpi:
+    command: mpirun
+    args:
+    - '-n'
+    - '{n_ranks}'
+    - '-ppn'
+    - '{processes_per_node}'
+    - '-hostfile'
+    - 'hostfile'
+  batch:
+    submit: 'batch_submit {execute_experiment}'
+  variables:
+    processes_per_node: '5'
+    n_ranks: '{processes_per_node}'
+  applications:
+    basic:
+      workloads:
+        test_wl:
+          experiments:
+            test_experiment: {}
+spack:
+  concretized: true
+"""
+
+    workspace_name = 'test_dryrun'
+    ws1 = ramble.workspace.create(workspace_name)
+    ws1.write()
+
+    config_path = os.path.join(ws1.config_dir, ramble.workspace.config_file_name)
+
+    with open(config_path, 'w+') as f:
+        f.write(test_config)
+
+    ws1._re_read()
+
+    output = workspace('setup', '--dry-run', global_args=['-w', workspace_name])
+
+    assert "Would download file:///tmp/test_file.log" in output
+    assert os.path.exists(os.path.join(ws1.root, 'experiments',
+                                       'basic', 'test_wl',
+                                       'test_experiment',
+                                       'execute_experiment'))

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -1239,6 +1239,7 @@ spack:
 
     assert os.path.exists(os.path.join(remote_archive_path, ws1.latest_archive + '.tar.gz'))
 
+
 def test_dryrun_noexpvars_setup():
     test_config = """
 ramble:

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -746,11 +746,14 @@ class Workspace(object):
         # Iterate over applications in ramble.yaml first
         if application_namespace in ws_dict[ramble_namespace]:
             app_dict = ws_dict[ramble_namespace][application_namespace]
+
             for application, contents in app_dict.items():
                 application_vars = None
                 application_env_vars = None
+
                 if variables_namespace in contents:
                     application_vars = contents[variables_namespace]
+
                 if env_var_namespace in contents:
                     application_env_vars = contents[env_var_namespace]
                 self.extract_success_criteria('application', contents)
@@ -817,12 +820,18 @@ class Workspace(object):
 
         experiments = workload[experiment_namespace]
         for experiment, contents in experiments.items():
-            experiment_vars = None
+
+            # FIXME: what is the cleanest way to do this?
+            import ruamel
+            experiment_vars = ruamel.yaml.comments.CommentedMap()
             experiment_env_vars = None
+
             if variables_namespace in contents:
                 experiment_vars = contents[variables_namespace]
+
             if env_var_namespace in contents:
                 experiment_env_vars = contents[env_var_namespace]
+
             self.extract_success_criteria('experiment', contents)
 
             matrices = []

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -821,9 +821,7 @@ class Workspace(object):
         experiments = workload[experiment_namespace]
         for experiment, contents in experiments.items():
 
-            # FIXME: what is the cleanest way to do this?
-            import ruamel
-            experiment_vars = ruamel.yaml.comments.CommentedMap()
+            experiment_vars = syaml.syaml_dict()
             experiment_env_vars = None
 
             if variables_namespace in contents:


### PR DESCRIPTION
Previously the following `ramble.yaml` would give a hard to understand error, and users were unable to not specify experiment level variables (which are not always needed):

```
 31   applications:
 32     hostname:
 33       workloads:
 34         parallel:
 35           experiments:
 36             with_name_{exp_name}_{n_nodes}:
 37                 {}
```

This PR allows for an empty value to be passed and a default empty dict to be created 