### PR TITLE
Add Experimental Upload of experiment results

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -604,24 +604,30 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                                     'units': fom_conf['units']
                                 }
 
-        results = {}
         exp_ns = self.expander.experiment_namespace
-        results[exp_ns] = {}
+        results = { 'name': exp_ns }
 
         success = True if fom_values else False
         success = success and criteria_list.passed()
 
         tty.debug('fom_vals = %s' % fom_values)
         if success:
-            results[exp_ns]['RAMBLE_STATUS'] = 'SUCCESS'
-            results[exp_ns]['RAMBLE_VARIABLES'] = self.variables
-            results[exp_ns]['CONTEXTS'] = {}
+            results['RAMBLE_STATUS'] = 'SUCCESS'
+            results['RAMBLE_VARIABLES'] = self.variables
+            results['CONTEXTS'] = []
 
-            for context, foms in fom_values.items():
-                results[exp_ns]['CONTEXTS'][context] = foms.copy()
+            for context, fom_map in fom_values.items():
+                context_map = { 'name': context, 'foms': []}
+
+                for fom_name, fom in fom_map.items():
+                    fom_copy = fom.copy()
+                    fom_copy['name'] = fom_name
+                    context_map['foms'].append(fom_copy)
+
+                results['CONTEXTS'].append(context_map)
 
         else:
-            results[exp_ns]['RAMBLE_STATUS'] = 'FAILED'
+            results['RAMBLE_STATUS'] = 'FAILED'
 
         workspace.append_result(results)
 

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -605,7 +605,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                                 }
 
         exp_ns = self.expander.experiment_namespace
-        results = { 'name': exp_ns }
+        results = {'name': exp_ns}
 
         success = True if fom_values else False
         success = success and criteria_list.passed()
@@ -617,7 +617,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
             results['CONTEXTS'] = []
 
             for context, fom_map in fom_values.items():
-                context_map = { 'name': context, 'foms': []}
+                context_map = {'name': context, 'foms': []}
 
                 for fom_name, fom in fom_map.items():
                     fom_copy = fom.copy()

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -334,6 +334,13 @@ def workspace_analyze_setup_parser(subparser):
              'Supported formats are json, yaml, or text',
         required=False)
 
+    subparser.add_argument(
+        '-u', '--upload',
+        dest='upload',
+        action='store_true',
+        help='Push experiment data to remote store (as defined in config)',
+        required=False)
+
 
 def workspace_analyze(args):
     ws = ramble.cmd.require_active_workspace(cmd_name='workspace analyze')
@@ -342,6 +349,10 @@ def workspace_analyze(args):
     with ws.write_transaction():
         ws.run_pipeline('analyze')
         ws.dump_results(output_formats=args.output_formats)
+
+    # FIXME: this will fire the analyze logic of twice currently
+    if args.upload:
+        ws.upload_results()
 
 
 header_color = '@*b'

--- a/lib/ramble/ramble/experimental/uploader.py
+++ b/lib/ramble/ramble/experimental/uploader.py
@@ -1,0 +1,186 @@
+class Uploader():
+    # TODO: should the class store the base uri?
+    def perform_upload(self, uri, workspace_name, data):
+        # TODO: move content checking to __init__ ?
+        if not uri:
+            raise ValueError(
+                "%s requires %s argument." % (self.__class__, uri))
+        if not data:
+            raise ValueError(
+                "%s requires %s argument." % (self.__class__, json_str))
+        pass
+
+'''
+Class representation of experiment data
+'''
+class Experiment():
+    def __init__(self, name, data):
+        self.name = name
+        self.foms = []
+        self.id = None # This is essentially the hash
+        self.data = data
+        self.application_name = data['RAMBLE_VARIABLES']['application_name']
+        self.bulk_hash = None # proxy for workspace or "uploaded with"
+        self.n_nodes = data['RAMBLE_VARIABLES']['n_nodes']
+        self.processes_per_node = data['RAMBLE_VARIABLES']['processes_per_node']
+        self.n_ranks = data['RAMBLE_VARIABLES']['n_ranks']
+        self.n_threads = data['RAMBLE_VARIABLES']['n_threads']
+        #'platform' # TODO: add this
+
+        self.id = None # TODO: find a good way to set this once the object is "finished"
+
+    def generate_hash(self):
+        # Avoid regenerating a hash when possible
+        # (The hash of an object must never change during its lifetime..)
+        if self.id is None:
+            # TODO: this might be better as a hash of something we intuatively
+            # expect to be uniqie, like:
+            # "{RAMBLE_STATUS}-{application_name}-{experiment_name}-{time}-etc"
+            # If we don't want this, we can go back to this class just being a dict
+            self.id = hash(self)
+        return self.id
+
+    def get_hash(self):
+        return self.generate_hash()
+
+    def to_json(self):
+        import json
+        #return json.dumps(self, default=lambda o: o.__dict__)
+        #j = json.dumps( self.__dict__ )
+        #print(type(j))
+
+        # deep copy so the assignment below doesn't affect the foms array
+        import copy
+        j = copy.deepcopy(self.__dict__)
+
+        j['foms'] = json.dumps(self.foms)
+        j['data'] = json.dumps(self.data)
+        return j
+
+
+
+'''
+Goal: convert results to a more searchable and decomposed format for insertion
+into data store (etc)
+
+Input:
+    { expierment_name: { "CONTEXTS": { "context_name": "FOM_name { unit: "value", "value":value" }...}
+
+
+Output: The general idea is the decompose the results into a more "database" like forwat, where the runs and FOMs are in a different table, giving:
+
+experiments: {experiment_id, experiment details...}
+foms: {experiment_id, fom_name, fom_value, fom_unit..} # +context?
+
+results[table][row][data] ?
+'''
+@staticmethod
+def format_data(data_in):
+    print(data_in)
+    results = []
+
+    # TODO: what is the nice way to deal with the distinction between
+    # numberic/float and string FOM values
+    for exp in data_in['experiments']:
+        if exp['RAMBLE_STATUS'] == 'SUCCESS':
+            e = Experiment( exp['name'], exp )
+            results.append( e )
+            #experiment_id = exp.hash()
+            #'experiment_id': experiment_id,
+            for context in exp['CONTEXTS']:
+                for fom in context['foms']:
+                    e.foms.append(
+                        {
+                            'name': fom['name'],
+                            'value' : fom['value'],
+                            'unit': fom['units'],
+                            'context': context['name'],
+                        }
+                    )
+
+    return results
+
+
+
+class CloudSpannerUploader(Uploader):
+    def insert_data(self, uri: str, workspace_name, data) -> None:
+        pass
+
+    def perform_upload(self, uri, workspace_name, results):
+        pass
+
+class BigQueryUploader(Uploader):
+
+    def insert_data(self, uri: str, workspace_name, results) -> None:
+
+        # TODO: create these tables
+        exp_table_id = "{uri}.{table_name}".format(uri=uri, table_name="experiments")
+        fom_table_id = "{uri}.{table_name}".format(uri=uri, table_name="foms")
+
+        from google.cloud import bigquery
+        client = bigquery.Client()
+
+        exps_to_insert = []
+        foms_to_insert = []
+
+        from datetime import datetime
+        current_dateTime = datetime.now()
+
+        exps_hash = "{name}::{date}".format(name=workspace_name, date=current_dateTime)
+
+        for experiment in results:
+            # TODO: remove
+            print(experiment.__dict__)
+
+            experiment.generate_hash()
+            experiment.bulk_hash = exps_hash
+
+            exps_to_insert.append( experiment.to_json() )
+
+            for fom in experiment.foms:
+                fom_data = fom
+                fom_data['experiment_id'] = experiment.get_hash()
+                fom_data['experiment_name'] = experiment.name
+                foms_to_insert.append( fom_data )
+
+        print(exps_to_insert)
+
+        # Make an API request.
+        errors1 = client.insert_rows_json(exp_table_id, exps_to_insert)
+        errors2 = None
+        if errors1 == []:
+            errors2 = client.insert_rows_json(fom_table_id, foms_to_insert)
+
+        for errors, name in zip([errors1, errors2], ['exp','fom']):
+            if errors == []:
+                print("New rows have been added in {}.".format(name))
+            else:
+                print("Encountered errors while inserting rows: {}".format(errors))
+
+
+    def perform_upload(self, uri, workspace_name, results):
+        super().perform_upload(uri, workspace_name, results)
+
+        # import spack.util.spack_json as sjson
+        #json_str = sjson.dump(results)
+
+        self.insert_data(uri, workspace_name, results)
+
+    def get_max_current_id(uri, table):
+        # TODO: Generating an id based on the max in use id is dangerous, and
+        # technically gives a race condition in parallel, and should be done in
+        # a more graceful and scalable way..  like hashing the experiment? or
+        # generating a known unique id for it
+        query = "SELECT MAX(id) FROM `{uri}.{table}` LIMIT 1".format(uri = uri, table = table)
+        query_job = client.query(query)
+        results = query_job.result()  # Waits for job to complete.
+        return results[0]
+
+
+    def get_expierment_id(experiment):
+        #get_max_current_id(...) # Warning: dangerous..
+
+        # This should be stable per machine/python version, but is not
+        # guarnteed to be globally stable
+        return hash(json.dumps(expiriment, sort_keys=True))
+

--- a/lib/ramble/ramble/experimental/uploader.py
+++ b/lib/ramble/ramble/experimental/uploader.py
@@ -1,4 +1,6 @@
 import llnl.util.tty as tty
+import json
+
 
 class Uploader():
     # TODO: should the class store the base uri?
@@ -9,33 +11,34 @@ class Uploader():
                 "%s requires %s argument." % (self.__class__, uri))
         if not data:
             raise ValueError(
-                "%s requires %s argument." % (self.__class__, json_str))
+                "%s requires %s argument." % (self.__class__, data))
         pass
 
-'''
-Class representation of experiment data
-'''
+
 class Experiment():
+    '''
+    Class representation of experiment data
+    '''
     def __init__(self, name, data):
         self.name = name
         self.foms = []
-        self.id = None # This is essentially the hash
+        self.id = None  # This is essentially the hash
         self.data = data
         self.application_name = data['RAMBLE_VARIABLES']['application_name']
-        self.bulk_hash = None # proxy for workspace or "uploaded with"
+        self.bulk_hash = None  # proxy for workspace or "uploaded with"
         self.n_nodes = data['RAMBLE_VARIABLES']['n_nodes']
         self.processes_per_node = data['RAMBLE_VARIABLES']['processes_per_node']
         self.n_ranks = data['RAMBLE_VARIABLES']['n_ranks']
         self.n_threads = data['RAMBLE_VARIABLES']['n_threads']
-        #'platform' # TODO: add this
+        # 'platform' # TODO: add this
 
-        self.id = None # TODO: find a good way to set this once the object is "finished"
+        self.id = None  # TODO: find a good way to set this once the object is "finished"
 
     def generate_hash(self):
         # Avoid regenerating a hash when possible
         # (The hash of an object must never change during its lifetime..)
         if self.id is None:
-            # TODO: this might be better as a hash of something we intuatively
+            #  TODO: this might be better as a hash of something we intuatively
             # expect to be uniqie, like:
             # "{RAMBLE_STATUS}-{application_name}-{experiment_name}-{time}-etc"
             # If we don't want this, we can go back to this class just being a dict
@@ -46,10 +49,6 @@ class Experiment():
         return self.generate_hash()
 
     def to_json(self):
-        import json
-        #return json.dumps(self, default=lambda o: o.__dict__)
-        #j = json.dumps( self.__dict__ )
-        #print(type(j))
 
         # deep copy so the assignment below doesn't affect the foms array
         import copy
@@ -60,24 +59,28 @@ class Experiment():
         return j
 
 
-
-'''
-Goal: convert results to a more searchable and decomposed format for insertion
-into data store (etc)
-
-Input:
-    { expierment_name: { "CONTEXTS": { "context_name": "FOM_name { unit: "value", "value":value" }...}
-
-
-Output: The general idea is the decompose the results into a more "database" like forwat, where the runs and FOMs are in a different table, giving:
-
-experiments: {experiment_id, experiment details...}
-foms: {experiment_id, fom_name, fom_value, fom_unit..} # +context?
-
-results[table][row][data] ?
-'''
 @staticmethod
 def format_data(data_in):
+    '''
+    Goal: convert results to a more searchable and decomposed format for insertion
+    into data store (etc)
+
+    Input:
+        { expierment_name:
+            { "CONTEXTS": {
+                "context_name": "FOM_name { unit: "value", "value":value" }
+            ...}
+            }
+        }
+
+    Output: The general idea is the decompose the results into a more "database"
+    like format, where the runs and FOMs are in a different table, giving:
+
+    experiments: {experiment_id, experiment details...}
+    foms: {experiment_id, fom_name, fom_value, fom_unit..} # +context?
+
+    results[table][row][data] ?
+    '''
     tty.debug("Format Data in")
     tty.debug(data_in)
     results = []
@@ -86,16 +89,16 @@ def format_data(data_in):
     # numberic/float and string FOM values
     for exp in data_in['experiments']:
         if exp['RAMBLE_STATUS'] == 'SUCCESS':
-            e = Experiment( exp['name'], exp )
-            results.append( e )
-            #experiment_id = exp.hash()
-            #'experiment_id': experiment_id,
+            e = Experiment(exp['name'], exp)
+            results.append(e)
+            # experiment_id = exp.hash()
+            # 'experiment_id': experiment_id,
             for context in exp['CONTEXTS']:
                 for fom in context['foms']:
                     e.foms.append(
                         {
                             'name': fom['name'],
-                            'value' : fom['value'],
+                            'value': fom['value'],
                             'unit': fom['units'],
                             'context': context['name'],
                         }
@@ -104,11 +107,10 @@ def format_data(data_in):
     return results
 
 
-
 class BigQueryUploader(Uploader):
-    from google.cloud import bigquery
 
     def insert_data(self, uri: str, workspace_name, results) -> None:
+        from google.cloud import bigquery
 
         # TODO: create these tables
         exp_table_id = "{uri}.{table_name}".format(uri=uri, table_name="experiments")
@@ -128,13 +130,13 @@ class BigQueryUploader(Uploader):
             experiment.generate_hash()
             experiment.bulk_hash = exps_hash
 
-            exps_to_insert.append( experiment.to_json() )
+            exps_to_insert.append(experiment.to_json())
 
             for fom in experiment.foms:
                 fom_data = fom
                 fom_data['experiment_id'] = experiment.get_hash()
                 fom_data['experiment_name'] = experiment.name
-                foms_to_insert.append( fom_data )
+                foms_to_insert.append(fom_data)
 
         tty.debug("Experiments to insert:")
         tty.debug(exps_to_insert)
@@ -145,36 +147,33 @@ class BigQueryUploader(Uploader):
         if errors1 == []:
             errors2 = client.insert_rows_json(fom_table_id, foms_to_insert)
 
-        for errors, name in zip([errors1, errors2], ['exp','fom']):
+        for errors, name in zip([errors1, errors2], ['exp', 'fom']):
             if errors == []:
                 tty.msg("New rows have been added in {}.".format(name))
             else:
                 tty.die("Encountered errors while inserting rows: {}".format(errors))
 
-
     def perform_upload(self, uri, workspace_name, results):
         super().perform_upload(uri, workspace_name, results)
 
         # import spack.util.spack_json as sjson
-        #json_str = sjson.dump(results)
+        # json_str = sjson.dump(results)
 
         self.insert_data(uri, workspace_name, results)
 
-    def get_max_current_id(uri, table):
+    # def get_max_current_id(uri, table):
         # TODO: Generating an id based on the max in use id is dangerous, and
         # technically gives a race condition in parallel, and should be done in
         # a more graceful and scalable way..  like hashing the experiment? or
         # generating a known unique id for it
-        query = "SELECT MAX(id) FROM `{uri}.{table}` LIMIT 1".format(uri = uri, table = table)
-        query_job = client.query(query)
-        results = query_job.result()  # Waits for job to complete.
-        return results[0]
-
+        # query = "SELECT MAX(id) FROM `{uri}.{table}` LIMIT 1".format(uri=uri, table=table)
+        # query_job = client.query(query)
+        # results = query_job.result()  # Waits for job to complete.
+        # return results[0]
 
     def get_expierment_id(experiment):
-        #get_max_current_id(...) # Warning: dangerous..
+        # get_max_current_id(...) # Warning: dangerous..
 
         # This should be stable per machine/python version, but is not
         # guarnteed to be globally stable
-        return hash(json.dumps(expiriment, sort_keys=True))
-
+        return hash(json.dumps(experiment, sort_keys=True))

--- a/lib/ramble/ramble/experimental/uploader.py
+++ b/lib/ramble/ramble/experimental/uploader.py
@@ -1,3 +1,11 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
 import llnl.util.tty as tty
 import json
 

--- a/lib/ramble/ramble/schema/config.py
+++ b/lib/ramble/ramble/schema/config.py
@@ -59,6 +59,20 @@ properties['config']['workspace_dirs'] = {
     'default': '$ramble/var/ramble/workspaces'
 }
 
+properties['config']['upload'] = {
+    'type': 'object',
+    'properties': {
+        'uri': {
+            'type': 'string',
+            'default': ''
+        },
+        'type': {
+            'type': 'string',
+            'default': 'BigQuery'
+        },
+    }
+}
+
 #: Full schema with metadata
 schema = {
     '$schema': 'http://json-schema.org/schema#',

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1120,8 +1120,9 @@ class Workspace(object):
             # Read upload type and push it there
             if ramble.config.get('config:upload:type') == 'BigQuery':  # TODO: enum?
                 formatted_data = ramble.experimental.uploader.format_data(self.results)
-                uploader = ramble.experimental.uploader.BigQueryUploader() # TODO: strategy object?
 
+                # TODO: strategy object?
+                uploader = ramble.experimental.uploader.BigQueryUploader()
 
                 uri = ramble.config.get('config:upload:uri')
                 if not uri:
@@ -1133,11 +1134,11 @@ class Workspace(object):
                 raise ConfigError("Unknown config:upload:type value")
 
         else:
-           raise ConfigError("Missing correct conifg:upload parameters" )
+            raise ConfigError("Missing correct conifg:upload parameters")
 
     def append_result(self, result):
         if not self.results:
-            self.results = { 'experiments': [] }
+            self.results = {'experiments': []}
 
         self.results['experiments'].append(result)
 

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -630,7 +630,7 @@ _ramble_workspace_setup() {
 }
 
 _ramble_workspace_analyze() {
-    RAMBLE_COMPREPLY="-h --help -f --formats"
+    RAMBLE_COMPREPLY="-h --help -f --formats -u --upload"
 }
 
 _ramble_workspace_info() {


### PR DESCRIPTION
This PR adds the `ramble workspace analyze --upload` command to push results into a database (targeting bigQuery first). I've added most of this logic in the experimental namespace, as it's likely to change

It includes a few other changes:

- Adds general uploader logic / command
- Restructure the main results dict to be more list centric and database-like 
- Adds config:upload block 

There are some design decisions around how we want to integrate this into main line (should it live along side the code? should it be a submodule?) so opening this kick off those discussions 