### PR TITLE
Fix invalid reference to getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Documentation
 For help with Ramble’s commands, run `ramble help` or `ramble help --all`.
 
 For more information on concepts in Ramble, see Ramble’s
-[Getting Started](./docs/getting_started.rst) guide.
+[Getting Started](./lib/ramble/docs/getting_started.rst) guide.
 
 Example configuration files are also contained in the
 [examples](./examples) directory.


### PR DESCRIPTION
#63 missed the reference to the getting_started.rst file.

Fixes #60 