### PR TITLE
Reduce unit test warnings

### DIFF
--- a/lib/ramble/ramble/test/end_to_end/dryrun_chained_experiments.py
+++ b/lib/ramble/ramble/test/end_to_end/dryrun_chained_experiments.py
@@ -27,6 +27,7 @@ pytestmark = pytest.mark.usefixtures('mutable_config',
 workspace = RambleCommand('workspace')
 
 
+@pytest.mark.filterwarnings("ignore:invalid decimal literal:DeprecationWarning")
 def test_dryrun_chained_experiments(mutable_config,
                                     mutable_mock_workspace_path):
     test_config = r"""


### PR DESCRIPTION
Unit test warnings appear to be coming from the use of fnmatch.filter when testing chained experiments.

These warnings do not present themselves when running the test by hand, so this merge simply ignores them on this test.