### PR TITLE
Fix ramble commands when requirements are not installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ These can include anything from:
  - Performance focused scalaing studies
  - Compiler flag sweeps
 
-To install ramble and configure your experiment workspace, make sure you have Python.
+To install ramble and configure your experiment workspace, make sure you have
+Python, and Ramble’s dependencies are installed as per the dependency section
+below.
 Then:
 
     $ git clone -c feature.manyFiles=true https://github.com/GoogleCloudPlatform/ramble.git

--- a/lib/ramble/ramble/cmd/unit_test.py
+++ b/lib/ramble/ramble/cmd/unit_test.py
@@ -13,9 +13,9 @@ import collections
 import sys
 import re
 import argparse
-import pytest
 from six import StringIO
 
+import llnl.util.tty as tty
 import llnl.util.tty.color as color
 from llnl.util.filesystem import working_dir
 from llnl.util.tty.colify import colify
@@ -75,7 +75,11 @@ def do_list(args, extra_args):
     old_output = sys.stdout
     try:
         sys.stdout = output = StringIO()
-        pytest.main(['--collect-only'] + extra_args)
+        try:
+            import pytest
+            pytest.main(['--collect-only'] + extra_args)
+        except ImportError:
+            tty.die('Pytest python module not found. Ensure requirements.txt are installed.')
     finally:
         sys.stdout = old_output
 
@@ -156,7 +160,11 @@ def unit_test(parser, args, unknown_args):
     if args.pytest_help:
         # make the pytest.main help output more accurate
         sys.argv[0] = 'ramble test'
-        return pytest.main(['-h'])
+        try:
+            import pytest
+            return pytest.main(['-h'])
+        except ImportError:
+            tty.die('Pytest python module not found. Ensure requirements.txt are installed.')
 
     # add back any parsed pytest args we need to pass to pytest
     pytest_args = add_back_pytest_args(args, unknown_args)
@@ -176,4 +184,8 @@ def unit_test(parser, args, unknown_args):
             return
 
         with ramble.workspace.no_active_workspace():
-            return pytest.main(pytest_args)
+            try:
+                import pytest
+                return pytest.main(pytest_args)
+            except ImportError:
+                tty.die('Pytest python module not found. Ensure requirements.txt are installed.')

--- a/share/ramble/cloud-build/ramble-pr-validation.yaml
+++ b/share/ramble/cloud-build/ramble-pr-validation.yaml
@@ -101,6 +101,37 @@ steps:
         exit $$error
     id: ramble-tests
     entrypoint: sh
+  - name: spack/centos7
+    args:
+      - '-c'
+      - |
+        export PATH="$$(. /opt/spack/share/spack/setup-env.sh && spack location -i miniconda3)/bin:$${PATH}"
+        conda uninstall --force-remove pytest
+        yum install -y -q which mercurial
+
+        cd /workspace
+
+        git branch develop origin/develop
+
+        . /opt/spack/share/spack/setup-env.sh
+        . /workspace/share/ramble/setup-env.sh
+
+        ramble help
+        # $$ characters are required for cloud-build:
+        # https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values
+        missing_req_err=$$?
+
+        if [ $$missing_req_err -gt 0 ]; then
+          echo " ***** Ramble failed to work when requirements.txt were not installed"
+          error=1
+        fi
+
+        # $$ characters are required for cloud-build:
+        # https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values
+        exit $$error
+    id: ramble-missing-req-test
+    entrypoint: sh
+
 timeout: 600s
 options:
   machineType: N1_HIGHCPU_8


### PR DESCRIPTION
This merge adds tests, and fixes ramble commands (such as `ramble help`) when requirements are not installed.

Fixes #70 