### PR TITLE
Ensure unit tests run without an active workspace

### DIFF
--- a/lib/ramble/ramble/cmd/unit_test.py
+++ b/lib/ramble/ramble/cmd/unit_test.py
@@ -21,6 +21,7 @@ from llnl.util.filesystem import working_dir
 from llnl.util.tty.colify import colify
 
 import ramble.paths
+import ramble.workspace
 
 description = "run ramble's unit tests (wrapper around pytest)"
 section = "developer"
@@ -174,4 +175,5 @@ def unit_test(parser, args, unknown_args):
             do_list(args, pytest_args)
             return
 
-        return pytest.main(pytest_args)
+        with ramble.workspace.no_active_workspace():
+            return pytest.main(pytest_args)

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1745,11 +1745,17 @@ def no_active_workspace():
     """Deactivate the active workspace for the duration of the context. Has no
        effect when there is no active workspace."""
     ws = active_workspace()
+    env_var = None
+    if ramble_workspace_var in os.environ.keys():
+        env_var = os.environ[ramble_workspace_var]
+        del os.environ[ramble_workspace_var]
+
     try:
         deactivate()
         yield
     finally:
         if ws:
+            os.environ[ramble_workspace_var] = env_var
             activate(ws)
 
 


### PR DESCRIPTION
This merge ensures workspaces are deactivated before running unit-tests.

Fixes #57 