### PR TITLE
Allow users to specify output_capture for executables

### DIFF
--- a/lib/ramble/ramble/appkit.py
+++ b/lib/ramble/ramble/appkit.py
@@ -23,3 +23,5 @@ from ramble.spec import Spec
 
 import ramble.language.application_language
 from ramble.language.application_language import *
+
+from ramble.schema.applications import OUTPUT

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -33,6 +33,7 @@ import ramble.expander
 from ramble.keywords import keywords
 from ramble.workspace import namespace
 
+from ramble.schema.applications import OUTPUT
 from ramble.language.application_language import ApplicationMeta, register_builtin
 from ramble.error import RambleError
 
@@ -494,7 +495,8 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                 self.executables[name] = {
                     'template': conf['template'],
                     'mpi': conf['mpi'] if 'mpi' in conf else False,
-                    'redirect': conf['redirect'] if 'redirect' in conf else '{log_file}',
+                    'redirect': conf['redirect'] if 'redirect' in conf else '{log_file}', # TODO: why do we need to duplicate this default
+                    'output_capture': conf['output_capture'] if 'output_capture' in conf else OUTPUT.DEFAULT
                 }
 
         for input_file in inputs:
@@ -554,7 +556,8 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
 
                 if command_config['redirect']:
                     out_log = self.expander.expand_var(command_config['redirect'])
-                    exec_vars['redirect'] = ' >> "%s"' % out_log
+                    output_operator = command_config['output_capture']
+                    exec_vars['redirect'] = f' {output_operator} "{out_log}"'
                 else:
                     exec_vars['redirect'] = ''
 

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -492,11 +492,16 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         # Define custom executables
         if namespace.custom_executables in self.internals.keys():
             for name, conf in self.internals[namespace.custom_executables].items():
+
+                output_capture = OUTPUT.DEFAULT
+                if 'output_capture' in conf:
+                    output_capture = conf['output_capture']
+
                 self.executables[name] = {
                     'template': conf['template'],
                     'mpi': conf['mpi'] if 'mpi' in conf else False,
-                    'redirect': conf['redirect'] if 'redirect' in conf else '{log_file}', # TODO: why do we need to duplicate this default
-                    'output_capture': conf['output_capture'] if 'output_capture' in conf else OUTPUT.DEFAULT
+                    'redirect': conf['redirect'] if 'redirect' in conf else '{log_file}',
+                    'output_capture': output_capture
                 }
 
         for input_file in inputs:

--- a/lib/ramble/ramble/language/application_language.py
+++ b/lib/ramble/ramble/language/application_language.py
@@ -10,6 +10,7 @@ import llnl.util.tty as tty
 
 import ramble.language.language_base
 from ramble.language.language_base import DirectiveError
+from ramble.schema.applications import OUTPUT
 
 
 class ApplicationMeta(ramble.language.language_base.DirectiveMeta):
@@ -75,7 +76,7 @@ def workload(name, executables=None, executable=None, input=None,
 
 
 @application_directive('executables')
-def executable(name, template, use_mpi=False, redirect='{log_file}', **kwargs):
+def executable(name, template, use_mpi=False, redirect='{log_file}', output_capture=OUTPUT.DEFAULT, **kwargs):
     """Adds an executable to this application
 
     Defines a new executable that can be used to configure workloads and
@@ -89,6 +90,8 @@ def executable(name, template, use_mpi=False, redirect='{log_file}', **kwargs):
                  wrapped with an `mpirun` like command or not.
      - redirect (optional): Sets the path for outputs to be written to.
                             defaults to {log_file}
+     - output_capture (optional): Declare which ouptu (stdout, stderr, both) to
+                                  capture. Defaults to stdout
 
     """
 
@@ -97,7 +100,8 @@ def executable(name, template, use_mpi=False, redirect='{log_file}', **kwargs):
             {
                 'template': template,
                 'mpi': use_mpi,
-                'redirect': redirect
+                'redirect': redirect,
+                'output_capture': output_capture
             }  # noqa: E123
 
     return _execute_executable

--- a/lib/ramble/ramble/language/application_language.py
+++ b/lib/ramble/ramble/language/application_language.py
@@ -76,7 +76,8 @@ def workload(name, executables=None, executable=None, input=None,
 
 
 @application_directive('executables')
-def executable(name, template, use_mpi=False, redirect='{log_file}', output_capture=OUTPUT.DEFAULT, **kwargs):
+def executable(name, template, use_mpi=False, redirect='{log_file}',
+               output_capture=OUTPUT.DEFAULT, **kwargs):
     """Adds an executable to this application
 
     Defines a new executable that can be used to configure workloads and

--- a/lib/ramble/ramble/schema/applications.py
+++ b/lib/ramble/ramble/schema/applications.py
@@ -14,11 +14,13 @@
 
 import ramble.schema.licenses
 
+
 class OUTPUT:
     STDERR = "2>"
     STDOUT = ">>"
     ALL = "&>"
     DEFAULT = STDOUT
+
 
 # FIXME: should this use the vector notation which type natively supports?
 string_or_num = {

--- a/lib/ramble/ramble/schema/applications.py
+++ b/lib/ramble/ramble/schema/applications.py
@@ -14,6 +14,11 @@
 
 import ramble.schema.licenses
 
+class OUTPUT:
+    STDERR = "2>"
+    STDOUT = ">>"
+    ALL = "&>"
+    DEFAULT = STDOUT
 
 # FIXME: should this use the vector notation which type natively supports?
 string_or_num = {
@@ -95,7 +100,8 @@ custom_executables_def = {
         'default': {
             'template': [],
             'use_mpi': False,
-            'redirect': '{log_file}'
+            'redirect': '{log_file}',
+            'output_capture': OUTPUT.DEFAULT
         },
         'properties': {
             'template': array_or_scalar_of_strings_or_nums,

--- a/lib/ramble/ramble/test/application_language.py
+++ b/lib/ramble/ramble/test/application_language.py
@@ -62,9 +62,13 @@ def add_executable(app_inst, exe_num=1):
     mpi_list_exec_name = 'MultiLineMpiExe%s' % exe_num
     template = 'application%s.x -i {input_path}' % exe_num
     redirect_test = '{output_file}'
+    output_capture = '>>'
 
-    executable(nompi_exec_name, template,  # noqa: F405
-               use_mpi=False, redirect=redirect_test)(app_inst)
+    executable(nompi_exec_name, 
+               template,  # noqa: F405
+               use_mpi=False, 
+               redirect=redirect_test,
+               output_capture=output_capture)(app_inst)
 
     executable(mpi_exec_name, template,  # noqa: F405
                use_mpi=True)(app_inst)
@@ -80,7 +84,8 @@ def add_executable(app_inst, exe_num=1):
         nompi_exec_name: {
             'template': template,
             'mpi': False,
-            'redirect': redirect_test
+            'redirect': redirect_test,
+            'output_capture': output_capture
         },
         mpi_exec_name: {
             'template': template,

--- a/lib/ramble/ramble/test/application_language.py
+++ b/lib/ramble/ramble/test/application_language.py
@@ -64,9 +64,9 @@ def add_executable(app_inst, exe_num=1):
     redirect_test = '{output_file}'
     output_capture = '>>'
 
-    executable(nompi_exec_name, 
+    executable(nompi_exec_name,
                template,  # noqa: F405
-               use_mpi=False, 
+               use_mpi=False,
                redirect=redirect_test,
                output_capture=output_capture)(app_inst)
 

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -1678,6 +1678,7 @@ ramble:
                     - 'exp_level_cmd'
                     use_mpi: false
                     redirect: '{log_file}'
+                    output_capture: '&>'
 spack:
   concretized: true
 """

--- a/lib/ramble/ramble/test/end_to_end.py
+++ b/lib/ramble/ramble/test/end_to_end.py
@@ -752,6 +752,7 @@ ramble:
                     - 'lscpu'
                     use_mpi: false
                     redirect: '{log_file}'
+                    output_capture: '>>'
                 executables:
                 - lscpu
                 - builtin::env_vars

--- a/var/ramble/repos/builtin/applications/hostname/application.py
+++ b/var/ramble/repos/builtin/applications/hostname/application.py
@@ -18,9 +18,9 @@ class Hostname(ExecutableApplication):
 
     input_file('test', url="https://no.domain/file/test_dir.tgz", description="Example input file...")
 
-    executable('local', 'time hostname', use_mpi=False, output_capture="&>")
-    executable('serial', '/usr/bin/time hostname', use_mpi=False, output_capture="&>")
-    executable('parallel', '/usr/bin/time hostname', use_mpi=True, output_capture="&>")
+    executable('local', 'time hostname', use_mpi=False, output_capture=OUTPUT.ALL)
+    executable('serial', '/usr/bin/time hostname', use_mpi=False, output_capture=OUTPUT.ALL)
+    executable('parallel', '/usr/bin/time hostname', use_mpi=True, output_capture=OUTPUT.ALL)
 
     workload('local', executable='local')
     workload('serial', executable='serial')

--- a/var/ramble/repos/builtin/applications/hostname/application.py
+++ b/var/ramble/repos/builtin/applications/hostname/application.py
@@ -18,9 +18,11 @@ class Hostname(ExecutableApplication):
 
     input_file('test', url="https://no.domain/file/test_dir.tgz", description="Example input file...")
 
-    executable('serial', '/usr/bin/time hostname', use_mpi=False)
-    executable('parallel', '/usr/bin/time hostname', use_mpi=True)
+    executable('local', 'time hostname', use_mpi=False, output_capture="&>")
+    executable('serial', '/usr/bin/time hostname', use_mpi=False, output_capture="&>")
+    executable('parallel', '/usr/bin/time hostname', use_mpi=True, output_capture="&>")
 
+    workload('local', executable='local')
     workload('serial', executable='serial')
     workload('parallel', executable='parallel')
 


### PR DESCRIPTION
This includes both applications via application.py, and custom exectuables defined in yaml