### PR TITLE
Add supported auxility software files to spack include files

### DIFF
--- a/lib/ramble/ramble/application_types/spack.py
+++ b/lib/ramble/ramble/application_types/spack.py
@@ -137,8 +137,9 @@ class SpackApplication(ApplicationBase):
             # Write auxiliary software files into created spack env.
             for name, contents in workspace.all_auxiliary_software_files():
                 aux_file_path = expander.expand_var(os.path.join('{spack_env}', f'{name}'))
+                runner.add_include_file(aux_file_path)
                 with open(aux_file_path, 'w+') as f:
-                    f.write(contents)
+                    f.write(expander.expand_var(contents))
 
             runner.activate()
 
@@ -154,8 +155,10 @@ class SpackApplication(ApplicationBase):
                     mpi_spec = workspace.get_named_spec(spec_info['mpi'],
                                                         'mpi_library')
                     mpi_added[spec_info['mpi']] = True
-                    runner.add_spec(workspace.spec_string(mpi_spec,
-                                                          use_custom_specifier=True))
+                    runner.add_spec(
+                        expander.expand_var(workspace.spec_string(mpi_spec,
+                                            use_custom_specifier=True))
+                    )
 
                 pkg_specs = self._extract_specs(workspace, expander, name,
                                                 app_context)
@@ -166,14 +169,14 @@ class SpackApplication(ApplicationBase):
                         spec_str = workspace.spec_string(pkg_info,
                                                          as_dep=False)
 
-                        runner.add_spec(spec_str)
+                        runner.add_spec(expander.expand_var(spec_str))
 
                 if name not in added_specs:
                     added_specs[name] = True
                     spec_str = workspace.spec_string(spec_info,
                                                      as_dep=False)
 
-                    runner.add_spec(spec_str)
+                    runner.add_spec(expander.expand_var(spec_str))
 
             for name, spec_info in self.software_specs.items():
                 if 'required' in spec_info and spec_info['required']:

--- a/lib/ramble/ramble/spack_runner.py
+++ b/lib/ramble/ramble/spack_runner.py
@@ -48,6 +48,12 @@ class SpackRunner(object):
 
     compiler_find_args = ['compiler', 'find']
 
+    _allowed_config_files = ['compilers.yaml', 'concretizer.yaml',
+                             'mirrors.yaml', 'repos.yaml',
+                             'packages.yaml', 'modules.yaml',
+                             'config.yaml', 'upstreams.yaml',
+                             'bootstrap.yaml', 'spack.yaml']
+
     def __init__(self, shell='bash', dry_run=False):
         """
         Ensure spack is found in the path, and setup some default variables.
@@ -72,6 +78,7 @@ class SpackRunner(object):
         self.env_path = None
         self.active = False
         self.compilers = []
+        self.includes = []
         self.dry_run = dry_run
 
     def set_env(self, env_path):
@@ -265,6 +272,18 @@ class SpackRunner(object):
         if spec not in self.env_contents:
             self.env_contents.append(spec)
 
+    def add_include_file(self, include_file):
+        """
+        Add an include file to this spack environment.
+
+        This file needs to be a config section supported by spack, otherwise
+        spack will error. So, we validate against a list of supported sections.
+        """
+
+        file_name = os.path.basename(include_file)
+        if file_name in self._allowed_config_files:
+            self.includes.append(include_file)
+
     def concretize(self):
         """
         Concretize a spack environment.
@@ -283,6 +302,8 @@ class SpackRunner(object):
 
         env_file[spack_namespace]['specs'] = []
         env_file[spack_namespace]['specs'].extend(self.env_contents)
+
+        env_file[spack_namespace]['include'] = self.includes
 
         # Write spack.yaml to environment before concretizing
         with open(os.path.join(self.env_path, 'spack.yaml'), 'w+') as f:

--- a/lib/ramble/ramble/test/spack_runner.py
+++ b/lib/ramble/ramble/test/spack_runner.py
@@ -165,3 +165,24 @@ def test_config_install_flags(tmpdir, capsys, mutable_config):
         assert expected_str in captured.out
     except ramble.spack_runner.RunnerError as e:
         pytest.skip('%s' % e)
+
+
+def test_env_include(tmpdir, capsys, mutable_config):
+    try:
+        env_path = tmpdir.join('spack-env')
+        sr = ramble.spack_runner.SpackRunner(dry_run=True)
+        sr.create_env(env_path)
+        sr.activate()
+        sr.add_spec('zlib')
+        good_include_path = '/path/to/include/config.yaml'
+        bad_include_path = '/path/to/include/junk.yaml'
+        sr.add_include_file(good_include_path)
+        sr.add_include_file(bad_include_path)
+        sr.concretize()
+
+        with open(os.path.join(env_path, 'spack.yaml'), 'r') as f:
+            data = f.read()
+            assert good_include_path in data
+            assert bad_include_path not in data
+    except ramble.spack_runner.RunnerError as e:
+        pytest.skip('%s' % e)


### PR DESCRIPTION
This merge connects the auxiliary software files to spack's environment file by using the `include` list. This allows the auxility software files to set spack's configuration settings within the environment context.

Fixes #44 