### PR TITLE
Fix an issue where flake8 errors on moved files

### DIFF
--- a/lib/ramble/ramble/cmd/flake8.py
+++ b/lib/ramble/ramble/cmd/flake8.py
@@ -188,6 +188,9 @@ def filter_file(source, dest, output=False):
     # https://gitlab.com/pycqa/flake8/issues/583
     ignore_f811_on_previous_line = False
 
+    if not os.path.isfile(source):
+        return
+
     with open(source) as infile:
         parent = os.path.dirname(dest)
         mkdirp(parent)


### PR DESCRIPTION
Previously, if files were moved (or renamed) in git, the flake8 tests would error (because the source path doesn't exist).

This merge changes the behavior to only run flake8 on files if they exist.