### PR TITLE
Add yaml support for custom executables and executable order control

### DIFF
--- a/lib/ramble/docs/workspace_config.rst
+++ b/lib/ramble/docs/workspace_config.rst
@@ -275,6 +275,75 @@ In the above example, ``test_value`` extracts the value of ``real_value`` as
 defined in the experiment ``hostname.serial.test_exp1``. When evaluated, this
 will set ``test_value`` to ``'exp1_value'``.
 
+^^^^^^^^^^^^^^^^^^^^^^
+Controlling Internals:
+^^^^^^^^^^^^^^^^^^^^^^
+
+Within a workspace config, an internals dictionary can be used to control
+several internal aspects of the application, workload, and experiment.
+
+An internals dictionary can be defined anywhere a variables dictionary can be
+defined (i.e. within a workspace, a specific application, a specific workload,
+or a specific experiment). This section will describe the features available
+within the internals dictionary.
+
+"""""""""""""""""""
+Custom Executables:
+"""""""""""""""""""
+
+Custom executables can be created within the internals dictionary. Below is an
+example, showing how to create a ``lscpu`` executable at the application level.
+
+.. code-block:: yaml
+
+    ramble:
+      applications:
+        hostname:
+          internals:
+            custom_executables:
+              lscpu:
+                template:
+                - 'lscpu'
+                use_mpi: false
+                redirect: '{log_file}'
+         ...
+
+The above example creates a custom executable, named ``lscpu`` that will inject
+the command ``lscpu`` into the command for an experiment when it is used. It is
+important to note that this only creates the executable, and does not use it.
+
+
+"""""""""""""""""""""""""""""
+Controlling Executable Order:
+"""""""""""""""""""""""""""""
+
+The internals dictionary allows the ability to control the order pre-defined
+executables (or custom executables) are pieced together to build an experiment.
+
+.. code-block:: yaml
+
+   ramble:
+     applications:
+       hostname:
+         internals:
+           custom_executables:
+             lscpu:
+               template:
+               - 'lscpu'
+               use_mpi: false
+               redirect: '{log_file}'
+           executables:
+           - serial
+           - builtin::env_vars
+           - lscpu
+
+The above example builds off of the custom executable example, and shows how
+one can control the order of the executables in the ``{command}`` expansion.
+
+The default for the hostname application is ``[builtin::env_vars,
+serial/parallel]`` but this changes the order and injects ``lscpu`` into the
+expansion.
+
 ^^^^^^^^^^^^^^^^^^^
 Reserved Variables:
 ^^^^^^^^^^^^^^^^^^^
@@ -286,7 +355,7 @@ to function properly. This section will describe them.
 Required Variables:
 """""""""""""""""""
 
-Ramble requires the following variables to be define:
+Ramble requires the following variables to be defined:
 
 * ``n_ranks`` - Defines the number of MPI ranks to use. If not explicitly set,
   is defined as: ``{processes_per_node}*{n_nodes}``
@@ -334,6 +403,8 @@ Ramble automatically generates definitions for the following varialbes:
 * ``command`` - Set to all of the commands needed to perform an experiment.
 * ``spack_setup`` - Set to the commands needed to load a spack environment for
   an experiment. Set to an empty string for non-spack applications
+* ``mpi_command`` - By default, set to the contents of ``ramble:mpi```
+* ``batch_submit`` - By default, set to the contents of ``ramble:batch:submit``
 
 """""""""""""""""""""""""""""""""""
 Spack Specific Generated Variables:
@@ -344,16 +415,6 @@ When using spack applications, Ramble also geneates the following variables:
   <spec>`` for packages defined in a ramble ``spec_name`` package set.
   ``<software_spec_name>`` is set to the name of the package (one level lower
   than ramble's ``spec_name``).
-
-"""""""""""""""""""
-Reserved Variables:
-"""""""""""""""""""
-
-Ramble's internals use the following definitions. Overriding them within a
-config file can negatively impact the functionality of ramble.
-
-* ``mpi_command``
-* ``batch_submit``
 
 -----------------
 Spack Dictionary:

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -30,6 +30,8 @@ import ramble.mirror
 import ramble.fetch_strategy
 import ramble.expander
 
+from ramble.workspace import namespace
+
 from ramble.language.application_language import ApplicationMeta, register_builtin
 from ramble.error import RambleError
 
@@ -283,8 +285,6 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         - command: set to the commands needed to execute the experiment
         - spack_setup: set to an empty string, so spack applications can override this
         """
-        from ramble.workspace import namespace
-
         executables = self.workloads[self.expander.workload_name]['executables']
         inputs = self.workloads[self.expander.workload_name]['inputs']
 

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -70,6 +70,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         self.expander = None
         self.variables = None
         self.experiment_set = None
+        self.internals = None
         self._env_variable_sets = None
 
         self._file_path = file_path
@@ -160,6 +161,12 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         self.variables = variables
         self.experiment_set = experiment_set
         self.expander = ramble.expander.Expander(self.variables, self.experiment_set)
+
+    def set_internals(self, internals):
+        """Set internal refernece to application internals
+        """
+
+        self.internals = internals
 
     def get_pipeline_phases(self, pipeline):
         phases = []
@@ -276,8 +283,23 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         - command: set to the commands needed to execute the experiment
         - spack_setup: set to an empty string, so spack applications can override this
         """
+        from ramble.workspace import namespace
+
         executables = self.workloads[self.expander.workload_name]['executables']
         inputs = self.workloads[self.expander.workload_name]['inputs']
+
+        # Use yaml defined executable order, if defined
+        if namespace.executables in self.internals:
+            executables = self.internals[namespace.executables]
+
+        # Define custom executables
+        if namespace.custom_executables in self.internals.keys():
+            for name, conf in self.internals[namespace.custom_executables].items():
+                self.executables[name] = {
+                    'template': conf['template'],
+                    'mpi': conf['mpi'] if 'mpi' in conf else False,
+                    'redirect': conf['redirect'] if 'redirect' in conf else '{log_file}',
+                }
 
         for input_file in inputs:
             input_conf = self.inputs[input_file]

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -408,33 +408,38 @@ def workspace_info(args):
 
     # Build experiment set
     experiment_set = ramble.experiment_set.ExperimentSet(ws)
-    for app, workloads, app_vars, app_env_vars in ws.all_applications():
-        for workload, experiments, workload_vars, workload_env_vars in \
+    for app, workloads, app_vars, app_env_vars, app_internals in ws.all_applications():
+        for workload, experiments, workload_vars, workload_env_vars, workload_internals in \
                 ws.all_workloads(workloads):
-            for exp, _, exp_vars, exp_env_vars, exp_matrices in ws.all_experiments(experiments):
-                experiment_set.set_application_context(app, app_vars, app_env_vars)
+            for exp, _, exp_vars, exp_env_vars, exp_matrices, exp_internals in \
+                    ws.all_experiments(experiments):
+                experiment_set.set_application_context(app, app_vars, app_env_vars, app_internals)
                 experiment_set.set_workload_context(workload, workload_vars,
-                                                    workload_env_vars)
+                                                    workload_env_vars, workload_internals)
                 experiment_set.set_experiment_context(exp,
                                                       exp_vars,
                                                       exp_env_vars,
-                                                      exp_matrices)
+                                                      exp_matrices,
+                                                      exp_internals)
 
     # Print experiment information
     color.cprint('')
     color.cprint(section_title('Experiments:'))
-    for app, workloads, app_vars, app_env_vars in ws.all_applications():
-        for workload, experiments, workload_vars, workload_env_vars in \
+    for app, workloads, app_vars, app_env_vars, app_internals in ws.all_applications():
+        for workload, experiments, workload_vars, workload_env_vars, workload_internals in \
                 ws.all_workloads(workloads):
-            for exp, _, exp_vars, exp_env_vars, exp_matrices in ws.all_experiments(experiments):
+            for exp, _, exp_vars, exp_env_vars, exp_matrices, exp_internals in \
+                    ws.all_experiments(experiments):
                 print_experiment_set = ramble.experiment_set.ExperimentSet(ws)
-                print_experiment_set.set_application_context(app, app_vars, app_env_vars)
+                print_experiment_set.set_application_context(app, app_vars,
+                                                             app_env_vars, app_internals)
                 print_experiment_set.set_workload_context(workload, workload_vars,
-                                                          workload_env_vars)
+                                                          workload_env_vars, workload_internals)
                 print_experiment_set.set_experiment_context(exp,
                                                             exp_vars,
                                                             exp_env_vars,
-                                                            exp_matrices)
+                                                            exp_matrices,
+                                                            exp_internals)
 
                 color.cprint(nested_1('  Application: ') + app)
                 color.cprint(nested_2('    Workload: ') + workload)
@@ -479,6 +484,17 @@ def workspace_info(args):
                                 color.cprint(
                                     f'          {var} = {val} ==> {expanded}'.replace('@',
                                                                                       '@@'))
+
+                        if app_inst.internals:
+                            if ramble.workspace.namespace.custom_executables in app_inst.internals:
+                                color.cprint(nested_4('        Custom Executables') + ':')
+                                for name in app_inst.internals[
+                                        ramble.workspace.namespace.custom_executables]:
+
+                                    color.cprint(f'          {name}')
+                            if ramble.workspace.namespace.executables in app_inst.internals:
+                                color.cprint(nested_4('        Executable Order') + ': ' +
+                                             str(app_inst.internals['executables']))
 
     # Print MPI command
     color.cprint('')

--- a/lib/ramble/ramble/schema/applications.py
+++ b/lib/ramble/ramble/schema/applications.py
@@ -23,6 +23,12 @@ string_or_num = {
     ]
 }
 
+array_of_strings_or_nums = {
+    'type': 'array',
+    'default': [],
+    'items': string_or_num
+}
+
 array_or_scalar_of_strings_or_nums = {
     'anyOf': [
         {
@@ -63,6 +69,54 @@ matrices_def = {
     }
 }
 
+success_criteria_def = {
+    'type': 'object',
+    'default': {},
+    'properties': {
+        'name': {'type': 'string'},
+        'mode': {'type': 'string'},
+        'match': {'type': 'string'},
+        'file': {'type': 'string'}
+    },
+    'additionalProperties': False,
+}
+
+success_list_def = {
+    'type': 'array',
+    'default': [],
+    'items': success_criteria_def
+}
+
+custom_executables_def = {
+    'type': 'object',
+    'properties': {},
+    'additionalProperties': {
+        'type': 'object',
+        'default': {
+            'template': [],
+            'use_mpi': False,
+            'redirect': '{log_file}'
+        },
+        'properties': {
+            'template': array_or_scalar_of_strings_or_nums,
+            'use_mpi': {'type': 'boolean'},
+            'redirect': string_or_num,
+        }
+    },
+    'default': {},
+}
+
+executables_def = array_of_strings_or_nums
+
+internals_def = {
+    'type': 'object',
+    'default': {},
+    'properties': {
+        'custom_executables': custom_executables_def,
+        'executables': executables_def,
+    },
+    'additionalProperties': False
+}
 
 #: Properties for inclusion in other schemas
 applications_schema = {
@@ -73,11 +127,12 @@ applications_schema = {
         'additionalProperties': {
             'type': 'object',
             'default': '{}',
-            'additionalProperties': {
-                'variables': variables_def,
-                'env-vars': ramble.schema.licenses.env_var_actions
-            },
+            'additionalProperties': False,
             'properties': {
+                'variables': variables_def,
+                'env-vars': ramble.schema.licenses.env_var_actions,
+                'internals': internals_def,
+                'success_criteria': success_list_def,
                 'workloads': {
                     'type': 'object',
                     'default': {},
@@ -85,11 +140,12 @@ applications_schema = {
                     'additionalProperties': {
                         'type': 'object',
                         'default': {},
-                        'additionalProperties': {
-                            'variables': variables_def,
-                            'env-vars': ramble.schema.licenses.env_var_actions
-                        },
+                        'additionalProperties': False,
                         'properties': {
+                            'variables': variables_def,
+                            'env-vars': ramble.schema.licenses.env_var_actions,
+                            'internals': internals_def,
+                            'success_criteria': success_list_def,
                             'experiments': {
                                 'type': 'object',
                                 'default': {},
@@ -97,13 +153,15 @@ applications_schema = {
                                 'additionalProperties': {
                                     'type': 'object',
                                     'default': {},
-                                    'additionalProperties': {
+                                    'additionalProperties': False,
+                                    'properties': {
                                         'variables': variables_def,
                                         'matrix': matrix_def,
                                         'matrices': matrices_def,
-                                        'env-vars': ramble.schema.licenses.env_var_actions
-                                    },
-                                    'properties': {}
+                                        'env-vars': ramble.schema.licenses.env_var_actions,
+                                        'internals': internals_def,
+                                        'success_criteria': success_list_def,
+                                    }
                                 }
                             }
                         }

--- a/lib/ramble/ramble/schema/workspace.py
+++ b/lib/ramble/ramble/schema/workspace.py
@@ -52,6 +52,7 @@ spec_def = {
     }
 }
 
+
 keys = ('ramble', 'workspace')
 
 #: Properties for inclusion in other schemas
@@ -96,6 +97,14 @@ properties = {
                     'submit': {'type': 'string'}
                 },
                 'additionalProperties': False
+            },
+            'variables': ramble.schema.applications.variables_def,
+            'internals': ramble.schema.applications.internals_def,
+            'success_criteria': ramble.schema.applications.success_list_def,
+            'include': {
+                'type': 'array',
+                'default': [],
+                'items': {'type': 'string'},
             },
             'applications': {
                 'type': applications_properties['type'],

--- a/lib/ramble/ramble/test/end_to_end.py
+++ b/lib/ramble/ramble/test/end_to_end.py
@@ -632,3 +632,89 @@ spack:
                 data = f.read()
                 # Test the license exists
                 assert f"export {var_name2}{i}={var_val}" in data
+
+
+def test_custom_executables(mutable_config, mutable_mock_workspace_path, mock_applications):
+    test_config = """
+ramble:
+  mpi:
+    command: mpirun
+    args:
+    - '-n'
+    - '{n_ranks}'
+    - '-ppn'
+    - '{processes_per_node}'
+    - '-hostfile'
+    - 'hostfile'
+  batch:
+    submit: 'batch_submit {execute_experiment}'
+  variables:
+    partition: 'part1'
+    processes_per_node: '16'
+    n_threads: '1'
+  applications:
+    interleved-env-vars:
+      workloads:
+        test_wl3:
+          experiments:
+            simple_test:
+              internals:
+                custom_executables:
+                  lscpu:
+                    template:
+                    - 'lscpu'
+                    use_mpi: false
+                    redirect: '{log_file}'
+                executables:
+                - lscpu
+                - builtin::env_vars
+                - baz
+              variables:
+                n_nodes: 1
+              env-vars:
+                set:
+                  MY_VAR: 'TEST'
+spack:
+  concretized: true
+  compilers: {}
+  mpi_libraries: {}
+  applications: {}
+"""
+    workspace_name = 'test_custom_executables'
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+
+        config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+
+        with open(config_path, 'w+') as f:
+            f.write(test_config)
+        ws._re_read()
+
+        workspace('setup', '--dry-run', global_args=['-w', workspace_name])
+
+        experiment_root = ws.experiment_dir
+        exp_dir = os.path.join(experiment_root, 'interleved-env-vars', 'test_wl3', 'simple_test')
+        exp_script = os.path.join(exp_dir, 'execute_experiment')
+
+        import re
+        custom_regex = re.compile('lscpu >>')
+        export_regex = re.compile(r'export MY_VAR=TEST')
+        cmd_regex = re.compile('foo >>')
+
+        # Assert command order is: lscpu -> export -> foo
+        with open(exp_script, 'r') as f:
+            custom_found = False
+            cmd_found = False
+            export_found = False
+
+            for line in f.readlines():
+                if not custom_found and custom_regex.search(line):
+                    assert not cmd_found
+                    assert not export_found
+                    custom_found = True
+                if custom_found and not export_found and export_regex.search(line):
+                    assert not cmd_found
+                    export_found = True
+                if export_found and not cmd_found and cmd_regex.search(line):
+                    cmd_found = True
+            assert custom_found and cmd_found and export_found

--- a/lib/ramble/ramble/test/experiment_set.py
+++ b/lib/ramble/ramble/test/experiment_set.py
@@ -48,9 +48,9 @@ def test_single_experiment_in_set(mutable_mock_workspace_path):
             'n_nodes': '2',
         }
 
-        exp_set.set_application_context(app_name, app_vars, None)
-        exp_set.set_workload_context(wl_name, wl_vars, None)
-        exp_set.set_experiment_context(exp_name, exp_vars, None, None)
+        exp_set.set_application_context(app_name, app_vars, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, None, None)
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
 
@@ -83,9 +83,9 @@ def test_vector_experiment_in_set(mutable_mock_workspace_path):
             'n_nodes': ['2', '4']
         }
 
-        exp_set.set_application_context(app_name, app_vars, None)
-        exp_set.set_workload_context(wl_name, wl_vars, None)
-        exp_set.set_experiment_context(exp_name, exp_vars, None, None)
+        exp_set.set_application_context(app_name, app_vars, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, None, None)
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_8' in exp_set.experiments.keys()
@@ -119,10 +119,10 @@ def test_nonunique_vector_errors(mutable_mock_workspace_path, capsys):
             'n_nodes': ['2', '4']
         }
 
-        exp_set.set_application_context(app_name, app_vars, None)
-        exp_set.set_workload_context(wl_name, wl_vars, None)
+        exp_set.set_application_context(app_name, app_vars, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None)
         with pytest.raises(SystemExit):
-            exp_set.set_experiment_context(exp_name, exp_vars, None, None)
+            exp_set.set_experiment_context(exp_name, exp_vars, None, None, None)
             captured = capsys.readouterr()
             assert "is not unique." in captured
 
@@ -155,9 +155,9 @@ def test_zipped_vector_experiments(mutable_mock_workspace_path):
             'n_nodes': ['2', '4']
         }
 
-        exp_set.set_application_context(app_name, app_vars, None)
-        exp_set.set_workload_context(wl_name, wl_vars, None)
-        exp_set.set_experiment_context(exp_name, exp_vars, None, None)
+        exp_set.set_application_context(app_name, app_vars, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, None, None)
 
         assert 'basic.test_wl.series1_4_2' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_16_4' in exp_set.experiments.keys()
@@ -195,9 +195,9 @@ def test_matrix_experiments(mutable_mock_workspace_path):
             ['n_nodes']
         ]
 
-        exp_set.set_application_context(app_name, app_vars, None)
-        exp_set.set_workload_context(wl_name, wl_vars, None)
-        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices)
+        exp_set.set_application_context(app_name, app_vars, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None)
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_6' in exp_set.experiments.keys()
@@ -235,9 +235,9 @@ def test_matrix_multiplication_experiments(mutable_mock_workspace_path):
             ['n_nodes', 'processes_per_node']
         ]
 
-        exp_set.set_application_context(app_name, app_vars, None)
-        exp_set.set_workload_context(wl_name, wl_vars, None)
-        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices)
+        exp_set.set_application_context(app_name, app_vars, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None)
 
         assert 'basic.test_wl.series1_2' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_8' in exp_set.experiments.keys()
@@ -279,9 +279,9 @@ def test_matrix_vector_experiments(mutable_mock_workspace_path):
             ['n_nodes']
         ]
 
-        exp_set.set_application_context(app_name, app_vars, None)
-        exp_set.set_workload_context(wl_name, wl_vars, None)
-        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices)
+        exp_set.set_application_context(app_name, app_vars, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None)
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_8' in exp_set.experiments.keys()
@@ -322,9 +322,9 @@ def test_multi_matrix_experiments(mutable_mock_workspace_path):
             ['processes_per_node']
         ]
 
-        exp_set.set_application_context(app_name, app_vars, None)
-        exp_set.set_workload_context(wl_name, wl_vars, None)
-        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices)
+        exp_set.set_application_context(app_name, app_vars, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None)
 
         assert 'basic.test_wl.series1_4_2' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_12_4' in exp_set.experiments.keys()
@@ -363,11 +363,11 @@ def test_matrix_undefined_var_errors(mutable_mock_workspace_path, capsys):
             ['foo']
         ]
 
-        exp_set.set_application_context(app_name, app_vars, None)
-        exp_set.set_workload_context(wl_name, wl_vars, None)
+        exp_set.set_application_context(app_name, app_vars, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None)
 
         with pytest.raises(SystemExit):
-            exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices)
+            exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None)
             captured = capsys.readouterr()
             assert "variable foo has not been defined yet." in captured
 
@@ -405,9 +405,9 @@ def test_experiment_names_match(mutable_mock_workspace_path):
             ['processes_per_node']
         ]
 
-        exp_set.set_application_context(app_name, app_vars, None)
-        exp_set.set_workload_context(wl_name, wl_vars, None)
-        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices)
+        exp_set.set_application_context(app_name, app_vars, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None)
 
         assert 'basic.test_wl.series1_4_2' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_12_4' in exp_set.experiments.keys()
@@ -453,10 +453,10 @@ def test_cross_experiment_variable_references(mutable_mock_workspace_path):
             'test_var': 'test_var in basic.test_wl.series1_4'
         }
 
-        exp_set.set_application_context(app_name, app_vars, None)
-        exp_set.set_workload_context(wl_name, wl_vars, None)
-        exp_set.set_experiment_context(exp1_name, exp1_vars, None, None)
-        exp_set.set_experiment_context(exp2_name, exp2_vars, None, None)
+        exp_set.set_application_context(app_name, app_vars, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None)
+        exp_set.set_experiment_context(exp1_name, exp1_vars, None, None, None)
+        exp_set.set_experiment_context(exp2_name, exp2_vars, None, None, None)
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
         assert 'basic.test_wl.series2_4' in exp_set.experiments.keys()
@@ -494,9 +494,9 @@ def test_cross_experiment_missing_experiment_errors(mutable_mock_workspace_path)
             'test_var': 'processes_per_node in basic.test_wl.does_not_exist'
         }
 
-        exp_set.set_application_context(app_name, app_vars, None)
-        exp_set.set_workload_context(wl_name, wl_vars, None)
-        exp_set.set_experiment_context(exp1_name, exp1_vars, None, None)
+        exp_set.set_application_context(app_name, app_vars, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None)
+        exp_set.set_experiment_context(exp1_name, exp1_vars, None, None, None)
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
 
@@ -539,9 +539,9 @@ def test_n_ranks_correct_defaults(mutable_mock_workspace_path):
             ['n_nodes']
         ]
 
-        exp_set.set_application_context(app_name, app_vars, None)
-        exp_set.set_workload_context(wl_name, wl_vars, None)
-        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices)
+        exp_set.set_application_context(app_name, app_vars, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None)
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_6' in exp_set.experiments.keys()
@@ -578,9 +578,9 @@ def test_n_nodes_correct_defaults(mutable_mock_workspace_path):
             ['n_ranks']
         ]
 
-        exp_set.set_application_context(app_name, app_vars, None)
-        exp_set.set_workload_context(wl_name, wl_vars, None)
-        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices)
+        exp_set.set_application_context(app_name, app_vars, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None)
 
         assert 'basic.test_wl.series1_4_2' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_6_3' in exp_set.experiments.keys()
@@ -615,9 +615,9 @@ def test_processes_per_node_correct_defaults(mutable_mock_workspace_path):
             'n_nodes': ['2', '3']
         }
 
-        exp_set.set_application_context(app_name, app_vars, None)
-        exp_set.set_workload_context(wl_name, wl_vars, None)
-        exp_set.set_experiment_context(exp_name, exp_vars, None, None)
+        exp_set.set_application_context(app_name, app_vars, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, None, None)
 
         assert 'basic.test_wl.series1_4_2' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_6_2' in exp_set.experiments.keys()
@@ -643,7 +643,7 @@ def test_reserved_keywords_error_in_application(mutable_mock_workspace_path, var
         }
 
         with pytest.raises(ramble.experiment_set.RambleVariableDefinitionError):
-            exp_set.set_application_context(app_name, app_vars, None)
+            exp_set.set_application_context(app_name, app_vars, None, None)
             captured = capsys.readouterr()
             assert "In application basic" in captured
             assert f"{var}" in captured
@@ -675,9 +675,9 @@ def test_reserved_keywords_error_in_workload(mutable_mock_workspace_path, var, c
             var: 'should_fail'
         }
 
-        exp_set.set_application_context(app_name, app_vars, None)
+        exp_set.set_application_context(app_name, app_vars, None, None)
         with pytest.raises(ramble.experiment_set.RambleVariableDefinitionError):
-            exp_set.set_workload_context(wl_name, wl_vars, None)
+            exp_set.set_workload_context(wl_name, wl_vars, None, None)
             captured = capsys.readouterr()
             assert "In workload basic.test_wl" in captured
             assert f"{var}" in captured
@@ -717,10 +717,10 @@ def test_reserved_keywords_error_in_experiment(mutable_mock_workspace_path, var,
             var: 'should_fail'
         }
 
-        exp_set.set_application_context(app_name, app_vars, None)
-        exp_set.set_workload_context(wl_name, wl_vars, None)
+        exp_set.set_application_context(app_name, app_vars, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None)
         with pytest.raises(ramble.experiment_set.RambleVariableDefinitionError):
-            exp_set.set_experiment_context(exp_name, exp_vars, None, None)
+            exp_set.set_experiment_context(exp_name, exp_vars, None, None, None)
             captured = capsys.readouterr()
             assert "In experiment basic.test_wl.series1_{n_ranks}_{processes_per_node}" in captured
             assert f"{var}" in captured
@@ -759,10 +759,10 @@ def test_missing_required_keyword_errors(mutable_mock_workspace_path, var, capsy
             'n_nodes': ['2', '3']
         }
 
-        exp_set.set_application_context(app_name, app_vars, None)
-        exp_set.set_workload_context(wl_name, wl_vars, None)
+        exp_set.set_application_context(app_name, app_vars, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None)
         with pytest.raises(ramble.experiment_set.RambleVariableDefinitionError):
-            exp_set.set_experiment_context(exp_name, exp_vars, None, None)
+            exp_set.set_experiment_context(exp_name, exp_vars, None, None, None)
             captured = capsys.readouterr()
             assert f'Required key "{var}" is not defined' in captured
             assert 'One or more required keys are not defined within an experiment.' in captured

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -785,8 +785,8 @@ class Workspace(object):
         import ramble.spec
 
         specs = []
-        for app, workloads, _, _, _ in self.all_applications():
-            for workload, _, _, _, _ in self.all_workloads(workloads):
+        for app, workloads, *_ in self.all_applications():
+            for workload, *_ in self.all_workloads(workloads):
                 app_spec = ramble.spec.Spec(app)
                 app_spec.workloads[workload] = True
                 specs.append(app_spec)
@@ -1094,7 +1094,7 @@ class Workspace(object):
         mpi_dict = spack_dict[namespace.mpi_lib]
         applications_dict = spack_dict[namespace.application]
 
-        for app_name, _, _, _, _ in self.all_applications():
+        for app_name, *_ in self.all_applications():
             app_inst = ramble.repository.get(app_name)
 
             for comp, info in app_inst.default_compilers.items():
@@ -1693,29 +1693,25 @@ class Workspace(object):
                     else False)
         return False
 
-    def get_workspace_vars(self):
-        """Return a dict of workspace variables"""
+    def _get_workspace_section(self, section):
+        """Return a dict of a workspace section"""
         workspace_dict = self._get_workspace_dict()
 
-        return workspace_dict[namespace.ramble][namespace.variables] \
-            if namespace.variables in \
+        return workspace_dict[namespace.ramble][section] \
+            if section in \
             workspace_dict[namespace.ramble] else syaml.syaml_dict()
+
+    def get_workspace_vars(self):
+        """Return a dict of workspace variables"""
+        return self._get_workspace_section(namespace.variables)
 
     def get_workspace_env_vars(self):
         """Return a dict of workspace environment variables"""
-        workspace_dict = self._get_workspace_dict()
-
-        return workspace_dict[namespace.ramble][namespace.env_var] \
-            if namespace.env_var in \
-            workspace_dict[namespace.ramble] else None
+        return self._get_workspace_section(namespace.env_var)
 
     def get_workspace_internals(self):
         """Return a dict of workspace internals"""
-        workspace_dict = self._get_workspace_dict()
-
-        return workspace_dict[namespace.ramble][namespace.internals] \
-            if namespace.internals in \
-            workspace_dict[namespace.ramble] else None
+        return self._get_workspace_section(namespace.internals)
 
     def get_spack_dict(self):
         """Return the spack dictionary for this workspace"""

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -58,6 +58,9 @@ class namespace:
     experiment = 'experiments'
     variables = 'variables'
     success = 'success_criteria'
+    internals = 'internals'
+    custom_executables = 'custom_executables'
+    executables = 'executables'
     env_var = 'env-vars'
     mpi = 'mpi'
     batch = 'batch'
@@ -782,8 +785,8 @@ class Workspace(object):
         import ramble.spec
 
         specs = []
-        for app, workloads, _, _ in self.all_applications():
-            for workload, _, _, _ in self.all_workloads(workloads):
+        for app, workloads, _, _, _ in self.all_applications():
+            for workload, _, _, _, _ in self.all_workloads(workloads):
                 app_spec = ramble.spec.Spec(app)
                 app_spec.workloads[workload] = True
                 specs.append(app_spec)
@@ -808,16 +811,21 @@ class Workspace(object):
             for application, contents in app_dict.items():
                 application_vars = None
                 application_env_vars = None
+                application_internals = None
 
                 if namespace.variables in contents:
                     application_vars = contents[namespace.variables]
 
                 if namespace.env_var in contents:
                     application_env_vars = contents[namespace.env_var]
+
+                if namespace.internals in contents:
+                    application_internals = contents[namespace.internals]
+
                 self.extract_success_criteria('application', contents)
 
                 yield application, contents, application_vars, \
-                    application_env_vars
+                    application_env_vars, application_internals
 
         tty.debug('  Iterating over configs in directories...')
         # Iterate over applications defined in application directories
@@ -831,13 +839,17 @@ class Workspace(object):
             for application, contents in app_dict.items():
                 application_vars = None
                 application_env_vars = None
+                application_internals = None
                 if namespace.variables in contents:
                     application_vars = \
                         contents[namespace.variables]
                 if namespace.env_var in contents:
                     application_env_vars = contents[namespace.env_var]
+                if namespace.internals in contents:
+                    application_internals = contents[namespace.internals]
                 self.extract_success_criteria('application', contents)
-                yield application, contents, application_vars, application_env_vars
+                yield application, contents, application_vars, \
+                    application_env_vars, application_internals
 
     def all_workloads(self, application):
         """Iterator over workloads in an application dict
@@ -856,13 +868,17 @@ class Workspace(object):
         for workload, contents in workloads.items():
             workload_variables = None
             workload_env_vars = None
+            workload_internals = None
             if namespace.variables in contents:
                 workload_variables = contents[namespace.variables]
             if namespace.env_var in contents:
                 workload_env_vars = contents[namespace.env_var]
+            if namespace.internals in contents:
+                workload_internals = contents[namespace.internals]
             self.extract_success_criteria('workload', contents)
 
-            yield workload, contents, workload_variables, workload_env_vars
+            yield workload, contents, workload_variables, \
+                workload_env_vars, workload_internals
 
     def all_experiments(self, workload):
         """Iterator over experiments in a workload dict
@@ -881,12 +897,16 @@ class Workspace(object):
 
             experiment_vars = syaml.syaml_dict()
             experiment_env_vars = None
+            experiment_internals = None
 
             if namespace.variables in contents:
                 experiment_vars = contents[namespace.variables]
 
             if namespace.env_var in contents:
                 experiment_env_vars = contents[namespace.env_var]
+
+            if namespace.internals in contents:
+                experiment_internals = contents[namespace.internals]
 
             self.extract_success_criteria('experiment', contents)
 
@@ -909,7 +929,7 @@ class Workspace(object):
                         matrices.append(matrix)
 
             yield experiment, contents, experiment_vars, \
-                experiment_env_vars, matrices
+                experiment_env_vars, matrices, experiment_internals
 
     def _build_spec_dict(self, info_dict, app_name=None, for_config=False):
         spec = {}
@@ -1074,7 +1094,7 @@ class Workspace(object):
         mpi_dict = spack_dict[namespace.mpi_lib]
         applications_dict = spack_dict[namespace.application]
 
-        for app_name, _, _, _ in self.all_applications():
+        for app_name, _, _, _, _ in self.all_applications():
             app_inst = ramble.repository.get(app_name)
 
             for comp, info in app_inst.default_compilers.items():
@@ -1300,20 +1320,21 @@ class Workspace(object):
                                                 use_custom_specifier=False)
                     runner.install_compiler(comp_str)
 
-        for app, workloads, app_vars, app_env_vars in self.all_applications():
-            experiment_set.set_application_context(app, app_vars, app_env_vars)
+        for app, workloads, app_vars, app_env_vars, app_ints in self.all_applications():
+            experiment_set.set_application_context(app, app_vars, app_env_vars, app_ints)
 
-            for workload, experiments, workload_vars, workload_env_vars in \
+            for workload, experiments, workload_vars, workload_env_vars, workload_ints in \
                     self.all_workloads(workloads):
                 experiment_set.set_workload_context(workload, workload_vars,
-                                                    workload_env_vars)
+                                                    workload_env_vars, workload_ints)
 
-                for experiment, _, exp_vars, exp_env_vars, exp_matrices in \
+                for experiment, _, exp_vars, exp_env_vars, exp_matrices, exp_ints in \
                         self.all_experiments(experiments):
                     experiment_set.set_experiment_context(experiment,
                                                           exp_vars,
                                                           exp_env_vars,
-                                                          exp_matrices)
+                                                          exp_matrices,
+                                                          exp_ints)
 
         for exp, app_inst in experiment_set.all_experiments():
             tty.debug('On experiment: %s' % exp)
@@ -1686,6 +1707,14 @@ class Workspace(object):
 
         return workspace_dict[namespace.ramble][namespace.env_var] \
             if namespace.env_var in \
+            workspace_dict[namespace.ramble] else None
+
+    def get_workspace_internals(self):
+        """Return a dict of workspace internals"""
+        workspace_dict = self._get_workspace_dict()
+
+        return workspace_dict[namespace.ramble][namespace.internals] \
+            if namespace.internals in \
             workspace_dict[namespace.ramble] else None
 
     def get_spack_dict(self):


### PR DESCRIPTION
This merge adds the ability to define custom executables in the YAML workspace configuration file.

Additionally, this adds the ability to control the executables used for creating the '{command}' variable within experiments.