### PR TITLE
Rework epander / experiment / application logic

### DIFF
--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -24,7 +24,7 @@ import ramble.cmd.common.arguments as arguments
 
 import ramble.workspace
 import ramble.workspace.shell
-import ramble.expander
+import ramble.experiment_set
 
 if sys.version_info >= (3, 3):
     from collections.abc import Sequence  # novm noqa: F401
@@ -378,7 +378,9 @@ def nested_4(s):
 
 def workspace_info_setup_parser(subparser):
     """Information about a workspace"""
-    pass
+    subparser.add_argument('-v', '--verbose', action='count', default=0,
+                           help='level of verbosity. Add flags to ' +
+                                'increase description of workspace')
 
 
 def workspace_info(args):
@@ -396,54 +398,57 @@ def workspace_info(args):
 
     # Print workspace variables information
     workspace_vars = ws.get_workspace_vars()
-    if workspace_vars:
-        color.cprint('')
-        color.cprint(section_title('Workspace Variables:'))
-        for arg, val in workspace_vars.items():
-            color.cprint('  - %s = %s' % (arg, val))
 
     # Print experiment information
-    expander = ramble.expander.Expander(ws)
     color.cprint('')
     color.cprint(section_title('Experiments:'))
     for app, workloads, app_vars, app_env_vars in ws.all_applications():
-        color.cprint(nested_1('  Application: ') + app)
-        expander.set_application(app)
-        expander.set_application_vars(app_vars)
-        if app_vars:
-            color.cprint(nested_4('    Application Parameters:'))
-            for name, value in app_vars.items():
-                color.cprint('      %s = %s --> %s'
-                             % (name, value, expander.expand_var(value)))
-
         for workload, experiments, workload_vars, workload_env_vars in \
                 ws.all_workloads(workloads):
-            color.cprint(nested_2('    Workload: ') + workload)
-            expander.set_workload(workload)
-            expander.set_workload_vars(workload_vars)
-            if workload_vars:
-                color.cprint(nested_4('      Workload Parameters:'))
-                for name, value in workload_vars.items():
-                    color.cprint('        %s = %s --> %s'
-                                 % (name, value, expander.expand_var(value)))
-
             for exp, _, exp_vars, exp_env_vars, exp_matrices in ws.all_experiments(experiments):
-                expander.set_experiment(exp)
-                expander.set_experiment_vars(exp_vars)
-                expander.set_experiment_matrices(exp_matrices)
+                experiment_set = ramble.experiment_set.ExperimentSet(ws)
+                experiment_set.set_application_context(app, app_vars, app_env_vars)
+                experiment_set.set_workload_context(workload, workload_vars,
+                                                    workload_env_vars)
+                experiment_set.set_experiment_context(exp,
+                                                      exp_vars,
+                                                      exp_env_vars,
+                                                      exp_matrices)
 
-                for _ in expander.rendered_experiments():
-                    color.cprint(nested_3('      Experiment: ') +
-                                 expander.experiment_name)
+                color.cprint(nested_1('  Application: ') + app)
+                color.cprint(nested_2('    Workload: ') + workload)
 
-                    color.cprint(nested_4('        Experiment Parameters:'))
-                    rendered_vars = expander.get_level_vars(level='experiment')
-                    if 'experiment_name' in rendered_vars:
-                        del rendered_vars['experiment_name']
+                for exp_name, app_inst in experiment_set.all_experiments():
+                    color.cprint(nested_3('      Experiment: ') + exp_name)
 
-                    for name, value in rendered_vars.items():
-                        color.cprint('          %s = %s --> %s'
-                                     % (name, value, expander.expand_var(value)))
+                    if args.verbose >= 1:
+                        if workspace_vars:
+                            color.cprint(nested_4('        Variables from ') +
+                                         section_title('Workspace') + ':')
+                            for var, val in workspace_vars.items():
+                                expanded = app_inst.expander.expand_var('{' + var + '}')
+                                color.cprint(f'          {var} = {val} ==> {expanded}')
+
+                        if app_vars:
+                            color.cprint(nested_4('        Variables from ') +
+                                         nested_1('Application') + ':')
+                            for var, val in app_vars.items():
+                                expanded = app_inst.expander.expand_var('{' + var + '}')
+                                color.cprint(f'          {var} = {val} ==> {expanded}')
+
+                        if workload_vars:
+                            color.cprint(nested_4('        Variables from ') +
+                                         nested_2('Workload') + ':')
+                            for var, val in workload_vars.items():
+                                expanded = app_inst.expander.expand_var('{' + var + '}')
+                                color.cprint(f'          {var} = {val} ==> {expanded}')
+
+                        if exp_vars:
+                            color.cprint(nested_4('        Variables from ') +
+                                         nested_3('Experiment') + ':')
+                            for var, val in exp_vars.items():
+                                expanded = app_inst.expander.expand_var('{' + var + '}')
+                                color.cprint(f'          {var} = {val} ==> {expanded}')
 
     # Print MPI command
     color.cprint('')

--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -6,15 +6,10 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-import os
-import math
 import string
 import ast
 import six
 import operator
-import itertools
-
-import llnl.util.tty as tty
 
 import ramble.error
 
@@ -42,669 +37,123 @@ class Expander(object):
     Additionally, math will be evaluated as part of expansion.
     """
 
-    app_name_key = 'application_name'
-    app_run_dir_key = 'application_run_dir'
-    app_input_dir_key = 'application_input_dir'
+    def __init__(self, variables):
+        self._variables = variables
 
-    wl_name_key = 'workload_name'
-    wl_run_dir_key = 'workload_run_dir'
-    wl_input_dir_key = 'workload_input_dir'
-    spack_key = 'spack_env'
+        self._application_name = None
+        self._workload_name = None
+        self._experiment_name = None
 
-    exp_name_key = 'experiment_name'
-    exp_run_dir_key = 'experiment_run_dir'
+        self._application_namespace = None
+        self._workload_namespace = None
+        self._experiment_namespace = None
+        self._spec_namespace = None
 
-    ranks_key = 'n_ranks'
-    ppn_key = 'processes_per_node'
-    nodes_key = 'n_nodes'
-    threads_key = 'n_threads'
+        self._application_input_dir = None
+        self._workload_input_dir = None
 
-    mpi_key = 'mpi_command'
-    batch_submit_key = 'batch_submit'
-    spec_name_key = 'spec_name'
-
-    log_dir_key = 'log_dir'
-    log_file_key = 'log_file'
-    err_file_key = 'err_file'
-
-    def __init__(self, workspace):
-        self.current_level = 'base'
-        self._workspace = workspace
-
-        self._expansion_dict = None
-
-        self.workspace_vars = self._workspace.get_workspace_vars().copy()
-
-        self.application_vars = None
-        self.workload_vars = None
-        self.experiment_vars = None
-        self.experiment_matrices = None
-
-        self.workspace_env_vars = self._workspace.get_workspace_env_vars()
-        self.workspace_env_vars = self.workspace_env_vars.copy() if \
-            self.workspace_env_vars else None
-
-        self.application_env_vars = None
-        self.workload_env_vars = None
-        self.experiment_env_vars = None
-
-        self.base_vars = {}
-        self.package_paths = {}
-        self.set_var(self.log_dir_key, self._workspace.log_dir)
-        self.set_var(self.mpi_key, self._workspace.mpi_command)
-        self.set_var(self.batch_submit_key,
-                     self._workspace.batch_submit)
-
-    def get_level_vars(self, level=None):
-        cur_level = self.current_level
-        if level:
-            cur_level = level
-
-        if cur_level == 'application':
-            return self.application_vars
-        elif cur_level == 'workload':
-            return self.workload_vars
-        elif cur_level == 'experiment':
-            return self.experiment_vars
-        else:  # Default to returning the base_vars dict
-            return self.base_vars
-
-    def set_var(self, var, val, level=None):
-        level_vars = self.get_level_vars(level)
-
-        if level_vars is None:
-            tty.die('Level variables for %s not defined yet' % level)
-
-        level_vars[var] = val
-        self._expansion_dict = None
-
-    def remove_var(self, var, level=None):
-        level_vars = self.get_level_vars(level)
-
-        if var in level_vars:
-            del level_vars[var]
-
-        self._expansion_dict = None
-
-    def get_var(self, var, level=None):
-        level_vars = self.get_level_vars(level)
-
-        if var in level_vars:
-            return level_vars[var]
-
-        return None
-
-    def set_package_path(self, package, path):
-        self.package_paths['%s' % package] = path
-        self._expansion_dict = None
-
-    def remove_package_path(self, package):
-        key = '%s_path' % package
-        if key in self.package_paths:
-            del self.package_paths[key]
-        self._expansion_dict = None
-
-    def get_package_path(self, package):
-        key = '%s_path' % package
-        if key in self.package_paths:
-            return self.package_paths[key]
-        return None
-
-    def set_application(self, app_name):
-        tty.debug('Expander: Setting app name %s' % app_name)
-        self.flush_context()
-        self.set_var(self.app_name_key, app_name)
-        self.set_var(self.app_run_dir_key,
-                     os.path.join(self._workspace.experiment_dir, app_name))
-
-        self.set_var(self.app_input_dir_key,
-                     os.path.join(self._workspace.input_dir, app_name))
-
-        # The default spec name used is the same as the application name
-        self.set_var(self.spec_name_key, app_name, level='base')
+        self._application_run_dir = None
+        self._workload_run_dir = None
+        self._experiment_run_dir = None
 
     @property
     def application_name(self):
-        app_name = self._find_key(self.app_name_key)
+        if not self._application_name:
+            self._application_name = self.expand_var('{application_name}')
 
-        if app_name:
-            return self.expand_var(app_name)
-        return None
-
-    @property
-    def application_run_dir(self):
-        app_dir = self._find_key(self.app_run_dir_key)
-
-        if app_dir:
-            return self.expand_var(app_dir)
-        return None
-
-    @property
-    def application_input_dir(self):
-        app_input_dir = self._find_key(self.app_input_dir_key)
-
-        if app_input_dir:
-            return self.expand_var(app_input_dir)
-        return None
-
-    def set_workload(self, wl_name):
-        tty.debug('Expander: Setting wl name %s' % wl_name)
-        if not self.application_name:
-            raise ApplicationNotDefinedError('Application is not ' +
-                                             'set correctly')
-
-        self.set_var(self.wl_name_key, wl_name)
-        self.set_var(self.wl_run_dir_key,
-                     os.path.join(self.application_run_dir,
-                                  self.workload_name))
-
-        self.set_var(self.wl_input_dir_key,
-                     os.path.join(self.application_input_dir,
-                                  self.workload_name))
-
-        self.remove_var(self.exp_name_key)
-        self.remove_var(self.exp_run_dir_key)
-        self.workload_vars = None
-        self.experiment_vars = None
+        return self._application_name
 
     @property
     def workload_name(self):
-        wl_name = self._find_key(self.wl_name_key)
+        if not self._workload_name:
+            self._workload_name = self.expand_var('{workload_name}')
 
-        if wl_name:
-            return self.expand_var(wl_name)
-        return None
-
-    @property
-    def workload_run_dir(self):
-        wl_run_dir = self._find_key(self.wl_run_dir_key)
-
-        if wl_run_dir:
-            return self.expand_var(wl_run_dir)
-        return None
-
-    @property
-    def workload_input_dir(self):
-        wl_input_dir = self._find_key(self.wl_input_dir_key)
-
-        if wl_input_dir:
-            return self.expand_var(wl_input_dir)
-        return None
-
-    @property
-    def workload_namespace(self):
-        app_name = self.application_name
-        wl_name = self.workload_name
-        if app_name and wl_name:
-            return '%s.%s' % (app_name, wl_name)
-        return None
-
-    @property
-    def spec_namespace(self):
-        app_name = self.expand_var('{spec_name}')
-        wl_name = self.workload_name
-        if app_name and wl_name:
-            return '%s.%s' % (app_name, wl_name)
-        return None
-
-    def set_experiment(self, exp_name):
-        tty.debug('Expander: Setting exp name %s' % exp_name)
-        if not self.workload_name:
-            raise WorkloadNotDefinedError('Workload is not set correctly.')
-
-        self.set_var(self.exp_name_key, exp_name)
-
-    """Finalize the setup of this experiment
-
-    Perform the last steps of setting up an experiment.
-
-    Compute the mpi variables that are required, and construct the experiment name,
-    run directory, and log file paths.
-
-    Inputs:
-        None
-    Returns:
-        None
-    """
-    def _finalize_experiment(self):
-        self._compute_mpi_vars()
-
-        # Remove potentially generated experiment name
-        self.remove_var(self.exp_name_key, level='experiment')
-
-        # Generate a new experiment name, from the template.
-        # Name template would be stored in base_vars, while
-        # generated name is stored in experiment_vars
-        self.set_var(self.exp_name_key, self.expand_var('{' + self.exp_name_key + '}'),
-                     level='experiment')
-
-        self.set_var(self.exp_run_dir_key,
-                     os.path.join(self.workload_run_dir, self.experiment_name))
-
-        self.set_var(self.log_file_key,
-                     os.path.join(self.experiment_run_dir,
-                                  '%s.out' % self.experiment_name))
-
-        self.set_var(self.err_file_key,
-                     os.path.join(self.experiment_run_dir,
-                                  '%s.err' % self.experiment_name))
-
-    """Render experiments by processing vector and matrix variables.
-
-    Interally collects all matrix and vector variables.
-
-    Before processing vectors and matrices, pull out vector spec_names, if they exist.
-    These are crossed with the remaining experiments.
-
-    Matrices are processed second.
-    Vectors in the same matrix are crossed, sibling matrices are zipped.
-    All matrices are required to result in the same number of elements, but not
-    be the same shape.
-    Matrix elements are only allowed to be the names of variables. These variables
-    are required to be vectors.
-
-    After matrices are processed, any remaining vectors are zipped together.
-    All vectors are required to be of the same size.
-
-    The resulting zip of vectors is then crossed with all of the matrices to
-    build a final list of experiments.
-
-    After collecting the matrices, this method modifies the internal expander
-    data structures, and yields nothing. This allows the experiments to be
-    iterated over without having to perform the expansion again.
-
-        Inputs:
-            - extra_vars: (Dict) Extra variables to use when expanding variables
-        Returns:
-            - Nothing.
-    """
-    def rendered_experiments(self, extra_vars=None):
-        all_expansions = self.get_expansion_dict(extra_vars)
-
-        experiments = []
-        matrix_experiments = []
-
-        if self.experiment_matrices:
-            """ Matrix syntax is:
-               matrix:
-               - <var1>
-               - <var2>
-               - [1, 2, 3, 4] # inline vector
-               matrices:
-               - matrix_a:
-                 - <var1>
-                 - <var2>
-               - matrix:b:
-                 - <var_3>
-                 - <var_4>
-
-                 Matrices consume vector variables.
-            """
-
-            # Perform some error checking
-            last_size = -1
-            matrix_vars = set()
-            matrix_vectors = []
-            matrix_variables = []
-            for matrix in self.experiment_matrices:
-                matrix_size = 1
-                vectors = []
-                variable_names = []
-                for var in matrix:
-                    if var in matrix_vars:
-                        tty.die('Variable %s has been used in multiple matrices.\n' % var
-                                + 'Ensure each variable is only used once across all matrices')
-                    matrix_vars.add(var)
-
-                    if var not in all_expansions:
-                        tty.die('In experiment %s' % self.experiment_name
-                                + ' variable %s has not been defined yet.' % var)
-
-                    if not isinstance(all_expansions[var], list):
-                        tty.die('In experiment %s' % self.experiment_name
-                                + ' variable %s does not refer to a vector.' % var)
-
-                    matrix_size = matrix_size * len(all_expansions[var])
-
-                    tty.debug('MATRIX USING VAR: %s' % var)
-                    vectors.append(all_expansions[var])
-                    variable_names.append(var)
-
-                    # Remove the variable, so it's not proccessed as a vector anymore.
-                    del all_expansions[var]
-
-                if last_size == -1:
-                    last_size = matrix_size
-
-                if last_size != matrix_size:
-                    tty.die('Matrices defined in experiment %s do not ' % self.experiment_name
-                            + 'result in the same number of elements.')
-
-                matrix_vectors.append(vectors)
-                matrix_variables.append(variable_names)
-
-            # Create the empty initial dictionairies
-            matrix_experiments = []
-            for _ in range(matrix_size):
-                matrix_experiments.append({})
-
-            # Generate all of the exp var dicts
-            for names, vectors in zip(matrix_variables, matrix_vectors):
-                for exp_idx, entry in enumerate(itertools.product(*vectors)):
-                    for name_idx, name in enumerate(names):
-                        matrix_experiments[exp_idx][name] = entry[name_idx]
-
-        # After matrices have been processed, extract any remaining vector variables
-        vector_vars = {}
-
-        # Extract vector variables
-        max_vector_size = 0
-        for var, val in all_expansions.items():
-            if isinstance(val, list):
-                vector_vars[var] = val.copy()
-                max_vector_size = max(len(val), max_vector_size)
-
-        if vector_vars:
-            # Check that sizes are the same
-            for var, val in vector_vars.items():
-                if len(val) != max_vector_size:
-                    tty.die('Size of vector %s is not' % var
-                            + ' the same as max %s' % len(val)
-                            + '. In experiment %s' % self.experiment_name)
-
-            # Iterate over the vector length, and set the value in the
-            # experiment dict to the index value.
-            for i in range(0, max_vector_size):
-                exp_vars = {}
-                for var, val in vector_vars.items():
-                    exp_vars[var] = val[i]
-
-                if matrix_experiments:
-                    for matrix_experiment in matrix_experiments:
-                        for var, val in matrix_experiment.items():
-                            exp_vars[var] = val
-
-                        experiments.append(exp_vars.copy())
-                else:
-                    experiments.append(exp_vars.copy())
-
-        elif matrix_experiments:
-            experiments = matrix_experiments
-        else:
-            # Ensure at least one experiment is rendered, if everything was a scalar
-            experiments.append({})
-
-        rendered_experiments = set()
-        for exp in experiments:
-            tty.debug('Rendering experiment:')
-            for var, val in exp.items():
-                self.set_var(var, val, level='experiment')
-            self.set_var(self.spack_key,
-                         os.path.join(self._workspace.software_dir,
-                                      '%s.%s' % ('{spec_name}', all_expansions[self.wl_name_key])),
-                         level='experiment')
-
-            self._finalize_experiment()
-            final_exp_name = self.expand_var('{' + self.exp_name_key + '}')
-            tty.debug('   Exp vars: %s' % exp)
-            tty.debug('   Final name: %s' % final_exp_name)
-
-            if final_exp_name in rendered_experiments:
-                tty.die('Experiment %s is not unique.' % final_exp_name)
-            rendered_experiments.add(final_exp_name)
-
-            yield
-
-    def set_application_env_vars(self, application_env_vars):
-        if application_env_vars:
-            self.application_env_vars = application_env_vars.copy()
-        else:
-            self.application_env_vars = None
-        self.workload_env_vars = None
-        self.experiment_env_vars = None
-
-    def set_workload_env_vars(self, workload_env_vars):
-        if workload_env_vars:
-            self.workload_env_vars = workload_env_vars.copy()
-        else:
-            self.workload_env_vars = None
-        self.experiment_env_vars = None
-
-    def set_experiment_env_vars(self, experiment_env_vars):
-        if experiment_env_vars:
-            self.experiment_env_vars = experiment_env_vars.copy()
-        else:
-            self.experiment_env_vars = None
-
-    def all_env_var_sets(self):
-        env_vars = [self.workspace_env_vars,
-                    self.application_env_vars,
-                    self.workload_env_vars,
-                    self.experiment_env_vars]
-
-        for var_set in env_vars:
-            if var_set and len(var_set.keys()):
-                yield var_set
-
-    def set_application_vars(self, application_vars):
-        self._expansion_dict = None
-        if application_vars:
-            self.application_vars = application_vars.copy()
-        else:
-            self.application_vars = None
-        self.workload_vars = None
-        self.experiment_vars = None
-
-    def set_workload_vars(self, workload_vars):
-        self._expansion_dict = None
-        if workload_vars:
-            self.workload_vars = workload_vars.copy()
-        else:
-            self.workload_vars = None
-        self.experiment_vars = None
-
-    def set_experiment_vars(self, experiment_vars):
-        self._expansion_dict = None
-        if experiment_vars is not None:
-            self.experiment_vars = experiment_vars.copy()
-        else:
-            self.experiment_vars = None
-
-    def set_experiment_matrices(self, experiment_matrices):
-        self._expansion_dict = None
-        if experiment_matrices:
-            tty.debug('Setting matrices: %s' % experiment_matrices)
-            self.experiment_matrices = experiment_matrices.copy()
-        else:
-            self.experiment_matrices = None
-
-    def unset_mpi_vars(self):
-        self.remove_var(self.nodes_key, level='experiment')
-        self.remove_var(self.threads_key, level='experiment')
-        self.remove_var(self.ranks_key, level='experiment')
-        self.remove_var(self.ppn_key, level='experiment')
-        self.remove_var(self.nodes_key, level='experiment')
-
-    def _compute_mpi_vars(self):
-        n_ranks = self._find_key(self.ranks_key)
-        ppn = self._find_key(self.ppn_key)
-        n_nodes = self._find_key(self.nodes_key)
-        n_threads = self._find_key(self.threads_key)
-
-        all_expansions = self.get_expansion_dict()
-
-        if n_ranks:
-            n_ranks = int(self.expand_var(n_ranks,
-                                          all_expansions=all_expansions))
-
-        if ppn:
-            ppn = int(self.expand_var(ppn,
-                                      all_expansions=all_expansions))
-
-        if n_nodes:
-            n_nodes = int(self.expand_var(n_nodes,
-                                          all_expansions=all_expansions))
-
-        if n_threads:
-            n_threads = int(self.expand_var(n_threads,
-                                            all_expansions=all_expansions))
-
-        if n_ranks and ppn:
-            test_n_nodes = math.ceil(int(n_ranks) / int(ppn))
-
-            if n_nodes and n_nodes < test_n_nodes:
-                tty.error('n_nodes in %s is %s and should be %s' %
-                          (self.experiment_namespace, n_nodes,
-                           test_n_nodes))
-            elif not n_nodes:
-                tty.debug('Defining n_nodes in %s' %
-                          self.experiment_namespace)
-                self.experiment_vars[self.nodes_key] = test_n_nodes
-        elif n_ranks and n_nodes:
-            ppn = math.ceil(int(n_ranks) / int(n_nodes))
-            tty.debug('Defining processes_per_node in %s' %
-                      self.experiment_namespace)
-            self.experiment_vars[self.ppn_key] = ppn
-        elif ppn and n_nodes:
-            n_ranks = ppn * n_nodes
-            tty.debug('Defining n_ranks in %s' %
-                      self.experiment_namespace)
-            self.experiment_vars[self.ranks_key] = n_ranks
-        elif not n_nodes:
-            self.experiment_vars[self.nodes_key] = 1
-
-        if not n_threads:
-            self.experiment_vars[self.threads_key] = 1
-
-    def _find_key(self, key):
-        if self.experiment_vars and key in self.experiment_vars:
-            return self.experiment_vars[key]
-        elif self.workload_vars and key in self.workload_vars:
-            return self.workload_vars[key]
-        elif self.application_vars and key in self.application_vars:
-            return self.application_vars[key]
-        elif self.workspace_vars and key in self.workspace_vars:
-            return self.workspace_vars[key]
-        elif self.package_paths and key in self.package_paths:
-            return self.package_paths[key]
-        elif self.base_vars and key in self.base_vars:
-            return self.base_vars[key]
-        else:
-            return None
-
-    @property
-    def n_ranks(self):
-        found = self._find_key('n_ranks')
-        return int(found) if found else found
-
-    @property
-    def processes_per_node(self):
-        found = self._find_key('processes_per_node')
-        return int(found) if found else found
-
-    @property
-    def n_nodes(self):
-        found = self._find_key('n_nodes')
-        return int(found) if found else found
+        return self._workload_name
 
     @property
     def experiment_name(self):
-        exp_name = self._find_key(self.exp_name_key)
+        if not self._experiment_name:
+            self._experiment_name = self.expand_var('{experiment_name}')
 
-        if exp_name:
-            return self.expand_var(exp_name)
-        return None
+        return self._experiment_name
 
     @property
-    def experiment_run_dir(self):
-        exp_run_dir = self._find_key(self.exp_run_dir_key)
+    def application_namespace(self):
+        if not self._application_namespace:
+            self._application_namespace = self.application_name
 
-        if exp_run_dir:
-            return self.expand_var(exp_run_dir)
-        return None
+        return self._application_namespace
+
+    @property
+    def workload_namespace(self):
+        if not self._workload_namespace:
+            self._workload_namespace = '%s.%s' % (self.application_name,
+                                                  self.workload_name)
+
+        return self._workload_namespace
 
     @property
     def experiment_namespace(self):
-        app_name = self.application_name
-        wl_name = self.workload_name
-        exp_name = self.experiment_name
-        if app_name and wl_name and exp_name:
-            return '%s.%s.%s' % (app_name,
-                                 wl_name,
-                                 exp_name)
-        return None
+        if not self._experiment_namespace:
+            self._experiment_namespace = '%s.%s.%s' % (self.application_name,
+                                                       self.workload_name,
+                                                       self.experiment_name)
 
-    def flush_context(self):
-        self.remove_var(self.app_name_key)
-        self.remove_var(self.app_run_dir_key)
-        self.remove_var(self.app_input_dir_key)
+        return self._experiment_namespace
 
-        self.remove_var(self.wl_name_key)
-        self.remove_var(self.wl_run_dir_key)
-        self.remove_var(self.wl_input_dir_key)
+    @property
+    def spec_namespace(self):
+        if not self._spec_namespace:
+            self._spec_namespace = self.expand_var('{spec_name}.{workload_name}')
 
-        self.remove_var(self.exp_name_key)
-        self.remove_var(self.exp_run_dir_key)
+        return self._spec_namespace
 
-        self.pacakge_vars = {}
-        self.application_vars = None
-        self.workload_vars = None
-        self.experiment_vars = None
-        self.experiment_matrices = None
-        self._expansion_dict = None
+    @property
+    def application_input_dir(self):
+        if not self._application_input_dir:
+            self._application_input_dir = self.expand_var('{application_input_dir}')
 
-        self.application_env_vars = None
-        self.workload_env_vars = None
-        self.experiment_env_vars = None
+        return self._application_input_dir
 
-    def get_expansion_dict(self, extra_vars=None):
-        """Return a dict of all vars that can be used for expansions"""
-        if not self._expansion_dict:
-            expansions = self.base_vars.copy()
-            if self.package_paths:
-                expansions.update(self.package_paths)
-            if self.workspace_vars:
-                expansions.update(self.workspace_vars)
-            if self.application_vars is not None:
-                expansions.update(self.application_vars)
-            if self.workload_vars:
-                expansions.update(self.workload_vars)
-            if self.experiment_vars:
-                expansions.update(self.experiment_vars)
+    @property
+    def workload_input_dir(self):
+        if not self._workload_input_dir:
+            self._workload_input_dir = self.expand_var('{workload_input_dir}')
 
-            # Cache expansion dict up to here. The builtin expansion dict should not
-            # contain extra_vars
-            self._expansion_dict = expansions.copy()
-        else:
-            expansions = self._expansion_dict.copy()
+        return self._workload_input_dir
 
-        if extra_vars:
-            expansions.update(extra_vars)
+    @property
+    def application_run_dir(self):
+        if not self._application_run_dir:
+            self._application_run_dir = self.expand_var('{application_run_dir}')
 
-        return expansions
+        return self._application_run_dir
 
-    def all_vars(self, extra_vars=None):
-        """Return a dict containing all expanded variables"""
+    @property
+    def workload_run_dir(self):
+        if not self._workload_run_dir:
+            self._workload_run_dir = self.expand_var('{workload_run_dir}')
 
-        expansions = self.get_expansion_dict(extra_vars)
+        return self._workload_run_dir
 
-        var_dict = {}
+    @property
+    def experiment_run_dir(self):
+        if not self._experiment_run_dir:
+            self._experiment_run_dir = self.expand_var('{experiment_run_dir}')
 
-        for var, val in expansions.items():
-            expanded_val = self.expand_var(val, all_expansions=expansions)
-            var_dict[var] = expanded_val
-        return var_dict
+        return self._experiment_run_dir
 
-    def expand_var(self, var, extra_vars=None, all_expansions=None):
+    def expand_var(self, var, extra_vars=None):
         """Perform expansion of a string
 
         Expand a string by building up a dict of all
         expansion variables.
         """
-        if not all_expansions:
-            expansions = self.get_expansion_dict(extra_vars)
-        else:
-            expansions = all_expansions
+
+        expansions = self._variables
+        if extra_vars:
+            expansions = self._variables.copy()
+            expansions.update(extra_vars)
 
         expanded = self._partial_expand(expansions, str(var))
 

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -1,0 +1,443 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from enum import Enum
+import os
+import itertools
+import math
+
+import llnl.util.tty as tty
+
+import ramble.expander
+import ramble.repository
+
+
+class ExperimentSet(object):
+    """Class to represent a full set of experiments
+
+    This class contains logic to take sets of variable definitions and generate
+    experiments from the variable hierarchy.
+
+    Experiments are housed in the internal self.experiments dictionary. Keys of
+    this dictionary are experiment names, while values are application
+    instances.
+    """
+
+    # In order of lowest to highest precedence
+    _contexts = Enum('contexts', ['base', 'application',
+                                  'workload', 'experiment',
+                                  'required'])
+
+    app_name_key = 'application_name'
+    app_run_dir_key = 'application_run_dir'
+    app_input_dir_key = 'application_input_dir'
+
+    wl_name_key = 'workload_name'
+    wl_run_dir_key = 'workload_run_dir'
+    wl_input_dir_key = 'workload_input_dir'
+    spack_key = 'spack_env'
+
+    exp_name_key = 'experiment_name'
+    exp_run_dir_key = 'experiment_run_dir'
+
+    ranks_key = 'n_ranks'
+    ppn_key = 'processes_per_node'
+    nodes_key = 'n_nodes'
+    threads_key = 'n_threads'
+
+    mpi_key = 'mpi_command'
+    batch_submit_key = 'batch_submit'
+    spec_name_key = 'spec_name'
+
+    log_dir_key = 'log_dir'
+    log_file_key = 'log_file'
+    err_file_key = 'err_file'
+
+    def __init__(self, workspace):
+        """Create experiment set class"""
+        self.experiments = {}
+        self._workspace = workspace
+
+        self._env_variables = {}
+        self._variables = {}
+        self._context_names = {}
+
+        for context in self._contexts:
+            self._context_names[context] = None
+            self._env_variables[context] = None
+            self._variables[context] = None
+
+        self._variables[self._contexts.base] = {}
+        self._variables[self._contexts.required] = {}
+
+        self._matrices = {
+            self._contexts.experiment: None
+        }
+
+        # Set all workspace variables as base variables.
+        workspace_vars = workspace.get_workspace_vars()
+        if workspace_vars:
+            for var, val in workspace_vars.items():
+                self.set_base_var(var, val)
+
+        # Set some base variables from the workspace definition.
+        self.set_base_var(self.mpi_key, workspace.mpi_command)
+        self.set_base_var(self.log_dir_key, workspace.log_dir)
+        self.set_base_var(self.batch_submit_key, workspace.batch_submit)
+        self.set_base_var(self.spec_name_key, '{application_name}')
+
+    def set_base_var(self, var, val):
+        """Set a base variable definition"""
+        self._variables[self._contexts.base][var] = val
+
+    def set_required_var(self, var, val):
+        """Set a required variable definition"""
+        self._variables[self._contexts.required][var] = val
+
+    def _set_context(self, context, name, variables, env_variables):
+        """Abstraction method to set context attributes"""
+        if context not in self._contexts:
+            tty.die(f'Context {context} is not a valid context.')
+
+        self._context_names[context] = name
+        self._variables[context] = variables
+        self._env_variables[context] = env_variables
+
+    def set_application_context(self, application_name,
+                                application_variables,
+                                application_env_variables):
+        """Set up current application context"""
+
+        self._set_context(self._contexts.application, application_name,
+                          application_variables, application_env_variables)
+
+    def set_workload_context(self, workload_name,
+                             workload_variables,
+                             workload_env_variables):
+        """Set up current workload context"""
+        self._set_context(self._contexts.workload, workload_name,
+                          workload_variables, workload_env_variables)
+
+    def set_experiment_context(self, experiment_template,
+                               experiment_variables,
+                               experiment_env_variables,
+                               experiment_matrices):
+        """Set up current experiment context"""
+        self._set_context(self._contexts.experiment, experiment_template,
+                          experiment_variables, experiment_env_variables)
+
+        self._matrices[self._contexts.experiment] = experiment_matrices
+        self._ingest_experiments()
+
+    @property
+    def application_namespace(self):
+        """Property to return application namespace (application name)"""
+        if self._context_names[self._contexts.application]:
+            return self._context_names[self._contexts.application]
+        return None
+
+    @property
+    def workload_namespace(self):
+        """Property to return workload namespace
+
+        Workload namespaces are of the form: application_name.workload_name
+        """
+        app_ns = self.application_namespace
+        wl_ns = self._context_names[self._contexts.workload]
+
+        if app_ns and wl_ns:
+            return f'{app_ns}.{wl_ns}'
+
+        return None
+
+    @property
+    def experiment_namespace(self):
+        """Property to return experiment namespace
+
+        Experiment namespaces are of the form: application_name.workload_name.experiment_name
+        """
+        wl_ns = self.workload_namespace
+        exp_ns = self._context_names[self._contexts.experiment]
+
+        if wl_ns and exp_ns:
+            return f'{wl_ns}.{exp_ns}'
+        return None
+
+    def _compute_mpi_vars(self, expander, variables):
+        """Compute required MPI variables
+
+        Perform computation of required MPI variables, including:
+        - n_ranks
+        - n_nodes
+        - processes_per_node
+        - n_threads
+        """
+        n_ranks = variables[self.ranks_key] if self.ranks_key in \
+            variables.keys() else None
+        ppn = variables[self.ppn_key] if self.ppn_key in variables.keys() else \
+            None
+        n_nodes = variables[self.nodes_key] if self.nodes_key in \
+            variables.keys() else None
+        n_threads = variables[self.threads_key] if self.threads_key in \
+            variables.keys() else None
+
+        if n_ranks:
+            n_ranks = int(expander.expand_var(n_ranks))
+
+        if ppn:
+            ppn = int(expander.expand_var(ppn))
+
+        if n_nodes:
+            n_nodes = int(expander.expand_var(n_nodes))
+
+        if n_threads:
+            n_threads = int(expander.expand_var(n_threads))
+
+        if n_ranks and ppn:
+            test_n_nodes = math.ceil(int(n_ranks) / int(ppn))
+
+            if n_nodes and n_nodes < test_n_nodes:
+                tty.error('n_nodes in %s is %s and should be %s' %
+                          (self.experiment_namespace, n_nodes,
+                           test_n_nodes))
+            elif not n_nodes:
+                tty.debug('Defining n_nodes in %s' %
+                          self.experiment_namespace)
+                variables[self.nodes_key] = test_n_nodes
+        elif n_ranks and n_nodes:
+            ppn = math.ceil(int(n_ranks) / int(n_nodes))
+            tty.debug('Defining processes_per_node in %s' %
+                      self.experiment_namespace)
+            variables[self.ppn_key] = ppn
+        elif ppn and n_nodes:
+            n_ranks = ppn * n_nodes
+            tty.debug('Defining n_ranks in %s' %
+                      self.experiment_namespace)
+            variables[self.ranks_key] = n_ranks
+        elif not n_nodes:
+            variables[self.nodes_key] = 1
+
+        if not n_threads:
+            variables[self.threads_key] = 1
+
+    def _ingest_experiments(self):
+        """Ingest experiments based on the current context.
+
+        Interally collects all matrix and vector variables.
+
+        Matrices are processed first.
+
+        Vectors in the same matrix are crossed, sibling matrices are zipped.
+        All matrices are required to result in the same number of elements, but
+        not be the same shape.
+
+        Matrix elements are only allowed to be the names of variables. These
+        variables are required to be vectors.
+
+        After matrices are processed, any remaining vectors are zipped
+        together. All vectors are required to be of the same size.
+
+        The resulting zip of vectors is then crossed with all of the matrices
+        to build a final list of experiments.
+
+        After collecting the matrices, this method modifies generates new
+        experiments and injects them into the self.experiments dictionary.
+
+        Inputs:
+            - None
+        Returns:
+            - None
+        """
+
+        context_variables = {}
+        ordered_env_variables = []
+
+        for context in self._contexts:
+            if self._variables[context]:
+                context_variables.update(self._variables[context])
+            if self._env_variables[context]:
+                ordered_env_variables.append(self._env_variables[context])
+
+        for context in self._contexts:
+            var_name = f'{context.name}_name'
+            context_variables[var_name] = self._context_names[context]
+
+        # Set namespaces
+        context_variables['application_namespace'] = self.application_namespace
+        context_variables['workload_namespace'] = self.workload_namespace
+        context_variables['experiment_namespace'] = self.experiment_namespace
+
+        # Set required variables for directories.
+        context_variables[self.app_run_dir_key] = os.path.join(self._workspace.experiment_dir,
+                                                               '{%s}' % self.app_name_key)
+        context_variables[self.app_input_dir_key] = os.path.join(self._workspace.input_dir,
+                                                                 '{%s}' % self.app_name_key)
+
+        context_variables[self.wl_run_dir_key] = os.path.join('{%s}' % self.app_run_dir_key,
+                                                              '{%s}' % self.wl_name_key)
+        context_variables[self.wl_input_dir_key] = os.path.join('{%s}' % self.app_input_dir_key,
+                                                                '{%s}' % self.wl_name_key)
+
+        context_variables[self.exp_run_dir_key] = os.path.join('{%s}' % self.wl_run_dir_key,
+                                                               '{%s}' % self.exp_name_key)
+
+        experiment_template_name = context_variables[self.exp_name_key]
+        new_experiments = []
+        matrix_experiments = []
+
+        if self._matrices[self._contexts.experiment]:
+            """ Matrix syntax is:
+               matrix:
+               - <var1>
+               - <var2>
+               - [1, 2, 3, 4] # inline vector
+               matrices:
+               - matrix_a:
+                 - <var1>
+                 - <var2>
+               - matrix:b:
+                 - <var_3>
+                 - <var_4>
+
+                 Matrices consume vector variables.
+            """
+
+            # Perform some error checking
+            last_size = -1
+            matrix_vars = set()
+            matrix_vectors = []
+            matrix_variables = []
+            for matrix in self._matrices[self._contexts.experiment]:
+                matrix_size = 1
+                vectors = []
+                variable_names = []
+                for var in matrix:
+                    if var in matrix_vars:
+                        tty.die('Variable %s has been used in multiple matrices.\n' % var
+                                + 'Ensure each variable is only used once across all matrices')
+                    matrix_vars.add(var)
+
+                    if var not in context_variables:
+                        tty.die(f'In experiment {context_variables["experiment_name"]}'
+                                + f' variable {var} has not been defined yet.')
+
+                    if not isinstance(context_variables[var], list):
+                        tty.die(f'In experiment {context_variables["experiment_name"]}'
+                                + f' variable {var} does not refer to a vector.')
+
+                    matrix_size = matrix_size * len(context_variables[var])
+
+                    vectors.append(context_variables[var])
+                    variable_names.append(var)
+
+                    # Remove the variable, so it's not proccessed as a vector anymore.
+                    del context_variables[var]
+
+                if last_size == -1:
+                    last_size = matrix_size
+
+                if last_size != matrix_size:
+                    tty.die('Matrices defined in experiment '
+                            + f'{context_variables["experiment_name"]}'
+                            + ' do not result in the same number of elements.')
+
+                matrix_vectors.append(vectors)
+                matrix_variables.append(variable_names)
+
+            # Create the empty initial dictionairies
+            matrix_experiments = []
+            for _ in range(matrix_size):
+                matrix_experiments.append({})
+
+            # Generate all of the exp var dicts
+            for names, vectors in zip(matrix_variables, matrix_vectors):
+                for exp_idx, entry in enumerate(itertools.product(*vectors)):
+                    for name_idx, name in enumerate(names):
+                        matrix_experiments[exp_idx][name] = entry[name_idx]
+
+        # After matrices have been processed, extract any remaining vector variables
+        vector_vars = {}
+
+        # Extract vector variables
+        max_vector_size = 0
+        for var, val in context_variables.items():
+            if isinstance(val, list):
+                vector_vars[var] = val.copy()
+                max_vector_size = max(len(val), max_vector_size)
+
+        if vector_vars:
+            # Check that sizes are the same
+            for var, val in vector_vars.items():
+                if len(val) != max_vector_size:
+                    tty.die(f'Size of vector {var} is not'
+                            + ' the same as max %s' % len(val)
+                            + f'. In experiment {context_variables["experiment_name"]}.')
+
+            # Iterate over the vector length, and set the value in the
+            # experiment dict to the index value.
+            for i in range(0, max_vector_size):
+                exp_vars = {}
+                for var, val in vector_vars.items():
+                    exp_vars[var] = val[i]
+
+                if matrix_experiments:
+                    for matrix_experiment in matrix_experiments:
+                        for var, val in matrix_experiment.items():
+                            exp_vars[var] = val
+
+                        new_experiments.append(exp_vars.copy())
+                else:
+                    new_experiments.append(exp_vars.copy())
+
+        elif matrix_experiments:
+            new_experiments = matrix_experiments
+        else:
+            # Ensure at least one experiment is rendered, if everything was a scalar
+            new_experiments.append({})
+
+        rendered_experiments = set()
+        for exp in new_experiments:
+            tty.debug('Rendering experiment:')
+            for var, val in exp.items():
+                context_variables[var] = val
+            context_variables[self.spack_key] = os.path.join(self._workspace.software_dir,
+                                                             '%s.%s' % ('{spec_name}',
+                                                                        '{' + self.wl_name_key
+                                                                        + '}'))
+
+            expander = ramble.expander.Expander(context_variables)
+            self._compute_mpi_vars(expander, context_variables)
+            final_app_name = expander.expand_var('{' + self.app_name_key + '}')
+            final_wl_name = expander.expand_var('{' + self.wl_name_key + '}')
+            final_exp_name = expander.expand_var(experiment_template_name)
+
+            context_variables[self.app_name_key] = final_app_name
+            context_variables[self.wl_name_key] = final_wl_name
+            context_variables[self.exp_name_key] = final_exp_name
+
+            log_file = expander.expand_var(os.path.join('{experiment_run_dir}',
+                                                        '{experiment_name}.out'))
+            context_variables['log_file'] = log_file
+
+            tty.debug('   Exp vars: %s' % exp)
+            tty.debug('   Final name: %s' % final_exp_name)
+
+            if final_exp_name in rendered_experiments:
+                tty.die('Experiment %s is not unique.' % final_exp_name)
+            rendered_experiments.add(final_exp_name)
+
+            app_inst = ramble.repository.get(final_app_name)
+            app_inst.set_variables(context_variables)
+            app_inst.set_env_variable_sets(ordered_env_variables)
+
+            self.experiments[final_exp_name] = app_inst
+
+    def all_experiments(self):
+        """Iteartor over all experiments in this set"""
+        for exp, inst in self.experiments.items():
+            yield exp, inst

--- a/lib/ramble/ramble/spack_runner.py
+++ b/lib/ramble/ramble/spack_runner.py
@@ -87,7 +87,7 @@ class SpackRunner(object):
 
         self.env_path = env_path
 
-    def generate_expand_vars(self, expander, specs=[], shell='bash'):
+    def generate_expand_vars(self, shell='bash'):
         """
         Generate a string to load a spack environment within a generated
         script.

--- a/lib/ramble/ramble/test/expander.py
+++ b/lib/ramble/ramble/test/expander.py
@@ -6,310 +6,51 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-import pytest
-
-import ramble.workspace
 import ramble.expander
-from ramble.main import RambleCommand
-
-pytestmark = pytest.mark.usefixtures('mutable_config',
-                                     'mutable_mock_workspace_path',
-                                     'mutable_mock_repo',
-                                     )
-
-workspace  = RambleCommand('workspace')
-add  = RambleCommand('add')
-remove  = RambleCommand('remove')
 
 
-def test_expansions(mutable_mock_workspace_path):
-    workspace('create', 'test')
-
-    assert 'test' in workspace('list')
-
-    with ramble.workspace.read('test') as ws:
-        add('basic')
-        exp = ramble.expander.Expander(ws)
-
-        assert exp.workspace_vars['processes_per_node'] == -1
-
-        exp.set_var('level1_var', 'level1')
-        exp.set_var('level2_var', 'level2 {level1_var}')
-        exp.set_var('level3_var', 'level3 {level2_var}')
-        assert exp.expand_var('{level3_var}') == \
-            "level3 level2 level1"
-
-        assert exp.expand_var('2*{processes_per_node}') == '-2'
-
-        assert exp.expand_var('2**4') == '16'
-
-        assert exp.expand_var('((((16-10+2)/4)**2)*4)') == '16.0'
-
-
-def test_layered_expansions(mutable_mock_workspace_path):
-    application_vars = {
-        'app_var': 'test_app',
-        'ppn': '5'
-    }
-    workload_vars = {
-        'wl_var': 'test_wl',
-        'n_threads': '2'
-    }
-    experiment_vars = {
-        'exp_var': 'test_exp',
-        'n_nodes': '3'
+def exp_dict():
+    return {
+        'application_name': 'foo',
+        'workload_name': 'bar',
+        'experiment_name': 'baz',
+        'application_input_dir': '/workspace/inputs/foo',
+        'workload_input_dir': '/workspace/inputs/foo/bar',
+        'application_run_dir': '/workspace/experiments/foo',
+        'workload_run_dir': '/workspace/experiments/foo/bar',
+        'experiment_run_dir': '/workspace/experiments/foo/bar/baz',
+        'spec_name': 'spack_foo.bar',
+        'n_ranks': '4',
+        'processes_per_node': '2',
+        'n_nodes': '2',
+        'var1': '{var2}',
+        'var2': '{var3}',
+        'var3': '3',
     }
 
-    workspace('create', 'test')
 
-    assert 'test' in workspace('list')
+def test_expansions():
+    expansion_vars = exp_dict()
 
-    with ramble.workspace.read('test') as ws:
-        add('basic')
-        exp = ramble.expander.Expander(ws)
+    expander = ramble.expander.Expander(expansion_vars)
 
-        exp.set_application('basic')
-        exp.set_application_vars(application_vars)
+    assert expander.expand_var('{var1}') == '3'
+    assert expander.expand_var('{var2}') == '3'
+    assert expander.expand_var('{var3}') == '3'
+    assert expander.expand_var('{application_name}') == 'foo'
 
-        exp.set_workload('test_wl')
-        exp.set_workload_vars(workload_vars)
+    assert expander.expand_var('{n_nodes}') == '2'
+    assert expander.expand_var('{processes_per_node}') == '2'
+    assert expander.expand_var('{n_nodes}*{processes_per_node}') == '4'
+    assert expander.expand_var('2**4') == '16'
+    assert expander.expand_var('((((16-10+2)/4)**2)*4)') == '16.0'
 
-        exp.set_experiment('single_node')
-        exp.set_experiment_vars(experiment_vars)
 
-        union = {}
-        union.update(application_vars)
-        union.update(workload_vars)
-        union.update(experiment_vars)
+def test_expansion_namespaces():
+    expansion_vars = exp_dict()
 
-        for key, val in union.items():
-            expansion = '{' + key + '}'
-            result = exp.expand_var(expansion)
-            assert result == val
+    expander = ramble.expander.Expander(expansion_vars)
 
-
-def test_experiment_name_expansions(mutable_mock_workspace_path):
-    workspace('create', 'test')
-
-    assert 'test' in workspace('list')
-
-    experiment_name_template = 'exp_name_{new_var}'
-
-    with ramble.workspace.read('test') as ws:
-        exp = ramble.expander.Expander(ws)
-        exp.set_application('basic')
-        exp.set_application_vars({})
-
-        exp.set_workload('test_wl')
-        exp.set_workload_vars({})
-
-        exp.set_experiment(experiment_name_template)
-        exp.set_experiment_vars({'new_var': '2'})
-
-        exp._finalize_experiment()
-
-        assert exp.experiment_name == 'exp_name_2'
-
-
-def test_vector_expansions(mutable_mock_workspace_path):
-    workspace('create', 'test')
-
-    assert 'test' in workspace('list')
-
-    template_base = 'exp_name'
-    experiment_name_template = template_base + '_{n_nodes}'
-
-    exp_vars_vector = {
-        'n_nodes': [1, 2, 4, 8],
-        'n_ranks': '{processes_per_node}*{n_nodes}',
-        'processes_per_node': '1'
-    }
-
-    expected_exp_names = set()
-    for n in exp_vars_vector['n_nodes']:
-        expected_exp_names.add(template_base + '_%s' % n)
-
-    with ramble.workspace.read('test') as ws:
-        exp = ramble.expander.Expander(ws)
-        exp.set_application('basic')
-        exp.set_application_vars({})
-
-        exp.set_workload('test_wl')
-        exp.set_workload_vars({})
-
-        exp.set_experiment(experiment_name_template)
-        exp.set_experiment_vars(exp_vars_vector)
-
-        for _ in exp.rendered_experiments():
-            assert exp.experiment_name in expected_exp_names
-            expected_exp_names.remove(exp.experiment_name)
-
-    assert len(expected_exp_names) == 0
-
-
-def test_zipped_vector_expansions(mutable_mock_workspace_path):
-    workspace('create', 'test')
-
-    assert 'test' in workspace('list')
-
-    template_base = 'exp_name'
-    experiment_name_template = template_base + '_{n_nodes}_{processes_per_node}'
-
-    exp_vars_vector = {
-        'n_nodes': [1, 2, 4, 8],
-        'n_ranks': '{processes_per_node}*{n_nodes}',
-        'processes_per_node': [10, 20, 30, 40]
-    }
-
-    expected_exp_names = set()
-    for n, p in zip(exp_vars_vector['n_nodes'], exp_vars_vector['processes_per_node']):
-        expected_exp_names.add(template_base + '_%s_%s' % (n, p))
-
-    with ramble.workspace.read('test') as ws:
-        exp = ramble.expander.Expander(ws)
-        exp.set_application('basic')
-        exp.set_application_vars({})
-
-        exp.set_workload('test_wl')
-        exp.set_workload_vars({})
-
-        exp.set_experiment(experiment_name_template)
-        exp.set_experiment_vars(exp_vars_vector)
-
-        for _ in exp.rendered_experiments():
-            assert exp.experiment_name in expected_exp_names
-            expected_exp_names.remove(exp.experiment_name)
-
-    assert len(expected_exp_names) == 0
-
-
-def test_matrix_expansions(mutable_mock_workspace_path):
-    import itertools
-    workspace('create', 'test')
-
-    assert 'test' in workspace('list')
-
-    template_base = 'exp_name'
-    experiment_name_template = template_base + '_{n_nodes}_{processes_per_node}'
-
-    exp_vars_vector = {
-        'n_nodes': [1, 2, 4],
-        'n_ranks': '{processes_per_node}*{n_nodes}',
-        'processes_per_node': [10, 20, 30, 40]
-    }
-
-    exp_matrix_vecs = [['n_nodes', 'processes_per_node']]
-
-    expected_exp_names = set()
-    for config in itertools.product(exp_vars_vector['n_nodes'],
-                                    exp_vars_vector['processes_per_node']):
-        expected_exp_names.add(template_base + '_%s_%s' % (config[0],
-                                                           config[1]))
-
-    with ramble.workspace.read('test') as ws:
-        exp = ramble.expander.Expander(ws)
-        exp.set_application('basic')
-        exp.set_application_vars({})
-
-        exp.set_workload('test_wl')
-        exp.set_workload_vars({})
-
-        exp.set_experiment(experiment_name_template)
-        exp.set_experiment_vars(exp_vars_vector)
-        exp.set_experiment_matrices(exp_matrix_vecs)
-
-        for _ in exp.rendered_experiments():
-            assert exp.experiment_name in expected_exp_names
-            expected_exp_names.remove(exp.experiment_name)
-
-    assert len(expected_exp_names) == 0
-
-
-def test_multi_matrix_expansions(mutable_mock_workspace_path):
-    import itertools
-    workspace('create', 'test')
-
-    assert 'test' in workspace('list')
-
-    template_base = 'exp_name'
-    experiment_name_template = template_base + '_{n_nodes}_{processes_per_node}_{exp_idx}'
-
-    exp_vars_vector = {
-        'n_nodes': [1, 2, 4],
-        'n_ranks': '{processes_per_node}*{n_nodes}',
-        'processes_per_node': [10, 20, 30, 40],
-        'exp_idx': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
-    }
-
-    exp_matrix_vecs = [['n_nodes', 'processes_per_node'], ['exp_idx']]
-
-    expected_exp_names = set()
-    for config in zip(itertools.product(exp_vars_vector['n_nodes'],
-                                        exp_vars_vector['processes_per_node']),
-                      exp_vars_vector['exp_idx']):
-        expected_exp_names.add(template_base + '_%s_%s_%s' % (config[0][0],
-                                                              config[0][1],
-                                                              config[1]))
-
-    with ramble.workspace.read('test') as ws:
-        exp = ramble.expander.Expander(ws)
-        exp.set_application('basic')
-        exp.set_application_vars({})
-
-        exp.set_workload('test_wl')
-        exp.set_workload_vars({})
-
-        exp.set_experiment(experiment_name_template)
-        exp.set_experiment_vars(exp_vars_vector)
-        exp.set_experiment_matrices(exp_matrix_vecs)
-
-        for _ in exp.rendered_experiments():
-            assert exp.experiment_name in expected_exp_names
-            expected_exp_names.remove(exp.experiment_name)
-
-    assert len(expected_exp_names) == 0
-
-
-def test_matrix_vector_expansions(mutable_mock_workspace_path):
-    import itertools
-    workspace('create', 'test')
-
-    assert 'test' in workspace('list')
-
-    template_base = 'exp_name'
-    experiment_name_template = template_base + '_{n_nodes}_{processes_per_node}_{exp_idx}'
-
-    exp_vars_vector = {
-        'n_nodes': [1, 2, 4],
-        'n_ranks': '{processes_per_node}*{n_nodes}',
-        'processes_per_node': [10, 20, 30, 40],
-        'exp_idx': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
-    }
-
-    exp_matrix_vecs = [['n_nodes', 'processes_per_node']]
-
-    expected_exp_names = set()
-    for config in itertools.product(exp_vars_vector['n_nodes'],
-                                    exp_vars_vector['processes_per_node'],
-                                    exp_vars_vector['exp_idx']):
-        expected_exp_names.add(template_base + '_%s_%s_%s' % (config[0],
-                                                              config[1],
-                                                              config[2]))
-
-    with ramble.workspace.read('test') as ws:
-        exp = ramble.expander.Expander(ws)
-        exp.set_application('basic')
-        exp.set_application_vars({})
-
-        exp.set_workload('test_wl')
-        exp.set_workload_vars({})
-
-        exp.set_experiment(experiment_name_template)
-        exp.set_experiment_vars(exp_vars_vector)
-        exp.set_experiment_matrices(exp_matrix_vecs)
-
-        for _ in exp.rendered_experiments():
-            assert exp.experiment_name in expected_exp_names
-            expected_exp_names.remove(exp.experiment_name)
-
-    assert len(expected_exp_names) == 0
+    assert expander.application_namespace == 'foo'
+    assert expander.workload_namespace == 'foo.bar'
+    assert expander.experiment_namespace == 'foo.bar.baz'

--- a/lib/ramble/ramble/test/experiment_set.py
+++ b/lib/ramble/ramble/test/experiment_set.py
@@ -1,0 +1,416 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import pytest
+
+import ramble.workspace
+import ramble.experiment_set
+from ramble.main import RambleCommand
+
+pytestmark = pytest.mark.usefixtures('mutable_config',
+                                     'mutable_mock_workspace_path',
+                                     'mutable_mock_repo',
+                                     )
+
+workspace  = RambleCommand('workspace')
+
+
+def test_single_experiment_in_set(mutable_mock_workspace_path):
+    workspace('create', 'test')
+
+    assert 'test' in workspace('list')
+
+    with ramble.workspace.read('test') as ws:
+        exp_set = ramble.experiment_set.ExperimentSet(ws)
+
+        app_name = 'basic'
+        app_vars = {
+            'app_var1': '1',
+            'app_var2': '2',
+            'n_ranks': '{processes_per_node}*{n_nodes}'
+        }
+
+        wl_name = 'test_wl'
+        wl_vars = {
+            'wl_var1': '1',
+            'wl_var2': '2',
+            'processes_per_node': '2'
+        }
+        exp_name = 'series1_{n_ranks}'
+        exp_vars = {
+            'exp_var1': '1',
+            'exp_var2': '2',
+            'n_nodes': '2',
+        }
+
+        exp_set.set_application_context(app_name, app_vars, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, None)
+
+        assert 'series1_4' in exp_set.experiments.keys()
+
+
+def test_vector_experiment_in_set(mutable_mock_workspace_path):
+    workspace('create', 'test')
+
+    assert 'test' in workspace('list')
+
+    with ramble.workspace.read('test') as ws:
+        exp_set = ramble.experiment_set.ExperimentSet(ws)
+
+        app_name = 'basic'
+        app_vars = {
+            'app_var1': '1',
+            'app_var2': '2',
+            'n_ranks': '{processes_per_node}*{n_nodes}'
+        }
+
+        wl_name = 'test_wl'
+        wl_vars = {
+            'wl_var1': '1',
+            'wl_var2': '2',
+            'processes_per_node': '2'
+        }
+        exp_name = 'series1_{n_ranks}'
+        exp_vars = {
+            'exp_var1': '1',
+            'exp_var2': '2',
+            'n_nodes': ['2', '4']
+        }
+
+        exp_set.set_application_context(app_name, app_vars, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, None)
+
+        assert 'series1_4' in exp_set.experiments.keys()
+        assert 'series1_8' in exp_set.experiments.keys()
+
+
+def test_nonunique_vector_errors(mutable_mock_workspace_path, capsys):
+    workspace('create', 'test')
+
+    assert 'test' in workspace('list')
+
+    with ramble.workspace.read('test') as ws:
+        exp_set = ramble.experiment_set.ExperimentSet(ws)
+
+        app_name = 'basic'
+        app_vars = {
+            'app_var1': '1',
+            'app_var2': '2',
+            'n_ranks': '{processes_per_node}*{n_nodes}'
+        }
+
+        wl_name = 'test_wl'
+        wl_vars = {
+            'wl_var1': '1',
+            'wl_var2': '2',
+            'processes_per_node': '2'
+        }
+        exp_name = 'series1_{preocesses_per_node}'
+        exp_vars = {
+            'exp_var1': '1',
+            'exp_var2': '2',
+            'n_nodes': ['2', '4']
+        }
+
+        exp_set.set_application_context(app_name, app_vars, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None)
+        with pytest.raises(SystemExit):
+            exp_set.set_experiment_context(exp_name, exp_vars, None, None)
+            captured = capsys.readouterr()
+            assert "is not unique." in captured
+
+
+def test_zipped_vector_experiments(mutable_mock_workspace_path):
+    workspace('create', 'test')
+
+    assert 'test' in workspace('list')
+
+    with ramble.workspace.read('test') as ws:
+        exp_set = ramble.experiment_set.ExperimentSet(ws)
+
+        app_name = 'basic'
+        app_vars = {
+            'app_var1': '1',
+            'app_var2': '2',
+            'n_ranks': '{processes_per_node}*{n_nodes}'
+        }
+
+        wl_name = 'test_wl'
+        wl_vars = {
+            'wl_var1': '1',
+            'wl_var2': '2',
+            'processes_per_node': ['2', '4']
+        }
+        exp_name = 'series1_{n_ranks}_{processes_per_node}'
+        exp_vars = {
+            'exp_var1': '1',
+            'exp_var2': '2',
+            'n_nodes': ['2', '4']
+        }
+
+        exp_set.set_application_context(app_name, app_vars, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, None)
+
+        assert 'series1_4_2' in exp_set.experiments.keys()
+        assert 'series1_16_4' in exp_set.experiments.keys()
+
+
+def test_matrix_experiments(mutable_mock_workspace_path):
+    workspace('create', 'test')
+
+    assert 'test' in workspace('list')
+
+    with ramble.workspace.read('test') as ws:
+        exp_set = ramble.experiment_set.ExperimentSet(ws)
+
+        app_name = 'basic'
+        app_vars = {
+            'app_var1': '1',
+            'app_var2': '2',
+            'n_ranks': '{processes_per_node}*{n_nodes}'
+        }
+
+        wl_name = 'test_wl'
+        wl_vars = {
+            'wl_var1': '1',
+            'wl_var2': '2',
+            'processes_per_node': '2'
+        }
+        exp_name = 'series1_{n_ranks}'
+        exp_vars = {
+            'exp_var1': '1',
+            'exp_var2': '2',
+            'n_nodes': ['2', '3']
+        }
+
+        exp_matrices = [
+            ['n_nodes']
+        ]
+
+        exp_set.set_application_context(app_name, app_vars, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices)
+
+        assert 'series1_4' in exp_set.experiments.keys()
+        assert 'series1_6' in exp_set.experiments.keys()
+
+
+def test_matrix_multiplication_experiments(mutable_mock_workspace_path):
+    workspace('create', 'test')
+
+    assert 'test' in workspace('list')
+
+    with ramble.workspace.read('test') as ws:
+        exp_set = ramble.experiment_set.ExperimentSet(ws)
+
+        app_name = 'basic'
+        app_vars = {
+            'app_var1': '1',
+            'app_var2': '2',
+            'n_ranks': '{processes_per_node}*{n_nodes}'
+        }
+
+        wl_name = 'test_wl'
+        wl_vars = {
+            'wl_var1': '1',
+            'wl_var2': '2',
+            'processes_per_node': ['1', '4', '6']
+        }
+        exp_name = 'series1_{n_ranks}'
+        exp_vars = {
+            'exp_var1': '1',
+            'exp_var2': '2',
+            'n_nodes': ['2', '4']
+        }
+
+        exp_matrices = [
+            ['n_nodes', 'processes_per_node']
+        ]
+
+        exp_set.set_application_context(app_name, app_vars, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices)
+
+        assert 'series1_2' in exp_set.experiments.keys()
+        assert 'series1_8' in exp_set.experiments.keys()
+        assert 'series1_12' in exp_set.experiments.keys()
+        assert 'series1_4' in exp_set.experiments.keys()
+        assert 'series1_16' in exp_set.experiments.keys()
+        assert 'series1_24' in exp_set.experiments.keys()
+
+
+def test_matrix_vector_experiments(mutable_mock_workspace_path):
+    workspace('create', 'test')
+
+    assert 'test' in workspace('list')
+
+    with ramble.workspace.read('test') as ws:
+        exp_set = ramble.experiment_set.ExperimentSet(ws)
+
+        app_name = 'basic'
+        app_vars = {
+            'app_var1': '1',
+            'app_var2': '2',
+            'n_ranks': '{processes_per_node}*{n_nodes}'
+        }
+
+        wl_name = 'test_wl'
+        wl_vars = {
+            'wl_var1': '1',
+            'wl_var2': '2',
+            'processes_per_node': ['2', '4']
+        }
+        exp_name = 'series1_{n_ranks}'
+        exp_vars = {
+            'exp_var1': '1',
+            'exp_var2': '2',
+            'n_nodes': ['2', '3']
+        }
+
+        exp_matrices = [
+            ['n_nodes']
+        ]
+
+        exp_set.set_application_context(app_name, app_vars, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices)
+
+        assert 'series1_4' in exp_set.experiments.keys()
+        assert 'series1_8' in exp_set.experiments.keys()
+        assert 'series1_6' in exp_set.experiments.keys()
+        assert 'series1_12' in exp_set.experiments.keys()
+
+
+def test_multi_matrix_experiments(mutable_mock_workspace_path):
+    workspace('create', 'test')
+
+    assert 'test' in workspace('list')
+
+    with ramble.workspace.read('test') as ws:
+        exp_set = ramble.experiment_set.ExperimentSet(ws)
+
+        app_name = 'basic'
+        app_vars = {
+            'app_var1': '1',
+            'app_var2': '2',
+            'n_ranks': '{processes_per_node}*{n_nodes}'
+        }
+
+        wl_name = 'test_wl'
+        wl_vars = {
+            'wl_var1': '1',
+            'wl_var2': '2',
+            'processes_per_node': ['2', '4']
+        }
+        exp_name = 'series1_{n_ranks}_{processes_per_node}'
+        exp_vars = {
+            'exp_var1': '1',
+            'exp_var2': '2',
+            'n_nodes': ['2', '3']
+        }
+
+        exp_matrices = [
+            ['n_nodes'],
+            ['processes_per_node']
+        ]
+
+        exp_set.set_application_context(app_name, app_vars, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices)
+
+        assert 'series1_4_2' in exp_set.experiments.keys()
+        assert 'series1_12_4' in exp_set.experiments.keys()
+
+
+def test_matrix_undefined_var_errors(mutable_mock_workspace_path, capsys):
+    workspace('create', 'test')
+
+    assert 'test' in workspace('list')
+
+    with ramble.workspace.read('test') as ws:
+        exp_set = ramble.experiment_set.ExperimentSet(ws)
+
+        app_name = 'basic'
+        app_vars = {
+            'app_var1': '1',
+            'app_var2': '2',
+            'n_ranks': '{processes_per_node}*{n_nodes}'
+        }
+
+        wl_name = 'test_wl'
+        wl_vars = {
+            'wl_var1': '1',
+            'wl_var2': '2',
+            'processes_per_node': ['2', '4']
+        }
+        exp_name = 'series1_{n_ranks}_{processes_per_node}'
+        exp_vars = {
+            'exp_var1': '1',
+            'exp_var2': '2',
+            'n_nodes': ['2', '3']
+        }
+
+        exp_matrices = [
+            ['n_nodes'],
+            ['foo']
+        ]
+
+        exp_set.set_application_context(app_name, app_vars, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None)
+
+        with pytest.raises(SystemExit):
+            exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices)
+            captured = capsys.readouterr()
+            assert "variable foo has not been defined yet." in captured
+
+
+def test_experiment_names_match(mutable_mock_workspace_path):
+    workspace('create', 'test')
+
+    assert 'test' in workspace('list')
+
+    with ramble.workspace.read('test') as ws:
+        exp_set = ramble.experiment_set.ExperimentSet(ws)
+
+        app_name = 'basic'
+        app_vars = {
+            'app_var1': '1',
+            'app_var2': '2',
+            'n_ranks': '{processes_per_node}*{n_nodes}'
+        }
+
+        wl_name = 'test_wl'
+        wl_vars = {
+            'wl_var1': '1',
+            'wl_var2': '2',
+            'processes_per_node': ['2', '4']
+        }
+        exp_name = 'series1_{n_ranks}_{processes_per_node}'
+        exp_vars = {
+            'exp_var1': '1',
+            'exp_var2': '2',
+            'n_nodes': ['2', '3']
+        }
+
+        exp_matrices = [
+            ['n_nodes'],
+            ['processes_per_node']
+        ]
+
+        exp_set.set_application_context(app_name, app_vars, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices)
+
+        assert 'series1_4_2' in exp_set.experiments.keys()
+        assert 'series1_12_4' in exp_set.experiments.keys()
+
+        for exp, app in exp_set.all_experiments():
+            assert exp == app.variables['experiment_name']

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -25,7 +25,7 @@ import ramble.util.path
 import ramble.error
 import ramble.repository
 import ramble.spack_runner
-import ramble.expander
+import ramble.experiment_set
 import ramble.util.web
 import ramble.fetch_strategy
 import ramble.util.install_cache
@@ -473,6 +473,8 @@ class Workspace(object):
         #     'yaml': <yaml>
         #  }
         self.application_configs = {}
+
+        self._experiment_script = None
 
         self._read()
 
@@ -1215,7 +1217,7 @@ class Workspace(object):
 
     def run_pipeline(self, pipeline):
         all_experiments_file = None
-        expander = ramble.expander.Expander(self)
+        experiment_set = ramble.experiment_set.ExperimentSet(self)
 
         if not self.is_concretized():
             error_message = 'Cannot run %s in a ' % pipeline + \
@@ -1233,8 +1235,9 @@ class Workspace(object):
                                                 workspace_all_experiments_file)
             all_experiments_file = open(all_experiments_path, 'w+')
             all_experiments_file.write('#!/bin/sh\n')
+            self._experiment_script = all_experiments_file
 
-            expander.set_var('experiments_file', all_experiments_file)
+            experiment_set.set_base_var('experiments_file', all_experiments_file)
 
             runner = ramble.spack_runner.SpackRunner(dry_run=self.dry_run)
             spack_dict = self.get_spack_dict()
@@ -1247,35 +1250,24 @@ class Workspace(object):
                     runner.install_compiler(comp_str)
 
         for app, workloads, app_vars, app_env_vars in self.all_applications():
-            expander.set_application(app)
-            expander.set_application_vars(app_vars)
-            expander.set_application_env_vars(app_env_vars)
-            tty.debug('Getting application: %s' % app)
-            tty.debug('Getting application: %s' % expander.application_name)
-            app_inst = ramble.repository.get(expander.application_name)
-
-            tty.msg('  Working on ' + app_inst.application_class +
-                    ' ' + app_inst.name)
+            experiment_set.set_application_context(app, app_vars, app_env_vars)
 
             for workload, experiments, workload_vars, workload_env_vars in \
                     self.all_workloads(workloads):
-                expander.set_workload(workload)
-                expander.set_workload_vars(workload_vars)
-                expander.set_workload_env_vars(workload_env_vars)
+                experiment_set.set_workload_context(workload, workload_vars,
+                                                    workload_env_vars)
 
                 for experiment, _, exp_vars, exp_env_vars, exp_matrices in \
                         self.all_experiments(experiments):
-                    expander.set_experiment(experiment)
-                    expander.set_experiment_vars(exp_vars)
-                    expander.set_experiment_env_vars(exp_env_vars)
-                    expander.set_experiment_matrices(exp_matrices)
+                    experiment_set.set_experiment_context(experiment,
+                                                          exp_vars,
+                                                          exp_env_vars,
+                                                          exp_matrices)
 
-                    for _ in expander.rendered_experiments():
-                        app_inst = ramble.repository.get(expander.application_name)
-                        for phase in app_inst.get_pipeline_phases(pipeline):
-                            app_inst.run_phase(phase, self, expander)
-                        # Tidy up deduced variable values
-                        expander.unset_mpi_vars()
+        for exp, app_inst in experiment_set.all_experiments():
+            tty.debug('On experiment: %s' % exp)
+            for phase in app_inst.get_pipeline_phases(pipeline):
+                app_inst.run_phase(phase, self)
 
         if pipeline == 'setup':
             all_experiments_file.close()
@@ -1304,6 +1296,10 @@ class Workspace(object):
                 tty.error("Failed downloads:")
                 tty.colify(s.cformat("{name}") for s in list(self._input_mirror_stats.errors))
                 tty.die('Mirroring has errors.')
+
+    @property
+    def experiments_script(self):
+        return self._experiment_script
 
     @property
     def latest_archive_path(self):

--- a/var/ramble/repos/builtin.mock/applications/basic-inherited/application.py
+++ b/var/ramble/repos/builtin.mock/applications/basic-inherited/application.py
@@ -12,7 +12,7 @@ from ramble.app.builtin.mock.basic import Basic as BaseBasic
 
 
 class BasicInherited(BaseBasic):
-    name = "Basic Inheritance Test Application"
+    name = "basic-inherited"
 
     input_file('inherited_input', url='file:///tmp/inherited_file.log',
                description='Again, not a file', extension='.log')

--- a/var/ramble/repos/builtin.mock/applications/basic/application.py
+++ b/var/ramble/repos/builtin.mock/applications/basic/application.py
@@ -10,7 +10,7 @@ from ramble.appkit import *
 
 
 class Basic(ExecutableApplication):
-    name = "Basic Test Application"
+    name = "basic"
 
     executable('foo', 'bar', use_mpi=False)
     executable('bar', 'baz', use_mpi=True)

--- a/var/ramble/repos/builtin/applications/wrfv3/application.py
+++ b/var/ramble/repos/builtin/applications/wrfv3/application.py
@@ -74,12 +74,12 @@ class Wrfv3(SpackApplication):
                     fom_regex=r'Avg time / Max time:\s+(?P<avg_max_ratio>[0-9]+\.[0-9]*).*',
                     group_name='avg_max_ratio', units='')
 
-    def _analyze_experiments(self, workspace, expander):
+    def _analyze_experiments(self, workspace):
         import glob
         import re
         # Generate stats file
 
-        file_list = glob.glob(expander.expand_var('{experiment_run_dir}/rsl.out.*'))
+        file_list = glob.glob(self.expander.expand_var('{experiment_run_dir}/rsl.out.*'))
 
         if file_list:
             timing_regex = re.compile(r'Timing for main.*(?P<main_time>[0-9]+\.[0-9]*).*')
@@ -101,7 +101,7 @@ class Wrfv3(SpackApplication):
 
             avg_time = sum_time / max(count, 1)
 
-            stats_path = expander.expand_var('{experiment_run_dir}/stats.out')
+            stats_path = self.expander.expand_var('{experiment_run_dir}/stats.out')
             with open(stats_path, 'w+') as f:
                 f.write('Average time: %s s\n' % (avg_time))
                 f.write('Cumulative time: %s s\n' % (sum_time))
@@ -110,4 +110,4 @@ class Wrfv3(SpackApplication):
                 f.write('Avg time / Max time: %s s\n' % (avg_time / max(max_time, float(1.0))))
                 f.write('Number of times: %s\n' % (count))
 
-        super()._analyze_experiments(workspace, expander)
+        super()._analyze_experiments(workspace)

--- a/var/ramble/repos/builtin/applications/wrfv4/application.py
+++ b/var/ramble/repos/builtin/applications/wrfv4/application.py
@@ -81,12 +81,12 @@ class Wrfv4(SpackApplication):
     archive_pattern('{experiment_run_dir}/rsl.out.*')
     archive_pattern('{experiment_run_dir}/rsl.error.*')
 
-    def _analyze_experiments(self, workspace, expander):
+    def _analyze_experiments(self, workspace):
         import glob
         import re
         # Generate stats file
 
-        file_list = glob.glob(expander.expand_var('{experiment_run_dir}/rsl.out.*'))
+        file_list = glob.glob(self.expander.expand_var('{experiment_run_dir}/rsl.out.*'))
 
         if file_list:
             timing_regex = re.compile(r'Timing for main.*(?P<main_time>[0-9]+\.[0-9]*).*')
@@ -108,7 +108,7 @@ class Wrfv4(SpackApplication):
 
             avg_time = sum_time / max(count, 1)
 
-            stats_path = expander.expand_var('{experiment_run_dir}/stats.out')
+            stats_path = self.expander.expand_var('{experiment_run_dir}/stats.out')
             with open(stats_path, 'w+') as f:
                 f.write('Average time: %s s\n' % (avg_time))
                 f.write('Cumulative time: %s s\n' % (sum_time))
@@ -117,4 +117,4 @@ class Wrfv4(SpackApplication):
                 f.write('Avg time / Max time: %s s\n' % (avg_time / max(max_time, float(1.0))))
                 f.write('Number of times: %s\n' % (count))
 
-        super()._analyze_experiments(workspace, expander)
+        super()._analyze_experiments(workspace)


### PR DESCRIPTION
This merge is a major redesign of the logic to render, store, and expand experiments and the variables.

Fundamentally, this change creates an experiment set object which houses all of the experiments and the classes for each of them. This also pushes the variables into the application instances, and changes the expander class to just house the expansion logic instead of all of the variables as well.