### PR TITLE
Ensure RAMBLE_VARIABLES contains only expanded variables

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -639,7 +639,11 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         tty.debug('fom_vals = %s' % fom_values)
         if success:
             results['RAMBLE_STATUS'] = 'SUCCESS'
-            results['RAMBLE_VARIABLES'] = self.variables
+            results['RAMBLE_VARIABLES'] = {}
+            results['RAMBLE_RAW_VARIABLES'] = {}
+            for var, val in self.variables.items():
+                results['RAMBLE_RAW_VARIABLES'][var] = val
+                results['RAMBLE_RAW_VARIABLES'][var] = self.expander.expand_var(val)
             results['CONTEXTS'] = []
 
             for context, fom_map in fom_values.items():

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -502,6 +502,7 @@ class ExperimentSet(object):
                 Expander.expansion_str(self.keywords.workload_name))
             final_exp_name = expander.expand_var(experiment_template_name)
 
+            experiment_vars[self.keywords.experiment_template_name] = experiment_template_name
             experiment_vars[self.keywords.application_name] = final_app_name
             experiment_vars[self.keywords.workload_name] = final_wl_name
             experiment_vars[self.keywords.experiment_name] = final_exp_name
@@ -511,7 +512,7 @@ class ExperimentSet(object):
             log_file = expander.expand_var(
                 os.path.join(Expander.expansion_str(self.keywords.experiment_run_dir),
                              Expander.expansion_str(self.keywords.experiment_name) + '.out'))
-            experiment_vars['log_file'] = log_file
+            experiment_vars[self.keywords.log_file] = log_file
 
             tty.debug('   Exp vars: %s' % exp)
             tty.debug('   Final name: %s' % final_exp_name)

--- a/lib/ramble/ramble/keywords.py
+++ b/lib/ramble/ramble/keywords.py
@@ -56,6 +56,7 @@ class Keywords(object):
         'n_threads': key_type.required,
         'batch_submit': key_type.required,
         'mpi_command': key_type.required,
+        'experiment_template_name': key_type.required,
     }
 
     @classmethod


### PR DESCRIPTION
This merge updates RAMBLE_VARIABLES (in results .json and .yaml files) to only contain expanded forms of the variables (i.e. not `{processes_per_node}*{n_nodes}`).

RAMBLE_RAW_VARIABLES is added to only contain the un-expanded forms.

Additionally, experiment_template_name is added to tracked variables, to help connect rendered experiments with the series that generated them.