### PR TITLE
Fix workloads with multiple inputs

### DIFF
--- a/lib/ramble/ramble/keywords.py
+++ b/lib/ramble/ramble/keywords.py
@@ -47,6 +47,7 @@ class Keywords(object):
         'err_file': key_type.reserved,
         'command': key_type.reserved,
         'spack_env': key_type.reserved,
+        'input_name': key_type.reserved,
 
         'spec_name': key_type.optional,
         'env_name': key_type.optional,

--- a/lib/ramble/ramble/language/application_language.py
+++ b/lib/ramble/ramble/language/application_language.py
@@ -160,7 +160,7 @@ def figure_of_merit(name, fom_regex, group_name, log_file='{log_file}', units=''
 
 
 @application_directive('inputs')
-def input_file(name, url, description, target_dir='{workload_name}', sha256=None, extension=None,
+def input_file(name, url, description, target_dir='{input_name}', sha256=None, extension=None,
                expand=True, **kwargs):
     """Adds an input file definition to this application
 

--- a/lib/ramble/ramble/test/application_language.py
+++ b/lib/ramble/ramble/test/application_language.py
@@ -157,7 +157,7 @@ def add_input_file(app_inst, input_num=1):
     input_defs[input_name] = {
         'url': input_url,
         'description': input_desc,
-        'target_dir': '{workload_name}'
+        'target_dir': '{input_name}'
     }
 
     return input_defs

--- a/lib/ramble/ramble/test/application_tests.py
+++ b/lib/ramble/ramble/test/application_tests.py
@@ -344,8 +344,8 @@ def basic_exp_dict():
     }
 
 
-def test_get_executables_and_inputs_initial(mutable_mock_apps_repo):
-    """_get_executables_and_inputs, test1, workload executables and inputs"""
+def test_get_executables_initial(mutable_mock_apps_repo):
+    """_get_executables, test1, workload executables"""
 
     executable_application_instance = mutable_mock_apps_repo.get('basic')
 
@@ -359,14 +359,13 @@ def test_get_executables_and_inputs_initial(mutable_mock_apps_repo):
                                                               'inputs': ['input']}}
     executable_application_instance.internals = {}
 
-    executables, inputs = executable_application_instance._get_executables_and_inputs()
+    executables = executable_application_instance._get_executables()
 
     assert 'bar' in executables
-    assert 'input' in inputs
 
 
-def test_get_executables_and_inputs_yaml_defined(mutable_mock_apps_repo):
-    """_get_executables_and_inputs, test2, yaml-defined order"""
+def test_get_executables_yaml_defined(mutable_mock_apps_repo):
+    """_get_executables, test2, yaml-defined order"""
 
     executable_application_instance = mutable_mock_apps_repo.get('basic')
 
@@ -394,13 +393,13 @@ def test_get_executables_and_inputs_yaml_defined(mutable_mock_apps_repo):
     }
     executable_application_instance.set_internals(defined_internals)
 
-    executables, inputs = executable_application_instance._get_executables_and_inputs()
+    executables = executable_application_instance._get_executables()
 
     assert 'test_exec' in executables
 
 
-def test_get_executables_and_inputs_custom_executables(mutable_mock_apps_repo):
-    """_get_executables_and_inputs, test3, custom executables"""
+def test_get_executables_custom_executables(mutable_mock_apps_repo):
+    """_get_executables, test3, custom executables"""
 
     executable_application_instance = mutable_mock_apps_repo.get('basic')
 
@@ -428,7 +427,7 @@ def test_get_executables_and_inputs_custom_executables(mutable_mock_apps_repo):
     }
     executable_application_instance.set_internals(defined_internals)
 
-    executables, inputs = executable_application_instance._get_executables_and_inputs()
+    executable_application_instance._get_executables()
 
     assert 'test_exec2' in executable_application_instance.executables
 
@@ -442,23 +441,44 @@ def test_set_input_path(mutable_mock_apps_repo):
 
     # Set up the instance to pass the initial part of the function
     executable_application_instance.expander = ramble.expander.Expander(expansion_vars, None)
-    executable_application_instance.workloads = {'test_wl': {'executables': ['foo'],
-                                                             'inputs': ['input']},
-                                                 'test_wl2': {'executables': ['bar'],
-                                                              'inputs': ['input']}}
 
     executable_application_instance.internals = {}
 
-    executable_application_instance.inputs = {'input': {'target_dir': '.'}}
     executable_application_instance.variables = {}
 
-    executables, inputs = executable_application_instance._get_executables_and_inputs()
+    executable_application_instance._set_input_path()
 
-    executable_application_instance._set_input_path(inputs)
-
-    default_answer = '/workspace/inputs/bar/.'
+    default_answer = '/workspace/inputs/bar/test_wl2/input'
 
     assert executable_application_instance.variables['input'] == default_answer
+
+
+def test_set_input_path_multi_input(mutable_mock_apps_repo):
+    """Tests set_input_path with multiple inputs in a given workload"""
+
+    executable_application_instance = mutable_mock_apps_repo.get('input-test')
+
+    expansion_vars = basic_exp_dict()
+    del expansion_vars['inputs']
+    expansion_vars['application_name'] = 'input-test'
+    expansion_vars['workload_name'] = 'test'
+
+    # Set up the instance to pass the initial part of the function
+    executable_application_instance.expander = ramble.expander.Expander(expansion_vars, None)
+
+    executable_application_instance.internals = {}
+
+    executable_application_instance.variables = {}
+
+    executable_application_instance._set_input_path()
+
+    input1_path = '/workspace/inputs/bar/test_wl2/test-input1'
+    input2_path = '/workspace/inputs/bar/test_wl2/test-input2'
+    input3_path = '/workspace/inputs/bar/test_wl2/input3.txt'
+
+    assert executable_application_instance.variables['test-input1'] == input1_path
+    assert executable_application_instance.variables['test-input2'] == input2_path
+    assert executable_application_instance.variables['test-input3'] == input3_path
 
 
 def test_set_default_experiment_variables(mutable_mock_apps_repo):
@@ -480,10 +500,6 @@ def test_set_default_experiment_variables(mutable_mock_apps_repo):
 
     executable_application_instance.inputs = {'input': {'target_dir': '.'}}
     executable_application_instance.variables = {}
-
-    executables, inputs = executable_application_instance._get_executables_and_inputs()
-
-    executable_application_instance._set_input_path(inputs)
 
     executable_application_instance.workload_variables = {'test_wl2': {'n_ranks':
                                                                        {'default': '1'}}}
@@ -513,9 +529,7 @@ def test_inject_commands(mutable_mock_apps_repo):
     executable_application_instance.inputs = {'input': {'target_dir': '.'}}
     executable_application_instance.variables = {}
 
-    executables, inputs = executable_application_instance._get_executables_and_inputs()
-
-    executable_application_instance._set_input_path(inputs)
+    executables = executable_application_instance._get_executables()
 
     executable_application_instance.workload_variables = {'test_wl2': {'n_ranks':
                                                                        {'default': '1'}}}
@@ -588,9 +602,7 @@ ramble:
     executable_application_instance.inputs = {'input': {'target_dir': '.'}}
     executable_application_instance.variables = {}
 
-    executables, inputs = executable_application_instance._get_executables_and_inputs()
-
-    executable_application_instance._set_input_path(inputs)
+    executables = executable_application_instance._get_executables()
 
     executable_application_instance.workload_variables = {'test_wl2': {'n_ranks':
                                                                        {'default': '1'}}}

--- a/var/ramble/repos/builtin.mock/applications/input-test/application.py
+++ b/var/ramble/repos/builtin.mock/applications/input-test/application.py
@@ -16,7 +16,14 @@ class InputTest(ExecutableApplication):
     executable('test', 'echo "repo test"', use_mpi=False)
 
     cwd = os.getcwd()
-    input_file('test', url=f'file://{cwd}/input.tar.gz',
+    input_file('test-input1', url=f'file://{cwd}/input1.tar.gz',
                description='Test input')
 
-    workload('test', executables=['test'], inputs=['test'])
+    input_file('test-input2', url=f'file://{cwd}/input2.tar.gz',
+               description='Test input')
+
+    input_file('test-input3', url=f'file://{cwd}/input3.txt',
+               expand=False,
+               description='Test input')
+
+    workload('test', executables=['test'], inputs=['test-input1', 'test-input2', 'test-input3'])

--- a/var/ramble/repos/builtin/applications/lammps/application.py
+++ b/var/ramble/repos/builtin/applications/lammps/application.py
@@ -73,7 +73,7 @@ class Lammps(SpackApplication):
                       description='Number of timesteps',
                       workloads=['lj', 'eam', 'polymer-chain-melt', 'chute', 'rhodo'])
 
-    workload_variable('input_path', default='{application_input_dir}/in.{workload_name}.txt',
+    workload_variable('input_path', default='{workload_input_dir}/in.{workload_name}.txt',
                       description='Path for the workload input file.',
                       workloads=['lj', 'eam', 'chain', 'chute', 'rhodo'])
 


### PR DESCRIPTION
This merge fixes an issue where workloads with multiple inputs (archives or files) would not configure any inputs past the first properly.

Notable changes (primarily internal to Ramble and application definitions) are that inputs are now stored at:
$workspace/inputs/application/workload/input-name

The lammps application definition used the older format, and has been updated.