### PR TITLE
Add test hostname workload with no inputs

### DIFF
--- a/var/ramble/repos/builtin/applications/hostname/application.py
+++ b/var/ramble/repos/builtin/applications/hostname/application.py
@@ -23,6 +23,7 @@ class Hostname(ExecutableApplication):
 
     workload('serial', executable='serial', inputs=['test'])
     workload('parallel', executable='parallel', inputs=['test'])
+    workload('test', executable='parallel')
 
     figure_of_merit('user time', log_file='{experiment_run_dir}/{experiment_name}.out',
                     fom_regex=r'(?P<user_time>[0-9]+\.[0-9]+)user.*',

--- a/var/ramble/repos/builtin/applications/hostname/application.py
+++ b/var/ramble/repos/builtin/applications/hostname/application.py
@@ -16,14 +16,13 @@ class Hostname(ExecutableApplication):
 
     tags = ["test-app"]
 
-    input_file('test', url="https://no.domain/file/test_dir.tgz", description="Test file...")
+    input_file('test', url="https://no.domain/file/test_dir.tgz", description="Example input file...")
 
     executable('serial', '/usr/bin/time hostname', use_mpi=False)
     executable('parallel', '/usr/bin/time hostname', use_mpi=True)
 
-    workload('serial', executable='serial', inputs=['test'])
-    workload('parallel', executable='parallel', inputs=['test'])
-    workload('test', executable='parallel')
+    workload('serial', executable='serial')
+    workload('parallel', executable='parallel')
 
     figure_of_merit('user time', log_file='{experiment_run_dir}/{experiment_name}.out',
                     fom_regex=r'(?P<user_time>[0-9]+\.[0-9]+)user.*',


### PR DESCRIPTION
Inputs are broken, making non of the currently workloads easily usable 