### PR TITLE
Add chained experiment support

### DIFF
--- a/lib/ramble/docs/workspace_config.rst
+++ b/lib/ramble/docs/workspace_config.rst
@@ -680,14 +680,16 @@ scripts to each of the batch systems.
 Experiment Chains:
 ------------------
 
-Experiments can be chained together, to allow multiple experiments to be
-executed within the same context. This can be useful for executing multiple
-experiments on the same set of hardware.
+Multiple experiments can be executed within the same context by a process known
+as chaining, this allows multiple experiments (potentially from multiple
+applications) to be executed in the same context and is useful for many
+potential use cases such as running multiple experiments on the same physical
+hardware
 
 There are two important parts for defining an experiment chain. The first of
-these is simply defining the experiment chain, and the second is suppressing
-generation of template experiments.
-
+these is simply defining the experiment chain, and the second is defining
+experiments which are only intended to be used when chained into another
+experiment, known as template experiments.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Defining Experiment Chains:
@@ -736,7 +738,7 @@ the following format:
    chained_experiments: # List of experiments to chain
    - name: Fully qualified experiment namespace
      command: Command that executes the sub experiment
-     order: Order to chain this experiment. Can be append, or prepend
+     order: Order to chain this experiment. Defaults to 'after_root'
      variables: Variables dictionary to override the variables from the
                 original experiment
 
@@ -750,7 +752,15 @@ The ``name`` attribute can use `globbing
 syntax<https://docs.python.org/3/library/fnmatch.html#module-fnmatch>` to chain
 multiple experiments at once.
 
-The ``order`` keyword is optional. It defaults to a valud of ``append``.
+The ``order`` keyword is optional. Valid options include:
+* ``before_chain`` Chained experiment is injected at the beginning of the chain
+* ``before_root`` Chained experiment is injected right before the root experiment in the chain
+* ``after_root`` Chained experiment is injected right after the root experiment in the chain
+* ``after_chain`` Chained experiment is injected at the end of the chain
+
+The ``root`` experiment is defined as the initial experiment that started the
+chain. When examining the entire chain, the root experiment is the only one
+that does not have ``chain.{idx}`` in its name.
 
 The ``variables`` keyword is optional. It can be used to override the
 definition of variables from the chained experiment if needed.

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -82,6 +82,16 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         self._verbosity = 'short'
         self._inject_required_builtins()
 
+    def copy(self):
+        """Deep copy an application instance"""
+        new_copy = type(self)(self._file_path)
+
+        new_copy.set_env_variable_sets(self._env_variable_sets)
+        new_copy.set_variables(self.variables, self.experiment_set)
+        new_copy.set_internals(self.internals)
+
+        return new_copy
+
     def _inject_required_builtins(self):
         required_builtins = []
         for builtin, blt_conf in self.builtins.items():

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -432,7 +432,7 @@ def workspace_info(args):
                                                       exp_internals,
                                                       exp_template,
                                                       exp_chained_exps)
-    experiment_set.finalize_set()
+    experiment_set.build_experiment_chains()
 
     # Print experiment information
     color.cprint('')
@@ -458,7 +458,7 @@ def workspace_info(args):
                                                             exp_template,
                                                             exp_chained_exps)
 
-                print_experiment_set.finalize_set()
+                print_experiment_set.build_experiment_chains()
 
                 color.cprint(nested_1('  Application: ') + app)
                 color.cprint(nested_2('    Workload: ') + workload)

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -432,6 +432,7 @@ def workspace_info(args):
                                                       exp_internals,
                                                       exp_template,
                                                       exp_chained_exps)
+    experiment_set.finalize_set()
 
     # Print experiment information
     color.cprint('')
@@ -456,6 +457,8 @@ def workspace_info(args):
                                                             exp_internals,
                                                             exp_template,
                                                             exp_chained_exps)
+
+                print_experiment_set.finalize_set()
 
                 color.cprint(nested_1('  Application: ') + app)
                 color.cprint(nested_2('    Workload: ') + workload)

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -439,7 +439,7 @@ def workspace_info(args):
     for app, workloads, app_vars, app_env_vars, app_internals, app_template, app_chained_exps \
             in ws.all_applications():
         for workload, experiments, workload_vars, workload_env_vars, workload_internals, \
-                workload_tempalte, workload_chained_exps in ws.all_workloads(workloads):
+                workload_template, workload_chained_exps in ws.all_workloads(workloads):
             for exp, _, exp_vars, exp_env_vars, exp_matrices, exp_internals, exp_template, \
                     exp_chained_exps in ws.all_experiments(experiments):
                 print_experiment_set = ramble.experiment_set.ExperimentSet(ws)
@@ -462,7 +462,10 @@ def workspace_info(args):
 
                 for exp_name, _ in print_experiment_set.all_experiments():
                     app_inst = experiment_set.get_experiment(exp_name)
-                    color.cprint(nested_3('      Experiment: ') + exp_name)
+                    if app_inst.is_template:
+                        color.cprint(nested_3('      Template Experiment: ') + exp_name)
+                    else:
+                        color.cprint(nested_3('      Experiment: ') + exp_name)
 
                     if args.verbose >= 1:
                         config_vars = ramble.config.config.get('config:variables')
@@ -521,6 +524,11 @@ def workspace_info(args):
                             if ramble.workspace.namespace.executables in app_inst.internals:
                                 color.cprint(nested_4('        Executable Order') + ': ' +
                                              str(app_inst.internals['executables']))
+
+                        if app_inst.chain_order:
+                            color.cprint(nested_4('        Experiment Chain') + ':')
+                            for exp in app_inst.chain_order:
+                                color.cprint(nested_4('         - ') + exp)
 
     # Print MPI command
     color.cprint('')

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -414,38 +414,48 @@ def workspace_info(args):
 
     # Build experiment set
     experiment_set = ramble.experiment_set.ExperimentSet(ws)
-    for app, workloads, app_vars, app_env_vars, app_internals in ws.all_applications():
-        for workload, experiments, workload_vars, workload_env_vars, workload_internals in \
-                ws.all_workloads(workloads):
-            for exp, _, exp_vars, exp_env_vars, exp_matrices, exp_internals in \
-                    ws.all_experiments(experiments):
-                experiment_set.set_application_context(app, app_vars, app_env_vars, app_internals)
+    for app, workloads, app_vars, app_env_vars, app_internals, app_template, app_chained_exps \
+            in ws.all_applications():
+        for workload, experiments, workload_vars, workload_env_vars, workload_internals, \
+                workload_template, workload_chained_exps in ws.all_workloads(workloads):
+            for exp, _, exp_vars, exp_env_vars, exp_matrices, exp_internals, exp_template, \
+                    exp_chained_exps in ws.all_experiments(experiments):
+                experiment_set.set_application_context(app, app_vars, app_env_vars, app_internals,
+                                                       app_template, app_chained_exps)
                 experiment_set.set_workload_context(workload, workload_vars,
-                                                    workload_env_vars, workload_internals)
+                                                    workload_env_vars, workload_internals,
+                                                    workload_template, workload_chained_exps)
                 experiment_set.set_experiment_context(exp,
                                                       exp_vars,
                                                       exp_env_vars,
                                                       exp_matrices,
-                                                      exp_internals)
+                                                      exp_internals,
+                                                      exp_template,
+                                                      exp_chained_exps)
 
     # Print experiment information
     color.cprint('')
     color.cprint(section_title('Experiments:'))
-    for app, workloads, app_vars, app_env_vars, app_internals in ws.all_applications():
-        for workload, experiments, workload_vars, workload_env_vars, workload_internals in \
-                ws.all_workloads(workloads):
-            for exp, _, exp_vars, exp_env_vars, exp_matrices, exp_internals in \
-                    ws.all_experiments(experiments):
+    for app, workloads, app_vars, app_env_vars, app_internals, app_template, app_chained_exps \
+            in ws.all_applications():
+        for workload, experiments, workload_vars, workload_env_vars, workload_internals, \
+                workload_tempalte, workload_chained_exps in ws.all_workloads(workloads):
+            for exp, _, exp_vars, exp_env_vars, exp_matrices, exp_internals, exp_template, \
+                    exp_chained_exps in ws.all_experiments(experiments):
                 print_experiment_set = ramble.experiment_set.ExperimentSet(ws)
                 print_experiment_set.set_application_context(app, app_vars,
-                                                             app_env_vars, app_internals)
+                                                             app_env_vars, app_internals,
+                                                             app_template, app_chained_exps)
                 print_experiment_set.set_workload_context(workload, workload_vars,
-                                                          workload_env_vars, workload_internals)
+                                                          workload_env_vars, workload_internals,
+                                                          workload_template, workload_chained_exps)
                 print_experiment_set.set_experiment_context(exp,
                                                             exp_vars,
                                                             exp_env_vars,
                                                             exp_matrices,
-                                                            exp_internals)
+                                                            exp_internals,
+                                                            exp_template,
+                                                            exp_chained_exps)
 
                 color.cprint(nested_1('  Application: ') + app)
                 color.cprint(nested_2('    Workload: ') + workload)

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -564,13 +564,12 @@ class ExperimentSet(object):
             self.experiments[experiment_namespace] = app_inst
             self.experiment_order.append(experiment_namespace)
 
-    def finalize_set(self):
+    def build_experiment_chains(self):
         base_experiments = self.experiment_order.copy()
 
         for experiment in base_experiments:
             instance = self.experiments[experiment]
             instance.create_experiment_chain(self._workspace)
-            instance.add_expand_vars(self._workspace)
 
     def all_experiments(self):
         """Iteartor over all experiments in this set"""

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -44,6 +44,8 @@ class ExperimentSet(object):
         """Create experiment set class"""
         self.experiments = {}
         self.experiment_order = []
+        self.chained_experiments = {}
+        self.chained_order = []
         self._workspace = workspace
 
         self._env_variables = {}
@@ -575,19 +577,28 @@ class ExperimentSet(object):
         for exp, inst in self.experiments.items():
             yield exp, inst
 
-    def add_experiment(self, name, instance):
-        if name in self.experiments.keys():
-            raise RambleExperimentSetError('Cannot add already defined ' +
-                                           f'experiment {name} to this experiment set.')
-        self.experiments[name] = instance
-        self.experiment_order.append(name)
+        for exp, inst in self.chained_experiments.items():
+            yield exp, inst
 
-    def search_experiments(self, pattern):
+    def add_chained_experiment(self, name, instance):
+        if name in self.chained_experiments.keys():
+            raise RambleExperimentSetError('Cannot add already defined chained ' +
+                                           f'experiment {name} to this experiment set.')
+        self.chained_experiments[name] = instance
+        self.chained_order.append(name)
+
+    def search_primary_experiments(self, pattern):
+        """Search primary experiments using a glob syntax.
+
+        NOTE: This does not search experiments defined in an experiment chain
+        """
         return fnmatch.filter(self.experiment_order, pattern)
 
     def get_experiment(self, experiment):
         if experiment in self.experiments.keys():
             return self.experiments[experiment]
+        if experiment in self.chained_experiments.keys():
+            return self.chained_experiments[experiment]
         return None
 
     def get_var_from_experiment(self, experiment, variable):

--- a/lib/ramble/ramble/schema/applications.py
+++ b/lib/ramble/ramble/schema/applications.py
@@ -118,6 +118,22 @@ internals_def = {
     'additionalProperties': False
 }
 
+chained_experiment_def = {
+    'type': 'array',
+    'default': [],
+    'items': {
+        'type': 'object',
+        'default': {},
+        'properties': {
+            'name': {'type': 'string'},
+            'command': {'type': 'string'},
+            'order': {'type': 'string'},
+            'variables': variables_def,
+        },
+        'additionalProperties': False
+    }
+}
+
 #: Properties for inclusion in other schemas
 applications_schema = {
     'applications': {
@@ -133,6 +149,8 @@ applications_schema = {
                 'env-vars': ramble.schema.licenses.env_var_actions,
                 'internals': internals_def,
                 'success_criteria': success_list_def,
+                'chained_experiments': chained_experiment_def,
+                'template': {'type': 'boolean'},
                 'workloads': {
                     'type': 'object',
                     'default': {},
@@ -146,6 +164,8 @@ applications_schema = {
                             'env-vars': ramble.schema.licenses.env_var_actions,
                             'internals': internals_def,
                             'success_criteria': success_list_def,
+                            'chained_experiments': chained_experiment_def,
+                            'template': {'type': 'boolean'},
                             'experiments': {
                                 'type': 'object',
                                 'default': {},
@@ -161,6 +181,8 @@ applications_schema = {
                                         'env-vars': ramble.schema.licenses.env_var_actions,
                                         'internals': internals_def,
                                         'success_criteria': success_list_def,
+                                        'chained_experiments': chained_experiment_def,
+                                        'template': {'type': 'boolean'},
                                     }
                                 }
                             }

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -354,7 +354,7 @@ ramble:
             test_experiment:
               chained_experiments:
               - name: basic.test_wl.test_experiment
-                order: 'append'
+                order: 'after_root'
                 command: '{execute_experiment}'
               variables:
                 n_nodes: '2'

--- a/lib/ramble/ramble/test/end_to_end.py
+++ b/lib/ramble/ramble/test/end_to_end.py
@@ -1151,13 +1151,13 @@ ramble:
       chained_experiments:
       - name: intel-mpi-benchmarks.collective.*
         command: '{execute_experiment}'
-        order: 'append'
+        order: 'after_root'
       workloads:
         water_bare:
           chained_experiments:
           - name: intel-mpi-benchmarks.*.collective_chain
             command: '{execute_experiment}'
-            order: 'prepend'
+            order: 'before_root'
             variables:
               n_ranks: '4'
           experiments:
@@ -1165,7 +1165,7 @@ ramble:
               chained_experiments:
               - name: intel-mpi-benchmarks.collective.collective_chain
                 command: '{execute_experiment}'
-                order: 'prepend'
+                order: 'before_root'
               variables:
                 n_nodes: '2'
 spack:

--- a/lib/ramble/ramble/test/end_to_end.py
+++ b/lib/ramble/ramble/test/end_to_end.py
@@ -1139,13 +1139,13 @@ ramble:
                 n_ranks: '2'
     gromacs:
       chained_experiments:
-      - name: intel-mpi-benchmarks.collective.to_chain
+      - name: intel-mpi-benchmarks.collective.*
         command: '{execute_experiment}'
         order: 'append'
       workloads:
         water_bare:
           chained_experiments:
-          - name: intel-mpi-benchmarks.collective.to_chain
+          - name: intel-mpi-benchmarks.*.to_chain
             command: '{execute_experiment}'
             order: 'prepend'
             variables:

--- a/lib/ramble/ramble/test/end_to_end.py
+++ b/lib/ramble/ramble/test/end_to_end.py
@@ -12,9 +12,13 @@ import re
 
 import pytest
 
+import spack.util.spack_yaml as syaml
+import spack.util.spack_json as sjson
+
 import ramble.workspace
 import ramble.config
 from ramble.main import RambleCommand
+
 
 # everything here uses the mock_workspace_path
 pytestmark = pytest.mark.usefixtures('mutable_config',
@@ -1137,13 +1141,15 @@ ramble:
       chained_experiments:
       - name: intel-mpi-benchmarks.collective.to_chain
         command: '{execute_experiment}'
-        order: 'prepend'
+        order: 'append'
       workloads:
         water_bare:
           chained_experiments:
           - name: intel-mpi-benchmarks.collective.to_chain
             command: '{execute_experiment}'
             order: 'prepend'
+            variables:
+              n_ranks: '4'
           experiments:
             parent_test:
               chained_experiments:
@@ -1176,6 +1182,10 @@ spack:
         mpi: impi2018
 """
 
+    mock_output_data = """
+  14 100 1.5 1.0 2.0
+"""
+
     workspace_name = 'test_dryrun_chained_experiments'
     ws = ramble.workspace.create(workspace_name)
     ws.write()
@@ -1190,6 +1200,79 @@ spack:
 
     ws.run_pipeline('setup')
 
-    script = os.path.join(ws.experiment_dir, 'gromacs', 'water_bare',
-                          'parent_test', 'execute_experiment')
+    template_dir = os.path.join(ws.experiment_dir, 'intel-mpi-benchmarks')
+    assert not os.path.exists(template_dir)
+
+    parent_dir = os.path.join(ws.experiment_dir, 'gromacs', 'water_bare',
+                              'parent_test')
+    script = os.path.join(parent_dir, 'execute_experiment')
     assert os.path.exists(script)
+
+    # Check all chained experiments are referenced
+    with open(script, 'r') as f:
+        parent_script_data = f.read()
+
+    for chain_idx in [0, 1, 2]:
+        chained_script = os.path.join(parent_dir, 'chained_experiments',
+                                      f'{chain_idx}' +
+                                      r'.intel-mpi-benchmarks.collective.to_chain',
+                                      'execute_experiment')
+        assert os.path.exists(chained_script)
+        assert chained_script in parent_script_data
+
+        # Check that experiment 1 has n_ranks = 4 instead of 2
+        if chain_idx == 1:
+            with open(chained_script, 'r') as f:
+                assert 'mpirun -n 4' in f.read()
+
+    # Check prepend / append order is correct
+    with open(script, 'r') as f:
+        # Order should be 1, 2, 0
+        found1 = False
+        regex1 = re.compile(r'.*1.intel-mpi-benchmarks.collective.to_chain.*')
+        found2 = False
+        regex2 = re.compile(r'.*2.intel-mpi-benchmarks.collective.to_chain.*')
+        found0 = False
+        regex0 = re.compile(r'.*0.intel-mpi-benchmarks.collective.to_chain.*')
+        for line in f.readlines():
+            if not found1 and regex1.match(line):
+                found1 = True
+            elif found1:
+                if not found2 and regex2.match(line):
+                    found2 = True
+                elif found2 and not found0 and regex0.match(line):
+                    found0 = True
+        assert found1 and found2 and found0
+
+    # Ensure results contain chain information, and properly extract figures of merit
+    chain_exp_name = '2.intel-mpi-benchmarks.collective.to_chain'
+    output_path_2 = os.path.join(parent_dir, 'chained_experiments',
+                                 chain_exp_name,
+                                 f'gromacs.water_bare.parent_test.chain.{chain_exp_name}.out')
+
+    with open(output_path_2, 'w+') as f:
+        f.write(mock_output_data)
+
+    ws.run_pipeline('analyze')
+    ws.dump_results(output_formats=['json', 'yaml'])
+
+    chain_def = ['gromacs.water_bare.parent_test.chain.1.intel-mpi-benchmarks.collective.to_chain',
+                 'gromacs.water_bare.parent_test.chain.2.intel-mpi-benchmarks.collective.to_chain',
+                 'gromacs.water_bare.parent_test',
+                 'gromacs.water_bare.parent_test.chain.0.intel-mpi-benchmarks.collective.to_chain']
+
+    names = ['results.latest.json', 'results.latest.yaml']
+    loaders = [sjson.load, syaml.load]
+    for name, loader in zip(names, loaders):
+        with open(os.path.join(ws.root, name), 'r') as f:
+            data = loader(f)
+
+            assert 'experiments' in data
+
+            for exp_def in data['experiments']:
+                if exp_def['name'] == 'gromacs.water_bare.parent_test.' + \
+                        'chain.2.intel-mpi-benchmarks.collective.to_chain':
+                    assert exp_def['RAMBLE_STATUS'] == 'SUCCESS'
+                else:
+                    assert exp_def['RAMBLE_STATUS'] == 'FAILED'
+                assert exp_def['EXPERIMENT_CHAIN'] == chain_def

--- a/lib/ramble/ramble/test/experiment_set.py
+++ b/lib/ramble/ramble/test/experiment_set.py
@@ -53,7 +53,7 @@ def test_single_experiment_in_set(mutable_mock_workspace_path):
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         exp_set.set_experiment_context(exp_name, exp_vars, None, None, None, None, None)
-        exp_set.finalize_set()
+        exp_set.build_experiment_chains()
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
 
@@ -89,7 +89,7 @@ def test_vector_experiment_in_set(mutable_mock_workspace_path):
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         exp_set.set_experiment_context(exp_name, exp_vars, None, None, None, None, None)
-        exp_set.finalize_set()
+        exp_set.build_experiment_chains()
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_8' in exp_set.experiments.keys()
@@ -162,7 +162,7 @@ def test_zipped_vector_experiments(mutable_mock_workspace_path):
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         exp_set.set_experiment_context(exp_name, exp_vars, None, None, None, None, None)
-        exp_set.finalize_set()
+        exp_set.build_experiment_chains()
 
         assert 'basic.test_wl.series1_4_2' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_16_4' in exp_set.experiments.keys()
@@ -203,7 +203,7 @@ def test_matrix_experiments(mutable_mock_workspace_path):
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None, None, None)
-        exp_set.finalize_set()
+        exp_set.build_experiment_chains()
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_6' in exp_set.experiments.keys()
@@ -244,7 +244,7 @@ def test_matrix_multiplication_experiments(mutable_mock_workspace_path):
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None, None, None)
-        exp_set.finalize_set()
+        exp_set.build_experiment_chains()
 
         assert 'basic.test_wl.series1_2' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_8' in exp_set.experiments.keys()
@@ -289,7 +289,7 @@ def test_matrix_vector_experiments(mutable_mock_workspace_path):
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None, None, None)
-        exp_set.finalize_set()
+        exp_set.build_experiment_chains()
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_8' in exp_set.experiments.keys()
@@ -333,7 +333,7 @@ def test_multi_matrix_experiments(mutable_mock_workspace_path):
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None, None, None)
-        exp_set.finalize_set()
+        exp_set.build_experiment_chains()
 
         assert 'basic.test_wl.series1_4_2' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_12_4' in exp_set.experiments.keys()
@@ -418,7 +418,7 @@ def test_experiment_names_match(mutable_mock_workspace_path):
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None, None, None)
-        exp_set.finalize_set()
+        exp_set.build_experiment_chains()
 
         assert 'basic.test_wl.series1_4_2' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_12_4' in exp_set.experiments.keys()
@@ -468,7 +468,7 @@ def test_cross_experiment_variable_references(mutable_mock_workspace_path):
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         exp_set.set_experiment_context(exp1_name, exp1_vars, None, None, None, None, None)
         exp_set.set_experiment_context(exp2_name, exp2_vars, None, None, None, None, None)
-        exp_set.finalize_set()
+        exp_set.build_experiment_chains()
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
         assert 'basic.test_wl.series2_4' in exp_set.experiments.keys()
@@ -509,7 +509,7 @@ def test_cross_experiment_missing_experiment_errors(mutable_mock_workspace_path)
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         exp_set.set_experiment_context(exp1_name, exp1_vars, None, None, None, None, None)
-        exp_set.finalize_set()
+        exp_set.build_experiment_chains()
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
 
@@ -555,7 +555,7 @@ def test_n_ranks_correct_defaults(mutable_mock_workspace_path):
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None, None, None)
-        exp_set.finalize_set()
+        exp_set.build_experiment_chains()
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_6' in exp_set.experiments.keys()
@@ -595,7 +595,7 @@ def test_n_nodes_correct_defaults(mutable_mock_workspace_path):
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None, None, None)
-        exp_set.finalize_set()
+        exp_set.build_experiment_chains()
 
         assert 'basic.test_wl.series1_4_2' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_6_3' in exp_set.experiments.keys()
@@ -633,7 +633,7 @@ def test_processes_per_node_correct_defaults(mutable_mock_workspace_path):
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         exp_set.set_experiment_context(exp_name, exp_vars, None, None, None, None, None)
-        exp_set.finalize_set()
+        exp_set.build_experiment_chains()
 
         assert 'basic.test_wl.series1_4_2' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_6_2' in exp_set.experiments.keys()
@@ -818,13 +818,13 @@ def test_chained_experiments_populate_new_experiments(mutable_mock_workspace_pat
         exp2_chains = [
             {
                 'name': 'basic.test_wl.test1',
-                'order': 'prepend',
+                'order': 'before_root',
                 'command': '{execute_experiment}',
                 'variables': {}
             },
             {
                 'name': 'basic.test_wl.test1',
-                'order': 'append',
+                'order': 'after_root',
                 'command': '{execute_experiment}',
                 'variables': {}
             }
@@ -834,7 +834,7 @@ def test_chained_experiments_populate_new_experiments(mutable_mock_workspace_pat
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         exp_set.set_experiment_context(exp1_name, exp1_vars, None, None, None, None, None)
         exp_set.set_experiment_context(exp2_name, exp2_vars, None, None, None, None, exp2_chains)
-        exp_set.finalize_set()
+        exp_set.build_experiment_chains()
 
         assert 'basic.test_wl.series2_4' in \
             exp_set.experiments
@@ -884,7 +884,7 @@ def test_chained_experiment_has_correct_directory(mutable_mock_workspace_path, c
         exp2_chains = [
             {
                 'name': 'basic.test_wl.test1',
-                'order': 'prepend',
+                'order': 'before_root',
                 'command': '{execute_experiment}',
                 'variables': {}
             },
@@ -894,7 +894,7 @@ def test_chained_experiment_has_correct_directory(mutable_mock_workspace_path, c
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         exp_set.set_experiment_context(exp1_name, exp1_vars, None, None, None, None, None)
         exp_set.set_experiment_context(exp2_name, exp2_vars, None, None, None, None, exp2_chains)
-        exp_set.finalize_set()
+        exp_set.build_experiment_chains()
 
         parent_name = 'basic.test_wl.series2_4'
         chained_name = 'basic.test_wl.series2_4.chain.0.basic.test_wl.test1'
@@ -943,7 +943,7 @@ def test_chained_cycle_errors(mutable_mock_workspace_path, capsys):
         exp2_chains = [
             {
                 'name': 'basic.test_wl.series2_4',
-                'order': 'prepend',
+                'order': 'before_root',
                 'command': '{execute_experiment}',
                 'variables': {}
             },
@@ -954,7 +954,7 @@ def test_chained_cycle_errors(mutable_mock_workspace_path, capsys):
         exp_set.set_experiment_context(exp1_name, exp1_vars, None, None, None, None, None)
         exp_set.set_experiment_context(exp2_name, exp2_vars, None, None, None, None, exp2_chains)
         with pytest.raises(ChainCycleDetectedError):
-            exp_set.finalize_set()
+            exp_set.build_experiment_chains()
             captured = capsys.readouterr
             assert "Cycle detected in experiment chain" in captured
 
@@ -1003,6 +1003,6 @@ def test_chained_invalid_order_errors(mutable_mock_workspace_path, capsys):
         exp_set.set_experiment_context(exp1_name, exp1_vars, None, None, None, None, None)
         exp_set.set_experiment_context(exp2_name, exp2_vars, None, None, None, None, exp2_chains)
         with pytest.raises(InvalidChainError):
-            exp_set.finalize_set()
+            exp_set.build_experiment_chains()
             captured = capsys.readouterr
             assert "Invalid experiment chain defined:" in captured

--- a/lib/ramble/ramble/test/experiment_set.py
+++ b/lib/ramble/ramble/test/experiment_set.py
@@ -11,6 +11,7 @@ import pytest
 
 import ramble.workspace
 import ramble.experiment_set
+from ramble.application import ChainCycleDetectedError, InvalidChainError
 from ramble.main import RambleCommand
 
 pytestmark = pytest.mark.usefixtures('mutable_config',
@@ -52,6 +53,7 @@ def test_single_experiment_in_set(mutable_mock_workspace_path):
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         exp_set.set_experiment_context(exp_name, exp_vars, None, None, None, None, None)
+        exp_set.finalize_set()
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
 
@@ -87,6 +89,7 @@ def test_vector_experiment_in_set(mutable_mock_workspace_path):
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         exp_set.set_experiment_context(exp_name, exp_vars, None, None, None, None, None)
+        exp_set.finalize_set()
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_8' in exp_set.experiments.keys()
@@ -159,6 +162,7 @@ def test_zipped_vector_experiments(mutable_mock_workspace_path):
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         exp_set.set_experiment_context(exp_name, exp_vars, None, None, None, None, None)
+        exp_set.finalize_set()
 
         assert 'basic.test_wl.series1_4_2' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_16_4' in exp_set.experiments.keys()
@@ -199,6 +203,7 @@ def test_matrix_experiments(mutable_mock_workspace_path):
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None, None, None)
+        exp_set.finalize_set()
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_6' in exp_set.experiments.keys()
@@ -239,6 +244,7 @@ def test_matrix_multiplication_experiments(mutable_mock_workspace_path):
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None, None, None)
+        exp_set.finalize_set()
 
         assert 'basic.test_wl.series1_2' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_8' in exp_set.experiments.keys()
@@ -283,6 +289,7 @@ def test_matrix_vector_experiments(mutable_mock_workspace_path):
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None, None, None)
+        exp_set.finalize_set()
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_8' in exp_set.experiments.keys()
@@ -326,6 +333,7 @@ def test_multi_matrix_experiments(mutable_mock_workspace_path):
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None, None, None)
+        exp_set.finalize_set()
 
         assert 'basic.test_wl.series1_4_2' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_12_4' in exp_set.experiments.keys()
@@ -410,6 +418,7 @@ def test_experiment_names_match(mutable_mock_workspace_path):
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None, None, None)
+        exp_set.finalize_set()
 
         assert 'basic.test_wl.series1_4_2' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_12_4' in exp_set.experiments.keys()
@@ -459,6 +468,7 @@ def test_cross_experiment_variable_references(mutable_mock_workspace_path):
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         exp_set.set_experiment_context(exp1_name, exp1_vars, None, None, None, None, None)
         exp_set.set_experiment_context(exp2_name, exp2_vars, None, None, None, None, None)
+        exp_set.finalize_set()
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
         assert 'basic.test_wl.series2_4' in exp_set.experiments.keys()
@@ -499,6 +509,7 @@ def test_cross_experiment_missing_experiment_errors(mutable_mock_workspace_path)
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         exp_set.set_experiment_context(exp1_name, exp1_vars, None, None, None, None, None)
+        exp_set.finalize_set()
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
 
@@ -544,6 +555,7 @@ def test_n_ranks_correct_defaults(mutable_mock_workspace_path):
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None, None, None)
+        exp_set.finalize_set()
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_6' in exp_set.experiments.keys()
@@ -583,6 +595,7 @@ def test_n_nodes_correct_defaults(mutable_mock_workspace_path):
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None, None, None)
+        exp_set.finalize_set()
 
         assert 'basic.test_wl.series1_4_2' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_6_3' in exp_set.experiments.keys()
@@ -620,6 +633,7 @@ def test_processes_per_node_correct_defaults(mutable_mock_workspace_path):
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         exp_set.set_experiment_context(exp_name, exp_vars, None, None, None, None, None)
+        exp_set.finalize_set()
 
         assert 'basic.test_wl.series1_4_2' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_6_2' in exp_set.experiments.keys()
@@ -820,19 +834,20 @@ def test_chained_experiments_populate_new_experiments(mutable_mock_workspace_pat
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         exp_set.set_experiment_context(exp1_name, exp1_vars, None, None, None, None, None)
         exp_set.set_experiment_context(exp2_name, exp2_vars, None, None, None, None, exp2_chains)
+        exp_set.finalize_set()
 
         assert 'basic.test_wl.series2_4' in \
             exp_set.experiments
         assert 'basic.test_wl.series2_4.chain.0.basic.test_wl.test1' in \
-            exp_set.experiments
+            exp_set.chained_experiments
         assert 'basic.test_wl.series2_4.chain.1.basic.test_wl.test1' in \
-            exp_set.experiments
+            exp_set.chained_experiments
         assert 'basic.test_wl.series2_6' in \
             exp_set.experiments
         assert 'basic.test_wl.series2_6.chain.0.basic.test_wl.test1' in \
-            exp_set.experiments
+            exp_set.chained_experiments
         assert 'basic.test_wl.series2_6.chain.1.basic.test_wl.test1' in \
-            exp_set.experiments
+            exp_set.chained_experiments
         assert 'basic.test_wl.test1' in exp_set.experiments
 
 
@@ -879,12 +894,13 @@ def test_chained_experiment_has_correct_directory(mutable_mock_workspace_path, c
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         exp_set.set_experiment_context(exp1_name, exp1_vars, None, None, None, None, None)
         exp_set.set_experiment_context(exp2_name, exp2_vars, None, None, None, None, exp2_chains)
+        exp_set.finalize_set()
 
         parent_name = 'basic.test_wl.series2_4'
         chained_name = 'basic.test_wl.series2_4.chain.0.basic.test_wl.test1'
         chained_dir = '0.basic.test_wl.test1'
         assert parent_name in exp_set.experiments
-        assert chained_name in exp_set.experiments
+        assert chained_name in exp_set.chained_experiments
 
         parent_inst = exp_set.get_experiment(parent_name)
         chained_inst = exp_set.get_experiment(chained_name)
@@ -892,3 +908,101 @@ def test_chained_experiment_has_correct_directory(mutable_mock_workspace_path, c
         parent_run_dir = parent_inst.expander.expand_var('{experiment_run_dir}')
         expected_dir = os.path.join(parent_run_dir, 'chained_experiments', chained_dir)
         assert chained_inst.variables['experiment_run_dir'] == expected_dir
+
+
+def test_chained_cycle_errors(mutable_mock_workspace_path, capsys):
+    workspace('create', 'test')
+
+    assert 'test' in workspace('list')
+
+    with ramble.workspace.read('test') as ws:
+        exp_set = ramble.experiment_set.ExperimentSet(ws)
+
+        app_name = 'basic'
+        app_vars = {
+            'app_var1': '1',
+            'app_var2': '2',
+            'processes_per_node': '1',
+        }
+
+        wl_name = 'test_wl'
+        wl_vars = {
+            'wl_var1': '1',
+            'wl_var2': '2',
+        }
+        exp1_name = 'test1'
+        exp1_vars = {
+            'n_ranks': '2'
+        }
+        exp2_name = 'series2_{n_ranks}'
+        exp2_vars = {
+            'exp_var1': '1',
+            'exp_var2': '2',
+            'n_ranks': '4'
+        }
+        exp2_chains = [
+            {
+                'name': 'basic.test_wl.series2_4',
+                'order': 'prepend',
+                'command': '{execute_experiment}',
+                'variables': {}
+            },
+        ]
+
+        exp_set.set_application_context(app_name, app_vars, None, None, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
+        exp_set.set_experiment_context(exp1_name, exp1_vars, None, None, None, None, None)
+        exp_set.set_experiment_context(exp2_name, exp2_vars, None, None, None, None, exp2_chains)
+        with pytest.raises(ChainCycleDetectedError):
+            exp_set.finalize_set()
+            captured = capsys.readouterr
+            assert "Cycle detected in experiment chain" in captured
+
+
+def test_chained_invalid_order_errors(mutable_mock_workspace_path, capsys):
+    workspace('create', 'test')
+
+    assert 'test' in workspace('list')
+
+    with ramble.workspace.read('test') as ws:
+        exp_set = ramble.experiment_set.ExperimentSet(ws)
+
+        app_name = 'basic'
+        app_vars = {
+            'app_var1': '1',
+            'app_var2': '2',
+            'processes_per_node': '1',
+        }
+
+        wl_name = 'test_wl'
+        wl_vars = {
+            'wl_var1': '1',
+            'wl_var2': '2',
+        }
+        exp1_name = 'test1'
+        exp1_vars = {
+            'n_ranks': '2'
+        }
+        exp2_name = 'series2_{n_ranks}'
+        exp2_vars = {
+            'exp_var1': '1',
+            'exp_var2': '2',
+            'n_ranks': '4'
+        }
+        exp2_chains = [
+            {
+                'name': 'basic.test_wl.test1',
+                'order': 'foo',
+                'command': '{execute_experiment}',
+                'variables': {}
+            },
+        ]
+
+        exp_set.set_application_context(app_name, app_vars, None, None, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
+        exp_set.set_experiment_context(exp1_name, exp1_vars, None, None, None, None, None)
+        exp_set.set_experiment_context(exp2_name, exp2_vars, None, None, None, None, exp2_chains)
+        with pytest.raises(InvalidChainError):
+            exp_set.finalize_set()
+            captured = capsys.readouterr
+            assert "Invalid experiment chain defined:" in captured

--- a/lib/ramble/ramble/test/experiment_set.py
+++ b/lib/ramble/ramble/test/experiment_set.py
@@ -6,6 +6,7 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+import os
 import pytest
 
 import ramble.workspace
@@ -48,9 +49,9 @@ def test_single_experiment_in_set(mutable_mock_workspace_path):
             'n_nodes': '2',
         }
 
-        exp_set.set_application_context(app_name, app_vars, None, None)
-        exp_set.set_workload_context(wl_name, wl_vars, None, None)
-        exp_set.set_experiment_context(exp_name, exp_vars, None, None, None)
+        exp_set.set_application_context(app_name, app_vars, None, None, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, None, None, None, None)
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
 
@@ -83,9 +84,9 @@ def test_vector_experiment_in_set(mutable_mock_workspace_path):
             'n_nodes': ['2', '4']
         }
 
-        exp_set.set_application_context(app_name, app_vars, None, None)
-        exp_set.set_workload_context(wl_name, wl_vars, None, None)
-        exp_set.set_experiment_context(exp_name, exp_vars, None, None, None)
+        exp_set.set_application_context(app_name, app_vars, None, None, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, None, None, None, None)
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_8' in exp_set.experiments.keys()
@@ -119,10 +120,10 @@ def test_nonunique_vector_errors(mutable_mock_workspace_path, capsys):
             'n_nodes': ['2', '4']
         }
 
-        exp_set.set_application_context(app_name, app_vars, None, None)
-        exp_set.set_workload_context(wl_name, wl_vars, None, None)
+        exp_set.set_application_context(app_name, app_vars, None, None, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         with pytest.raises(SystemExit):
-            exp_set.set_experiment_context(exp_name, exp_vars, None, None, None)
+            exp_set.set_experiment_context(exp_name, exp_vars, None, None, None, None, None)
             captured = capsys.readouterr()
             assert "is not unique." in captured
 
@@ -155,9 +156,9 @@ def test_zipped_vector_experiments(mutable_mock_workspace_path):
             'n_nodes': ['2', '4']
         }
 
-        exp_set.set_application_context(app_name, app_vars, None, None)
-        exp_set.set_workload_context(wl_name, wl_vars, None, None)
-        exp_set.set_experiment_context(exp_name, exp_vars, None, None, None)
+        exp_set.set_application_context(app_name, app_vars, None, None, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, None, None, None, None)
 
         assert 'basic.test_wl.series1_4_2' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_16_4' in exp_set.experiments.keys()
@@ -195,9 +196,9 @@ def test_matrix_experiments(mutable_mock_workspace_path):
             ['n_nodes']
         ]
 
-        exp_set.set_application_context(app_name, app_vars, None, None)
-        exp_set.set_workload_context(wl_name, wl_vars, None, None)
-        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None)
+        exp_set.set_application_context(app_name, app_vars, None, None, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None, None, None)
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_6' in exp_set.experiments.keys()
@@ -235,9 +236,9 @@ def test_matrix_multiplication_experiments(mutable_mock_workspace_path):
             ['n_nodes', 'processes_per_node']
         ]
 
-        exp_set.set_application_context(app_name, app_vars, None, None)
-        exp_set.set_workload_context(wl_name, wl_vars, None, None)
-        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None)
+        exp_set.set_application_context(app_name, app_vars, None, None, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None, None, None)
 
         assert 'basic.test_wl.series1_2' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_8' in exp_set.experiments.keys()
@@ -279,9 +280,9 @@ def test_matrix_vector_experiments(mutable_mock_workspace_path):
             ['n_nodes']
         ]
 
-        exp_set.set_application_context(app_name, app_vars, None, None)
-        exp_set.set_workload_context(wl_name, wl_vars, None, None)
-        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None)
+        exp_set.set_application_context(app_name, app_vars, None, None, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None, None, None)
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_8' in exp_set.experiments.keys()
@@ -322,9 +323,9 @@ def test_multi_matrix_experiments(mutable_mock_workspace_path):
             ['processes_per_node']
         ]
 
-        exp_set.set_application_context(app_name, app_vars, None, None)
-        exp_set.set_workload_context(wl_name, wl_vars, None, None)
-        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None)
+        exp_set.set_application_context(app_name, app_vars, None, None, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None, None, None)
 
         assert 'basic.test_wl.series1_4_2' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_12_4' in exp_set.experiments.keys()
@@ -363,11 +364,12 @@ def test_matrix_undefined_var_errors(mutable_mock_workspace_path, capsys):
             ['foo']
         ]
 
-        exp_set.set_application_context(app_name, app_vars, None, None)
-        exp_set.set_workload_context(wl_name, wl_vars, None, None)
+        exp_set.set_application_context(app_name, app_vars, None, None, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
 
         with pytest.raises(SystemExit):
-            exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None)
+            exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices,
+                                           None, None, None)
             captured = capsys.readouterr()
             assert "variable foo has not been defined yet." in captured
 
@@ -405,9 +407,9 @@ def test_experiment_names_match(mutable_mock_workspace_path):
             ['processes_per_node']
         ]
 
-        exp_set.set_application_context(app_name, app_vars, None, None)
-        exp_set.set_workload_context(wl_name, wl_vars, None, None)
-        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None)
+        exp_set.set_application_context(app_name, app_vars, None, None, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None, None, None)
 
         assert 'basic.test_wl.series1_4_2' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_12_4' in exp_set.experiments.keys()
@@ -453,10 +455,10 @@ def test_cross_experiment_variable_references(mutable_mock_workspace_path):
             'test_var': 'test_var in basic.test_wl.series1_4'
         }
 
-        exp_set.set_application_context(app_name, app_vars, None, None)
-        exp_set.set_workload_context(wl_name, wl_vars, None, None)
-        exp_set.set_experiment_context(exp1_name, exp1_vars, None, None, None)
-        exp_set.set_experiment_context(exp2_name, exp2_vars, None, None, None)
+        exp_set.set_application_context(app_name, app_vars, None, None, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
+        exp_set.set_experiment_context(exp1_name, exp1_vars, None, None, None, None, None)
+        exp_set.set_experiment_context(exp2_name, exp2_vars, None, None, None, None, None)
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
         assert 'basic.test_wl.series2_4' in exp_set.experiments.keys()
@@ -494,9 +496,9 @@ def test_cross_experiment_missing_experiment_errors(mutable_mock_workspace_path)
             'test_var': 'processes_per_node in basic.test_wl.does_not_exist'
         }
 
-        exp_set.set_application_context(app_name, app_vars, None, None)
-        exp_set.set_workload_context(wl_name, wl_vars, None, None)
-        exp_set.set_experiment_context(exp1_name, exp1_vars, None, None, None)
+        exp_set.set_application_context(app_name, app_vars, None, None, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
+        exp_set.set_experiment_context(exp1_name, exp1_vars, None, None, None, None, None)
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
 
@@ -539,9 +541,9 @@ def test_n_ranks_correct_defaults(mutable_mock_workspace_path):
             ['n_nodes']
         ]
 
-        exp_set.set_application_context(app_name, app_vars, None, None)
-        exp_set.set_workload_context(wl_name, wl_vars, None, None)
-        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None)
+        exp_set.set_application_context(app_name, app_vars, None, None, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None, None, None)
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_6' in exp_set.experiments.keys()
@@ -578,9 +580,9 @@ def test_n_nodes_correct_defaults(mutable_mock_workspace_path):
             ['n_ranks']
         ]
 
-        exp_set.set_application_context(app_name, app_vars, None, None)
-        exp_set.set_workload_context(wl_name, wl_vars, None, None)
-        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None)
+        exp_set.set_application_context(app_name, app_vars, None, None, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None, None, None)
 
         assert 'basic.test_wl.series1_4_2' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_6_3' in exp_set.experiments.keys()
@@ -615,9 +617,9 @@ def test_processes_per_node_correct_defaults(mutable_mock_workspace_path):
             'n_nodes': ['2', '3']
         }
 
-        exp_set.set_application_context(app_name, app_vars, None, None)
-        exp_set.set_workload_context(wl_name, wl_vars, None, None)
-        exp_set.set_experiment_context(exp_name, exp_vars, None, None, None)
+        exp_set.set_application_context(app_name, app_vars, None, None, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, None, None, None, None)
 
         assert 'basic.test_wl.series1_4_2' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_6_2' in exp_set.experiments.keys()
@@ -643,7 +645,7 @@ def test_reserved_keywords_error_in_application(mutable_mock_workspace_path, var
         }
 
         with pytest.raises(ramble.experiment_set.RambleVariableDefinitionError):
-            exp_set.set_application_context(app_name, app_vars, None, None)
+            exp_set.set_application_context(app_name, app_vars, None, None, None, None)
             captured = capsys.readouterr()
             assert "In application basic" in captured
             assert f"{var}" in captured
@@ -675,9 +677,9 @@ def test_reserved_keywords_error_in_workload(mutable_mock_workspace_path, var, c
             var: 'should_fail'
         }
 
-        exp_set.set_application_context(app_name, app_vars, None, None)
+        exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         with pytest.raises(ramble.experiment_set.RambleVariableDefinitionError):
-            exp_set.set_workload_context(wl_name, wl_vars, None, None)
+            exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
             captured = capsys.readouterr()
             assert "In workload basic.test_wl" in captured
             assert f"{var}" in captured
@@ -717,10 +719,10 @@ def test_reserved_keywords_error_in_experiment(mutable_mock_workspace_path, var,
             var: 'should_fail'
         }
 
-        exp_set.set_application_context(app_name, app_vars, None, None)
-        exp_set.set_workload_context(wl_name, wl_vars, None, None)
+        exp_set.set_application_context(app_name, app_vars, None, None, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         with pytest.raises(ramble.experiment_set.RambleVariableDefinitionError):
-            exp_set.set_experiment_context(exp_name, exp_vars, None, None, None)
+            exp_set.set_experiment_context(exp_name, exp_vars, None, None, None, None, None)
             captured = capsys.readouterr()
             assert "In experiment basic.test_wl.series1_{n_ranks}_{processes_per_node}" in captured
             assert f"{var}" in captured
@@ -759,11 +761,134 @@ def test_missing_required_keyword_errors(mutable_mock_workspace_path, var, capsy
             'n_nodes': ['2', '3']
         }
 
-        exp_set.set_application_context(app_name, app_vars, None, None)
-        exp_set.set_workload_context(wl_name, wl_vars, None, None)
+        exp_set.set_application_context(app_name, app_vars, None, None, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         with pytest.raises(ramble.experiment_set.RambleVariableDefinitionError):
-            exp_set.set_experiment_context(exp_name, exp_vars, None, None, None)
+            exp_set.set_experiment_context(exp_name, exp_vars, None, None, None, None, None)
             captured = capsys.readouterr()
             assert f'Required key "{var}" is not defined' in captured
             assert 'One or more required keys are not defined within an experiment.' in captured
             assert "In experiment basic.test_wl.series1_{n_ranks}_{processes_per_node}" in captured
+
+
+def test_chained_experiments_populate_new_experiments(mutable_mock_workspace_path, capsys):
+    workspace('create', 'test')
+
+    assert 'test' in workspace('list')
+
+    with ramble.workspace.read('test') as ws:
+        exp_set = ramble.experiment_set.ExperimentSet(ws)
+
+        app_name = 'basic'
+        app_vars = {
+            'app_var1': '1',
+            'app_var2': '2',
+            'processes_per_node': '1',
+        }
+
+        wl_name = 'test_wl'
+        wl_vars = {
+            'wl_var1': '1',
+            'wl_var2': '2',
+        }
+        exp1_name = 'test1'
+        exp1_vars = {
+            'n_ranks': '2'
+        }
+        exp2_name = 'series2_{n_ranks}'
+        exp2_vars = {
+            'exp_var1': '1',
+            'exp_var2': '2',
+            'n_ranks': ['4', '6']
+        }
+        exp2_chains = [
+            {
+                'name': 'basic.test_wl.test1',
+                'order': 'prepend',
+                'command': '{execute_experiment}',
+                'variables': {}
+            },
+            {
+                'name': 'basic.test_wl.test1',
+                'order': 'append',
+                'command': '{execute_experiment}',
+                'variables': {}
+            }
+        ]
+
+        exp_set.set_application_context(app_name, app_vars, None, None, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
+        exp_set.set_experiment_context(exp1_name, exp1_vars, None, None, None, None, None)
+        exp_set.set_experiment_context(exp2_name, exp2_vars, None, None, None, None, exp2_chains)
+
+        assert 'basic.test_wl.series2_4' in \
+            exp_set.experiments
+        assert 'basic.test_wl.series2_4.chain.0.basic.test_wl.test1' in \
+            exp_set.experiments
+        assert 'basic.test_wl.series2_4.chain.1.basic.test_wl.test1' in \
+            exp_set.experiments
+        assert 'basic.test_wl.series2_6' in \
+            exp_set.experiments
+        assert 'basic.test_wl.series2_6.chain.0.basic.test_wl.test1' in \
+            exp_set.experiments
+        assert 'basic.test_wl.series2_6.chain.1.basic.test_wl.test1' in \
+            exp_set.experiments
+        assert 'basic.test_wl.test1' in exp_set.experiments
+
+
+def test_chained_experiment_has_correct_directory(mutable_mock_workspace_path, capsys):
+    workspace('create', 'test')
+
+    assert 'test' in workspace('list')
+
+    with ramble.workspace.read('test') as ws:
+        exp_set = ramble.experiment_set.ExperimentSet(ws)
+
+        app_name = 'basic'
+        app_vars = {
+            'app_var1': '1',
+            'app_var2': '2',
+            'processes_per_node': '1',
+        }
+
+        wl_name = 'test_wl'
+        wl_vars = {
+            'wl_var1': '1',
+            'wl_var2': '2',
+        }
+        exp1_name = 'test1'
+        exp1_vars = {
+            'n_ranks': '2'
+        }
+        exp2_name = 'series2_{n_ranks}'
+        exp2_vars = {
+            'exp_var1': '1',
+            'exp_var2': '2',
+            'n_ranks': '4'
+        }
+        exp2_chains = [
+            {
+                'name': 'basic.test_wl.test1',
+                'order': 'prepend',
+                'command': '{execute_experiment}',
+                'variables': {}
+            },
+        ]
+
+        exp_set.set_application_context(app_name, app_vars, None, None, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
+        exp_set.set_experiment_context(exp1_name, exp1_vars, None, None, None, None, None)
+        exp_set.set_experiment_context(exp2_name, exp2_vars, None, None, None, None, exp2_chains)
+
+        parent_name = 'basic.test_wl.series2_4'
+        chained_name = 'basic.test_wl.series2_4.chain.0.basic.test_wl.test1'
+        chained_dir = '0.basic.test_wl.test1'
+        assert parent_name in exp_set.experiments
+        assert chained_name in exp_set.experiments
+
+        parent_inst = exp_set.get_experiment(parent_name)
+        chained_inst = exp_set.get_experiment(chained_name)
+
+        parent_run_dir = parent_inst.expander.expand_var('{experiment_run_dir}')
+        expected_dir = os.path.join(parent_run_dir, 'chained_experiments', chained_dir)
+        assert chained_inst.variables['experiment_run_dir'] == expected_dir

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1384,7 +1384,7 @@ class Workspace(object):
                                                           exp_template,
                                                           exp_chained_exps)
 
-        experiment_set.finalize_set()
+        experiment_set.build_experiment_chains()
 
         for exp, app_inst in experiment_set.all_experiments():
             tty.debug('On experiment: %s' % exp)

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1384,6 +1384,8 @@ class Workspace(object):
                                                           exp_template,
                                                           exp_chained_exps)
 
+        experiment_set.finalize_set()
+
         for exp, app_inst in experiment_set.all_experiments():
             tty.debug('On experiment: %s' % exp)
             for phase in app_inst.get_pipeline_phases(pipeline):


### PR DESCRIPTION
This merge adds support, testing, and documentation for chained experiments.

Chained experiments are a mechanism to replicate experiments within the context of another experiment. This can be useful (as an example) when the desired behavior is multiple experiments running on the same set of resources.

This merge adds documentation, tests, and the functionality for chained experiments.