### PR TITLE
Add Sphinx config

### DIFF
--- a/bin/ramble
+++ b/bin/ramble
@@ -1,3 +1,4 @@
+#!/bin/sh
 # Copyright 2022-2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or

--- a/lib/ramble/docs/conf.py
+++ b/lib/ramble/docs/conf.py
@@ -4,9 +4,9 @@
 # https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed
+# except according to those terms.
 
 import os
-import re
 import subprocess
 import sys
 from glob import glob
@@ -16,6 +16,13 @@ from sphinx.domains.python import PythonDomain
 from sphinx.ext.apidoc import main as sphinx_apidoc
 from sphinx.parsers import RSTParser
 
+# The name of the Pygments (syntax highlighting) style to use.
+# We use our own extension of the default style with a few modifications
+from pygments.styles.default import DefaultStyle
+from pygments.token import Generic
+
+import pkg_resources
+
 # -- Ramble customizations -----------------------------------------------------
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -23,8 +30,11 @@ from sphinx.parsers import RSTParser
 link_name = os.path.abspath("_ramble_root")
 if not os.path.exists(link_name):
     os.symlink(os.path.abspath("../../.."), link_name, target_is_directory=True)
+
 sys.path.insert(0, os.path.abspath("_ramble_root/lib/ramble/external"))
 sys.path.append(os.path.abspath("_ramble_root/lib/ramble/"))
+
+import ramble  # noqa: E402
 
 # Add the Ramble bin directory to the path so that we can use its output in docs.
 os.environ["RAMBLE_ROOT"] = os.path.abspath("_ramble_root")
@@ -74,6 +84,7 @@ sphinx_apidoc(
 # Enable todo items
 todo_include_todos = True
 
+
 #
 # Disable duplicate cross-reference warnings.
 #
@@ -117,7 +128,6 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
-    #"sphinx_design",
     "sphinxcontrib.programoutput",
 ]
 
@@ -154,8 +164,6 @@ copyright = "2022-2023, Google LLC"
 # built documents.
 #
 # The short X.Y version.
-import ramble
-
 version = ".".join(str(s) for s in ramble.ramble_version_info[:2])
 # The full version, including alpha/beta/rc tags.
 release = ramble.ramble_version
@@ -209,12 +217,6 @@ nitpick_ignore = [
 # output. They are ignored by default.
 # show_authors = False
 
-# The name of the Pygments (syntax highlighting) style to use.
-# We use our own extension of the default style with a few modifications
-from pygments.style import Style
-from pygments.styles.default import DefaultStyle
-from pygments.token import Comment, Generic, Text
-
 
 class RambleStyle(DefaultStyle):
     styles = DefaultStyle.styles.copy()
@@ -223,15 +225,11 @@ class RambleStyle(DefaultStyle):
     styles[Generic.Prompt] = "bold #346ec9"
 
 
-import pkg_resources
-
 dist = pkg_resources.Distribution(__file__)
 sys.path.append(".")  # make 'conf' module findable
 ep = pkg_resources.EntryPoint.parse("ramble = conf:RambleStyle", dist=dist)
 dist._ep_map = {"pygments.styles": {"plugin1": ep}}
 pkg_resources.working_set.add(dist)
-
-#pygments_style = "ramble"
 
 # A list of ignored prefixes for module index sorting.
 # modindex_common_prefix = []
@@ -321,11 +319,11 @@ htmlhelp_basename = "Rambledoc"
 
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
-    #'papersize': 'letterpaper',
+    # 'papersize': 'letterpaper',
     # The font size ('10pt', '11pt' or '12pt').
-    #'pointsize': '10pt',
+    # 'pointsize': '10pt',
     # Additional stuff for the LaTeX preamble.
-    #'preamble': '',
+    # 'preamble': '',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples

--- a/lib/ramble/docs/conf.py
+++ b/lib/ramble/docs/conf.py
@@ -1,0 +1,399 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+
+import os
+import re
+import subprocess
+import sys
+from glob import glob
+
+from docutils.statemachine import StringList
+from sphinx.domains.python import PythonDomain
+from sphinx.ext.apidoc import main as sphinx_apidoc
+from sphinx.parsers import RSTParser
+
+# -- Ramble customizations -----------------------------------------------------
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+link_name = os.path.abspath("_ramble_root")
+if not os.path.exists(link_name):
+    os.symlink(os.path.abspath("../../.."), link_name, target_is_directory=True)
+sys.path.insert(0, os.path.abspath("_ramble_root/lib/ramble/external"))
+sys.path.append(os.path.abspath("_ramble_root/lib/ramble/"))
+
+# Add the Ramble bin directory to the path so that we can use its output in docs.
+os.environ["RAMBLE_ROOT"] = os.path.abspath("_ramble_root")
+os.environ["PATH"] += "%s%s" % (os.pathsep, os.path.abspath("_ramble_root/bin"))
+
+# Set an environment variable so that colify will print output like it would to
+# a terminal.
+os.environ["COLIFY_SIZE"] = "25x120"
+os.environ["COLUMNS"] = "120"
+
+# Generate full package list if needed
+subprocess.call(["ramble", "list", "--format=html", "--update=package_list.html"])
+
+# Generate a command index if an update is needed
+subprocess.call(
+    [
+        "ramble",
+        "commands",
+        "--format=rst",
+        "--update=command_index.rst",
+    ]
+    + glob("*rst")
+)
+
+#
+# Run sphinx-apidoc
+#
+# Remove any previous API docs
+# Read the Docs doesn't clean up after previous builds
+# Without this, the API Docs will never actually update
+#
+apidoc_args = [
+    "--force",  # Overwrite existing files
+    "--no-toc",  # Don't create a table of contents file
+    "--output-dir=.",  # Directory to place all output
+    "--module-first",  # emit module docs before submodule docs
+]
+sphinx_apidoc(
+    apidoc_args
+    + [
+        "_ramble_root/lib/ramble/ramble",
+        "_ramble_root/lib/ramble/ramble/test/*.py",
+        "_ramble_root/lib/ramble/ramble/test/cmd/*.py",
+    ]
+)
+
+# Enable todo items
+todo_include_todos = True
+
+#
+# Disable duplicate cross-reference warnings.
+#
+class PatchedPythonDomain(PythonDomain):
+    def resolve_xref(self, env, fromdocname, builder, typ, target, node, contnode):
+        if "refspecific" in node:
+            del node["refspecific"]
+        return super(PatchedPythonDomain, self).resolve_xref(
+            env, fromdocname, builder, typ, target, node, contnode
+        )
+
+
+#
+# Disable tabs to space expansion in code blocks
+# since Makefiles require tabs.
+#
+class NoTabExpansionRSTParser(RSTParser):
+    def parse(self, inputstring, document):
+        if isinstance(inputstring, str):
+            lines = inputstring.splitlines()
+            inputstring = StringList(lines, document.current_source)
+        super().parse(inputstring, document)
+
+
+def setup(sphinx):
+    sphinx.add_domain(PatchedPythonDomain, override=True)
+    sphinx.add_source_parser(NoTabExpansionRSTParser, override=True)
+
+
+# -- General configuration -----------------------------------------------------
+
+# If your documentation needs a minimal Sphinx version, state it here.
+needs_sphinx = "3.4"
+
+# Add any Sphinx extension module names here, as strings. They can be extensions
+# coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.graphviz",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.todo",
+    "sphinx.ext.viewcode",
+    #"sphinx_design",
+    "sphinxcontrib.programoutput",
+]
+
+# Set default graphviz options
+graphviz_dot_args = [
+    "-Grankdir=LR",
+    "-Gbgcolor=transparent",
+    "-Nshape=box",
+    "-Nfontname=monaco",
+    "-Nfontsize=10",
+]
+
+# Get nice vector graphics
+graphviz_output_format = "svg"
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ["_templates"]
+
+# The suffix of source filenames.
+source_suffix = ".rst"
+
+# The encoding of source files.
+source_encoding = "utf-8-sig"
+
+# The master toctree document.
+master_doc = "index"
+
+# General information about the project.
+project = "Ramble"
+copyright = "2022-2023, Google LLC"
+
+# The version info for the project you're documenting, acts as replacement for
+# |version| and |release|, also used in various other places throughout the
+# built documents.
+#
+# The short X.Y version.
+import ramble
+
+version = ".".join(str(s) for s in ramble.ramble_version_info[:2])
+# The full version, including alpha/beta/rc tags.
+release = ramble.ramble_version
+
+# The language for content autogenerated by Sphinx. Refer to documentation
+# for a list of supported languages.
+# language = None
+
+# Places to look for .po/.mo files for doc translations
+# locale_dirs = []
+
+# Sphinx gettext settings
+gettext_compact = True
+gettext_uuid = False
+
+# There are two options for replacing |today|: either, you set today to some
+# non-false value, then it is used:
+# today = ''
+# Else, today_fmt is used as the format for a strftime call.
+# today_fmt = '%B %d, %Y'
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+exclude_patterns = ["_build", "_ramble_root"]
+
+nitpicky = True
+nitpick_ignore = [
+    # Python classes that intersphinx is unable to resolve
+    ("py:class", "argparse.HelpFormatter"),
+    ("py:class", "contextlib.contextmanager"),
+    ("py:class", "module"),
+    ("py:class", "_io.BufferedReader"),
+    ("py:class", "unittest.case.TestCase"),
+    ("py:class", "_frozen_importlib_external.SourceFileLoader"),
+    ("py:class", "clingo.Control"),
+    ("py:class", "six.moves.urllib.parse.ParseResult"),
+    ("py:class", "TextIO"),
+]
+
+# The reST default role (used for this markup: `text`) to use for all documents.
+# default_role = None
+
+# If true, '()' will be appended to :func: etc. cross-reference text.
+# add_function_parentheses = True
+
+# If true, the current module name will be prepended to all description
+# unit titles (such as .. function::).
+# add_module_names = True
+
+# If true, sectionauthor and moduleauthor directives will be shown in the
+# output. They are ignored by default.
+# show_authors = False
+
+# The name of the Pygments (syntax highlighting) style to use.
+# We use our own extension of the default style with a few modifications
+from pygments.style import Style
+from pygments.styles.default import DefaultStyle
+from pygments.token import Comment, Generic, Text
+
+
+class RambleStyle(DefaultStyle):
+    styles = DefaultStyle.styles.copy()
+    background_color = "#f4f4f8"
+    styles[Generic.Output] = "#355"
+    styles[Generic.Prompt] = "bold #346ec9"
+
+
+import pkg_resources
+
+dist = pkg_resources.Distribution(__file__)
+sys.path.append(".")  # make 'conf' module findable
+ep = pkg_resources.EntryPoint.parse("ramble = conf:RambleStyle", dist=dist)
+dist._ep_map = {"pygments.styles": {"plugin1": ep}}
+pkg_resources.working_set.add(dist)
+
+#pygments_style = "ramble"
+
+# A list of ignored prefixes for module index sorting.
+# modindex_common_prefix = []
+
+
+# -- Options for HTML output ---------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+html_theme = "sphinx_rtd_theme"
+
+# Theme options are theme-specific and customize the look and feel of a theme
+# further.  For a list of options available for each theme, see the
+# documentation.
+html_theme_options = {"logo_only": True}
+
+# Add any paths that contain custom themes here, relative to this directory.
+# html_theme_path = ["_themes"]
+
+# The name for this set of Sphinx documents.  If None, it defaults to
+# "<project> v<release> documentation".
+# html_title = None
+
+# A shorter title for the navigation bar.  Default is the same as html_title.
+# html_short_title = None
+
+# The name of an image file (relative to this directory) to place at the top
+# of the sidebar.
+# html_logo = "_ramble_root/share/ramble/logo/ramble-logo-white-text.svg"
+
+# The name of an image file (within the static path) to use as favicon of the
+# docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
+# pixels large.
+# html_favicon = "_ramble_root/share/ramble/logo/favicon.ico"
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+# html_static_path = ["_static"]
+
+# If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
+# using the given strftime format.
+html_last_updated_fmt = "%b %d, %Y"
+
+# If true, SmartyPants will be used to convert quotes and dashes to
+# typographically correct entities.
+# html_use_smartypants = True
+
+# Custom sidebar templates, maps document names to template names.
+# html_sidebars = {}
+
+# Additional templates that should be rendered to pages, maps page names to
+# template names.
+# html_additional_pages = {}
+
+# If false, no module index is generated.
+# html_domain_indices = True
+
+# If false, no index is generated.
+# html_use_index = True
+
+# If true, the index is split into individual pages for each letter.
+# html_split_index = False
+
+# If true, links to the reST sources are added to the pages.
+# html_show_sourcelink = True
+
+# If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
+# html_show_sphinx = False
+
+# If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
+# html_show_copyright = True
+
+# If true, an OpenSearch description file will be output, and all pages will
+# contain a <link> tag referring to it.  The value of this option must be the
+# base URL from which the finished HTML is served.
+# html_use_opensearch = ''
+
+# This is the file name suffix for HTML files (e.g. ".xhtml").
+# html_file_suffix = None
+
+# Output file base name for HTML help builder.
+htmlhelp_basename = "Rambledoc"
+
+
+# -- Options for LaTeX output --------------------------------------------------
+
+latex_elements = {
+    # The paper size ('letterpaper' or 'a4paper').
+    #'papersize': 'letterpaper',
+    # The font size ('10pt', '11pt' or '12pt').
+    #'pointsize': '10pt',
+    # Additional stuff for the LaTeX preamble.
+    #'preamble': '',
+}
+
+# Grouping the document tree into LaTeX files. List of tuples
+# (source start file, target name, title, author, documentclass [howto/manual]).
+latex_documents = [
+    ("index", "Ramble.tex", "Ramble Documentation", "Google LLC", "manual"),
+]
+
+# The name of an image file (relative to this directory) to place at the top of
+# the title page.
+# latex_logo = None
+
+# For "manual" documents, if this is true, then toplevel headings are parts,
+# not chapters.
+# latex_use_parts = False
+
+# If true, show page references after internal links.
+# latex_show_pagerefs = False
+
+# If true, show URL addresses after external links.
+# latex_show_urls = False
+
+# Documents to append as an appendix to all manuals.
+# latex_appendices = []
+
+# If false, no module index is generated.
+# latex_domain_indices = True
+
+
+# -- Options for manual page output --------------------------------------------
+
+# One entry per manual page. List of tuples
+# (source start file, name, description, authors, manual section).
+man_pages = [("index", "Ramble", "Ramble Documentation", ["Google LLC"], 1)]
+
+# If true, show URL addresses after external links.
+# man_show_urls = False
+
+
+# -- Options for Texinfo output ------------------------------------------------
+
+# Grouping the document tree into Texinfo files. List of tuples
+# (source start file, target name, title, author,
+#  dir menu entry, description, category)
+texinfo_documents = [
+    (
+        "index",
+        "Ramble",
+        "Ramble Documentation",
+        "Ramble",
+        "One line description of project.",
+        "Miscellaneous",
+    ),
+]
+
+# Documents to append as an appendix to all manuals.
+# texinfo_appendices = []
+
+# If false, no module index is generated.
+# texinfo_domain_indices = True
+
+# How to display URL addresses: 'footnote', 'no', or 'inline'.
+# texinfo_show_urls = 'footnote'
+
+
+# -- Extension configuration -------------------------------------------------
+
+# sphinx.ext.intersphinx
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+}

--- a/lib/ramble/docs/getting_started.rst
+++ b/lib/ramble/docs/getting_started.rst
@@ -6,12 +6,14 @@
    option. This file may not be copied, modified, or distributed
    except according to those terms.
 
+.. getting_started:
+
 ===============
 Getting Started
 ===============
 
 --------------------
-System Requirements:
+System Requirements
 --------------------
 
 Ramble's dependencies are listed within the top level
@@ -20,30 +22,31 @@ requirements.txt file.
 In addition to the listed python dependencies, Ramble depends on
 spack for some application definition files.
 
-Please see `Spack's documentation<https://spack.readthedocs.io/en/latest/getting_started.html>`_
-for getting spack installed.
+Please see Spack's `documentation <https://spack.readthedocs.io/en/latest/getting_started.html>`_ for getting spack installed.
 
 
 -------------
-Installation:
+Installation
 -------------
 
 Installing ramble is easy. You can clone it from the
-`github repository<https://github.com/GoogleCloudPlatform/ramble>`_ using this command:
+`github repository <https://github.com/GoogleCloudPlatform/ramble>`_ using this command:
 
 .. code-block:: console
+
    $ git clone -c feature.manyFiles=true https://github.com/GoogleCloudPlatform/ramble.git
 
 
 This will create a directory called ``ramble``.
 
 ^^^^^^^^^^^^^^
-Shell Support:
+Shell Support
 ^^^^^^^^^^^^^^
 
 Once you have cloned Ramble, we recommend sourcing the appropriate script for your shell:
 
 .. code-block:: console
+
    # For bash/zsh/sh
    $ . ramble/share/ramble/setup-env.sh
 
@@ -70,40 +73,44 @@ environment.
 
 
 -------------
-Command Help:
+Command Help
 -------------
 To get information on the available commands, you can execute:
 
 .. code-block:: console
+
     $ ramble help --all
 
 
 For help with sub-commands, the ``-h`` flag can be used:
 
 .. code-block:: console
+  
    $ ramble <subcommand> -h
 
 
 ---------------------
-Defined Applications:
+Defined Applications
 ---------------------
 
 In order to get information about the available applications defined within
 ``ramble``, you can use the command:
 
 .. code-block:: console
+
    $ ramble list
 
 
 This command uses filtering to search the defined applications, e.g.:
 
 .. code-block:: console
+
    $ ramble list wrf
 
 will list both ``wrfv3`` and ``wrfv4``.
 
 ------------------
-Ramble Workspaces:
+Ramble Workspaces
 ------------------
 
 To configure experiments, you need to use a Ramble workspace. A workspace is a
@@ -125,12 +132,13 @@ A workspace can be selected when executing ``ramble`` through the use of the
 ``-w`` and ``-D`` flags.
 
 ^^^^^^^^^^^^^^^^^^^^
-Creating Workspaces:
+Creating Workspaces
 ^^^^^^^^^^^^^^^^^^^^
 
 To create a new Ramble workspace, you can use:
 
 .. code-block:: console
+
     $ ramble workspace create [<name>] [-d <path>]
 
 Once a workspace is created, you can activate the workspace. This allows some
@@ -138,15 +146,17 @@ subsequent commands to work without explicitly passing in a workspace. This
 is done through:
 
 .. code-block:: console
+
     $ ramble workspace activate [<name>/<path>]
 
 With an activated workspace, you can get information about the workspace with:
 
 .. code-block:: console
+
     $ ramble workspace info
 
 ^^^^^^^^^^^^^^^^^^^^^^^^
-Configuring A Workspace:
+Configuring A Workspace
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 Within the created workspace, a ``configs`` directory is created to house the
@@ -155,6 +165,7 @@ configuration files.
 A newly created workspace will contain:
 
 .. code-block:: console
+
    - configs
      | - ramble.yaml
      | - execute_experiment.tpl
@@ -166,8 +177,8 @@ a "rendered" version within every experiment directory.
 These files can be edited with your favorite editor, or though the command:
 
 .. code-block:: console
+
     $ ramble workspace edit
-```
 
 Flags exist to control whether you want to edit a template file, or the
 configuration file.
@@ -176,6 +187,7 @@ Variables are defined of the format ``{file_prefix}``, that contain the path to
 the rendered version within every experiment. As an example:
 
 .. code-block:: console
+
     configs/execute_experiment.tpl
 
 Will define ``{execute_experiment}`` with a value set to the path of hte
@@ -183,7 +195,7 @@ generated file.
 (More explicitly, ``execute_experiment={experiment_run_dir}/{template_name_sans_extension}``)
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-Concretizing A Workspace:
+Concretizing A Workspace
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 After configuring a workspace with applications, workloads, and experiments,
@@ -191,6 +203,7 @@ Ramble can be used to inject default software configurations for the requested
 experiments. To do this, you can use the:
 
 .. code-block:: console
+
     $ ramble workspace concretize
 
 This will fill out the ``spack`` dictionary within the ``ramble.yaml`` file
@@ -198,12 +211,13 @@ with defaults. The defaults can be configured however you want before
 installing the actual software.
 
 ^^^^^^^^^^^^^^^^^^^^^^^
-Setting Up A Workspace:
+Setting Up A Workspace
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 Once a workspace is concretized, it can be set up. This process is executed through:
 
 .. code-block:: console
+
     $ ramble workspace setup
 
 The setup action will:
@@ -213,25 +227,27 @@ The setup action will:
  - Create the ``all_experiments`` script
 
 ^^^^^^^^^^^^^^^^^^^^^^
-Executing Experiments:
+Executing Experiments
 ^^^^^^^^^^^^^^^^^^^^^^
 
 After the workspace is set up, its experiments can be executed. The two methods
 to run the experiments are:
 
 .. code-block:: console
+   
     $ ramble on
    or;
     $ ./all_experiments
 
 ^^^^^^^^^^^^^^^^^^^^^^
-Analyzing Experiments:
+Analyzing Experiments
 ^^^^^^^^^^^^^^^^^^^^^^
 
 Once the experiments within a workspace are complete, the experiments can be
 analyzed. This is done through:
 
 .. code-block:: console
+
     $ ramble workspace analyze
 
 This creates a ``results`` file in the root of the workspace that contains
@@ -239,7 +255,7 @@ extracted figures of merit.
 
 
 ^^^^^^^^^^^^^^^^^^^^^^
-Archiving A Workspace:
+Archiving A Workspace
 ^^^^^^^^^^^^^^^^^^^^^^
 
 Ramble can create an archive of a workspace. This is a self contained copy of various important aspects of the workspace, including:
@@ -252,9 +268,11 @@ Ramble can create an archive of a workspace. This is a self contained copy of va
 You can archive a workspace with:
 
 .. code-block:: console
+
     $ ramble workspace archive
 
 And you can create a tar-ball with:
 
 .. code-block:: console
+
     $ ramble workspace archive -t

--- a/lib/ramble/docs/index.rst
+++ b/lib/ramble/docs/index.rst
@@ -2,9 +2,7 @@
 Ramble
 ===================
 
-If you're new to Ramble and want to start using it, see :doc:`getting_started`,
-or refer to the full manual below.
-
+If you're new to Ramble and want to start using it, see :doc:`getting_started`.
 
 .. toctree::
    :maxdepth: 2
@@ -24,6 +22,7 @@ or refer to the full manual below.
    :maxdepth: 2
    :caption: Contributing
 
+   Contributing Guidelines <https://github.com/GoogleCloudPlatform/ramble#contributing>
    developer_guide
 
 .. toctree::

--- a/lib/ramble/docs/index.rst
+++ b/lib/ramble/docs/index.rst
@@ -1,0 +1,41 @@
+===================
+Ramble
+===================
+
+If you're new to Ramble and want to start using it, see :doc:`getting_started`,
+or refer to the full manual below.
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Basics
+
+   ramble
+   getting_started
+   workspace_config
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Reference
+
+   command_index
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contributing
+
+   developer_guide
+
+.. toctree::
+   :maxdepth: 2
+   :caption: External Resources
+
+   Spack <https://github.com/spack/spack>
+
+==================
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/lib/ramble/docs/index.rst
+++ b/lib/ramble/docs/index.rst
@@ -1,3 +1,11 @@
+.. Copyright 2022-2023 Google LLC
+
+   Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+   https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+   <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+   option. This file may not be copied, modified, or distributed
+   except according to those terms.
+
 ===================
 Ramble
 ===================

--- a/lib/ramble/ramble/config.py
+++ b/lib/ramble/ramble/config.py
@@ -8,20 +8,19 @@
 """This module implements Ramble's configuration file handling.
 
 This implements Ramble's configuration system, which handles merging
-multiple scopes with different levels of precedence.  See the
-documentation on :ref:`configuration-scopes` for details on how Ramble's
-configuration system behaves.  The scopes are:
+multiple scopes with different levels of precedence.
+
+The scopes are:
 
   #. ``default``
   #. ``system``
   #. ``site``
   #. ``user``
 
-And corresponding :ref:`per-platform scopes <platform-scopes>`. Important
-functions in this module are:
+Important functions in this module are:
 
-* :py:func:`get_config`
-* :py:func:`update_config`
+* :py:func:`Configuration.get_config`
+* :py:func:`Configuration.update_config`
 
 ``get_config`` reads in YAML data for a particular scope and returns
 it. Callers can then modify the data and write it back with
@@ -1192,7 +1191,7 @@ def default_modify_scope(section='config'):
     priority scope.
 
     Arguments:
-        section (boolean): Section for which to get the default scope.
+        section (bool): Section for which to get the default scope.
             If this is not 'experiments', a general (non-workspace) scope is
             used.
     """

--- a/lib/ramble/ramble/fetch_strategy.py
+++ b/lib/ramble/ramble/fetch_strategy.py
@@ -1492,7 +1492,7 @@ def from_kwargs(**kwargs):
             ``version()`` directive in a package.
 
     Returns:
-        fetch_strategy: The fetch strategy that matches the args, based
+        FetchStrategy: The fetch strategy that matches the args, based
             on attribute names (e.g., ``git``, ``hg``, etc.)
 
     Raises:

--- a/lib/ramble/ramble/stage.py
+++ b/lib/ramble/ramble/stage.py
@@ -532,8 +532,8 @@ class InputStage(object):
         """Perform a fetch if the resource is not already cached
 
         Arguments:
-            mirror (MirrorCache): the mirror to cache this Stage's resource in
-            stats (MirrorStats): this is updated depending on whether the
+            mirror (ramble.caches.MirrorCache): the mirror to cache this Stage's resource in
+            stats (ramble.mirror.MirrorStats): this is updated depending on whether the
                 caching operation succeeded or failed
         """
         if isinstance(self.default_fetcher, fs.BundleFetchStrategy):
@@ -798,7 +798,7 @@ def get_checksums_for_versions(
     Args:
         url_dict (dict): A dictionary of the form: version -> URL
         name (str): The name of the input
-        first_stage_function (callable): function that takes a Stage and a URL;
+        first_stage_function (Callable): function that takes a Stage and a URL;
             this is run on the stage of the first URL downloaded
         keep_stage (bool): whether to keep staging area when command completes
         batch (bool): whether to ask user how many versions to fetch (false)

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -423,8 +423,9 @@ class Workspace(object):
 
     Each workspace must have a config directory, that contains 2
     files by default.
-       - ramble.yaml
-       - execute_experiment.tpl
+
+    - ramble.yaml
+    - execute_experiment.tpl
 
     The ramble.yaml file is the overall configuration file for
     this workspace. It defines all experiments, variables, and
@@ -1374,8 +1375,9 @@ class Workspace(object):
 
         None of the input, or output files aside from these are archived.
         However, the archive should useful to perform the following actions:
-         - Re-extract figures of merit based on previous experiments
-         - Regenerate experiments, using the archived configuration.
+
+        - Re-extract figures of merit based on previous experiments
+        - Regenerate experiments, using the archived configuration.
 
         If an archive url is configured for ramble at config:archive_url this
         will automatically upload tar archives to that location.


### PR DESCRIPTION
This add sphinx configs into `./lib/ramble/docs` so that a user can generate the html documentation offline. We should have a follow on task to generate documentation automatically and deploy it somewhere.

This can be used by doing

```
cd ./lib/ramble/docs
sphinx-build . out/
```
to generate html output in `./out`