### PR TITLE
Add dry run tests for all applications

### DIFF
--- a/share/ramble/cloud-build/ramble-pr-validation.yaml
+++ b/share/ramble/cloud-build/ramble-pr-validation.yaml
@@ -54,7 +54,7 @@ steps:
         # https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values
         license_err=$$?
 
-        COVERAGE=true /workspace/share/ramble/qa/run-unit-tests
+        COVERAGE=true LONG=true /workspace/share/ramble/qa/run-unit-tests
         # $$ characters are required for cloud-build:
         # https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values
         unit_err=$$?

--- a/share/ramble/qa/run-unit-tests
+++ b/share/ramble/qa/run-unit-tests
@@ -42,4 +42,8 @@ bin/ramble help -a
 #-----------------------------------------------------------
 # Run unit tests with code coverage
 #-----------------------------------------------------------
-$coverage_run $(which ramble) unit-test -x --verbose
+if [ -z $LONG ]; then
+    $coverage_run $(which ramble) unit-test -x --verbose -m "not long"
+else
+    $coverage_run $(which ramble) unit-test -x --verbose
+fi

--- a/var/ramble/repos/builtin/applications/hpl/application.py
+++ b/var/ramble/repos/builtin/applications/hpl/application.py
@@ -168,25 +168,25 @@ class Hpl(SpackApplication):
             bestQ = int(totalCores / bestP)
 
             for var, config in self.workload_variables['standard'].items():
-                expander.set_var(var, config['default'])
+                self.variables[var] = config['default']
 
-            expander.set_var('N-Ns', '1')
-            expander.set_var('Ns', int(problemSize))
-            expander.set_var('N-NBs', '1')
-            expander.set_var('NBs', blockSize)
-            expander.set_var('N-Grids', '1')
-            expander.set_var('Ps', int(bestP))
-            expander.set_var('Qs', int(bestQ))
-            expander.set_var('NPFACTS', '1')
-            expander.set_var('PFACTS', '2')
-            expander.set_var('N-NBMINs', '1')
-            expander.set_var('NBMINs', '4')
-            expander.set_var('N-RFACTs', '1')
-            expander.set_var('RFACTs', '1')
-            expander.set_var('N-BCASTs', '1')
-            expander.set_var('BCASTs', '1')
-            expander.set_var('N-DEPTHs', '1')
-            expander.set_var('DEPTHs', '1')
+            self.variables['N-Ns'] = '1'
+            self.variables['Ns'] = int(problemSize)
+            self.variables['N-NBs'] = '1'
+            self.variables['NBs'] = blockSize
+            self.variables['N-Grids'] = '1'
+            self.variables['Ps'] = int(bestP)
+            self.variables['Qs'] = int(bestQ)
+            self.variables['NPFACTS'] = '1'
+            self.variables['PFACTS'] = '2'
+            self.variables['N-NBMINs'] = '1'
+            self.variables['NBMINs'] = '4'
+            self.variables['N-RFACTs'] = '1'
+            self.variables['RFACTs'] = '1'
+            self.variables['N-BCASTs'] = '1'
+            self.variables['BCASTs'] = '1'
+            self.variables['N-DEPTHs'] = '1'
+            self.variables['DEPTHs'] = '1'
 
     def _make_experiments(self, workspace):
         super()._make_experiments(workspace)

--- a/var/ramble/repos/builtin/applications/lulesh/application.py
+++ b/var/ramble/repos/builtin/applications/lulesh/application.py
@@ -78,7 +78,6 @@ class Lulesh(SpackApplication):
 
         cube_root = int(num_ranks ** (1. / 3.))
 
-        self.expander.set_var('n_ranks', cube_root**3, 'experiment')
-        self.expander._compute_mpi_vars()
+        self.variables['n_ranks'] = cube_root**3
 
         super()._make_experiments(workspace)


### PR DESCRIPTION
This merge adds two new tests that collectively dry-run every application/workload in Ramble. This includes applications in both the builtin and builtin.mock repositories.

HPL and LULESH both had issues in their application.py files, so this merge fixes those.