### PR TITLE
Compiler Specs were previously added to spack.yaml

### DIFF
--- a/lib/ramble/ramble/spack_runner.py
+++ b/lib/ramble/ramble/spack_runner.py
@@ -264,14 +264,6 @@ class SpackRunner(object):
             else:
                 self._dry_run_print(self.compiler_find_args)
 
-    def add_compiler(self, spec):
-        """Add a compiler to an environment.
-        """
-        self._check_active()
-
-        if spec not in self.env_contents:
-            self.env_contents.append(spec)
-
     def activate(self):
         """
         Ensure the spack environment is active in subsequent commands.
@@ -282,7 +274,7 @@ class SpackRunner(object):
 
         self.exe.add_default_env(self.env_key, self.env_path)
 
-        self.env_contents = self.compilers.copy()
+        self.env_contents = []
 
         self.active = True
 


### PR DESCRIPTION
This fixes a bug where compilers were added to the generated spack env, and was causing a whole host of issues including breaking platform detection and having odd mixing of gcc libs

Also removed no longer called add_compiler function