### PR TITLE
Convert workspace level internals to config section

### DIFF
--- a/lib/ramble/ramble/config.py
+++ b/lib/ramble/ramble/config.py
@@ -58,6 +58,7 @@ import ramble.schema.env_vars
 import ramble.schema.repos
 import ramble.schema.workspace
 import ramble.schema.applications
+import ramble.schema.internals
 import ramble.schema.licenses
 import ramble.schema.mirrors
 import ramble.schema.spack
@@ -75,6 +76,7 @@ section_schemas = {
     'config': ramble.schema.config.schema,
     'env_vars': ramble.schema.env_vars.schema,
     'repos': ramble.schema.repos.schema,
+    'internals': ramble.schema.internals.schema,
     'licenses': ramble.schema.licenses.schema,
     'mirrors': ramble.schema.mirrors.schema,
     'spack': ramble.schema.spack.schema,

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1488,7 +1488,7 @@ class Workspace(object):
 
     def get_workspace_internals(self):
         """Return a dict of workspace internals"""
-        return self._get_workspace_section(namespace.internals)
+        return ramble.config.config.get_config(namespace.internals)
 
     def get_spack_dict(self):
         """Return the spack dictionary for this workspace"""


### PR DESCRIPTION
This merge fixes an issue where workspace level internals previously were defined as an attribute of the workspace instead of a config section.

Now internals can be defined in any config scope, and they will be merged together.