### PR TITLE
Add install_compilers as a phase to spack applications

### DIFF
--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1311,16 +1311,6 @@ class Workspace(object):
 
             experiment_set.set_base_var('experiments_file', all_experiments_file)
 
-            runner = ramble.spack_runner.SpackRunner(dry_run=self.dry_run)
-            spack_dict = self.get_spack_dict()
-            if namespace.compiler in spack_dict:
-                for comp_name, comp_spec in \
-                        spack_dict[namespace.compiler].items():
-                    comp_str = self.spec_string(comp_spec,
-                                                as_dep=False,
-                                                use_custom_specifier=False)
-                    runner.install_compiler(comp_str)
-
         for app, workloads, app_vars, app_env_vars, app_ints in self.all_applications():
             experiment_set.set_application_context(app, app_vars, app_env_vars, app_ints)
 


### PR DESCRIPTION
This merge allows spack applications to control their own compiler installation. This changes the behavior so that only used spack compilers are installed, rather than all of the compilers that are listed.

A test is added to ensure unused compilers are not installed.