### PR TITLE
Generalize repository classes

### DIFF
--- a/lib/ramble/ramble/cmd/edit.py
+++ b/lib/ramble/ramble/cmd/edit.py
@@ -34,9 +34,9 @@ def edit_application(name, repo_path, namespace):
     if repo_path:
         repo = ramble.repository.Repo(repo_path)
     elif namespace:
-        repo = ramble.repository.path.get_repo(namespace)
+        repo = ramble.repository.apps_path.get_repo(namespace)
     else:
-        repo = ramble.repository.path
+        repo = ramble.repository.apps_path
     path = repo.filename_for_application_name(name)
 
     if os.path.exists(path):

--- a/lib/ramble/ramble/cmd/list.py
+++ b/lib/ramble/ramble/cmd/list.py
@@ -241,7 +241,7 @@ def list(parser, args):
     # Filter by tags
     if args.tags:
         applications_with_tags = set(
-            ramble.repository.path.applications_with_tags(*args.tags))
+            ramble.repository.apps_path.objects_with_tags(*args.tags))
         sorted_applications = set(sorted_applications) & applications_with_tags
         sorted_applications = sorted(sorted_applications)
 
@@ -249,7 +249,7 @@ def list(parser, args):
         # change output stream if user asked for update
         if os.path.exists(args.update):
             if os.path.getmtime(args.update) > \
-                    ramble.repository.path.last_mtime():
+                    ramble.repository.apps_path.last_mtime():
                 tty.msg('File is up to date: %s' % args.update)
                 return
 

--- a/lib/ramble/ramble/cmd/repo.py
+++ b/lib/ramble/ramble/cmd/repo.py
@@ -33,20 +33,22 @@ def setup_parser(subparser):
     scopes = ramble.config.scopes()
     scopes_metavar = ramble.config.scopes_metavar
 
+    default_type_def = ramble.repository.type_definitions[ramble.repository.default_type]
+
     # Create
     create_parser = sp.add_parser('create', help=repo_create.__doc__)
     create_parser.add_argument(
         'directory', help="directory to create the repo in")
     create_parser.add_argument(
-        'namespace', help="namespace to identify applications in the repository. "
-        "defaults to the directory name", nargs='?')
+        'namespace', help=f"namespace to identify {ramble.repository.default_type.name} "
+        "in the repository. defaults to the directory name", nargs='?')
     create_parser.add_argument(
         '-d', '--subdirectory',
         action='store',
-        default='applications',
+        default=default_type_def['dir_name'],
         help=(
-            "subdirectory to store applications in the repository."
-            "Default 'applications'. Use an empty string for no subdirectory."
+            "subdirectory to store applications in the repository. "
+            f"Default '{default_type_def['dir_name']}'. Use an empty string for no subdirectory."
         ),
     )
 

--- a/lib/ramble/ramble/cmd/repo.py
+++ b/lib/ramble/ramble/cmd/repo.py
@@ -43,7 +43,7 @@ def setup_parser(subparser):
     create_parser.add_argument(
         '-d', '--subdirectory',
         action='store',
-        default=ramble.repository.APPLICATIONS_DIR_NAME,
+        default='applications',
         help=(
             "subdirectory to store applications in the repository."
             "Default 'applications'. Use an empty string for no subdirectory."

--- a/lib/ramble/ramble/main.py
+++ b/lib/ramble/ramble/main.py
@@ -486,7 +486,8 @@ def setup_main_options(args):
         ramble.config.set('config:locks', args.locks, scope='command_line')
 
     if args.mock:
-        ramble.repository.path = ramble.repository.RepoPath(ramble.paths.mock_applications_path)
+        ramble.repository.apps_path = \
+            ramble.repository.RepoPath(ramble.paths.mock_applications_path)
 
     # If the user asked for it, don't check ssl certs.
     if args.insecure:

--- a/lib/ramble/ramble/spec.py
+++ b/lib/ramble/ramble/spec.py
@@ -283,19 +283,19 @@ class Spec(object):
     @property
     def application(self):
         if not self._application:
-            self._application = ramble.repository.path.get(self)
+            self._application = ramble.repository.apps_path.get(self)
         return self._application
 
     @property
     def application_class(self):
         if not self._application_class:
-            self._application_class = ramble.repository.path.get_app_class(self.fullname)
+            self._application_class = ramble.repository.apps_path.get_obj_class(self.fullname)
         return self._application_class
 
     @property
     def application_file_path(self):
-        file_dir = ramble.repository.path.dirname_for_application_name(self.fullname)
-        app_file = ramble.repository.path.filename_for_application_name(self.fullname)
+        file_dir = ramble.repository.apps_path.dirname_for_object_name(self.fullname)
+        app_file = ramble.repository.apps_path.filename_for_object_name(self.fullname)
         return os.path.join(file_dir, app_file)
 
 

--- a/lib/ramble/ramble/test/conftest.py
+++ b/lib/ramble/ramble/test/conftest.py
@@ -128,7 +128,8 @@ def working_env():
 #
 @pytest.fixture(scope='session')
 def mock_repo_path():
-    yield ramble.repository.Repo(ramble.paths.mock_applications_path)
+    yield ramble.repository.Repo(ramble.paths.mock_applications_path,
+                                 object_type=ramble.repository.ObjectTypes.applications)
 
 
 @pytest.fixture(scope='function')
@@ -141,7 +142,8 @@ def mock_applications(mock_repo_path):
 @pytest.fixture(scope='function')
 def mutable_mock_repo(mock_repo_path):
     """Function-scoped mock packages, for tests that need to modify them."""
-    mock_repo = ramble.repository.Repo(ramble.paths.mock_applications_path)
+    mock_repo = ramble.repository.Repo(ramble.paths.mock_applications_path,
+                                       object_type=ramble.repository.ObjectTypes.applications)
     with ramble.repository.use_repositories(mock_repo) as mock_repo_path:
         yield mock_repo_path
 

--- a/lib/ramble/ramble/test/mirror_tests.py
+++ b/lib/ramble/ramble/test/mirror_tests.py
@@ -118,7 +118,7 @@ spack:
     mirror_dir = tmpdir_factory.mktemp(f'mock-{app_name}-mirror')
 
     with archive_dir.as_cwd():
-        app_class = ramble.repository.path.get_app_class(app_name)('test')
+        app_class = ramble.repository.apps_path.get_obj_class(app_name)('test')
         create_archive(archive_dir, app_class)
 
         # Create workspace

--- a/lib/ramble/ramble/test/repository.py
+++ b/lib/ramble/ramble/test/repository.py
@@ -25,7 +25,9 @@ repo:
 """)
         if request.param != "applications":
             f.write(f"  subdirectory: '{request.param}'")
-    return (ramble.repository.Repo(str(repo_dir)), request.param)
+    return (ramble.repository.Repo(str(repo_dir),
+            object_type=ramble.repository.ObjectTypes.applications),
+            request.param)
 
 
 def test_repo_getapp(mutable_mock_repo):
@@ -41,8 +43,8 @@ def test_repo_multi_getapp(mutable_mock_repo, extra_repo):
 
 def test_repo_multi_getappclass(mutable_mock_repo, extra_repo):
     mutable_mock_repo.put_first(extra_repo[0])
-    mutable_mock_repo.get_app_class('basic')
-    mutable_mock_repo.get_app_class('builtin.mock.basic')
+    mutable_mock_repo.get_obj_class('basic')
+    mutable_mock_repo.get_obj_class('builtin.mock.basic')
 
 
 def test_repo_app_with_unknown_namespace(mutable_mock_repo):
@@ -51,12 +53,12 @@ def test_repo_app_with_unknown_namespace(mutable_mock_repo):
 
 
 def test_repo_unknown_app(mutable_mock_repo):
-    with pytest.raises(ramble.repository.UnknownApplicationError):
+    with pytest.raises(ramble.repository.UnknownObjectError):
         mutable_mock_repo.get('builtin.mock.nonexistentapplication')
 #
 #
 # def test_repo_anonymous_app(mutable_mock_repo):
-#     with pytest.raises(ramble.repository.UnknownApplicationError):
+#     with pytest.raises(ramble.repository.UnknownObjectError):
 #         mutable_mock_repo.get('+variant')
 #
 #


### PR DESCRIPTION
This merge generalizes the repository classes in preparation for holding other types (such as mods).

Primarily it converts the classes to use agnostic language (application -> object) to describe what the repositories house, but it also introduces ObjectTypes and type_definitions at the top which house the specific types that are supported.