### PR TITLE
Fix application info printing software definitions

### DIFF
--- a/lib/ramble/ramble/application_types/spack.py
+++ b/lib/ramble/ramble/application_types/spack.py
@@ -40,9 +40,7 @@ class SpackApplication(ApplicationBase):
     _spec_groups = [('default_compilers', 'Default Compilers'),
                     ('mpi_libraries', 'MPI Libraries'),
                     ('software_specs', 'Software Specs')]
-    _spec_keys = ['base', 'version', 'variants',
-                  'dependenices', 'target', 'arch'
-                  'compiler', 'mpi']
+    _spec_keys = ['spack_spec', 'compiler_spec', 'compiler']
 
     def __init__(self, file_path):
         super().__init__(file_path)
@@ -78,7 +76,7 @@ class SpackApplication(ApplicationBase):
                     for key in self._spec_keys:
                         if key in info and info[key]:
                             out_str.append('    %s = %s\n' % (key,
-                                                              info[key]))
+                                                              info[key].replace('@', '@@')))
 
         return ''.join(out_str)
 

--- a/lib/ramble/ramble/test/cmd/info.py
+++ b/lib/ramble/ramble/test/cmd/info.py
@@ -65,3 +65,23 @@ def test_info_fields(app_query, parser, info_lines):
     for text in expected_fields:
         match = [x for x in info_lines if text in x]
         assert match
+
+
+@pytest.mark.parametrize('app_query', [
+    'gromacs', 'wrfv3', 'wrfv4'
+])
+def test_spack_info_software(app_query):
+    expected_fields = (
+        'Description:',
+        'Setup Pipeline Phases:',
+        'Analyze Pipeline Phases:',
+        'Tags:',
+        'spack_spec =',
+        'compiler =',
+
+    )
+
+    out = info(app_query)
+
+    for field in expected_fields:
+        assert field in out


### PR DESCRIPTION
This merge fixes an issue where `ramble info <app>` would not print the software configuration for applications.

A test is added to help ensure this is caught in the future.