### PR TITLE
Cleanup `ramble workspace info` and create a standard color utility

### DIFF
--- a/lib/ramble/ramble/modifier.py
+++ b/lib/ramble/ramble/modifier.py
@@ -17,29 +17,7 @@ import llnl.util.tty as tty
 
 from ramble.language.modifier_language import ModifierMeta, register_builtin  # noqa: F401
 from ramble.error import RambleError
-
-
-header_color = '@*b'
-level1_color = '@*g'
-level2_color = '@*r'
-level3_color = '@*c'
-plain_format = '@.'
-
-
-def section_title(s):
-    return header_color + s + plain_format
-
-
-def subsection_title(s):
-    return level1_color + s + plain_format
-
-
-def nested_2_color(s):
-    return level2_color + s + plain_format
-
-
-def nested_3_color(s):
-    return level3_color + s + plain_format
+import ramble.util.colors as rucolor
 
 
 class ModifierBase(object, metaclass=ModifierMeta):
@@ -106,74 +84,74 @@ class ModifierBase(object, metaclass=ModifierMeta):
 
     def _long_print(self):
         out_str = []
-        out_str.append(section_title('Modifier: ') + f'{self.name}\n')
+        out_str.append(rucolor.section_title('Modifier: ') + f'{self.name}\n')
         out_str.append('\n')
 
-        out_str.append('%s\n' % section_title('Description:'))
+        out_str.append(rucolor.section_title('Description:\n'))
         if self.__doc__:
-            out_str.append('\t%s\n' % self.__doc__)
+            out_str.append(f'\t{self.__doc__}\n')
         else:
             out_str.append('\tNone\n')
 
         if hasattr(self, 'tags'):
             out_str.append('\n')
-            out_str.append('%s\n' % section_title('Tags:'))
+            out_str.append(rucolor.section_title('Tags:\n'))
             out_str.append(colified(self.tags, tty=True))
             out_str.append('\n')
 
         if hasattr(self, 'modes'):
             out_str.append('\n')
             for mode_name, wl_conf in self.modes.items():
-                out_str.append(section_title('Mode:') + f' {mode_name}\n')
+                out_str.append(rucolor.section_title('Mode:') + f' {mode_name}\n')
 
                 if mode_name in self.variable_modifications:
-                    out_str.append('\t' + subsection_title('Variable Modifications:') + '\n')
+                    out_str.append(rucolor.nested_1('\tVariable Modifications:\n'))
                     for var, conf in self.variable_modifications[mode_name].items():
                         indent = '\t\t'
 
-                        out_str.append(nested_2_color(f'{indent}{var}:\n'))
+                        out_str.append(rucolor.nested_2(f'{indent}{var}:\n'))
                         out_str.append(f'{indent}\tMethod: {conf["method"]}\n')
                         out_str.append(f'{indent}\tModification: {conf["modification"]}\n')
 
             out_str.append('\n')
 
         if hasattr(self, 'builtins'):
-            out_str.append(section_title('Builtin Executables:\n'))
+            out_str.append(rucolor.section_title('Builtin Executables:\n'))
             out_str.append('\t' + colified(self.builtins.keys(), tty=True) + '\n')
 
         if hasattr(self, 'executable_modifiers'):
-            out_str.append(section_title('Executable Modifiers:\n'))
+            out_str.append(rucolor.section_title('Executable Modifiers:\n'))
             out_str.append('\t' + colified(self.executable_modifiers.keys(), tty=True) + '\n')
 
         if hasattr(self, 'default_compilers'):
-            out_str.append(section_title('Default Compilers:\n'))
+            out_str.append(rucolor.section_title('Default Compilers:\n'))
             for comp_name, comp_def in self.default_compilers.items():
-                out_str.append('\t' + nested_2_color(f'{comp_name}:\n'))
-                out_str.append('\t\t' + nested_3_color('Spack Spec:') +
+                out_str.append(rucolor.nested_2(f'\t{comp_name}:\n'))
+                out_str.append(rucolor.nested_3('\t\tSpack Spec:') +
                                f'{comp_def["spack_spec"].replace("@", "@@")}\n')
 
                 if 'compiler_spec' in comp_def and comp_def['compiler_spec']:
-                    out_str.append('\t\t' + nested_3_color('Compiler Spec:\n') +
+                    out_str.append(rucolor.nested_3('\t\tCompiler Spec:\n') +
                                    f'{comp_def["compiler_spec"].replace("@", "@@")}\n')
 
                 if 'compiler' in comp_def and comp_def['compiler']:
-                    out_str.append('\t\t' + nested_3_color('Compiler:\n') +
+                    out_str.append(rucolor.nested_3('\t\tCompiler:\n') +
                                    f'{comp_def["compiler"]}\n')
             out_str.append('\n')
 
         if hasattr(self, 'software_specs'):
-            out_str.append(section_title('Software Specs:\n'))
+            out_str.append(rucolor.section_title('Software Specs:\n'))
             for spec_name, spec_def in self.software_specs.items():
-                out_str.append('\t' + nested_2_color(f'{spec_name}:\n'))
-                out_str.append('\t\t' + nested_3_color('Spack Spec:') +
+                out_str.append(rucolor.nested_2(f'\t{spec_name}:\n'))
+                out_str.append(rucolor.nested_3('\t\tSpack Spec:') +
                                f'{spec_def["spack_spec"].replace("@", "@@")}\n')
 
                 if 'compiler_spec' in spec_def and spec_def['compiler_spec']:
-                    out_str.append('\t\t' + nested_3_color('Compiler Spec:') +
+                    out_str.append(rucolor.nested_3('\t\tCompiler Spec:') +
                                    f'{spec_def["compiler_spec"].replace("@", "@@")}\n')
 
                 if 'compiler' in spec_def and spec_def['compiler']:
-                    out_str.append('\t\t' + nested_3_color('Compiler:') +
+                    out_str.append(rucolor.nested_3('\t\tCompiler:') +
                                    f'{spec_def["compiler"]}\n')
             out_str.append('\n')
 

--- a/lib/ramble/ramble/software_environments.py
+++ b/lib/ramble/ramble/software_environments.py
@@ -7,6 +7,7 @@
 # except according to those terms.
 
 import llnl.util.tty as tty
+import llnl.util.tty.color as color
 
 import ramble.repository
 import ramble.workspace
@@ -15,6 +16,8 @@ import ramble.error
 import ramble.renderer
 import ramble.expander
 from ramble.namespace import namespace
+
+import ramble.util.colors as rucolor
 
 
 class SoftwareEnvironments(object):
@@ -161,6 +164,76 @@ class SoftwareEnvironments(object):
                             expanded_pkg = expander.expand_var(pkg_name,
                                                                extra_vars=rendered_vars)
                             env_packages.append(expanded_pkg)
+
+    def print_environments(self, verbosity=0):
+        color.cprint(rucolor.section_title('Software Stack:'))
+        color.cprint(rucolor.nested_1('  Packages:'))
+        for raw_pkg in self.all_raw_packages():
+            color.cprint(rucolor.nested_2(f'    {raw_pkg}:'))
+
+            pkg_info = self.raw_package_info(raw_pkg)
+
+            if verbosity >= 1:
+                if namespace.variables in pkg_info and pkg_info[namespace.variables]:
+                    color.cprint(rucolor.nested_3('      Variables:'))
+                    for var, val in pkg_info[namespace.variables].items():
+                        color.cprint(f'        {var} = {val}')
+
+                if namespace.matrices in pkg_info and pkg_info[namespace.matrices]:
+                    color.cprint(rucolor.nested_3('      Matrices:'))
+                    for matrix in pkg_info[namespace.matrices]:
+                        base_str = '        - '
+                        for var in matrix:
+                            color.cprint(f'{base_str}- {var}')
+                            base_str = '          '
+
+                if namespace.matrix in pkg_info and pkg_info[namespace.matrix]:
+                    color.cprint(rucolor.nested_3('      Matrix:'))
+                    for var in pkg_info[namespace.matrix]:
+                        color.cprint(f'        - {var}')
+
+            color.cprint(rucolor.nested_3('      Rendered Packages:'))
+            for pkg in self.mapped_packages(raw_pkg):
+                color.cprint(rucolor.nested_4(f'        {pkg}:'))
+                pkg_spec = self.get_spec(pkg)
+                spec_str = pkg_spec[namespace.spack_spec].replace('@', '@@')
+                color.cprint(f'          Spack spec: {spec_str}')
+                if namespace.compiler_spec in pkg_spec and pkg_spec[namespace.compiler_spec]:
+                    spec_str = pkg_spec[namespace.compiler_spec].replace('@', '@@')
+                    color.cprint(f'          Compiler spec: {spec_str}')
+                if namespace.compiler in pkg_spec and pkg_spec[namespace.compiler]:
+                    color.cprint(f'          Compiler: {pkg_spec[namespace.compiler]}')
+
+        color.cprint(rucolor.nested_1('  Environments:'))
+        for raw_env in self.all_raw_environments():
+            color.cprint(rucolor.nested_2(f'    {raw_env}:'))
+
+            env_info = self.raw_environment_info(raw_env)
+
+            if verbosity >= 1:
+                if namespace.variables in env_info and env_info[namespace.variables]:
+                    color.cprint(rucolor.nested_3('      Variables:'))
+                    for var, val in env_info[namespace.variables].items():
+                        color.cprint(f'        {var} = {val}')
+
+                if namespace.matrices in env_info and env_info[namespace.matrices]:
+                    color.cprint(rucolor.nested_3('      Matrices:'))
+                    for matrix in env_info[namespace.matrices]:
+                        base_str = '        - '
+                        for var in matrix:
+                            color.cprint(f'{base_str}- {var}')
+                            base_str = '          '
+
+                if namespace.matrix in env_info and env_info[namespace.matrix]:
+                    color.cprint(rucolor.nested_3('      Matrix:'))
+                    for var in env_info[namespace.matrix]:
+                        color.cprint(f'        - {var}')
+
+            color.cprint(rucolor.nested_3('      Rendered Environments:'))
+            for env in self.mapped_environments(raw_env):
+                color.cprint(rucolor.nested_4(f'        {env} Packages:'))
+                for pkg in self.get_env_packages(env):
+                    color.cprint(f'          - {pkg}')
 
     def get_env(self, environment_name):
         """Return a reference to the environment definition"""

--- a/lib/ramble/ramble/util/colors.py
+++ b/lib/ramble/ramble/util/colors.py
@@ -1,0 +1,39 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+config_color = '@*Y'
+header_color = '@*b'
+level1_color = '@*g'
+level2_color = '@*r'
+level3_color = '@*c'
+level4_color = '@*m'
+plain_format = '@.'
+
+
+def config_title(s):
+    return config_color + s + plain_format
+
+
+def section_title(s):
+    return header_color + s + plain_format
+
+
+def nested_1(s):
+    return level1_color + s + plain_format
+
+
+def nested_2(s):
+    return level2_color + s + plain_format
+
+
+def nested_3(s):
+    return level3_color + s + plain_format
+
+
+def nested_4(s):
+    return level4_color + s + plain_format


### PR DESCRIPTION
This merge adds a standardized utility for coloring various text output, and it cleans up the workspace info command by moving printing logic into the relevant classes.