### PR TITLE
Fix `workspace info` creating spack environments

### DIFF
--- a/lib/ramble/ramble/application_types/spack.py
+++ b/lib/ramble/ramble/application_types/spack.py
@@ -88,7 +88,7 @@ class SpackApplication(ApplicationBase):
         try:
             runner = ramble.spack_runner.SpackRunner()
 
-            runner.create_env(self.expander.expand_var('{spack_env}'))
+            runner.configure_env(self.expander.expand_var('{spack_env}'))
             runner.activate()
             runner_vars = runner.generate_expand_vars()
             self.variables['spack_setup'] = runner_vars

--- a/lib/ramble/ramble/spack_runner.py
+++ b/lib/ramble/ramble/spack_runner.py
@@ -112,6 +112,14 @@ class SpackRunner(object):
 
         return '\n'.join(commands)
 
+    def configure_env(self, path):
+        """
+        Configured the spack environment path for subsequent spack commands
+        """
+
+        # Ensure subsequent commands use the created env now.
+        self.env_path = path
+
     def create_env(self, path, output=None, error=None):
         """
         Ensure a spack environment is created, and set the path to it within


### PR DESCRIPTION
Previously, `workspace info` would create spack environments, when it shouldn't be modifying a workspace directory.

This merge updates `workspace info` so it doesn't create / modify any files.

Fixes #60 