### PR TITLE
Remove mpi and batch dictionaries

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -106,5 +106,6 @@ The slurm execute experiment script shows an example of creating an
 `execute_experiment` script for use in a slurm cluster.
 
 To use this, place it in the configs directory for your workspace, and change
-the `ramble:batch:submit` definition in your ramble.yaml to: `sbatch {slurm_execute_experiment}`.
-Then when performing `ramble workspace setup`, the `all_experiments` script will submit to slurm.
+the `ramble:variables:batch_submit` definition in your ramble.yaml to:
+`sbatch {slurm_execute_experiment}`. Then when performing `ramble workspace
+setup`, the `all_experiments` script will submit to slurm.

--- a/examples/basic_expansion_config.yaml
+++ b/examples/basic_expansion_config.yaml
@@ -1,16 +1,7 @@
 ramble:
-  mpi:
-    command: mpirun
-    args:
-      - -n
-      - '{n_ranks}'
-      - -ppn
-      - '{processes_per_node}'
-      - -hostfile
-      - hostfile
-  batch:
-    submit: '{execute_experiment}'
   variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node} -hosfile hostfile'
+    batch_submit: '{execute_experiment}'
     n_ranks: '{processes_per_node}*{n_nodes}'
   applications:
     openfoam:

--- a/examples/basic_gromacs_config.yaml
+++ b/examples/basic_gromacs_config.yaml
@@ -1,17 +1,8 @@
 ramble:
     variables:
         processes_per_node: 16
-    mpi:
-        command: mpirun
-        args:
-        - '-n'
-        - '{n_ranks}'
-        - -ppn
-        - '{processes_per_node}'
-        - -hostfile
-        - hostfile
-    batch:
-        submit: '{execute_experiment}'
+        mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node} -hostfile hostfile'
+        batch_submit: '{execute_experiment}'
     applications:
         gromacs: # Application name
             workloads:

--- a/examples/basic_hostname_config.yaml
+++ b/examples/basic_hostname_config.yaml
@@ -20,15 +20,12 @@
 #               n_ranks: '{processes_per_node}'
 
 ramble:
-  mpi:
-    command: mpirun
-    args: []
-  batch:
-    submit: '{execute_experiment}'
   env-vars:
     set:
       OMP_NUM_THREADS: '{n_threads}'
   variables:
+    mpi_command: 'mpirun'
+    batch_submit: '{execute_experiment}'
     processes_per_node: -1
   applications:
     hostname:

--- a/examples/full_expansion_config.yaml
+++ b/examples/full_expansion_config.yaml
@@ -1,19 +1,10 @@
 ramble:
-  mpi:
-    command: mpirun
-    args:
-      - -n
-      - '{n_ranks}'
-      - -ppn
-      - '{processes_per_node}'
-      - -hostfile
-      - hostfile
-  batch:
-    submit: '{execute_experiment}'
   env-vars:
     set:
       I_MPI_DEBUG: '5'
   variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node} -hostfile hostfile'
+    batch_submit: '{execute_experiment}'
     processes_per_node: '16'
     n_ranks: '{processes_per_node}*{n_nodes}'
   applications:

--- a/lib/ramble/docs/workspace_config.rst
+++ b/lib/ramble/docs/workspace_config.rst
@@ -37,13 +37,9 @@ responsible for configuring, executing, analyzing, and archiving.
 .. code-block:: yaml
 
     ramble:
-      mpi:
-        command: mpirun
-        args:
-        - '-n'
-        - '{n_ranks}'
-      batch:
-        submit: '{execute_experiment}'
+      variables:
+        mpi_command: 'mpirun -n {n_ranks}'
+        batch_submit: '{execute_experiment}'
       applications:
         hostname:
           workloads:
@@ -85,6 +81,8 @@ string, and can take variables for expansion.
               experiments:
                 test_{n_ranks}_{n_nodes}:
                   variables:
+                    mpi_command: 'mpirun -n {n_ranks}'
+                    batch_submit: '{execute_experiment}'
                     n_ranks: '1'
                     n_nodes: '1'
 
@@ -114,8 +112,9 @@ individual experiments take precendence.
 .. code-block:: yaml
 
     ramble:
-      ...
       variables:
+        mpi_command: 'mpirun -n {n_ranks}'
+        batch_submit: '{execute_experiment}'
         processes_per_node: '16'
         n_ranks: '{n_nodes}*{processes_per_node}'
       applications:
@@ -145,8 +144,9 @@ math and variable expansion syntax as defined above).
 .. code-block:: yaml
 
     ramble:
-      ...
       variables:
+        mpi_command: 'mpirun -n {n_ranks}'
+        batch_submit: '{execute_experiment}'
         processes_per_node: '16'
         n_ranks: '{n_nodes}*{processes_per_node}'
       applications:
@@ -182,8 +182,9 @@ consumes.
 .. code-block:: yaml
 
     ramble:
-      ...
       variables:
+        mpi_command: 'mpirun -n {n_ranks}'
+        batch_submit: '{execute_experiment}'
         n_ranks: '{n_nodes}*{processes_per_node}'
       applications:
         hostname:
@@ -211,8 +212,9 @@ Mulitple matrices are allowed to be defined:
    :linenos:
 
     ramble:
-      ...
       variables:
+        mpi_command: 'mpirun -n {n_ranks}'
+        batch_submit: '{execute_experiment}'
         n_ranks: '{n_nodes}*{processes_per_node}'
       applications:
         hostname:
@@ -249,8 +251,9 @@ something ramble automatically generates in a different experiment.
 .. code-block:: yaml
 
     ramble:
-      ...
       variables:
+        mpi_command: 'mpirun -n {n_ranks}'
+        batch_submit: '{execute_experiment}'
         processes_per_node: '16'
         n_ranks: '{n_nodes}*{processes_per_node}'
       applications:
@@ -364,6 +367,8 @@ Ramble requires the following variables to be defined:
   ``ceiling({n_ranks}/{processes_per_node})``
 * ``processes_per_node`` - Defines how many ranks should be on each node. If
   not explicitly set, is defined as: ``ceiling({n_ranks}/{n_nodes})``
+* ``mpi_command`` - Template for generating an MPI command
+* ``batch_submit`` - Template for generating a batch system submit command
 
 """"""""""""""""""""
 Generated Variables:
@@ -403,8 +408,6 @@ Ramble automatically generates definitions for the following varialbes:
 * ``command`` - Set to all of the commands needed to perform an experiment.
 * ``spack_setup`` - Set to the commands needed to load a spack environment for
   an experiment. Set to an empty string for non-spack applications
-* ``mpi_command`` - By default, set to the contents of ``ramble:mpi```
-* ``batch_submit`` - By default, set to the contents of ``ramble:batch:submit``
 
 """""""""""""""""""""""""""""""""""
 Spack Specific Generated Variables:
@@ -546,12 +549,8 @@ Below is an example of running a Gromacs experiment in both MPICH and OpenMPI:
 .. code-block:: yaml
 
     ramble:
-      mpi:
-        command: ''
-        args: []
-      batch:
-        submit: '{execute_experiment}'
       variables:
+        batch_submit: '{execute_experiment}'
         mpi_command:
         - 'mpirun -n {n_ranks} -ppn {processes_per_node} ' # MPICH
         - 'mpirun -n {n_ranks} -nperhost {processes_per_node} ' # OpenMPI
@@ -613,26 +612,14 @@ Batch System Control:
 Similar to the previously describe MPI command control, experiments can use
 different batch systems by overriding the ``batch_submit`` variable.
 
-As in the MPI command example, the ``ramble:batch:submit`` definition is
-insufficient for changing how each experiment is submitted to a batch system
-(or even what batch system the experiment is submitted to).
-
 Below is an example configuration file showing how the ``batch_submit``
 variable can be used to submit the same experiment to multiple batch systems.
 
 .. code-block:: yaml
 
     ramble:
-      mpi:
-        command: mpirun
-        args:
-        - '-n'
-        - '{n_ranks}'
-        - '-ppn'
-        - '{processes_per_node}'
-      batch:
-        submit: ''
       variables:
+        mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
         batch_system:
         - slurm
         - pbs
@@ -700,8 +687,9 @@ The following example shows how to specify a chain of experiments:
 .. code-block:: yaml
 
     ramble:
-      ...
       variables:
+        mpi_command: 'mpirun -n {n_ranks}'
+        batch_submit: '{execute_experiment}'
         processes_per_node: '16'
         n_ranks: '{n_nodes}*{processes_per_node}'
       applications:
@@ -775,8 +763,9 @@ it as a template.
 .. code-block:: yaml
 
     ramble:
-      ...
       variables:
+        mpi_command: 'mpirun -n {n_ranks}'
+        batch_submit: '{execute_experiment}'
         processes_per_node: '16'
         n_ranks: '{n_nodes}*{processes_per_node}'
       applications:
@@ -820,8 +809,9 @@ Below is an example showing how chains of chains can be defined:
 .. code-block:: yaml
 
     ramble:
-      ...
       variables:
+        mpi_command: 'mpirun -n {n_ranks}'
+        batch_submit: '{execute_experiment}'
         processes_per_node: '16'
         n_ranks: '{n_nodes}*{processes_per_node}'
       applications:

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -533,11 +533,6 @@ def workspace_info(args):
                             for exp in app_inst.chain_order:
                                 color.cprint(nested_4('         - ') + exp)
 
-    # Print MPI command
-    color.cprint('')
-    color.cprint(section_title('MPI Command:'))
-    color.cprint('    %s' % ws.mpi_command)
-
     # Print software stack information
     color.cprint('')
     color.cprint(section_title('Software Stack:'))

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -91,9 +91,7 @@ class ExperimentSet(object):
                           workspace_internals)
 
         # Set some base variables from the workspace definition.
-        self.set_base_var(self.keywords.mpi_command, workspace.mpi_command)
         self.set_base_var(self.keywords.log_dir, workspace.log_dir)
-        self.set_base_var(self.keywords.batch_submit, workspace.batch_submit)
         self.set_base_var(self.keywords.spec_name,
                           Expander.expansion_str(self.keywords.application_name))
 

--- a/lib/ramble/ramble/schema/workspace.py
+++ b/lib/ramble/ramble/schema/workspace.py
@@ -65,39 +65,6 @@ properties = {
                 'type': 'object',
                 'additionalProperties': {'type': 'string'},
             },
-            'mpi': {
-                'type': 'object',
-                'default': {
-                    'command': {
-                        'type': 'string',
-                        'default': 'mpirun'
-                    },
-                    'args': {
-                        'type': 'array',
-                        'default': []
-                    }
-                },
-                'properties': {
-                    'command': {
-                        'type': 'string',
-                        'default': 'mpirun'
-                    },
-                    'args': {
-                        'type': 'array',
-                        'default': []
-                    }
-                },
-            },
-            'batch': {
-                'type': 'object',
-                'default': {
-                    'submit': ''
-                },
-                'properties': {
-                    'submit': {'type': 'string'}
-                },
-                'additionalProperties': False
-            },
             'variables': ramble.schema.applications.variables_def,
             'internals': ramble.schema.applications.internals_def,
             'success_criteria': ramble.schema.applications.success_list_def,

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -80,8 +80,6 @@ def check_info_basic(output):
     assert 'Workload' in output
     assert 'Experiment' in output
 
-    assert 'MPI Command' in output
-
 
 def check_results(ws):
     fn = ws.dump_results(output_formats=['text', 'json', 'yaml'])
@@ -161,18 +159,9 @@ def test_workspace_list(mutable_mock_workspace_path):
 def test_workspace_info():
     test_config = """
 ramble:
-  mpi:
-    command: mpirun
-    args:
-    - '-n'
-    - '{n_ranks}'
-    - '-ppn'
-    - '{processes_per_node}'
-    - '-hostfile'
-    - 'hostfile'
-  batch:
-    submit: 'batch_submit {execute_experiment}'
   variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
     processes_per_node: '5'
     n_ranks: '{processes_per_node}*{n_nodes}'
   applications:
@@ -212,18 +201,9 @@ spack:
 def test_workspace_info_prints_all_levels():
     test_config = """
 ramble:
-  mpi:
-    command: mpirun
-    args:
-    - '-n'
-    - '{n_ranks}'
-    - '-ppn'
-    - '{processes_per_node}'
-    - '-hostfile'
-    - 'hostfile'
-  batch:
-    submit: 'batch_submit {execute_experiment}'
   variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
     processes_per_node: '5'
     n_ranks: '{processes_per_node}*{n_nodes}'
   applications:
@@ -274,18 +254,9 @@ config:
 def test_workspace_info_with_templates():
     test_config = """
 ramble:
-  mpi:
-    command: mpirun
-    args:
-    - '-n'
-    - '{n_ranks}'
-    - '-ppn'
-    - '{processes_per_node}'
-    - '-hostfile'
-    - 'hostfile'
-  batch:
-    submit: 'batch_submit {execute_experiment}'
   variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
     processes_per_node: '5'
     n_ranks: '{processes_per_node}*{n_nodes}'
   applications:
@@ -326,18 +297,9 @@ spack:
 def test_workspace_info_with_experiment_chain():
     test_config = """
 ramble:
-  mpi:
-    command: mpirun
-    args:
-    - '-n'
-    - '{n_ranks}'
-    - '-ppn'
-    - '{processes_per_node}'
-    - '-hostfile'
-    - 'hostfile'
-  batch:
-    submit: 'batch_submit {execute_experiment}'
   variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
     processes_per_node: '5'
     n_ranks: '{processes_per_node}*{n_nodes}'
   applications:
@@ -692,18 +654,9 @@ def test_edit_override_gets_correct_path():
 def test_dryrun_setup():
     test_config = """
 ramble:
-  mpi:
-    command: mpirun
-    args:
-    - '-n'
-    - '{n_ranks}'
-    - '-ppn'
-    - '{processes_per_node}'
-    - '-hostfile'
-    - 'hostfile'
-  batch:
-    submit: 'batch_submit {execute_experiment}'
   variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
     processes_per_node: '5'
     n_ranks: '{processes_per_node}*{n_nodes}'
   applications:
@@ -741,18 +694,9 @@ spack:
 def test_matrix_vector_workspace_full():
     test_config = """
 ramble:
-  mpi:
-    command: mpirun
-    args:
-    - '-n'
-    - '{n_ranks}'
-    - '-ppn'
-    - '{processes_per_node}'
-    - '-hostfile'
-    - 'hostfile'
-  batch:
-    submit: 'batch_submit {execute_experiment}'
   variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
     processes_per_node: [2, 4]
     n_ranks: '{processes_per_node}*{n_nodes}'
   applications:
@@ -819,18 +763,9 @@ spack:
 def test_invalid_vector_workspace():
     test_config = """
 ramble:
-  mpi:
-    command: mpirun
-    args:
-    - '-n'
-    - '{n_ranks}'
-    - '-ppn'
-    - '{processes_per_node}'
-    - '-hostfile'
-    - 'hostfile'
-  batch:
-    submit: 'batch_submit {execute_experiment}'
   variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
     processes_per_node: [2, 4]
     n_ranks: '{processes_per_node}*{n_nodes}'
   applications:
@@ -876,17 +811,9 @@ spack:
 def test_invalid_size_matrices_workspace():
     test_config = """
 ramble:
-  mpi:
-    command: mpirun
-    args:
-    - '-n'
-    - '{n_ranks}'
-    - '-ppn'
-    - '{processes_per_node}'
-    - '-hostfile'
-    - 'hostfile'
-  batch:
-    submit: 'batch_submit {execute_experiment}'
+  variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
   applications:
     basic:
       workloads:
@@ -931,17 +858,9 @@ spack:
 def test_undefined_var_matrices_workspace():
     test_config = """
 ramble:
-  mpi:
-    command: mpirun
-    args:
-    - '-n'
-    - '{n_ranks}'
-    - '-ppn'
-    - '{processes_per_node}'
-    - '-hostfile'
-    - 'hostfile'
-  batch:
-    submit: 'batch_submit {execute_experiment}'
+  variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
   applications:
     basic:
       workloads:
@@ -979,17 +898,9 @@ spack:
 def test_non_vector_var_matrices_workspace():
     test_config = """
 ramble:
-  mpi:
-    command: mpirun
-    args:
-    - '-n'
-    - '{n_ranks}'
-    - '-ppn'
-    - '{processes_per_node}'
-    - '-hostfile'
-    - 'hostfile'
-  batch:
-    submit: 'batch_submit {execute_experiment}'
+  variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
   applications:
     basic:
       workloads:
@@ -1029,17 +940,9 @@ spack:
 def test_multi_use_vector_var_matrices_workspace():
     test_config = """
 ramble:
-  mpi:
-    command: mpirun
-    args:
-    - '-n'
-    - '{n_ranks}'
-    - '-ppn'
-    - '{processes_per_node}'
-    - '-hostfile'
-    - 'hostfile'
-  batch:
-    submit: 'batch_submit {execute_experiment}'
+  variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
   applications:
     basic:
       workloads:
@@ -1084,11 +987,9 @@ def test_reconcretize_in_configs_dir(tmpdir):
     """
     test_config = """
 ramble:
-  mpi:
-    command: mpirun
-    args: []
-  batch:
-    submit: '{execute_experiment}'
+  variables:
+    mpi_command: 'mpirun'
+    batch_submit: '{execute_experiment}'
   applications:
     basic:
       workloads:
@@ -1133,18 +1034,9 @@ spack:
 def test_workspace_archive():
     test_config = """
 ramble:
-  mpi:
-    command: mpirun
-    args:
-    - '-n'
-    - '{n_ranks}'
-    - '-ppn'
-    - '{processes_per_node}'
-    - '-hostfile'
-    - 'hostfile'
-  batch:
-    submit: 'batch_submit {execute_experiment}'
   variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
     processes_per_node: '5'
     n_ranks: '{processes_per_node}*{n_nodes}'
   applications:
@@ -1214,18 +1106,9 @@ spack:
 def test_workspace_tar_archive():
     test_config = """
 ramble:
-  mpi:
-    command: mpirun
-    args:
-    - '-n'
-    - '{n_ranks}'
-    - '-ppn'
-    - '{processes_per_node}'
-    - '-hostfile'
-    - 'hostfile'
-  batch:
-    submit: 'batch_submit {execute_experiment}'
   variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
     processes_per_node: '5'
     n_ranks: '{processes_per_node}*{n_nodes}'
   applications:
@@ -1297,18 +1180,9 @@ spack:
 def test_workspace_tar_upload_archive():
     test_config = """
 ramble:
-  mpi:
-    command: mpirun
-    args:
-    - '-n'
-    - '{n_ranks}'
-    - '-ppn'
-    - '{processes_per_node}'
-    - '-hostfile'
-    - 'hostfile'
-  batch:
-    submit: 'batch_submit {execute_experiment}'
   variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
     processes_per_node: '5'
     n_ranks: '{processes_per_node}*{n_nodes}'
   applications:
@@ -1385,18 +1259,9 @@ spack:
 def test_workspace_tar_upload_archive_config_url():
     test_config = """
 ramble:
-  mpi:
-    command: mpirun
-    args:
-    - '-n'
-    - '{n_ranks}'
-    - '-ppn'
-    - '{processes_per_node}'
-    - '-hostfile'
-    - 'hostfile'
-  batch:
-    submit: 'batch_submit {execute_experiment}'
   variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
     processes_per_node: '5'
     n_ranks: '{processes_per_node}*{n_nodes}'
   applications:
@@ -1476,18 +1341,9 @@ spack:
 def test_dryrun_noexpvars_setup():
     test_config = """
 ramble:
-  mpi:
-    command: mpirun
-    args:
-    - '-n'
-    - '{n_ranks}'
-    - '-ppn'
-    - '{processes_per_node}'
-    - '-hostfile'
-    - 'hostfile'
-  batch:
-    submit: 'batch_submit {execute_experiment}'
   variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
     processes_per_node: '5'
     n_ranks: '{processes_per_node}'
   applications:
@@ -1537,18 +1393,9 @@ ramble:
 
     test_config = """
 ramble:
-  mpi:
-    command: mpirun
-    args:
-    - '-n'
-    - '{n_ranks}'
-    - '-ppn'
-    - '{processes_per_node}'
-    - '-hostfile'
-    - 'hostfile'
-  batch:
-    submit: 'batch_submit {execute_experiment}'
   variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
     processes_per_node: '5'
     n_ranks: '{processes_per_node}*{n_nodes}'
   applications:
@@ -1589,18 +1436,9 @@ spack:
 def test_invalid_template_name_errors(tpl_name, capsys):
     test_config = """
 ramble:
-  mpi:
-    command: mpirun
-    args:
-    - '-n'
-    - '{n_ranks}'
-    - '-ppn'
-    - '{processes_per_node}'
-    - '-hostfile'
-    - 'hostfile'
-  batch:
-    submit: 'batch_submit {execute_experiment}'
   variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
     processes_per_node: '5'
     n_ranks: '{processes_per_node}'
   applications:
@@ -1637,18 +1475,9 @@ spack:
 def test_custom_executables_info():
     test_config = """
 ramble:
-  mpi:
-    command: mpirun
-    args:
-    - '-n'
-    - '{n_ranks}'
-    - '-ppn'
-    - '{processes_per_node}'
-    - '-hostfile'
-    - 'hostfile'
-  batch:
-    submit: 'batch_submit {execute_experiment}'
   variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
     processes_per_node: '5'
     n_ranks: '{processes_per_node}'
   applications:
@@ -1703,18 +1532,9 @@ spack:
 def test_custom_executables_order_info():
     test_config = """
 ramble:
-  mpi:
-    command: mpirun
-    args:
-    - '-n'
-    - '{n_ranks}'
-    - '-ppn'
-    - '{processes_per_node}'
-    - '-hostfile'
-    - 'hostfile'
-  batch:
-    submit: 'batch_submit {execute_experiment}'
   variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
     processes_per_node: '5'
     n_ranks: '{processes_per_node}'
   applications:

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -1586,3 +1586,69 @@ spack:
     output = workspace('info', '-v', global_args=['-w', workspace_name])
 
     assert "['exp_level_cmd', 'wl_level_cmd', 'app_level_cmd']" in output
+
+
+def test_old_config_warns(capsys):
+    test_config = """
+ramble:
+  mpi:
+    command: mpirun
+    args:
+    - '-n'
+    - '{n_ranks}'
+  batch:
+    submit: '{execute_experiment}'
+  variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
+    processes_per_node: '5'
+    n_ranks: '{processes_per_node}'
+  applications:
+    basic:
+      internals:
+        custom_executables:
+          app_level_cmd:
+            template:
+            - 'app_level_cmd'
+            use_mpi: false
+            redirect: '{log_file}'
+      workloads:
+        test_wl:
+          internals:
+            custom_executables:
+              wl_level_cmd:
+                template:
+                - 'wl_level_cmd'
+                use_mpi: false
+                redirect: '{log_file}'
+          experiments:
+            test_experiment:
+              internals:
+                custom_executables:
+                  exp_level_cmd:
+                    template:
+                    - 'exp_level_cmd'
+                    use_mpi: false
+                    redirect: '{log_file}'
+                executables:
+                - exp_level_cmd
+                - wl_level_cmd
+                - app_level_cmd
+spack:
+  concretized: true
+"""
+
+    workspace_name = 'test_custom_executables_info'
+    ws1 = ramble.workspace.create(workspace_name)
+    ws1.write()
+
+    config_path = os.path.join(ws1.config_dir, ramble.workspace.config_file_name)
+
+    with open(config_path, 'w+') as f:
+        f.write(test_config)
+
+    ws1._re_read()
+    captured = capsys.readouterr()
+    assert 'Your workspace configuration contains deprecated sections' in captured.err
+    assert 'ramble:mpi' in captured.err
+    assert 'ramble:batch' in captured.err

--- a/lib/ramble/ramble/test/concretize_builtin.py
+++ b/lib/ramble/ramble/test/concretize_builtin.py
@@ -28,12 +28,9 @@ def test_concretize_does_not_set_required(mutable_config, mutable_mock_workspace
 
     test_config = """
 ramble:
-  mpi:
-    command: mpirun
-    args: []
-  batch:
-    submit: '{execute_experiment}'
   variables:
+    mpi_command: 'mpirun'
+    batch_submit: '{execute_experiment}'
     partition: ['part1', 'part2']
     processes_per_node: ['16', '36']
     n_ranks: '{processes_per_node}*{n_nodes}'

--- a/lib/ramble/ramble/test/end_to_end.py
+++ b/lib/ramble/ramble/test/end_to_end.py
@@ -30,18 +30,9 @@ workspace = RambleCommand('workspace')
 def test_wrfv4_dry_run(mutable_config, mutable_mock_workspace_path):
     test_config = """
 ramble:
-  mpi:
-    command: mpirun
-    args:
-    - '-n'
-    - '{n_ranks}'
-    - '-ppn'
-    - '{processes_per_node}'
-    - '-hostfile'
-    - 'hostfile'
-  batch:
-    submit: 'batch_submit {execute_experiment}'
   variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
     partition: ['part1', 'part2']
     processes_per_node: ['16', '36']
     n_ranks: '{processes_per_node}*{n_nodes}'
@@ -282,18 +273,9 @@ licenses:
 def test_hpl_dry_run(mutable_config, mutable_mock_workspace_path):
     test_config = """
 ramble:
-  mpi:
-    command: mpirun
-    args:
-    - '-n'
-    - '{n_ranks}'
-    - '-ppn'
-    - '{processes_per_node}'
-    - '-hostfile'
-    - 'hostfile'
-  batch:
-    submit: 'batch_submit {execute_experiment}'
   variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
     processes_per_node: 16
     n_threads: 1
   applications:
@@ -364,18 +346,9 @@ spack:
 def test_dependency_dry_run(mutable_config, mutable_mock_workspace_path):
     test_config = """
 ramble:
-  mpi:
-    command: mpirun
-    args:
-    - '-n'
-    - '{n_ranks}'
-    - '-ppn'
-    - '{processes_per_node}'
-    - '-hostfile'
-    - 'hostfile'
-  batch:
-    submit: 'batch_submit {execute_experiment}'
   variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
     partition: 'part1'
     processes_per_node: '16'
     n_threads: '1'
@@ -447,18 +420,9 @@ def test_missing_required_dry_run(mutable_config, mutable_mock_workspace_path):
     """Tests tty.die at end of ramble.application_types.spack._create_spack_env"""
     test_config = """
 ramble:
-  mpi:
-    command: mpirun
-    args:
-    - -n
-    - '{n_ranks}'
-    - -ppn
-    - '{processes_per_node}'
-    - -hostfile
-    - hostfile
-  batch:
-    submit: 'sbatch {execute_experiment}'
   variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
     processes_per_node: 30
     n_ranks: '{processes_per_node}*{n_nodes}'
     n_threads: '1'
@@ -513,18 +477,9 @@ spack:
 def test_env_var_builtin(mutable_config, mutable_mock_workspace_path, mock_applications):
     test_config = """
 ramble:
-  mpi:
-    command: mpirun
-    args:
-    - '-n'
-    - '{n_ranks}'
-    - '-ppn'
-    - '{processes_per_node}'
-    - '-hostfile'
-    - 'hostfile'
-  batch:
-    submit: 'batch_submit {execute_experiment}'
   variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
     partition: 'part1'
     processes_per_node: '16'
     n_threads: '1'
@@ -633,18 +588,9 @@ def test_configvar_dry_run(mutable_config, mutable_mock_workspace_path):
 
     test_config = """
 ramble:
-  mpi:
-    command: mpirun
-    args:
-    - '-n'
-    - '{{n_ranks}}'
-    - '-ppn'
-    - '{{processes_per_node}}'
-    - '-hostfile'
-    - 'hostfile'
-  batch:
-    submit: 'batch_submit {{execute_experiment}}'
   variables:
+    mpi_command: 'mpirun -n {{n_ranks}} -ppn {{processes_per_node}}'
+    batch_submit: 'batch_submit {{execute_experiment}}'
     partition: 'part1'
     processes_per_node: '16'
     n_threads: '1'
@@ -724,18 +670,9 @@ spack:
 def test_custom_executables(mutable_config, mutable_mock_workspace_path, mock_applications):
     test_config = """
 ramble:
-  mpi:
-    command: mpirun
-    args:
-    - '-n'
-    - '{n_ranks}'
-    - '-ppn'
-    - '{processes_per_node}'
-    - '-hostfile'
-    - 'hostfile'
-  batch:
-    submit: 'batch_submit {execute_experiment}'
   variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
     partition: 'part1'
     processes_per_node: '16'
     n_threads: '1'
@@ -810,18 +747,9 @@ spack:
 def test_unused_compilers_are_skipped(mutable_config, mutable_mock_workspace_path, capsys):
     test_config = """
 ramble:
-  mpi:
-    command: mpirun
-    args:
-    - '-n'
-    - '{n_ranks}'
-    - '-ppn'
-    - '{processes_per_node}'
-    - '-hostfile'
-    - 'hostfile'
-  batch:
-    submit: 'batch_submit {execute_experiment}'
   variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
     processes_per_node: '10'
     n_ranks: '{processes_per_node}*{n_nodes}'
     n_threads: '1'
@@ -898,18 +826,9 @@ spack:
 
     test_config = f"""
 ramble:
-  mpi:
-    command: mpirun
-    args:
-    - '-n'
-    - '{{n_ranks}}'
-    - '-ppn'
-    - '{{processes_per_node}}'
-    - '-hostfile'
-    - 'hostfile'
-  batch:
-    submit: 'batch_submit {{execute_experiment}}'
   variables:
+    mpi_command: 'mpirun -n {{n_ranks}} -ppn {{processes_per_node}}'
+    batch_submit: 'batch_submit {{execute_experiment}}'
     processes_per_node: '10'
     n_ranks: '{{processes_per_node}}*{{n_nodes}}'
     n_threads: '1'
@@ -981,18 +900,9 @@ def test_dryrun_series_contains_package_paths(mutable_config,
                                               mock_applications):
     test_config = r"""
 ramble:
-  mpi:
-    command: mpirun
-    args:
-    - '-n'
-    - '{n_ranks}'
-    - '-ppn'
-    - '{processes_per_node}'
-    - '-hostfile'
-    - 'hostfile'
-  batch:
-    submit: 'batch_submit {execute_experiment}'
   variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
     processes_per_node: '10'
     n_ranks: '{processes_per_node}*{n_nodes}'
     n_threads: '1'
@@ -1042,18 +952,9 @@ def test_dryrun_chained_experiments(mutable_config,
                                     mutable_mock_workspace_path):
     test_config = r"""
 ramble:
-  mpi:
-    command: mpirun
-    args:
-    - '-n'
-    - '{n_ranks}'
-    - '-ppn'
-    - '{processes_per_node}'
-    - '-hostfile'
-    - 'hostfile'
-  batch:
-    submit: 'batch_submit {execute_experiment}'
   variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
     processes_per_node: '10'
     n_ranks: '{processes_per_node}*{n_nodes}'
     n_threads: '1'
@@ -1232,13 +1133,9 @@ def test_known_applications(application):
     ws_name = f'test_all_apps_{application}'
 
     base_config = """ramble:
-  mpi:
-    command: 'mpirun'
-    args:
-    - '-n'
-    - '{n_ranks}'
-  batch:
-    submit: '{execute_experiment}'
+  variables:
+    mpi_command: 'mpirun -n {n_ranks}'
+    batch_submit: '{execute_experiment}'
   applications:\n"""
 
     app_info = info_cmd(application)

--- a/lib/ramble/ramble/test/experiment_set.py
+++ b/lib/ramble/ramble/test/experiment_set.py
@@ -34,7 +34,9 @@ def test_single_experiment_in_set(mutable_mock_workspace_path):
         app_vars = {
             'app_var1': '1',
             'app_var2': '2',
-            'n_ranks': '{processes_per_node}*{n_nodes}'
+            'n_ranks': '{processes_per_node}*{n_nodes}',
+            'mpi_command': '',
+            'batch_submit': ''
         }
 
         wl_name = 'test_wl'
@@ -70,7 +72,9 @@ def test_vector_experiment_in_set(mutable_mock_workspace_path):
         app_vars = {
             'app_var1': '1',
             'app_var2': '2',
-            'n_ranks': '{processes_per_node}*{n_nodes}'
+            'n_ranks': '{processes_per_node}*{n_nodes}',
+            'mpi_command': '',
+            'batch_submit': ''
         }
 
         wl_name = 'test_wl'
@@ -107,7 +111,9 @@ def test_nonunique_vector_errors(mutable_mock_workspace_path, capsys):
         app_vars = {
             'app_var1': '1',
             'app_var2': '2',
-            'n_ranks': '{processes_per_node}*{n_nodes}'
+            'n_ranks': '{processes_per_node}*{n_nodes}',
+            'mpi_command': '',
+            'batch_submit': ''
         }
 
         wl_name = 'test_wl'
@@ -143,7 +149,9 @@ def test_zipped_vector_experiments(mutable_mock_workspace_path):
         app_vars = {
             'app_var1': '1',
             'app_var2': '2',
-            'n_ranks': '{processes_per_node}*{n_nodes}'
+            'n_ranks': '{processes_per_node}*{n_nodes}',
+            'mpi_command': '',
+            'batch_submit': ''
         }
 
         wl_name = 'test_wl'
@@ -180,7 +188,9 @@ def test_matrix_experiments(mutable_mock_workspace_path):
         app_vars = {
             'app_var1': '1',
             'app_var2': '2',
-            'n_ranks': '{processes_per_node}*{n_nodes}'
+            'n_ranks': '{processes_per_node}*{n_nodes}',
+            'mpi_command': '',
+            'batch_submit': ''
         }
 
         wl_name = 'test_wl'
@@ -221,7 +231,9 @@ def test_matrix_multiplication_experiments(mutable_mock_workspace_path):
         app_vars = {
             'app_var1': '1',
             'app_var2': '2',
-            'n_ranks': '{processes_per_node}*{n_nodes}'
+            'n_ranks': '{processes_per_node}*{n_nodes}',
+            'mpi_command': '',
+            'batch_submit': ''
         }
 
         wl_name = 'test_wl'
@@ -266,7 +278,9 @@ def test_matrix_vector_experiments(mutable_mock_workspace_path):
         app_vars = {
             'app_var1': '1',
             'app_var2': '2',
-            'n_ranks': '{processes_per_node}*{n_nodes}'
+            'n_ranks': '{processes_per_node}*{n_nodes}',
+            'mpi_command': '',
+            'batch_submit': ''
         }
 
         wl_name = 'test_wl'
@@ -309,7 +323,9 @@ def test_multi_matrix_experiments(mutable_mock_workspace_path):
         app_vars = {
             'app_var1': '1',
             'app_var2': '2',
-            'n_ranks': '{processes_per_node}*{n_nodes}'
+            'n_ranks': '{processes_per_node}*{n_nodes}',
+            'mpi_command': '',
+            'batch_submit': ''
         }
 
         wl_name = 'test_wl'
@@ -351,7 +367,9 @@ def test_matrix_undefined_var_errors(mutable_mock_workspace_path, capsys):
         app_vars = {
             'app_var1': '1',
             'app_var2': '2',
-            'n_ranks': '{processes_per_node}*{n_nodes}'
+            'n_ranks': '{processes_per_node}*{n_nodes}',
+            'mpi_command': '',
+            'batch_submit': ''
         }
 
         wl_name = 'test_wl'
@@ -394,7 +412,9 @@ def test_experiment_names_match(mutable_mock_workspace_path):
         app_vars = {
             'app_var1': '1',
             'app_var2': '2',
-            'n_ranks': '{processes_per_node}*{n_nodes}'
+            'n_ranks': '{processes_per_node}*{n_nodes}',
+            'mpi_command': '',
+            'batch_submit': ''
         }
 
         wl_name = 'test_wl'
@@ -439,7 +459,9 @@ def test_cross_experiment_variable_references(mutable_mock_workspace_path):
         app_vars = {
             'app_var1': '1',
             'app_var2': '2',
-            'n_ranks': '{processes_per_node}*{n_nodes}'
+            'n_ranks': '{processes_per_node}*{n_nodes}',
+            'mpi_command': '',
+            'batch_submit': ''
         }
 
         wl_name = 'test_wl'
@@ -489,7 +511,9 @@ def test_cross_experiment_missing_experiment_errors(mutable_mock_workspace_path)
         app_vars = {
             'app_var1': '1',
             'app_var2': '2',
-            'n_ranks': '{processes_per_node}*{n_nodes}'
+            'n_ranks': '{processes_per_node}*{n_nodes}',
+            'mpi_command': '',
+            'batch_submit': ''
         }
 
         wl_name = 'test_wl'
@@ -533,6 +557,8 @@ def test_n_ranks_correct_defaults(mutable_mock_workspace_path):
         app_vars = {
             'app_var1': '1',
             'app_var2': '2',
+            'mpi_command': '',
+            'batch_submit': ''
         }
 
         wl_name = 'test_wl'
@@ -573,7 +599,9 @@ def test_n_nodes_correct_defaults(mutable_mock_workspace_path):
         app_vars = {
             'app_var1': '1',
             'app_var2': '2',
-            'n_ranks': ['4', '6']
+            'n_ranks': ['4', '6'],
+            'mpi_command': '',
+            'batch_submit': ''
         }
 
         wl_name = 'test_wl'
@@ -615,7 +643,9 @@ def test_processes_per_node_correct_defaults(mutable_mock_workspace_path):
         app_vars = {
             'app_var1': '1',
             'app_var2': '2',
-            'n_ranks': ['4', '6']
+            'n_ranks': ['4', '6'],
+            'mpi_command': '',
+            'batch_submit': ''
         }
 
         wl_name = 'test_wl'
@@ -655,7 +685,9 @@ def test_reserved_keywords_error_in_application(mutable_mock_workspace_path, var
             'app_var1': '1',
             'app_var2': '2',
             'n_ranks': ['4', '6'],
-            var: 'should_fail'
+            var: 'should_fail',
+            'mpi_command': '',
+            'batch_submit': ''
         }
 
         with pytest.raises(ramble.experiment_set.RambleVariableDefinitionError):
@@ -681,7 +713,9 @@ def test_reserved_keywords_error_in_workload(mutable_mock_workspace_path, var, c
         app_vars = {
             'app_var1': '1',
             'app_var2': '2',
-            'n_ranks': ['4', '6']
+            'n_ranks': ['4', '6'],
+            'mpi_command': '',
+            'batch_submit': ''
         }
 
         wl_name = 'test_wl'
@@ -717,7 +751,9 @@ def test_reserved_keywords_error_in_experiment(mutable_mock_workspace_path, var,
         app_vars = {
             'app_var1': '1',
             'app_var2': '2',
-            'n_ranks': ['4', '6']
+            'n_ranks': ['4', '6'],
+            'mpi_command': '',
+            'batch_submit': ''
         }
 
         wl_name = 'test_wl'
@@ -753,14 +789,15 @@ def test_missing_required_keyword_errors(mutable_mock_workspace_path, var, capsy
 
     with ramble.workspace.read('test') as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
-        if var in exp_set._variables[exp_set._contexts.base]:
-            del exp_set._variables[exp_set._contexts.base]
+        for context in exp_set._contexts:
+            if exp_set._variables[context] and var in exp_set._variables[context]:
+                del exp_set._variables[context][var]
 
         app_name = 'basic'
         app_vars = {
             'app_var1': '1',
             'app_var2': '2',
-            'n_ranks': ['4', '6']
+            'n_ranks': ['4', '6'],
         }
 
         wl_name = 'test_wl'
@@ -772,17 +809,24 @@ def test_missing_required_keyword_errors(mutable_mock_workspace_path, var, capsy
         exp_vars = {
             'exp_var1': '1',
             'exp_var2': '2',
-            'n_nodes': ['2', '3']
+            'n_nodes': ['2', '3'],
+            'batch_submit': '',
+            'mpi_command': ''
         }
+
+        if var in exp_vars.keys():
+            del exp_vars[var]
 
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         with pytest.raises(ramble.experiment_set.RambleVariableDefinitionError):
             exp_set.set_experiment_context(exp_name, exp_vars, None, None, None, None, None)
             captured = capsys.readouterr()
-            assert f'Required key "{var}" is not defined' in captured
-            assert 'One or more required keys are not defined within an experiment.' in captured
-            assert "In experiment basic.test_wl.series1_{n_ranks}_{processes_per_node}" in captured
+            assert f'Required key "{var}" is not defined' in captured.err
+            assert 'One or more required keys are not defined within an experiment.' \
+                in captured.err
+            assert "In experiment basic.test_wl.series1_{n_ranks}_{processes_per_node}" \
+                in captured.err
 
 
 def test_chained_experiments_populate_new_experiments(mutable_mock_workspace_path, capsys):
@@ -798,6 +842,8 @@ def test_chained_experiments_populate_new_experiments(mutable_mock_workspace_pat
             'app_var1': '1',
             'app_var2': '2',
             'processes_per_node': '1',
+            'mpi_command': '',
+            'batch_submit': ''
         }
 
         wl_name = 'test_wl'
@@ -864,6 +910,8 @@ def test_chained_experiment_has_correct_directory(mutable_mock_workspace_path, c
             'app_var1': '1',
             'app_var2': '2',
             'processes_per_node': '1',
+            'mpi_command': '',
+            'batch_submit': ''
         }
 
         wl_name = 'test_wl'
@@ -923,6 +971,8 @@ def test_chained_cycle_errors(mutable_mock_workspace_path, capsys):
             'app_var1': '1',
             'app_var2': '2',
             'processes_per_node': '1',
+            'mpi_command': '',
+            'batch_submit': ''
         }
 
         wl_name = 'test_wl'
@@ -972,6 +1022,8 @@ def test_chained_invalid_order_errors(mutable_mock_workspace_path, capsys):
             'app_var1': '1',
             'app_var2': '2',
             'processes_per_node': '1',
+            'mpi_command': '',
+            'batch_submit': ''
         }
 
         wl_name = 'test_wl'

--- a/lib/ramble/ramble/test/mirror_tests.py
+++ b/lib/ramble/ramble/test/mirror_tests.py
@@ -94,13 +94,9 @@ def test_mirror_create(tmpdir, mutable_mock_repo,
 
     test_config = f"""
 ramble:
-  mpi:
-    command: mpirun
-    args:
-    - '-n'
-    - '{{n_ranks}}'
-  batch:
-    submit: '{{execute_experiment}}'
+  variables:
+    mpi_command: 'mpirun -n {{n_ranks}}'
+    batch_submit: '{{execute_experiment}}'
   applications:
     {app_name}:
       workloads:

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -62,8 +62,6 @@ class namespace:
     custom_executables = 'custom_executables'
     executables = 'executables'
     env_var = 'env-vars'
-    mpi = 'mpi'
-    batch = 'batch'
     compiler = 'compilers'
     mpi_lib = 'mpi_libraries'
     external_spack_env = 'external_spack_env'
@@ -140,15 +138,12 @@ def default_config_yaml():
 #               n_ranks: '{processes_per_node}'
 
 ramble:
-  mpi:
-    command: mpirun
-    args: []
-  batch:
-    submit: '{execute_experiment}'
   env-vars:
     set:
       OMP_NUM_THREADS: '{n_threads}'
   variables:
+    mpi_command: mpirun -n {n_ranks}
+    batch_submit: '{execute_experiment}'
     processes_per_node: -1
   applications: {}
 spack:
@@ -1523,46 +1518,6 @@ class Workspace(object):
     def _date_string(self):
         now = datetime.datetime.now()
         return now.strftime("%Y-%m-%d_%H.%M.%S")
-
-    @property
-    def mpi_command(self):
-        if not hasattr(self, 'mpi_template') or not self.mpi_template:
-            mpi_config = \
-                self._get_workspace_dict()[namespace.ramble][namespace.mpi]
-
-            self.mpi_template = ''
-            if 'pre_command' in mpi_config:
-                self.mpi_template += " %s" % mpi_config['pre_command']
-            if 'pre_command_args' in mpi_config:
-                self.mpi_template += " %s" % \
-                    ' '.join(mpi_config['pre_command_args'])
-            if 'command' in mpi_config:
-                self.mpi_template += " %s" % mpi_config['command']
-            if 'args' in mpi_config:
-                self.mpi_template += " %s" % ' '.join(mpi_config['args'])
-            if 'post_command' in mpi_config:
-                self.mpi_template += " %s" % mpi_config['post_command']
-            if 'post_command_args' in mpi_config:
-                self.mpi_template += " %s" % \
-                    ' '.join(mpi_config['post_command_args'])
-
-        return self.mpi_template
-
-    @property
-    def batch_submit(self):
-        if not hasattr(self, 'batch_submit_command') or not \
-                self.batch_submit_command:
-
-            workspace_dict = self._get_workspace_dict()
-            if namespace.batch in workspace_dict[namespace.ramble]:
-                batch_section = \
-                    workspace_dict[namespace.ramble][namespace.batch]
-                batch_submit = batch_section['submit']
-            else:
-                batch_submit = ''
-
-            self.batch_submit_command = batch_submit
-        return self.batch_submit_command
 
     @property
     def internal(self):

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -594,6 +594,37 @@ class Workspace(object):
         """Read configuration file"""
         config = self.config_sections[section]
         self._read_yaml(config, f, raw_yaml)
+        self._check_deprecated(config['yaml'])
+
+    def _check_deprecated(self, config):
+        """
+        Trap and warn (or error) on deprecated configuration settings
+        in the workspace config.
+        """
+
+        error_sections = []
+        deprecated_sections = []
+        # Trap and warn on deprecated config options.
+        if namespace.ramble in config:
+            # TODO: (dwj) Remove the following deprecation check
+            # DEPRECATED
+            if 'mpi' in config[namespace.ramble]:
+                deprecated_sections.append('ramble:mpi')
+            if 'batch' in config[namespace.ramble]:
+                deprecated_sections.append('ramble:batch')
+
+        if len(deprecated_sections) > 0:
+            tty.warn('Your workspace configuration contains deprecated sections:')
+            for section in deprecated_sections:
+                tty.warn(f'     {section}')
+            tty.warn('Please see the current workspace documentation and update')
+            tty.warn('to ensure your workspace continues to function properly')
+
+        if len(error_sections) > 0:
+            tty.warn('Your workspace configuration contains invalid sections:')
+            for section in deprecated_sections:
+                tty.warn(f'     {section}')
+            tty.die('Please update to the latest format.')
 
     def _read_yaml(self, config, f, raw_yaml=None):
         if raw_yaml:

--- a/var/ramble/repos/builtin/applications/iperf2/examples/manual_run/ramble.yaml
+++ b/var/ramble/repos/builtin/applications/iperf2/examples/manual_run/ramble.yaml
@@ -20,10 +20,9 @@
 #               n_ranks: '{processes_per_node}'
 
 ramble:
-  mpi: {}
-  batch:
-    submit: '{execute_experiment}'
   variables:
+    mpi_command: ''
+    batch_submit: '{execute_experiment}'
     processes_per_node: -1
   applications:
     iperf2:


### PR DESCRIPTION
This merge removes the two primary dictionaries in the ramble.yaml file `ramble:mpi` and `ramble:batch` in favor of using the variables `mpi_command` and `batch_submit` respectively.

Tests and documenatation is updated to reflect this too.