### PR TITLE
Add support for cross experiment variable references

### DIFF
--- a/examples/basic_expansion_config.yaml
+++ b/examples/basic_expansion_config.yaml
@@ -23,6 +23,7 @@ ramble:
                 processes_per_node: ['16', '32']
                 #^-- (partition, processes_per_node) -> (part1, 16), (part2, 32)
                 n_nodes: ['2', '4']
+                wrf_path: execute_experiment in wrfv4.CONUS_2p5km.new_test
               matrices:
                 - - n_nodes
                 #^-- (partiton, processes_per_node, n_nodes) ->

--- a/lib/ramble/docs/workspace_config.rst
+++ b/lib/ramble/docs/workspace_config.rst
@@ -239,6 +239,42 @@ number of elements, as they are flattened and zipped together. In this case,
 there would be 4 experiments, each defined by a unique
 ``(processes_per_node, partition, n_nodes)`` tuple.
 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Cross Experiment Variable References:
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Variables can be defined to pull the value of a variable out of a different
+experiment. This is particularly useful when an experiment needs the path to
+something ramble automatically generates in a different experiment.
+
+.. code-block:: yaml
+
+    ramble:
+      ...
+      variables:
+        processes_per_node: '16'
+        n_ranks: '{n_nodes}*{processes_per_node}'
+      applications:
+        hostname:
+          variables:
+            n_threads: '1'
+          workloads:
+            serial:
+              variables:
+                n_nodes: '1'
+              experiments:
+                test_exp1:
+                  variables:
+                    n_ranks: '1'
+                    real_value: 'exp1_value'
+                test_exp2:
+                  variables:
+                    n_ranks: '1'
+                    test_value: real_value in hostname.serial.test_exp1
+
+In the above example, ``test_value`` extracts the value of ``real_value`` as
+defined in the experiment ``hostname.serial.test_exp1``. When evaluated, this
+will set ``test_value`` to ``'exp1_value'``.
+
 ^^^^^^^^^^^^^^^^^^^
 Reserved Variables:
 ^^^^^^^^^^^^^^^^^^^

--- a/lib/ramble/ramble/application_types/spack.py
+++ b/lib/ramble/ramble/application_types/spack.py
@@ -78,13 +78,13 @@ class SpackApplication(ApplicationBase):
 
         return ''.join(out_str)
 
-    def _add_expand_vars(self):
+    def add_expand_vars(self, workspace):
         """Add spack specific expansion variables
 
         This defines spack specific expansion variables, including:
         - spack_setup: contains the commands the load spack and the experiment's spack environment
         """
-        super()._add_expand_vars()
+        super().add_expand_vars(workspace)
         try:
             runner = ramble.spack_runner.SpackRunner()
 

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -419,11 +419,11 @@ def workspace_info(args):
                 print_experiment_set = ramble.experiment_set.ExperimentSet(ws)
                 print_experiment_set.set_application_context(app, app_vars, app_env_vars)
                 print_experiment_set.set_workload_context(workload, workload_vars,
-                                                    workload_env_vars)
+                                                          workload_env_vars)
                 print_experiment_set.set_experiment_context(exp,
-                                                      exp_vars,
-                                                      exp_env_vars,
-                                                      exp_matrices)
+                                                            exp_vars,
+                                                            exp_env_vars,
+                                                            exp_matrices)
 
                 color.cprint(nested_1('  Application: ') + app)
                 color.cprint(nested_2('    Workload: ') + workload)
@@ -438,28 +438,36 @@ def workspace_info(args):
                                          section_title('Workspace') + ':')
                             for var, val in workspace_vars.items():
                                 expanded = app_inst.expander.expand_var('{' + var + '}')
-                                color.cprint(f'          {var} = {val} ==> {expanded}'.replace('@', '@@'))
+                                color.cprint(
+                                    f'          {var} = {val} ==> {expanded}'.replace('@',
+                                                                                      '@@'))
 
                         if app_vars:
                             color.cprint(nested_4('        Variables from ') +
                                          nested_1('Application') + ':')
                             for var, val in app_vars.items():
                                 expanded = app_inst.expander.expand_var('{' + var + '}')
-                                color.cprint(f'          {var} = {val} ==> {expanded}'.replace('@', '@@'))
+                                color.cprint(
+                                    f'          {var} = {val} ==> {expanded}'.replace('@',
+                                                                                      '@@'))
 
                         if workload_vars:
                             color.cprint(nested_4('        Variables from ') +
                                          nested_2('Workload') + ':')
                             for var, val in workload_vars.items():
                                 expanded = app_inst.expander.expand_var('{' + var + '}')
-                                color.cprint(f'          {var} = {val} ==> {expanded}'.replace('@', '@@'))
+                                color.cprint(
+                                    f'          {var} = {val} ==> {expanded}'.replace('@',
+                                                                                      '@@'))
 
                         if exp_vars:
                             color.cprint(nested_4('        Variables from ') +
                                          nested_3('Experiment') + ':')
                             for var, val in exp_vars.items():
                                 expanded = app_inst.expander.expand_var('{' + var + '}')
-                                color.cprint(f'          {var} = {val} ==> {expanded}'.replace('@', '@@'))
+                                color.cprint(
+                                    f'          {var} = {val} ==> {expanded}'.replace('@',
+                                                                                      '@@'))
 
     # Print MPI command
     color.cprint('')

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -395,14 +395,12 @@ def workspace_info(args):
     # Print workspace variables information
     workspace_vars = ws.get_workspace_vars()
 
-    # Print experiment information
-    color.cprint('')
-    color.cprint(section_title('Experiments:'))
+    # Build experiment set
+    experiment_set = ramble.experiment_set.ExperimentSet(ws)
     for app, workloads, app_vars, app_env_vars in ws.all_applications():
         for workload, experiments, workload_vars, workload_env_vars in \
                 ws.all_workloads(workloads):
             for exp, _, exp_vars, exp_env_vars, exp_matrices in ws.all_experiments(experiments):
-                experiment_set = ramble.experiment_set.ExperimentSet(ws)
                 experiment_set.set_application_context(app, app_vars, app_env_vars)
                 experiment_set.set_workload_context(workload, workload_vars,
                                                     workload_env_vars)
@@ -411,10 +409,27 @@ def workspace_info(args):
                                                       exp_env_vars,
                                                       exp_matrices)
 
+    # Print experiment information
+    color.cprint('')
+    color.cprint(section_title('Experiments:'))
+    for app, workloads, app_vars, app_env_vars in ws.all_applications():
+        for workload, experiments, workload_vars, workload_env_vars in \
+                ws.all_workloads(workloads):
+            for exp, _, exp_vars, exp_env_vars, exp_matrices in ws.all_experiments(experiments):
+                print_experiment_set = ramble.experiment_set.ExperimentSet(ws)
+                print_experiment_set.set_application_context(app, app_vars, app_env_vars)
+                print_experiment_set.set_workload_context(workload, workload_vars,
+                                                    workload_env_vars)
+                print_experiment_set.set_experiment_context(exp,
+                                                      exp_vars,
+                                                      exp_env_vars,
+                                                      exp_matrices)
+
                 color.cprint(nested_1('  Application: ') + app)
                 color.cprint(nested_2('    Workload: ') + workload)
 
-                for exp_name, app_inst in experiment_set.all_experiments():
+                for exp_name, _ in print_experiment_set.all_experiments():
+                    app_inst = experiment_set.get_experiment(exp_name)
                     color.cprint(nested_3('      Experiment: ') + exp_name)
 
                     if args.verbose >= 1:
@@ -423,28 +438,28 @@ def workspace_info(args):
                                          section_title('Workspace') + ':')
                             for var, val in workspace_vars.items():
                                 expanded = app_inst.expander.expand_var('{' + var + '}')
-                                color.cprint(f'          {var} = {val} ==> {expanded}')
+                                color.cprint(f'          {var} = {val} ==> {expanded}'.replace('@', '@@'))
 
                         if app_vars:
                             color.cprint(nested_4('        Variables from ') +
                                          nested_1('Application') + ':')
                             for var, val in app_vars.items():
                                 expanded = app_inst.expander.expand_var('{' + var + '}')
-                                color.cprint(f'          {var} = {val} ==> {expanded}')
+                                color.cprint(f'          {var} = {val} ==> {expanded}'.replace('@', '@@'))
 
                         if workload_vars:
                             color.cprint(nested_4('        Variables from ') +
                                          nested_2('Workload') + ':')
                             for var, val in workload_vars.items():
                                 expanded = app_inst.expander.expand_var('{' + var + '}')
-                                color.cprint(f'          {var} = {val} ==> {expanded}')
+                                color.cprint(f'          {var} = {val} ==> {expanded}'.replace('@', '@@'))
 
                         if exp_vars:
                             color.cprint(nested_4('        Variables from ') +
                                          nested_3('Experiment') + ':')
                             for var, val in exp_vars.items():
                                 expanded = app_inst.expander.expand_var('{' + var + '}')
-                                color.cprint(f'          {var} = {val} ==> {expanded}')
+                                color.cprint(f'          {var} = {val} ==> {expanded}'.replace('@', '@@'))
 
     # Print MPI command
     color.cprint('')

--- a/lib/ramble/ramble/test/expander.py
+++ b/lib/ramble/ramble/test/expander.py
@@ -32,7 +32,7 @@ def exp_dict():
 def test_expansions():
     expansion_vars = exp_dict()
 
-    expander = ramble.expander.Expander(expansion_vars)
+    expander = ramble.expander.Expander(expansion_vars, None)
 
     assert expander.expand_var('{var1}') == '3'
     assert expander.expand_var('{var2}') == '3'
@@ -49,7 +49,7 @@ def test_expansions():
 def test_expansion_namespaces():
     expansion_vars = exp_dict()
 
-    expander = ramble.expander.Expander(expansion_vars)
+    expander = ramble.expander.Expander(expansion_vars, None)
 
     assert expander.application_namespace == 'foo'
     assert expander.workload_namespace == 'foo.bar'

--- a/lib/ramble/ramble/test/experiment_set.py
+++ b/lib/ramble/ramble/test/experiment_set.py
@@ -414,3 +414,95 @@ def test_experiment_names_match(mutable_mock_workspace_path):
 
         for exp, app in exp_set.all_experiments():
             assert exp == app.expander.expand_var('{experiment_namespace}')
+
+
+def test_cross_experiment_variable_references(mutable_mock_workspace_path):
+    workspace('create', 'test')
+
+    assert 'test' in workspace('list')
+
+    with ramble.workspace.read('test') as ws:
+        exp_set = ramble.experiment_set.ExperimentSet(ws)
+
+        app_name = 'basic'
+        app_vars = {
+            'app_var1': '1',
+            'app_var2': '2',
+            'n_ranks': '{processes_per_node}*{n_nodes}'
+        }
+
+        wl_name = 'test_wl'
+        wl_vars = {
+            'wl_var1': '1',
+            'wl_var2': '2',
+            'processes_per_node': '2'
+        }
+        exp1_name = 'series1_{n_ranks}'
+        exp1_vars = {
+            'exp_var1': '1',
+            'exp_var2': '2',
+            'n_nodes': '2',
+            'test_var': 'success'
+        }
+
+        exp2_name = 'series2_{n_ranks}'
+        exp2_vars = {
+            'exp_var1': '1',
+            'exp_var2': '2',
+            'n_nodes': '2',
+            'test_var': 'test_var in basic.test_wl.series1_4'
+        }
+
+        exp_set.set_application_context(app_name, app_vars, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None)
+        exp_set.set_experiment_context(exp1_name, exp1_vars, None, None)
+        exp_set.set_experiment_context(exp2_name, exp2_vars, None, None)
+
+        assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
+        assert 'basic.test_wl.series2_4' in exp_set.experiments.keys()
+
+        exp2_app = exp_set.experiments['basic.test_wl.series2_4']
+        assert exp2_app.expander.expand_var('{test_var}') == 'success'
+
+
+def test_cross_experiment_missing_experiment_errors(mutable_mock_workspace_path):
+    workspace('create', 'test')
+
+    assert 'test' in workspace('list')
+
+    with ramble.workspace.read('test') as ws:
+        exp_set = ramble.experiment_set.ExperimentSet(ws)
+
+        app_name = 'basic'
+        app_vars = {
+            'app_var1': '1',
+            'app_var2': '2',
+            'n_ranks': '{processes_per_node}*{n_nodes}'
+        }
+
+        wl_name = 'test_wl'
+        wl_vars = {
+            'wl_var1': '1',
+            'wl_var2': '2',
+            'processes_per_node': '2'
+        }
+        exp1_name = 'series1_{n_ranks}'
+        exp1_vars = {
+            'exp_var1': '1',
+            'exp_var2': '2',
+            'n_nodes': '2',
+            'test_var': 'processes_per_node in basic.test_wl.does_not_exist'
+        }
+
+        exp_set.set_application_context(app_name, app_vars, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None)
+        exp_set.set_experiment_context(exp1_name, exp1_vars, None, None)
+
+        assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
+
+        exp1_app = exp_set.experiments['basic.test_wl.series1_4']
+
+        with pytest.raises(ramble.expander.RambleSyntaxError) as e:
+            exp1_app.expander.expand_var('{test_var}')
+            expected = f'basic.test_wl_does_not_exist does not exist in "{exp1_vars["test_var"]}"'
+            assert e.error == expected

--- a/lib/ramble/ramble/test/experiment_set.py
+++ b/lib/ramble/ramble/test/experiment_set.py
@@ -52,7 +52,7 @@ def test_single_experiment_in_set(mutable_mock_workspace_path):
         exp_set.set_workload_context(wl_name, wl_vars, None)
         exp_set.set_experiment_context(exp_name, exp_vars, None, None)
 
-        assert 'series1_4' in exp_set.experiments.keys()
+        assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
 
 
 def test_vector_experiment_in_set(mutable_mock_workspace_path):
@@ -87,8 +87,8 @@ def test_vector_experiment_in_set(mutable_mock_workspace_path):
         exp_set.set_workload_context(wl_name, wl_vars, None)
         exp_set.set_experiment_context(exp_name, exp_vars, None, None)
 
-        assert 'series1_4' in exp_set.experiments.keys()
-        assert 'series1_8' in exp_set.experiments.keys()
+        assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
+        assert 'basic.test_wl.series1_8' in exp_set.experiments.keys()
 
 
 def test_nonunique_vector_errors(mutable_mock_workspace_path, capsys):
@@ -159,8 +159,8 @@ def test_zipped_vector_experiments(mutable_mock_workspace_path):
         exp_set.set_workload_context(wl_name, wl_vars, None)
         exp_set.set_experiment_context(exp_name, exp_vars, None, None)
 
-        assert 'series1_4_2' in exp_set.experiments.keys()
-        assert 'series1_16_4' in exp_set.experiments.keys()
+        assert 'basic.test_wl.series1_4_2' in exp_set.experiments.keys()
+        assert 'basic.test_wl.series1_16_4' in exp_set.experiments.keys()
 
 
 def test_matrix_experiments(mutable_mock_workspace_path):
@@ -199,8 +199,8 @@ def test_matrix_experiments(mutable_mock_workspace_path):
         exp_set.set_workload_context(wl_name, wl_vars, None)
         exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices)
 
-        assert 'series1_4' in exp_set.experiments.keys()
-        assert 'series1_6' in exp_set.experiments.keys()
+        assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
+        assert 'basic.test_wl.series1_6' in exp_set.experiments.keys()
 
 
 def test_matrix_multiplication_experiments(mutable_mock_workspace_path):
@@ -239,12 +239,12 @@ def test_matrix_multiplication_experiments(mutable_mock_workspace_path):
         exp_set.set_workload_context(wl_name, wl_vars, None)
         exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices)
 
-        assert 'series1_2' in exp_set.experiments.keys()
-        assert 'series1_8' in exp_set.experiments.keys()
-        assert 'series1_12' in exp_set.experiments.keys()
-        assert 'series1_4' in exp_set.experiments.keys()
-        assert 'series1_16' in exp_set.experiments.keys()
-        assert 'series1_24' in exp_set.experiments.keys()
+        assert 'basic.test_wl.series1_2' in exp_set.experiments.keys()
+        assert 'basic.test_wl.series1_8' in exp_set.experiments.keys()
+        assert 'basic.test_wl.series1_12' in exp_set.experiments.keys()
+        assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
+        assert 'basic.test_wl.series1_16' in exp_set.experiments.keys()
+        assert 'basic.test_wl.series1_24' in exp_set.experiments.keys()
 
 
 def test_matrix_vector_experiments(mutable_mock_workspace_path):
@@ -283,10 +283,10 @@ def test_matrix_vector_experiments(mutable_mock_workspace_path):
         exp_set.set_workload_context(wl_name, wl_vars, None)
         exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices)
 
-        assert 'series1_4' in exp_set.experiments.keys()
-        assert 'series1_8' in exp_set.experiments.keys()
-        assert 'series1_6' in exp_set.experiments.keys()
-        assert 'series1_12' in exp_set.experiments.keys()
+        assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
+        assert 'basic.test_wl.series1_8' in exp_set.experiments.keys()
+        assert 'basic.test_wl.series1_6' in exp_set.experiments.keys()
+        assert 'basic.test_wl.series1_12' in exp_set.experiments.keys()
 
 
 def test_multi_matrix_experiments(mutable_mock_workspace_path):
@@ -326,8 +326,8 @@ def test_multi_matrix_experiments(mutable_mock_workspace_path):
         exp_set.set_workload_context(wl_name, wl_vars, None)
         exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices)
 
-        assert 'series1_4_2' in exp_set.experiments.keys()
-        assert 'series1_12_4' in exp_set.experiments.keys()
+        assert 'basic.test_wl.series1_4_2' in exp_set.experiments.keys()
+        assert 'basic.test_wl.series1_12_4' in exp_set.experiments.keys()
 
 
 def test_matrix_undefined_var_errors(mutable_mock_workspace_path, capsys):
@@ -409,8 +409,8 @@ def test_experiment_names_match(mutable_mock_workspace_path):
         exp_set.set_workload_context(wl_name, wl_vars, None)
         exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices)
 
-        assert 'series1_4_2' in exp_set.experiments.keys()
-        assert 'series1_12_4' in exp_set.experiments.keys()
+        assert 'basic.test_wl.series1_4_2' in exp_set.experiments.keys()
+        assert 'basic.test_wl.series1_12_4' in exp_set.experiments.keys()
 
         for exp, app in exp_set.all_experiments():
-            assert exp == app.variables['experiment_name']
+            assert exp == app.expander.expand_var('{experiment_namespace}')


### PR DESCRIPTION
This merge performs three tasks:
1) Fixes the `ramble workspace info` command, in preparation for cross experiment variable reference expansion
2) Re-organizes the AST logic in the expander class to prepare for cross experiment variable references (and aid further extending the AST logic in the future)
3) Adds support into the AST logic for cross experiment variable references.

Cross experiment variable references allow an experiment to refer to a variable definition in a different experiment.

This takes the form of:

```
ramble:
  ...
  variables:
    n_ranks: '1'
    n_nodes: '1'
    n_threads: '1'
    processes_per_node: '1'
  applications:
    hostname:
      workloads:
        serial:
          experiments:
            test1:
              variables:
                test_var: 'my_value'
            test2:
              variables:
                other_var: test_var in hostname.serial.test1
```

In the above example, `other_var` in test2 would have a value of `'my_value'`.