### PR TITLE
Fix issue where we used ramble package name not spacks

### DIFF
--- a/lib/ramble/ramble/application_types/spack.py
+++ b/lib/ramble/ramble/application_types/spack.py
@@ -227,8 +227,8 @@ class SpackApplication(ApplicationBase):
             for pkg_name in \
                     workspace.software_environments.get_env_packages(app_context):
                 spec_str = workspace.software_environments.get_spec_string(pkg_name)
-                package_path = self.spack_runner.get_package_path(spec_str)
-                self.variables[pkg_name] = package_path
+                spack_pkg_name, package_path = self.spack_runner.get_package_path(spec_str)
+                self.variables[spack_pkg_name] = package_path
 
         except ramble.spack_runner.RunnerError as e:
             tty.die(e)

--- a/lib/ramble/ramble/spack_runner.py
+++ b/lib/ramble/ramble/spack_runner.py
@@ -468,14 +468,23 @@ class SpackRunner(object):
 
     def get_package_path(self, package_spec):
         """Return the installation directory for a package"""
-        args = ['location', '-i']
-        args.extend(package_spec.split())
+        loc_args = ['location', '-i']
+        loc_args.extend(package_spec.split())
+
+        name_args = ['find', '--format={name}']
+        name_args.extend(package_spec.split())
 
         if not self.dry_run:
-            return self.exe(*args, output=str).strip()
+            name = self.exe(*name_args, output=str).strip()
+            location = self.exe(*loc_args, output=str).strip()
+            return (name, location)
         else:
-            self._dry_run_print(args)
-            return os.path.join('dry-run', 'path', 'to', package_spec.split()[0])
+            self._dry_run_print(name_args)
+            self._dry_run_print(loc_args)
+
+            name = os.path.join(package_spec.split()[0])
+            location = os.path.join('dry-run', 'path', 'to', package_spec.split()[0])
+            return (name, location)
 
     def mirror_environment(self, mirror_path):
         """Create a spack mirror from the activated environment"""


### PR DESCRIPTION
Some applications need to know the path to the spack install directory of the package. This appears as `{package_name}` in the application.py `(eg {wrf}`). A recent change accidentally made it so that the path was stored internally as a mapping to the ramble_package_name (eg wrfv3) instead of the name by which the package is known to spack (eg wrf).

This means are written wrfv3 and wrfv4 are broken on head, and this addresses that.

@reviewer I chose to make `get_package_path` return a tuple now, but I'm open to changing that. We already have functionally to grab and parse all `added_packages` so it might make sense to use that instead? 