### PR TITLE
Allow sphinx to generate doc for namespace subpackages

### DIFF
--- a/lib/ramble/docs/conf.py
+++ b/lib/ramble/docs/conf.py
@@ -71,13 +71,12 @@ apidoc_args = [
     "--no-toc",  # Don't create a table of contents file
     "--output-dir=.",  # Directory to place all output
     "--module-first",  # emit module docs before submodule docs
+    "--implicit-namespaces"
 ]
 sphinx_apidoc(
     apidoc_args
     + [
         "_ramble_root/lib/ramble/ramble",
-        "_ramble_root/lib/ramble/ramble/test/*.py",
-        "_ramble_root/lib/ramble/ramble/test/cmd/*.py",
     ]
 )
 

--- a/lib/ramble/docs/conf.py
+++ b/lib/ramble/docs/conf.py
@@ -122,6 +122,7 @@ needs_sphinx = "3.4"
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
     "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
     "sphinx.ext.graphviz",
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",

--- a/lib/ramble/docs/requirements.txt
+++ b/lib/ramble/docs/requirements.txt
@@ -2,3 +2,4 @@ sphinx
 docutils
 sphinx_rtd_theme
 sphinxcontrib-programoutput
+sphinxcontrib-jquery


### PR DESCRIPTION
Some files were previously not showing in the sphinx documentation, as they were not technically subpackages (no init). This changes it so they (technically "modules") are now included in the docs