### PR TITLE
Add pre-commit setup for pre-push hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+- repo: local
+  hooks:
+  - id: flake8
+    name: flake8
+    entry: share/ramble/qa/run-flake8-tests
+    language: system
+  - id: short-unit-tests
+    name: short-unit-tests
+    entry: share/ramble/qa/run-unit-tests
+    language: system
+    stages: [push]

--- a/README.md
+++ b/README.md
@@ -62,10 +62,12 @@ When you send your request, make ``develop`` the destination branch on the
 
 Your PR must pass Ramble's unit tests and documentation tests, and must be
 [PEP 8](https://www.python.org/dev/peps/pep-0008/) compliant.  We enforce
-these guidelines with our CI process. To run these tests locally,
-please use the test runners:
- - share/ramble/qa/run-unit-tests
- - share/ramble/qa/run-flake8-tests
+these guidelines with our CI process.
+
+These tests can be run locally through test runners in the share/ramble/qa/
+directory. Alternatively, [pre-commit](https://pre-commit.com/#install) can be
+used to manage our git hooks. To install the hooks, simply run:
+- pre-commit install
 
  For additional requirements about contributing, including Google’s CLA, see our
  [Contribution Guide](.github/CONTRIBUTING.md).

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ flake8
 google-cloud-storage # for gcs fetch test
 google-api-core # for gcs fetch error .execptions
 coverage
+pre-commit

--- a/share/ramble/qa/run-flake8-tests
+++ b/share/ramble/qa/run-flake8-tests
@@ -1,3 +1,4 @@
+#!/bin/sh
 # Copyright 2022-2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
@@ -17,11 +18,26 @@
 # Usage:
 #     run-flake8-tests
 #
+ERROR=0
 . "$(dirname $0)/setup.sh"
 check_dependencies flake8
+if [ $? != 0 ]; then
+  ERROR=1
+fi
+
 
 # verify that the code style is correct
 ramble flake8 -U
+if [ $? != 0 ]; then
+  ERROR=1
+fi
 
 # verify that the license headers are present
 ramble license verify
+if [ $? != 0 ]; then
+  ERROR=1
+fi
+
+if [ $ERROR == 1 ]; then
+    exit 1
+fi

--- a/share/ramble/qa/run-unit-tests
+++ b/share/ramble/qa/run-unit-tests
@@ -1,3 +1,4 @@
+#!/bin/sh
 # Copyright 2022-2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
@@ -24,9 +25,13 @@
 # Run a few initial commands and set up test environment
 #-----------------------------------------------------------
 ORIGINAL_PATH="$PATH"
+ERROR=0
 
 . "$(dirname $0)/setup.sh"
 check_dependencies $coverage git hg svn
+if [ $? != 0 ]; then
+    ERROR=1
+fi
 
 # Move to root directory of Spack
 # Allows script to be run from anywhere
@@ -34,7 +39,13 @@ cd "$RAMBLE_ROOT"
 
 # Run spack help to cover command import
 bin/ramble -h
+if [ $? != 0 ]; then
+    ERROR=1
+fi
 bin/ramble help -a
+if [ $? != 0 ]; then
+    ERROR=1
+fi
 
 # Profile and print top 20 lines for a simple call to spack spec
 #ramble -p --lines 20 spec mpileaks%gcc ^elfutils@0.170
@@ -46,4 +57,11 @@ if [ -z $LONG ]; then
     $coverage_run $(which ramble) unit-test -x --verbose -m "not long"
 else
     $coverage_run $(which ramble) unit-test -x --verbose
+fi
+if [ $? != 0 ]; then
+    ERROR=1
+fi
+
+if [ $ERROR == 1 ]; then
+    exit 1
 fi


### PR DESCRIPTION
This merge adds a pre-commit configuration file to manage git hooks.

Currently, there are two hooks
 - The flake8 tests are added as a pre-commit hook
 - The unit-tests (short only) are added as a pre-push hook.

It also updates the requirements.txt and README based on that.