### PR TITLE
Skip compiler installation if the compiler is already available via spack

### DIFF
--- a/lib/ramble/ramble/schema/config.py
+++ b/lib/ramble/ramble/schema/config.py
@@ -40,6 +40,10 @@ properties['config']['spack_flags'] = {
         'concretize': {
             'type': 'string',
             'default': '--reuse'
+        },
+        'global_args': {
+            'type': 'string',
+            'default': ''
         }
     },
     'additionalProperties': False,

--- a/lib/ramble/ramble/test/spack_runner.py
+++ b/lib/ramble/ramble/test/spack_runner.py
@@ -103,7 +103,7 @@ def test_default_concretize_flags(tmpdir, capsys):
         pytest.skip('%s' % e)
 
 
-def test_config_concretize_flags(tmpdir, capsys, mutable_config):
+def test_config_concretize_flags(tmpdir, capsys):
     try:
         env_path = tmpdir.join('spack-env')
         sr = ramble.spack_runner.SpackRunner(dry_run=True)
@@ -111,11 +111,11 @@ def test_config_concretize_flags(tmpdir, capsys, mutable_config):
         sr.activate()
         sr.add_spec('zlib')
 
-        ramble.config.config.set('config:spack_flags:concretize', '-f --fresh')
-        sr.concretize()
-        captured = capsys.readouterr()
+        with ramble.config.override('config:spack_flags', {'concretize': '-f --fresh'}):
+            sr.concretize()
+            captured = capsys.readouterr()
 
-        assert "with args: ['concretize', '-f', '--fresh']" in captured.out
+            assert "with args: ['concretize', '-f', '--fresh']" in captured.out
     except ramble.spack_runner.RunnerError as e:
         pytest.skip('%s' % e)
 
@@ -143,7 +143,7 @@ def test_default_install_flags(tmpdir, capsys):
         pytest.skip('%s' % e)
 
 
-def test_config_install_flags(tmpdir, capsys, mutable_config):
+def test_config_install_flags(tmpdir, capsys):
     try:
         env_path = tmpdir.join('spack-env')
         sr = ramble.spack_runner.SpackRunner(dry_run=True)
@@ -152,22 +152,22 @@ def test_config_install_flags(tmpdir, capsys, mutable_config):
         sr.add_spec('zlib')
         sr.concretize()
 
-        ramble.config.config.set('config:spack_flags:install', '--fresh --keep-prefix')
-        sr.install()
-        captured = capsys.readouterr()
+        with ramble.config.override('config:spack_flags', {'install': '--fresh --keep-prefix'}):
+            sr.install()
+            captured = capsys.readouterr()
 
-        install_flags = ramble.config.config.get('config:spack_flags:install')
-        expected_str = "with args: ['install'"
-        for flag in install_flags.split():
-            expected_str += f", '{flag}'"
-        expected_str += "]"
+            install_flags = ramble.config.config.get('config:spack_flags:install')
+            expected_str = "with args: ['install'"
+            for flag in install_flags.split():
+                expected_str += f", '{flag}'"
+            expected_str += "]"
 
-        assert expected_str in captured.out
+            assert expected_str in captured.out
     except ramble.spack_runner.RunnerError as e:
         pytest.skip('%s' % e)
 
 
-def test_env_include(tmpdir, capsys, mutable_config):
+def test_env_include(tmpdir, capsys):
     try:
         env_path = tmpdir.join('spack-env')
         sr = ramble.spack_runner.SpackRunner(dry_run=True)


### PR DESCRIPTION
This merge updates the compiler installation logic in spack to check if the compiler is available (as a compiler) to spack before trying to install it. The downside is that system compilers are now considered valid compilers as opposed to only spack installed ones (as how the logic was before).

This means that a compiler spec might have to be re-installed in an environment if the environment should perform the equivalent of a `spack load` on it, since system compilers are not the same as valid spack compilers.

Tests are added, and the other spack runner tests that set config options were updated to avoid issues where they might overwrite user config settings.