### PR TITLE
Fix spack package paths

### DIFF
--- a/lib/ramble/docs/workspace_config.rst
+++ b/lib/ramble/docs/workspace_config.rst
@@ -477,6 +477,47 @@ is as follows:
 Not all of the options are required, but generally a spec object should contain
 at least ``base``, and ``version``.
 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+External Spack Environment Support:
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**NOTE**: Using external Spack environments is an advanced feature.
+
+Some experiments will want to use an externally defined Spack environment
+instead of having Ramble generate its own Spack environment file. This can be
+useful when the Spack environment a user wants to experiment with is
+complicated.
+
+This section shows how this feature can be used.
+
+.. code-block:: yaml
+
+    spack:
+      applications:
+        gromacs:
+          external_spack_env: name_or_path_to_spack_env
+          gromacs:
+            base: gromacs
+
+In the above example, the ``external_spack_env`` keyword refers an external
+Spack environment. This can be the name of a named Spack environment, or the
+path to a directory which contains a Spack environment. Ramble will copy the
+``spack.yaml`` file from this environment, instead of generating its own.
+
+This allows users to describe custom Spack environments and allow them to be
+used with Ramble generated experiments. However, users will still need to
+define some aspects of the ``spack:applications:<app_name>`` dictionary in the
+``ramble.yaml`` file. Specifically, any software specs that are required by the
+application.py file will need to have their ``base`` defined at a minimum.
+Ramble won't use any other information in the spec definition (i.e. ``version``
+or ``variants``), but adding the information to the ``ramble.yaml`` will
+enhance the provenance information that Ramble is able to track.
+
+It is important to note that Ramble copies in the external environment files
+every time ``ramble workspace setup`` is called. The new files will clobber the
+old files, changing the configuration of the environment that Ramble will use
+for the experiments it generates.
+
 --------------------------------------------
 Controlling MPI Libraries and Batch Systems:
 --------------------------------------------

--- a/lib/ramble/ramble/application_types/spack.py
+++ b/lib/ramble/ramble/application_types/spack.py
@@ -50,6 +50,7 @@ class SpackApplication(ApplicationBase):
             'install_compilers',
             'create_spack_env',
             'install_software',
+            'define_package_paths',
             'get_inputs',
             'make_experiments'
         ]
@@ -255,6 +256,32 @@ class SpackApplication(ApplicationBase):
 
             self.spack_runner.activate()
             self.spack_runner.install()
+        except ramble.spack_runner.RunnerError as e:
+            tty.die(e)
+
+    def _define_package_paths(self, workspace):
+        """Define variables containing the path to all spack packages
+
+        For every spack package defined within an application context, define
+        a variable that refers to that packages installation location.
+
+        As an example:
+        <ramble.yaml>
+        spack:
+          applications:
+            wrfv4:
+              wrf:
+                base: wrf
+                version: 4.2.2
+
+        Would define a variable `wrf` that contains the installation path of
+        wrf@4.2.2
+        """
+        try:
+            self.spack_runner.set_dry_run(workspace.dry_run)
+            self.spack_runner.set_env(self.expander.expand_var('{spack_env}'))
+
+            self.spack_runner.activate()
 
             app_context = self.expander.expand_var('{spec_name}')
             for name, spec_info in \

--- a/lib/ramble/ramble/test/end_to_end.py
+++ b/lib/ramble/ramble/test/end_to_end.py
@@ -1039,3 +1039,65 @@ spack:
 
     with open(lock_file, 'r') as f:
         assert 'zlib' in f.read()
+
+
+def test_dryrun_series_contains_package_paths(mutable_config,
+                                              mutable_mock_workspace_path,
+                                              mock_applications):
+    test_config = r"""
+ramble:
+  mpi:
+    command: mpirun
+    args:
+    - '-n'
+    - '{n_ranks}'
+    - '-ppn'
+    - '{processes_per_node}'
+    - '-hostfile'
+    - 'hostfile'
+  batch:
+    submit: 'batch_submit {execute_experiment}'
+  variables:
+    processes_per_node: '10'
+    n_ranks: '{processes_per_node}*{n_nodes}'
+    n_threads: '1'
+  applications:
+    zlib:
+      workloads:
+        ensure_installed:
+          experiments:
+            test_{test_id}:
+              variables:
+                n_nodes: '1'
+                test_id: [1, 2]
+spack:
+  concretized: true
+  compilers: {}
+  mpi_libraries: {}
+  applications:
+    zlib:
+      zlib:
+        base: zlib
+"""
+
+    workspace_name = 'test_dryrun_series_contains_package_paths'
+    ws = ramble.workspace.create(workspace_name)
+    ws.write()
+
+    config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+
+    with open(config_path, 'w+') as f:
+        f.write(test_config)
+
+    ws.dry_run = True
+    ws._re_read()
+
+    ws.run_pipeline('setup')
+
+    for test in ['test_1', 'test_2']:
+        script = os.path.join(ws.experiment_dir, 'zlib', 'ensure_installed',
+                              test, 'execute_experiment')
+
+        assert os.path.exists(script)
+        with open(script, 'r') as f:
+            assert r'{zlib}' not in f.read()

--- a/var/ramble/repos/builtin.mock/applications/zlib/application.py
+++ b/var/ramble/repos/builtin.mock/applications/zlib/application.py
@@ -1,0 +1,26 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.appkit import *
+
+
+class Zlib(SpackApplication):
+    name = "zlib"
+
+    software_spec('zlib', base='zlib')
+
+    executable('list_lib', 'ls {zlib}/lib', use_mpi=False)
+
+    workload('ensure_installed', executable='list_lib')
+
+    figure_of_merit('zlib_installed',
+                    fom_regex=r'(?P<lib_name>libz.so.*)', group_name='lib_name',
+                    units='', log_file='{log_file}')
+
+    success_criteria('zlib_installed', mode='string',
+                     match=r'libz.so', file='{log_file}')


### PR DESCRIPTION
This merge pulls spack package path definition out from being guarded by a cache. This ensures all experiments in an experiment series have correctly defined package paths. Previously, only the first experiment in the series had their paths defined.

Fixes #95 