### PR TITLE
Add jQuery as an explicit sphinx dependency

### DIFF
--- a/lib/ramble/docs/conf.py
+++ b/lib/ramble/docs/conf.py
@@ -129,6 +129,7 @@ extensions = [
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
     "sphinxcontrib.programoutput",
+    "sphinxcontrib.jquery",
 ]
 
 # Set default graphviz options


### PR DESCRIPTION
Search in the docs is currently failing because jQuery is missing, this attempts to fix it