### PR TITLE
Fix bug introduced by PR #36

### DIFF
--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -106,22 +106,19 @@ def workspace_activate(args):
     # Temporary workspace
     if args.temp:
         workspace = create_temp_workspace_directory()
-        wspath_dir = os.path.abspath(workspace)
-        ramble.workspace.set_workspace_path(wspath_dir)
-        short_name = os.path.basename(wspath_dir)
+        workspace_path = os.path.abspath(workspace)
+        short_name = os.path.basename(workspace_path)
         ramble.workspace.Workspace(workspace).write()
 
     # Named workspace
     elif ramble.workspace.exists(workspace_name_or_dir) and not args.dir:
-        wspath_dir = ramble.workspace.root(workspace_name_or_dir)
-        ramble.workspace.set_workspace_path(wspath_dir)
+        workspace_path = ramble.workspace.root(workspace_name_or_dir)
         short_name = workspace_name_or_dir
 
     # Workspace directory
     elif ramble.workspace.is_workspace_dir(workspace_name_or_dir):
-        workspace_path_dir = os.path.abspath(workspace_name_or_dir)
-        ramble.workspace.set_workspace_path(workspace_path_dir)
-        short_name = os.path.basename(workspace_path_dir)
+        workspace_path = os.path.abspath(workspace_name_or_dir)
+        short_name = os.path.basename(workspace_path)
 
     else:
         tty.die("No such workspace: '%s'" % workspace_name_or_dir)
@@ -137,8 +134,7 @@ def workspace_activate(args):
         env_mods = ramble.workspace.shell.deactivate()
 
     # Activate new workspace
-    workspace_path_dir = ramble.workspace.get_workspace_path()
-    active_workspace = ramble.workspace.Workspace(workspace_path_dir)
+    active_workspace = ramble.workspace.Workspace(workspace_path)
     cmds += ramble.workspace.shell.activate_header(
         ws=active_workspace,
         shell=args.shell,

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -281,9 +281,9 @@ def active_workspace():
 
 def get_workspace_path():
     """Returns current directory of ramble-managed workspaces"""
-    path_in_config = ramble.config.get('config:workspace_dirs')
+    path_in_config = ramble.config.get('config:workspace_dirs', scope='user')
     if not path_in_config:
-        path_in_config = '$ramble/var/ramble/GET_WORKSPACE_ERROR/'
+        path_in_config = ramble.config.get('config:workspace_dirs', scope='_builtin')
 
     wspath = ramble.util.path.canonicalize_path(path_in_config)
     return wspath
@@ -291,7 +291,7 @@ def get_workspace_path():
 
 def set_workspace_path(dirname):
     """Sets the parent directory of ramble-managed workspaces"""
-    ramble.config.set('config:workspace_dirs:', dirname)
+    ramble.config.set('config:workspace_dirs', dirname, scope='user')
 
 
 def _root(name):


### PR DESCRIPTION
PR https://github.com/GoogleCloudPlatform/ramble/pull/36, configurable workspace_dirs, introduced a bug with the following test sequence:
ramble config blame config | grep workspace_dirs

ramble workspace create test1
ramble workspace list
ramble config blame config | grep workspace_dirs
ramble workspace activate test1
ramble workspace list
ramble config blame config | grep workspace_dirs
ramble workspace create test2
ramble workspace list
ramble config blame config | grep workspace_dirs

The file ~/.ramble//config.yaml was getting written with an incorrect setting for workspace_dirs.