### PR TITLE
Deprecate older `env-vars` workspace section

### DIFF
--- a/lib/ramble/docs/workspace_config.rst
+++ b/lib/ramble/docs/workspace_config.rst
@@ -241,6 +241,70 @@ number of elements, as they are flattened and zipped together. In this case,
 there would be 4 experiments, each defined by a unique
 ``(processes_per_node, partition, n_nodes)`` tuple.
 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Environment Variable Control:
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Environment variables can be controlled within the workspace configuration
+file. These are defined within the ``env_vars`` configuration section. Below is
+an example of the format of this configuration section.
+
+.. code-block:: yaml
+
+    env_vars:
+      set:
+        var_name: var_value
+      append:
+      - var-separator: ','
+        vars:
+          var_to_append: val_to_append
+        paths:
+          path_to_append: val_to_append
+      prepend:
+      - paths:
+          path_to_prepend: val_to_prepend
+      unset:
+      - var_to_unset
+
+
+The above example is general, and intended to show the available functionality
+of configuring environment variables. Below the ``env_vars`` level, one of four
+actions is available. These actions are:
+* ``set`` - Define a variable equal to a given value. Overwrites previously configured values
+* ``append`` - Append the given value to the end of a previous variable definition. Delimited for vars is defined by ``var_separator``, ``paths`` uses ``:``
+* ``prepend`` - Prepent the given value to the beginning of a previous variable definition. Only supports paths, delimiter is ``:``
+* ``unset`` - Remove a variable definition, if it is set.
+
+This config section is allowed to be defined anywhere a variables configuration
+can be defined.
+
+As a more concrete example:
+
+.. code-block:: yaml
+
+    env_vars:
+      set:
+        SET_VAR: set_val
+      append:
+      - var-separator: ','
+        vars:
+          APPEND_VAR: app_val
+        paths:
+          PATH: app_path
+      prepend:
+      - paths:
+          PATH: prepend_path
+      unset:
+      - LD_LIBRARY_PATH
+
+Would result in roughly the following bash commands:
+
+.. code-block:: console
+
+    export SET_VAR=set_val
+    export APPEND_VAR=$APPEND_VAR,app_val
+    export PATH=prepend_path:$PATH:app_path
+    unset LD_LIBRARY_PATH
+
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Cross Experiment Variable References:
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/lib/ramble/ramble/test/cmd/config.py
+++ b/lib/ramble/ramble/test/cmd/config.py
@@ -292,7 +292,7 @@ def test_config_get_gets_ramble_yaml(mutable_mock_workspace_path, mutable_mock_r
 
         config_output = config('get')
 
-        expected_keys = ['applications', 'variables', 'env-vars',
+        expected_keys = ['applications', 'variables', 'env_vars',
                          'spack', 'mpi_command', 'batch_submit']
 
         for key in expected_keys:

--- a/lib/ramble/ramble/test/end_to_end/config_section_env_vars.py
+++ b/lib/ramble/ramble/test/end_to_end/config_section_env_vars.py
@@ -1,0 +1,78 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.workspace
+import ramble.config
+import ramble.software_environments
+from ramble.main import RambleCommand
+
+
+# everything here uses the mock_workspace_path
+pytestmark = pytest.mark.usefixtures('mutable_config',
+                                     'mutable_mock_workspace_path')
+
+workspace = RambleCommand('workspace')
+
+
+def test_config_section_env_vars(mutable_config, mutable_mock_workspace_path, mock_applications):
+    test_config = """
+ramble:
+  variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
+    partition: 'part1'
+    processes_per_node: '16'
+    n_threads: '1'
+  env_vars:
+    set:
+      MY_VAR: TEST
+  applications:
+    basic:
+      workloads:
+        test_wl:
+          experiments:
+            simple_test:
+              variables:
+                n_nodes: 1
+  spack:
+    concretized: true
+    packages: {}
+    environments: {}
+"""
+    workspace_name = 'test_config_section_env_vars'
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+
+        config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+
+        with open(config_path, 'w+') as f:
+            f.write(test_config)
+        ws._re_read()
+
+        out = workspace('setup', '--dry-run', global_args=['-w', workspace_name])
+
+        assert 'The env-vars workspace section is deprecated' not in out
+
+        experiment_root = ws.experiment_dir
+        exp1_dir = os.path.join(experiment_root, 'basic', 'test_wl', 'simple_test')
+        exp1_script = os.path.join(exp1_dir, 'execute_experiment')
+
+        import re
+        export_regex = re.compile(r'export MY_VAR=TEST')
+
+        # Assert experiment 1 has exports before commands
+        with open(exp1_script, 'r') as f:
+            export_found = False
+            for line in f.readlines():
+                if export_regex.search(line):
+                    export_found = True
+            assert export_found

--- a/lib/ramble/ramble/test/end_to_end/deprecated_env_vars.py
+++ b/lib/ramble/ramble/test/end_to_end/deprecated_env_vars.py
@@ -1,0 +1,78 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.workspace
+import ramble.config
+import ramble.software_environments
+from ramble.main import RambleCommand
+
+
+# everything here uses the mock_workspace_path
+pytestmark = pytest.mark.usefixtures('mutable_config',
+                                     'mutable_mock_workspace_path')
+
+workspace = RambleCommand('workspace')
+
+
+def test_deprecated_env_vars(mutable_config, mutable_mock_workspace_path, mock_applications):
+    test_config = """
+ramble:
+  variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
+    partition: 'part1'
+    processes_per_node: '16'
+    n_threads: '1'
+  env-vars:
+    set:
+      MY_VAR: TEST
+  applications:
+    basic:
+      workloads:
+        test_wl:
+          experiments:
+            simple_test:
+              variables:
+                n_nodes: 1
+  spack:
+    concretized: true
+    packages: {}
+    environments: {}
+"""
+    workspace_name = 'test_deprecated_env_vars'
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+
+        config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+
+        with open(config_path, 'w+') as f:
+            f.write(test_config)
+        ws._re_read()
+
+        out = workspace('setup', '--dry-run', global_args=['-w', workspace_name])
+
+        assert 'The env-vars workspace section is deprecated' in out
+
+        experiment_root = ws.experiment_dir
+        exp1_dir = os.path.join(experiment_root, 'basic', 'test_wl', 'simple_test')
+        exp1_script = os.path.join(exp1_dir, 'execute_experiment')
+
+        import re
+        export_regex = re.compile(r'export MY_VAR=TEST')
+
+        # Assert experiment 1 has exports before commands
+        with open(exp1_script, 'r') as f:
+            export_found = False
+            for line in f.readlines():
+                if export_regex.search(line):
+                    export_found = True
+            assert export_found

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -121,7 +121,7 @@ def default_config_yaml():
 #               n_ranks: '{processes_per_node}'
 
 ramble:
-  env-vars:
+  env_vars:
     set:
       OMP_NUM_THREADS: '{n_threads}'
   variables:
@@ -1483,8 +1483,15 @@ class Workspace(object):
 
     def get_workspace_env_vars(self):
         """Return a dict of workspace environment variables"""
+        deprecated_env_vars = self._get_workspace_section(namespace.env_var)
+        if deprecated_env_vars:
+            tty.warn('The env-vars workspace section is deprecated. Environment variables\n'
+                     'should be defined in the env_vars config section using the same\n'
+                     'syntax. Support for env-vars will be removed in a future. See\n'
+                     'the documentation for examples of the new syntax.')
+
         return union_dicts(ramble.config.config.get_config('env_vars'),
-                           self._get_workspace_section(namespace.env_var))
+                           deprecated_env_vars)
 
     def get_workspace_internals(self):
         """Return a dict of workspace internals"""


### PR DESCRIPTION
This merge adds warning messages for anyone using the env-vars workspace section. It adds tests to make sure the error messages are presented.