### PR TITLE
Updated version info, and update version to v0.3.0

### DIFF
--- a/lib/ramble/ramble/__init__.py
+++ b/lib/ramble/ramble/__init__.py
@@ -8,7 +8,7 @@
 
 
 #: major, minor, patch version for Ramble, in a tuple
-ramble_version_info = (0, 0, 1)
+ramble_version_info = (0, 3, 0)
 
 #: String containing Ramble version joined with .'s
 ramble_version = '.'.join(str(v) for v in ramble_version_info)

--- a/lib/ramble/ramble/main.py
+++ b/lib/ramble/ramble/main.py
@@ -43,7 +43,6 @@ import ramble.paths
 import ramble.repository
 import spack.util.debug
 import spack.util.environment
-import spack.util.executable as exe
 import spack.util.path
 from ramble.error import RambleError
 
@@ -111,20 +110,28 @@ def add_all_commands(parser):
 
 
 def get_version():
-    """Get a descriptive version of this instance of Ramble.
+    """Get a descriptive version of this instance of Spack.
 
     Outputs '<PEP440 version> (<git commit sha>)'.
 
     The commit sha is only added when available.
     """
+    import spack.util.git
     version = ramble.ramble_version
     git_path = os.path.join(ramble.paths.prefix, ".git")
     if os.path.exists(git_path):
-        git = exe.which("git")
+        git = spack.util.git.git()
         if not git:
             return version
-        rev = git('-C', ramble.paths.prefix, 'rev-parse', 'HEAD',
-                  output=str, error=os.devnull, fail_on_error=False)
+        rev = git(
+            "-C",
+            ramble.paths.prefix,
+            "rev-parse",
+            "HEAD",
+            output=str,
+            error=os.devnull,
+            fail_on_error=False,
+        )
         if git.returncode != 0:
             return version
         match = re.match(r"[a-f\d]{7,}$", rev)

--- a/lib/ramble/spack/util/git.py
+++ b/lib/ramble/spack/util/git.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""Single util module where Spack should get a git executable."""
+
+import sys
+from typing import Optional
+
+import llnl.util.lang
+
+import spack.util.executable as exe
+
+
+@llnl.util.lang.memoized
+def git(required: bool = False):
+    """Get a git executable.
+
+    Arguments:
+        required: if ``True``, fail if ``git`` is not found. By default return ``None``.
+    """
+    git: Optional[exe.Executable] = exe.which("git", required=required)
+
+    # If we're running under pytest, add this to ignore the fix for CVE-2022-39253 in
+    # git 2.38.1+. Do this in one place; we need git to do this in all parts of Spack.
+    if git and "pytest" in sys.modules:
+        git.add_default_arg("-c")
+        git.add_default_arg("protocol.file.allow=always")
+
+    return git


### PR DESCRIPTION
This merge updates the `ramble -V` command based on newer functionality in Spack. It also now reports `v0.3.0`.