### PR TITLE
Update applications to reflect upstream expander changes

### DIFF
--- a/lib/ramble/ramble/cmd/debug.py
+++ b/lib/ramble/ramble/cmd/debug.py
@@ -12,9 +12,7 @@ import os
 import platform
 import re
 from datetime import datetime
-from glob import glob
 
-import llnl.util.tty as tty
 from llnl.util.filesystem import working_dir
 
 import ramble.config

--- a/lib/ramble/ramble/test/cmd/debug.py
+++ b/lib/ramble/ramble/test/cmd/debug.py
@@ -6,8 +6,6 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-# import pytest
-
 from ramble.main import RambleCommand
 
 debug = RambleCommand('debug')

--- a/lib/ramble/ramble/test/cmd/debug.py
+++ b/lib/ramble/ramble/test/cmd/debug.py
@@ -6,11 +6,12 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-import pytest
+# import pytest
 
 from ramble.main import RambleCommand
 
 debug = RambleCommand('debug')
+
 
 def test_debug_report():
     output = debug('report')
@@ -18,4 +19,3 @@ def test_debug_report():
     assert "* **Ramble:**" in output
     assert "* **Python:**" in output
     assert "* **Platform:**" in output
-

--- a/lib/ramble/ramble/test/end_to_end.py
+++ b/lib/ramble/ramble/test/end_to_end.py
@@ -274,6 +274,88 @@ licenses:
                 assert os.path.exists(os.path.join(exp_dir, f'rsl.error.000{i}'))
 
 
+def test_hpl_dry_run(mutable_config, mutable_mock_workspace_path):
+    test_config = """
+ramble:
+  mpi:
+    command: mpirun
+    args:
+    - '-n'
+    - '{n_ranks}'
+    - '-ppn'
+    - '{processes_per_node}'
+    - '-hostfile'
+    - 'hostfile'
+  batch:
+    submit: 'batch_submit {execute_experiment}'
+  variables:
+    processes_per_node: 16
+    n_threads: 1
+  applications:
+    hpl:
+      workloads:
+        standard:
+          experiments:
+            test_exp:
+              variables:
+                n_ranks: 4
+spack:
+  concretized: true
+  compilers:
+    gcc9:
+      base: gcc
+      version: 9.3.0
+  mpi_libraries:
+    impi2018:
+      base: intel-mpi
+      version: 2018.4.274
+  applications:
+    hpl:
+      hpl:
+        base: hpl
+        version: '2.3'
+        variants: +openmp
+        compiler: gcc9
+        mpi: impi2018
+"""
+
+    workspace_name = 'test_end_to_end_hpl'
+    with ramble.workspace.create(workspace_name) as ws1:
+        ws1.write()
+
+        config_path = os.path.join(ws1.config_dir, ramble.workspace.config_file_name)
+
+        with open(config_path, 'w+') as f:
+            f.write(test_config)
+
+        # Write a command template
+        with open(os.path.join(ws1.config_dir, 'full_command.tpl'), 'w+') as f:
+            f.write('{command}')
+
+        ws1._re_read()
+
+        workspace('setup', '--dry-run', global_args=['-w', workspace_name])
+
+        # Test software directories
+        software_dirs = ['hpl.standard']
+        software_base_dir = os.path.join(ws1.root, ramble.workspace.workspace_software_path)
+        assert os.path.exists(software_base_dir)
+        for software_dir in software_dirs:
+            software_path = os.path.join(software_base_dir, software_dir)
+            assert os.path.exists(software_path)
+
+            spack_file = os.path.join(software_path, 'spack.yaml')
+            assert os.path.exists(spack_file)
+
+        expected_experiments = ['test_exp']
+
+        for exp in expected_experiments:
+            exp_dir = os.path.join(ws1.root, 'experiments',
+                                   'hpl', 'standard', exp)
+            assert os.path.isdir(exp_dir)
+            assert os.path.exists(os.path.join(exp_dir, 'execute_experiment'))
+
+
 def test_dependency_dry_run(mutable_config, mutable_mock_workspace_path):
     test_config = """
 ramble:

--- a/var/ramble/repos/builtin/applications/hpcg/application.py
+++ b/var/ramble/repos/builtin/applications/hpcg/application.py
@@ -74,13 +74,13 @@ class Hpcg(SpackApplication):
                     fom_regex=r'Final Summary::HPCG 2\.4 rating.*=(?P<rating>[0-9]+\.*[0-9]*)',
                     group_name='rating', units='')
 
-    def _make_experiments(self, workspace, expander):
-        super()._make_experiments(workspace, expander)
+    def _make_experiments(self, workspace):
+        super()._make_experiments(workspace)
 
-        input_path = expander.expand_var('{experiment_run_dir}/hpcg.dat')
+        input_path = self.expander.expand_var('{experiment_run_dir}/hpcg.dat')
 
         with open(input_path, 'w+') as f:
             f.write('HPCG benchmark input file\n')
             f.write('Sandia National Laboratories; University of Tennessee, Knoxville\n')
-            f.write(expander.expand_var('{matrix_size}\n'))
-            f.write(expander.expand_var('{iterations}\n'))
+            f.write(self.expander.expand_var('{matrix_size}\n'))
+            f.write(self.expander.expand_var('{iterations}\n'))

--- a/var/ramble/repos/builtin/applications/hpl/application.py
+++ b/var/ramble/repos/builtin/applications/hpl/application.py
@@ -188,11 +188,11 @@ class Hpl(SpackApplication):
             expander.set_var('N-DEPTHs', '1')
             expander.set_var('DEPTHs', '1')
 
-    def _make_experiments(self, workspace, expander):
-        super()._make_experiments(workspace, expander)
-        self._calculate_values(workspace, expander)
+    def _make_experiments(self, workspace):
+        super()._make_experiments(workspace)
+        self._calculate_values(workspace, self.expander)
 
-        input_path = expander.expand_var('{experiment_run_dir}/HPL.dat')
+        input_path = self.expander.expand_var('{experiment_run_dir}/HPL.dat')
 
         settings = ['output_file', 'device_out', 'N-Ns', 'Ns', 'N-NBs', 'NBs',
                     'PMAP', 'N-Grids', 'Ps', 'Qs', 'threshold', 'NPFACTS',
@@ -206,4 +206,4 @@ class Hpl(SpackApplication):
             f.write('Innovative Computing Laboratory, University of Tennessee\n')
 
             for setting in settings:
-                f.write(expander.expand_var('{' + setting + '}') + '\n')
+                f.write(self.expander.expand_var('{' + setting + '}') + '\n')

--- a/var/ramble/repos/builtin/applications/lulesh/application.py
+++ b/var/ramble/repos/builtin/applications/lulesh/application.py
@@ -64,7 +64,7 @@ class Lulesh(SpackApplication):
                     fom_regex=r'\s*Iteration count\s+=\s+(?P<iterations>[0-9]+)',
                     group_name='iterations', units='')
 
-    def _make_experiments(self, workspace, expander):
+    def _make_experiments(self, workspace):
         """
         LULESH requires the number of ranks to be a cube root of an integer.
 
@@ -74,12 +74,11 @@ class Lulesh(SpackApplication):
         We also need to recompute the number of nodes, or the value of
         processes per node here too.
         """
-        num_ranks = int(expander.expand_var('{n_ranks}'))
+        num_ranks = int(self.expander.expand_var('{n_ranks}'))
 
         cube_root = int(num_ranks ** (1. / 3.))
 
-        expander.set_var('n_ranks', cube_root**3, 'experiment')
-        expander._compute_mpi_vars()
+        self.expander.set_var('n_ranks', cube_root**3, 'experiment')
+        self.expander._compute_mpi_vars()
 
-        super()._add_expand_vars(expander)
-        super()._make_experiments(workspace, expander)
+        super()._make_experiments(workspace)


### PR DESCRIPTION
Previous changes updated the `_make_experiments` interface but these
applications were not updated to match

Fixes #85 