### PR TITLE
Change workspace name to basename for all workspaces

### DIFF
--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1574,13 +1574,9 @@ class Workspace(object):
     def name(self):
         """Human-readable representation of the workspace.
 
-        This is the path for directory workspaces and just the name
-        for named workspaces.
+        The name of the workspace is the basename of its path
         """
-        if self.internal:
-            return os.path.basename(self.path)
-        else:
-            return self.path
+        return os.path.basename(self.path)
 
     @property
     def path(self):


### PR DESCRIPTION
This merge changes the name property of workspaces to only return the bsaename of the path.

Previously, this was the full path for anonymous workspaces.