### PR TITLE
Convert spack_setup to builtins

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -356,6 +356,9 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                 del self.variables['executable_name']
 
         self.variables['command'] = '\n'.join(command)
+
+        # TODO (dwj): Remove this after we validate that 'spack_setup' is not in templates.
+        #             this is no longer needed, as spack was converted to builtins.
         self.variables['spack_setup'] = ''
 
         # Define variables for template paths

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -87,7 +87,8 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
 
         for workload, wl_conf in self.workloads.items():
             if self._workload_exec_key in wl_conf:
-                for builtin in required_builtins:
+                # Insert in reverse order, to make sure they are correctly ordered.
+                for builtin in reversed(required_builtins):
                     if builtin not in wl_conf[self._workload_exec_key]:
                         wl_conf[self._workload_exec_key].insert(0, builtin)
 

--- a/lib/ramble/ramble/language/application_language.py
+++ b/lib/ramble/ramble/language/application_language.py
@@ -402,6 +402,7 @@ def register_builtin(name, required=False):
     ```
     """
     def _store_builtin(app):
-        app.builtins[f'builtin::{name}'] = {'name': name,
-                                            'required': required}
+        builtin_name = f'builtin::{name}'
+        app.builtins[builtin_name] = {'name': name,
+                                      'required': required}
     return _store_builtin

--- a/lib/ramble/ramble/spack_runner.py
+++ b/lib/ramble/ramble/spack_runner.py
@@ -91,26 +91,49 @@ class SpackRunner(object):
         self.includes = []
         self.dry_run = dry_run
 
+    def set_dry_run(self, dry_run=False):
+        """
+        Set the dry_run state of this spack runner
+        """
+        self.dry_run = dry_run
+
     def set_env(self, env_path):
         if not os.path.isdir(env_path) or not os.path.exists(os.path.join(env_path, 'spack.yaml')):
             tty.die(f'Path {env_path} is not a spack environment')
 
         self.env_path = env_path
 
-    def generate_expand_vars(self, shell='bash'):
+    def generate_source_command(self, shell='bash'):
         """
-        Generate a string to load a spack environment within a generated
-        script.
+        Generate a string to source spack into an environment
         """
 
-        commands = ['source %s' % self.source_script]
+        commands = ['. %s' % self.source_script]
 
+        return commands
+
+    def generate_activate_command(self, shell='bash'):
+        """
+        Generate a string to activate a spack environment
+        """
+
+        commands = []
         if self.active:
             commands.append('spack env activate %s' % self.env_path)
 
-        commands.append('source %s/loads' % self.env_path)
+        return commands
 
-        return '\n'.join(commands)
+    def generate_deactivate_command(self, shell='bash'):
+        """
+        Generate a string to deactivate a spack environment
+        """
+
+        commands = []
+
+        if self.active:
+            commands.append('spack env deactivate')
+
+        return commands
 
     def configure_env(self, path):
         """

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -166,8 +166,6 @@ template_execute_script = """\
 # Some example variables are:
 #   - experiment_run_dir (Will be replaced with the experiment directory)
 #   - command (Will be replaced with the command to run the experiment)
-#   - spack_setup (Will be replaced with the commands needed to setup
-#                  and load a spack environment for a given experiment)
 #   - log_dir (Will be replaced with the logs directory)
 #   - experiment_name (Will be replaced with the name of the experiment)
 #   - workload_run_dir (Will be replaced with the directory of the workload
@@ -176,8 +174,6 @@ template_execute_script = """\
 #   Any experiment parameters will be available as variables as well.
 
 cd "{experiment_run_dir}"
-
-{spack_setup}
 
 {command}
 """


### PR DESCRIPTION
This merge migrates the previously defined `spack_setup` variable to use builtins that are registered in the spack application class.

These are automatically added to all spack application instances.

Additionally, a `builtin::spack_deactivate` builtin is added, to help with more complicate spack experiments that might need to deactivate and reactivate spack environments.