### PR TITLE
Fix workspace vars not propogating

### DIFF
--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -81,9 +81,11 @@ class ExperimentSet(object):
 
         # Set all workspace variables as base variables.
         workspace_vars = workspace.get_workspace_vars()
-        if workspace_vars:
-            for var, val in workspace_vars.items():
-                self.set_base_var(var, val)
+        workspace_env_vars = workspace.get_workspace_env_vars()
+        self._set_context(self._contexts.base,
+                          workspace.name,
+                          workspace_vars,
+                          workspace_env_vars)
 
         # Set some base variables from the workspace definition.
         self.set_base_var(self.mpi_key, workspace.mpi_command)

--- a/lib/ramble/ramble/test/end_to_end.py
+++ b/lib/ramble/ramble/test/end_to_end.py
@@ -355,6 +355,73 @@ spack:
             assert result
 
 
+def test_missing_required_dry_run(mutable_config, mutable_mock_workspace_path):
+    """Tests tty.die at end of ramble.application_types.spack._create_spack_env"""
+    test_config = """
+ramble:
+  mpi:
+    command: mpirun
+    args:
+    - -n
+    - '{n_ranks}'
+    - -ppn
+    - '{processes_per_node}'
+    - -hostfile
+    - hostfile
+  batch:
+    submit: 'sbatch {execute_experiment}'
+  variables:
+    processes_per_node: 30
+    n_ranks: '{processes_per_node}*{n_nodes}'
+    n_threads: '1'
+  applications:
+    wrfv3:
+      workloads:
+        CONUS_2p5km:
+          experiments:
+            eight_node:
+              variables:
+                n_nodes: '8'
+spack:
+  concretized: true
+  compilers:
+    gcc8:
+      base: gcc
+      version: 8.2.0
+      target: x86_64
+  mpi_libraries:
+    impi2018:
+      base: intel-mpi
+      version: 2018.4.274
+      target: x86_64
+  applications:
+    wrfv3:
+      my-wrf:
+        base: wrf
+        version: 3.9.1.1
+        variants: build_type=dm+sm compile_type=em_real nesting=basic ~pnetcdf
+        compiler: gcc8
+        mpi: impi2018
+"""
+
+    workspace_name = 'test_missing_required_dry_run'
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+
+        config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+
+        with open(config_path, 'w+') as f:
+            f.write(test_config)
+        ws._re_read()
+
+        output = workspace('setup',
+                           '--dry-run',
+                           global_args=['-w', workspace_name],
+                           fail_on_error=False)
+
+        assert "Software spec wrf is not defined in context wrfv3" in output
+
+
 def test_env_var_builtin(mutable_config, mutable_mock_workspace_path, mock_applications):
     test_config = """
 ramble:


### PR DESCRIPTION
This merge fixes defined workspace variables, and environment variables being configured within an experiment context.

Additionally, this adds a test that was incorrectly removed in #65 

Fixes #66 