### PR TITLE
Revive unused code path in workspace for includes

### DIFF
--- a/lib/ramble/ramble/schema/merged.py
+++ b/lib/ramble/ramble/schema/merged.py
@@ -20,7 +20,7 @@ import ramble.schema.workspace
 
 #: Properties for inclusion in other schemas
 properties = union_dicts(
-    ramble.schema.applications.properties,
+    ramble.schema.applications.applications_schema,
     ramble.schema.config.properties,
     ramble.schema.repos.properties,
     ramble.schema.workspace.properties

--- a/lib/ramble/ramble/test/data/config/config.yaml
+++ b/lib/ramble/ramble/test/data/config/config.yaml
@@ -3,3 +3,5 @@ config:
     spack_flags:
       install: --reuse
       concretize: --reuse
+    include:
+      - test_include: include.yaml

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -42,6 +42,7 @@ import spack.util.web as web_util
 
 import ramble.schema.workspace
 import ramble.schema.applications
+import ramble.schema.merged
 
 import ramble.util.lock as lk
 from ramble.util.path import substitute_path_variables


### PR DESCRIPTION
Previously this code path was not used anywhere (either in known prod or testing) and thus got broken during updates

This PR both fixes it and adds a test to cover it (woo increased coverage!)