### PR TITLE
Allow repo.yaml to specify a subdir for applications

### DIFF
--- a/lib/ramble/ramble/cmd/repo.py
+++ b/lib/ramble/ramble/cmd/repo.py
@@ -43,7 +43,7 @@ def setup_parser(subparser):
     create_parser.add_argument(
         '-d', '--subdirectory',
         action='store',
-        default=ramble.repository.applications_dir_name,
+        default=ramble.repository.APPLICATIONS_DIR_NAME,
         help=(
             "subdirectory to store applications in the repository."
             "Default 'applications'. Use an empty string for no subdirectory."

--- a/lib/ramble/ramble/cmd/repo.py
+++ b/lib/ramble/ramble/cmd/repo.py
@@ -40,6 +40,15 @@ def setup_parser(subparser):
     create_parser.add_argument(
         'namespace', help="namespace to identify applications in the repository. "
         "defaults to the directory name", nargs='?')
+    create_parser.add_argument(
+        '-d', '--subdirectory',
+        action='store',
+        default=ramble.repository.applications_dir_name,
+        help=(
+            "subdirectory to store applications in the repository."
+            "Default 'applications'. Use an empty string for no subdirectory."
+        ),
+    )
 
     # List
     list_parser = sp.add_parser('list', help=repo_list.__doc__)
@@ -72,7 +81,7 @@ def setup_parser(subparser):
 def repo_create(args):
     """Create a new application repository."""
     full_path, namespace = ramble.repository.create_repo(
-        args.directory, args.namespace
+        args.directory, args.namespace, args.subdirectory
     )
     tty.msg("Created repo with namespace '%s'." % namespace)
     tty.msg("To register it with ramble, run this command:",

--- a/lib/ramble/ramble/repository.py
+++ b/lib/ramble/ramble/repository.py
@@ -27,7 +27,6 @@ except ImportError:
 
 
 import six
-from enum import Enum
 
 import ruamel.yaml as yaml
 
@@ -53,11 +52,11 @@ def get_full_namespace(namespace):
 
 
 # Top-level filename for repo config.
-repo_config_name = 'repo.yaml'
+REPO_CONFIG_NAME = 'repo.yaml'
 # Top-level repo directory containing applcations
-applications_dir_name = 'applications'
+APPLICATIONS_DIR_NAME = 'applications'
 # Filename for applications in a repo.
-application_file_name = 'application.py'
+APPLICATION_FILE_NAME = 'application.py'
 
 #: Guaranteed unused default value for some functions.
 NOT_PROVIDED = object()
@@ -171,7 +170,7 @@ class FastApplicationChecker(Mapping):
 
             # Construct the file name from the directory
             app_file = os.path.join(
-                self.applications_path, app_name, application_file_name
+                self.applications_path, app_name, APPLICATION_FILE_NAME
             )
 
             # Use stat here to avoid lots of calls to the filesystem.
@@ -681,14 +680,14 @@ class Repo(object):
                 raise BadRepoError(msg)
 
         # Validate repository layout.
-        self.config_file = os.path.join(self.root, repo_config_name)
+        self.config_file = os.path.join(self.root, REPO_CONFIG_NAME)
         check(os.path.isfile(self.config_file),
-              "No %s found in '%s'" % (repo_config_name, root))
+              "No %s found in '%s'" % (REPO_CONFIG_NAME, root))
 
         # Read configuration and validate namespace
         config = self._read_config()
         check('namespace' in config, '%s must define a namespace.'
-              % os.path.join(root, repo_config_name))
+              % os.path.join(root, REPO_CONFIG_NAME))
 
         self.namespace = config['namespace']
         check(re.match(r'[a-zA-Z][a-zA-Z0-9_.]+', self.namespace),
@@ -697,7 +696,7 @@ class Repo(object):
               "Namespaces must be valid python identifiers separated by '.'")
 
         applications_dir = config["subdirectory"] if "subdirectory" in config else \
-            applications_dir_name
+            APPLICATIONS_DIR_NAME
         self.applications_path = os.path.join(self.root, applications_dir)
         check(os.path.isdir(self.applications_path),
               "No directory '%s' found in '%s'" % (applications_dir,
@@ -840,7 +839,7 @@ class Repo(object):
                 if (not yaml_data or 'repo' not in yaml_data or
                         not isinstance(yaml_data['repo'], dict)):
                     tty.die("Invalid %s in repository %s" % (
-                        repo_config_name, self.root))
+                        REPO_CONFIG_NAME, self.root))
 
                 return yaml_data['repo']
 
@@ -924,7 +923,7 @@ class Repo(object):
            the application exists before importing.
         """
         app_dir = self.dirname_for_application_name(app_name)
-        return os.path.join(app_dir, application_file_name)
+        return os.path.join(app_dir, APPLICATION_FILE_NAME)
 
     @property
     def _app_checker(self):
@@ -1055,7 +1054,7 @@ class Repo(object):
         return self.exists(app_name)
 
 
-def create_repo(root, namespace=None, subdir=applications_dir_name):
+def create_repo(root, namespace=None, subdir=APPLICATIONS_DIR_NAME):
     """Create a new repository in root with the specified namespace.
 
        If the namespace is not provided, use basename of root.
@@ -1092,14 +1091,14 @@ def create_repo(root, namespace=None, subdir=applications_dir_name):
             "Cannot create repository in %s: can't access parent!" % root)
 
     try:
-        config_path = os.path.join(root, repo_config_name)
+        config_path = os.path.join(root, REPO_CONFIG_NAME)
         applications_path = os.path.join(root, subdir)
 
         fs.mkdirp(applications_path)
         with open(config_path, 'w') as config:
             config.write("repo:\n")
             config.write(f"  namespace: '{namespace}'\n")
-            if subdir != applications_dir_name:
+            if subdir != APPLICATIONS_DIR_NAME:
                 config.write(f"  subdirectory: '{subdir}'\n")
 
     except (IOError, OSError) as e:

--- a/lib/ramble/ramble/test/cmd/repo.py
+++ b/lib/ramble/ramble/test/cmd/repo.py
@@ -25,6 +25,26 @@ def test_create_add_list_remove(mutable_config, tmpdir):
     # files are there
     repo('create', str(tmpdir), 'mockrepo')
     assert os.path.exists(os.path.join(str(tmpdir), 'repo.yaml'))
+    assert os.path.exists(os.path.join(str(tmpdir), 'applications'))
+
+    # Add the new repository and check it appears in the list output
+    repo('add', '--scope=site', str(tmpdir))
+    output = repo('list', '--scope=site', output=str)
+    assert 'mockrepo' in output
+
+    # Then remove it and check it's not there
+    repo('remove', '--scope=site', str(tmpdir))
+    output = repo('list', '--scope=site', output=str)
+    assert 'mockrepo' not in output
+
+
+@pytest.mark.parametrize('subdir', ['applications', '', 'foo'])
+def test_create_add_list_remove_flags(mutable_config, tmpdir, subdir):
+    # Create a new repository and check that the expected
+    # files are there
+    repo('create', str(tmpdir), 'mockrepo', '-d', subdir)
+    assert os.path.exists(os.path.join(str(tmpdir), 'repo.yaml'))
+    assert os.path.exists(os.path.join(str(tmpdir), subdir))
 
     # Add the new repository and check it appears in the list output
     repo('add', '--scope=site', str(tmpdir))

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -540,7 +540,7 @@ _ramble_repo() {
 _ramble_repo_create() {
     if $list_options
     then
-        RAMBLE_COMPREPLY="-h --help"
+        RAMBLE_COMPREPLY="-h --help -d --subdirectory"
     else
         _repos
     fi


### PR DESCRIPTION
This merge allows the repo.yaml in an application repository to specify they subdirectory the applications should live in.

The default is `applications`. Empty strings can be passed in to allow no subdirectory.

This replicates the functionality from a PR in spack https://github.com/spack/spack/pull/36643