### PR TITLE
Add internal version of cmd_quote for double quotes

### DIFF
--- a/lib/ramble/ramble/test/application_tests.py
+++ b/lib/ramble/ramble/test/application_tests.py
@@ -109,10 +109,10 @@ def test_env_var_append_command_gen(mutable_mock_repo):
     ]
 
     answer = [
-        "export var1='${var1},val1,val2';",
-        "export var2='${var2},val2,val1';",
-        "export path1='${path1}:path1';",
-        "export path2='${path2}:path2';"
+        'export var1="${var1},val1,val2";',
+        'export var2="${var2},val2,val1";',
+        'export path1="${path1}:path1";',
+        'export path2="${path2}:path2";'
     ]
 
     out_cmds, _ = basic_inst._get_env_append_commands(tests, set())
@@ -139,8 +139,8 @@ def test_env_var_prepend_command_gen(mutable_mock_repo):
     ]
 
     answer = [
-        "export path1='path2:path1:${path1}';",
-        "export path2='path1:path2:${path2}';"
+        'export path1="path2:path1:${path1}";',
+        'export path2="path1:path2:${path2}";'
     ]
 
     out_cmds, _ = basic_inst._get_env_prepend_commands(tests, set())

--- a/lib/ramble/ramble/test/end_to_end.py
+++ b/lib/ramble/ramble/test/end_to_end.py
@@ -190,7 +190,7 @@ licenses:
                 assert "export WRF_LICENSE=port@server" in data
 
                 # Test the required environment variables exist
-                assert "export OMP_NUM_THREADS='1'" in data
+                assert 'export OMP_NUM_THREADS="1"' in data
                 assert "export TEST_VAR=1" in data
                 assert 'unset TEST_VAR' in data
 
@@ -209,7 +209,7 @@ licenses:
                 assert "export WRF_LICENSE=port@server" in data
 
                 # Test the required environment variables exist
-                assert "export OMP_NUM_THREADS='1'" in data
+                assert 'export OMP_NUM_THREADS="1"' in data
                 assert "export TEST_VAR=1" in data
                 assert 'unset TEST_VAR' in data
 

--- a/lib/ramble/spack/util/environment.py
+++ b/lib/ramble/spack/util/environment.py
@@ -16,7 +16,6 @@ import sys
 
 import six
 from six.moves import cPickle
-from six.moves import shlex_quote as cmd_quote
 
 import llnl.util.tty as tty
 from llnl.util.lang import dedupe
@@ -56,6 +55,24 @@ _shell_unset_strings = {
 
 
 tracing_enabled = False
+
+_find_unsafe = re.compile(r'[^\w@%+=:,./-]', re.ASCII).search
+
+def cmd_quote(s):
+    """Return a shell-escaped version of the string *s*.
+
+    This is similar to how shlex.quote works, but it escapes with double quotes
+    instead of single quotes, to allow environment variable expansion within
+    quoted strings.
+    """
+    if not s:
+        return '""'
+    if _find_unsafe(s) is None:
+        return s
+
+    # use double quotes, and escape double quotes in the string
+    # the string $"b is then quoted as "$\"b"
+    return '"' + s.replace('"', '\\"') + '"'
 
 
 def is_system_path(path):


### PR DESCRIPTION
This merge brings in an internal version of shlex.cmd_quote which escapes using double quotes instead of single quotes.

Previously, this would escape strings with single quotes. Single quoted strings would not expand environment variables inside them. So something like:

```
env-vars:
  append:
  - vars:
      PATH: "my_path"
```

Would result in `export PATH='$PATH,my_path'` which wouldn't expand the `$PATH` properly.