### PR TITLE
Fix success regex for Quantum Espresso

### DIFF
--- a/var/ramble/repos/builtin/applications/quantum-espresso/application.py
+++ b/var/ramble/repos/builtin/applications/quantum-espresso/application.py
@@ -88,5 +88,5 @@ class QuantumEspresso(SpackApplication):
                     contexts=['Profile section'])
 
     success_criteria('job_done', mode='string',
-                     match=r'/s+JOB DONE.*',
+                     match=r'.*JOB DONE\..*',
                      file=log_str)


### PR DESCRIPTION
The success regex previously didn't properly identify success.