### PR TITLE
Add a clean command

### DIFF
--- a/lib/ramble/ramble/cmd/clean.py
+++ b/lib/ramble/ramble/cmd/clean.py
@@ -1,0 +1,76 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+
+import argparse
+import os
+import shutil
+
+import llnl.util.tty as tty
+
+import ramble.caches
+import ramble.config
+import ramble.repository
+import ramble.stage
+from ramble.paths import lib_path, var_path
+
+description = "remove temporary files and/or downloaded archives"
+section = "cleanup"
+level = "long"
+
+
+class AllClean(argparse.Action):
+    """Activates flags -d -m and -p simultaneously"""
+    def __call__(self, parser, namespace, values, option_string=None):
+        parser.parse_args(['-dmp'], namespace=namespace)
+
+
+def setup_parser(subparser):
+    subparser.add_argument(
+        '-d', '--downloads', action='store_true',
+        help="remove cached downloads (default)")
+    subparser.add_argument(
+        '-m', '--misc-cache', action='store_true',
+        help="remove long-lived caches")
+    subparser.add_argument(
+        '-p', '--python-cache', action='store_true',
+        help="remove .pyc, .pyo files and __pycache__ folders")
+    subparser.add_argument(
+        '-a', '--all', action=AllClean,
+        help="equivalent to -dmp",
+        nargs=0
+    )
+
+
+def clean(parser, args):
+    # If nothing was set, activate the default
+    if not any([args.downloads, args.misc_cache, args.python_cache]):
+        args.downloads = True
+
+    if args.downloads:
+        tty.msg('Removing cached downloads')
+        ramble.caches.fetch_cache.destroy()
+
+    if args.misc_cache:
+        tty.msg('Removing cached information on repositories')
+        ramble.caches.misc_cache.destroy()
+
+    if args.python_cache:
+        tty.msg('Removing python cache files')
+        for directory in [lib_path, var_path]:
+            for root, dirs, files in os.walk(directory):
+                for f in files:
+                    if f.endswith('.pyc') or f.endswith('.pyo'):
+                        fname = os.path.join(root, f)
+                        tty.debug('Removing {0}'.format(fname))
+                        os.remove(fname)
+                for d in dirs:
+                    if d == '__pycache__':
+                        dname = os.path.join(root, d)
+                        tty.debug('Removing {0}'.format(dname))
+                        shutil.rmtree(dname)

--- a/lib/ramble/ramble/test/cmd/clean.py
+++ b/lib/ramble/ramble/test/cmd/clean.py
@@ -1,0 +1,63 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import sys
+
+import pytest
+
+import ramble.caches
+import ramble.main
+
+clean = ramble.main.RambleCommand('clean')
+
+pytestmark = pytest.mark.skipif(sys.platform == "win32",
+                                reason="does not run on windows")
+
+
+@pytest.fixture()
+def mock_calls_for_clean(monkeypatch):
+
+    counts = {}
+
+    class Counter(object):
+        def __init__(self, name):
+            self.name = name
+            counts[name] = 0
+
+        def __call__(self, *args, **kwargs):
+            counts[self.name] += 1
+
+    monkeypatch.setattr(
+        ramble.caches.fetch_cache, 'destroy', Counter('downloads'),
+        raising=False)
+    monkeypatch.setattr(
+        ramble.caches.misc_cache, 'destroy', Counter('caches'))
+
+    yield counts
+
+
+all_effects = ['downloads', 'caches']
+
+
+@pytest.mark.usefixtures(
+    'config'
+)
+@pytest.mark.parametrize('command_line,effects', [
+    ('-d',       ['downloads']),
+    ('-m',       ['caches']),
+    ('-a',       all_effects),
+])
+def test_function_calls(command_line, effects, mock_calls_for_clean):
+
+    # Call the command with the supplied command line
+    clean(command_line)
+
+    # Assert that we called the expected functions the correct
+    # number of times
+    for name in all_effects:
+        assert mock_calls_for_clean[name] == (1 if name in effects else 0)


### PR DESCRIPTION
This merge adds `ramble clean` as a command. The clean command can be used to remove python cache files, cached inputs, and cached package files.

Tests are also added for the clean command.