### PR TITLE
add spell checking

### DIFF
--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -1,0 +1,18 @@
+name: ramble spelling
+
+on:
+  pull_request: []
+  push:
+    branches-ignore:
+    - main
+    - gh-pages
+
+jobs:
+  formatting:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Check Spelling
+      uses: crate-ci/typos@7ad296c72fa8265059cc03d1eda562fbdfcd6df2 # v1.9.0
+      with:
+        files: ./lib ./examples ./share ./bin ./etc ./README.md

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,11 @@
+# do not check external or spack
+[files]
+extend-exclude = [
+  "lib/ramble/llnl/*",
+  "lib/ramble/spack/*",
+  "lib/ramble/external/*",
+]
+
+[default.extend-words]
+cachable = "cachable"
+FO = "FO"

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,7 +33,7 @@ or
 ```bash
 ./all_experiments
 ```
-excuted from the root of the workspace.
+executed from the root of the workspace.
 
 ## Variable syntax:
 

--- a/examples/basic_expansion_config.yaml
+++ b/examples/basic_expansion_config.yaml
@@ -17,7 +17,7 @@ ramble:
                 wrf_path: execute_experiment in wrfv4.CONUS_2p5km.new_test
               matrices:
                 - - n_nodes
-                #^-- (partiton, processes_per_node, n_nodes) ->
+                #^-- (partition, processes_per_node, n_nodes) ->
                                 #(part1, 16, 2), (part1, 16, 4)
                                 #(part2, 32, 2), (part2, 32, 4)
     wrfv4:

--- a/examples/full_expansion_config.yaml
+++ b/examples/full_expansion_config.yaml
@@ -25,7 +25,7 @@ ramble:
               matrices:
                 - matrix_a:
                   - n_nodes
-                #^-- (partiton, processes_per_node, n_nodes) ->
+                #^-- (partition, processes_per_node, n_nodes) ->
                                 #(part1, 16, openfoam-skx, 2), (part1, 16, openfoam-skx, 4)
                                 #(part2, 32, openfoam-zen2, 2), (part2, 32, openfoam-zen2, 4)
 spack:

--- a/lib/ramble/docs/getting_started.rst
+++ b/lib/ramble/docs/getting_started.rst
@@ -64,7 +64,7 @@ If you do not want to use Ramble's shell support, you can always just run the
 ``ramble`` command directly from ``ramble/bin/ramble``.
 
 When the ``ramble`` command is executed, it searches for an appropriate Python
-interpreter to use, which can be explicitly overriden by setting the
+interpreter to use, which can be explicitly overridden by setting the
 ``RAMBLE_PYTHON`` environment variable. When sourcing the appropriate shell
 setup script, ``RAMBLE_PYTHON`` will be set to the interpreter found at
 sourcing time, ensuring future invocations of the ``ramble`` command will
@@ -190,7 +190,7 @@ the rendered version within every experiment. As an example:
 
     configs/execute_experiment.tpl
 
-Will define ``{execute_experiment}`` with a value set to the path of hte
+Will define ``{execute_experiment}`` with a value set to the path of the
 generated file.
 (More explicitly, ``execute_experiment={experiment_run_dir}/{template_name_sans_extension}``)
 
@@ -263,7 +263,7 @@ Ramble can create an archive of a workspace. This is a self contained copy of va
  - Rendered templates in the experiments directories
  - Files that would have figures of merit extracted
  - Auxiliary files that an application lists for archival
- - All genreated spack.yaml files
+ - All generated spack.yaml files
 
 You can archive a workspace with:
 

--- a/lib/ramble/docs/workspace_config.rst
+++ b/lib/ramble/docs/workspace_config.rst
@@ -24,7 +24,7 @@ Within the ``ramble.yaml`` file, there are two top level dictionairies.
    spack:
      ...
 
-Each of these dictionaires is used to control different aspects of the Ramble
+Each of these dictionaries is used to control different aspects of the Ramble
 workspace.
 
 ------------------
@@ -107,7 +107,7 @@ This syntax allows basic math operations ( ``+``, ``-``, ``/``, ``*``, and
 ``**`` ) to evaluate math expressions using variable definitions.
 
 If a variable is defined within multiple dictionaries, values defined closer to
-individual experiments take precendence.
+individual experiments take precedence.
 
 .. code-block:: yaml
 
@@ -162,9 +162,9 @@ math and variable expansion syntax as defined above).
                   variables:
                     n_ranks: '1'
 
-There are two noteable aspects of this config file are:
+There are two notable aspects of this config file are:
 1. ``n_nodes`` is a list of values
-2. The experiment name refernces variable values.
+2. The experiment name references variable values.
 
 All lists defined within any experiment namespace are required to be the same
 length. They are zipped together, and iterated over to generate unique experiments.
@@ -206,7 +206,7 @@ In the above example, the ``processes_per_node`` variable is consumed as part
 of a matrix. The result is a matrix of shape 1x2. After this matrix is
 consumed, it will be crossed with the zipped vectors (creating 8 unique experiments).
 
-Mulitple matrices are allowed to be defined:
+Multiple matrices are allowed to be defined:
 
 .. code-block:: yaml
    :linenos:
@@ -444,7 +444,7 @@ Ramble automatically generates definitions for the following varialbes:
 * ``workload_name`` - Set to the name of the workload within the application
 * ``experiment_name`` - Set to the name of the experiment
 * ``env_name`` - By default defined as ``{application_name}``. Can be
-  overriden to control the spack definition to use.
+  overridden to control the spack definition to use.
 * ``application_run_dir`` - Absolute path to
   ``$workspace_root/experiments/{application_name}``
 * ``workload_run_dir`` - Absolute path to
@@ -476,7 +476,7 @@ Ramble automatically generates definitions for the following varialbes:
 """""""""""""""""""""""""""""""""""
 Spack Specific Generated Variables:
 """""""""""""""""""""""""""""""""""
-When using spack applications, Ramble also geneates the following variables:
+When using spack applications, Ramble also generates the following variables:
 
 * ``<software_spec_name>`` - Set to the equivalent of ``spack location -i
   <spec>`` for packages defined in a ramble ``spec_name`` package set.
@@ -487,7 +487,7 @@ When using spack applications, Ramble also geneates the following variables:
 Spack Dictionary:
 -----------------
 
-Within a ramble.yaml file, the ``spack:`` dictionary controlls the software
+Within a ramble.yaml file, the ``spack:`` dictionary controls the software
 stack installation that ramble performs. This is accomplished by defining
 a packages dictionary, and an environments dictionary.
 
@@ -894,7 +894,7 @@ Defining Chains of Chains:
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Ramble supports the ability to define chains of experiment chains. This allows
-an experiment to automatically implicity include all of the experiments chained
+an experiment to automatically implicitly include all of the experiments chained
 into the explicitly chained experiment.
 
 Below is an example showing how chains of chains can be defined:

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -185,7 +185,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         self.expander = ramble.expander.Expander(self.variables, self.experiment_set)
 
     def set_internals(self, internals):
-        """Set internal refernece to application internals
+        """Set internal reference to application internals
         """
 
         self.internals = internals
@@ -889,7 +889,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         workspace.append_result(results)
 
     def _new_file_dict(self):
-        """Create a dictonary to represent a new log file"""
+        """Create a dictionary to represent a new log file"""
         return {
             'success_criteria': [],
             'contexts': [],
@@ -972,7 +972,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         command = []
         # ensure license variables are set / modified
         # Process one scope at a time, to ensure
-        # highest-precendence scopes are processed last
+        # highest-precedence scopes are processed last
         config_scopes = ramble.config.scopes()
         shell = ramble.config.get('config:shell')
         var_set = set()

--- a/lib/ramble/ramble/caches.py
+++ b/lib/ramble/ramble/caches.py
@@ -70,7 +70,7 @@ class MirrorCache(object):
         fetcher.archive(dst)
 
     def symlink(self, mirror_ref):
-        """Symlink a human readible path in our mirror to the actual
+        """Symlink a human readable path in our mirror to the actual
         storage location."""
 
         cosmetic_path = os.path.join(self.root, mirror_ref.cosmetic_path)

--- a/lib/ramble/ramble/cmd/flake8.py
+++ b/lib/ramble/ramble/cmd/flake8.py
@@ -312,7 +312,7 @@ def flake8(parser, args):
 
         # TODO: make these repeated blocks a function?
         if primary_file_list:
-            # Copy flake8 file so the paths will be reltive to the new location
+            # Copy flake8 file so the paths will be relative to the new location
             f = '.flake8'
             shutil.copy(f, primary_dest_dir)
             qa_dir = os.path.join(primary_dest_dir, 'share', 'ramble', 'qa')

--- a/lib/ramble/ramble/cmd/software_definitions.py
+++ b/lib/ramble/ramble/cmd/software_definitions.py
@@ -56,11 +56,11 @@ def collect_definitions():
 
     Iterate over all defined objects and extract their software definitions.
     Built maps representing which objects use a given software definition, and
-    where detected conflicts have occured.
+    where detected conflicts have occurred.
 
     The maps are global to this module, and reused in other internal methods.
     """
-    top_level_attrs = ['default_compilers', 'softwre_specs']
+    top_level_attrs = ['default_compilers', 'software_specs']
 
     types_to_print = [
         ramble.repository.ObjectTypes.applications

--- a/lib/ramble/ramble/config.py
+++ b/lib/ramble/ramble/config.py
@@ -582,7 +582,7 @@ class Configuration(object):
 
         If ``scope`` is ``None`` or not provided, return the merged contents
         of all of ramble's configuration scopes.  If ``scope`` is provided,
-        return only the confiugration as specified in that scope.
+        return only the configuration as specified in that scope.
 
         This off the top-level name from the YAML section.  That is, for a
         YAML config file that looks like this::
@@ -825,7 +825,7 @@ def _config():
     for name, path in configuration_paths:
         cfg.push_scope(ConfigScope(name, path))
 
-        # Each scope can have per-platfom overrides in subdirectories
+        # Each scope can have per-platform overrides in subdirectories
         _add_platform_scope(cfg, ConfigScope, name, path)
 
     # add command-line scopes
@@ -1138,7 +1138,7 @@ def merge_yaml(dest, source):
     # Source dict is merged into dest.
     elif they_are(dict):
         # save dest keys to reinsert later -- this ensures that  source items
-        # come *before* dest in OrderdDicts
+        # come *before* dest in OrderedDicts
         dest_keys = [dk for dk in dest.keys() if dk not in source]
 
         for sk, sv in iteritems(source):
@@ -1342,7 +1342,7 @@ class ConfigFormatError(ConfigError):
         super(ConfigError, self).__init__(message)
 
     def _get_mark(self, validation_error, data):
-        """Get the file/line mark fo a validation error from a Ramble YAML file.
+        """Get the file/line mark for a validation error from a Ramble YAML file.
         """
         def _get_mark_or_first_member_mark(obj):
             # mark of object itelf

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -304,7 +304,7 @@ class ExperimentSet(object):
     def _ingest_experiments(self):
         """Ingest experiments based on the current context.
 
-        Interally collects all matrix and vector variables.
+        Internally collects all matrix and vector variables.
 
         Matrices are processed first.
 
@@ -456,7 +456,7 @@ class ExperimentSet(object):
             instance.create_experiment_chain(self._workspace)
 
     def all_experiments(self):
-        """Iteartor over all experiments in this set"""
+        """Iterator over all experiments in this set"""
         for exp, inst in self.experiments.items():
             yield exp, inst
 
@@ -492,7 +492,7 @@ class ExperimentSet(object):
 
         Args:
           experiment: A fully qualified experiment name (application.workload.experiment)
-          varialbe: Name of variable to look up
+          variable: Name of variable to look up
         """
 
         if experiment not in self.experiments.keys():

--- a/lib/ramble/ramble/experimental/uploader.py
+++ b/lib/ramble/ramble/experimental/uploader.py
@@ -61,7 +61,7 @@ class Experiment():
         # Avoid regenerating a hash when possible
         # (The hash of an object must never change during its lifetime..)
         if self.id is None:
-            #  TODO: this might be better as a hash of something we intuatively
+            #  TODO: this might be better as a hash of something we intuitively
             # expect to be uniqie, like:
             # "{RAMBLE_STATUS}-{application_name}-{experiment_name}-{time}-etc"
             # If we don't want this, we can go back to this class just being a dict
@@ -193,5 +193,5 @@ class BigQueryUploader(Uploader):
         # get_max_current_id(...) # Warning: dangerous..
 
         # This should be stable per machine/python version, but is not
-        # guarnteed to be globally stable
+        # guaranteed to be globally stable
         return hash(json.dumps(experiment, sort_keys=True))

--- a/lib/ramble/ramble/fetch_strategy.py
+++ b/lib/ramble/ramble/fetch_strategy.py
@@ -547,7 +547,7 @@ class URLFetchStrategy(FetchStrategy):
         # NOTE: The tar program on Mac OS X will encode HFS metadata in
         # hidden files, which can end up *alongside* a single top-level
         # directory.  We initially ignore presence of hidden files to
-        # accomodate these "semi-exploding" tarballs but ensure the files
+        # accommodate these "semi-exploding" tarballs but ensure the files
         # are copied to the source directory.
         files = os.listdir(tarball_container)
         non_hidden = [f for f in files if not f.startswith('.')]

--- a/lib/ramble/ramble/keywords.py
+++ b/lib/ramble/ramble/keywords.py
@@ -122,7 +122,7 @@ class Keywords(object):
             for key in required_set:
                 tty.warn(f'Required key "{key}" is not defined')
             raise RambleKeywordError('One or more required keys ' +
-                                     'are not definied within an experiment.')
+                                     'are not defined within an experiment.')
 
 
 keywords = llnl.util.lang.Singleton(Keywords)

--- a/lib/ramble/ramble/language/application_language.py
+++ b/lib/ramble/ramble/language/application_language.py
@@ -181,7 +181,7 @@ def figure_of_merit(name, log_file, fom_regex, group_name, units='',
 @application_directive('inputs')
 def input_file(name, url, description, target_dir='{workload_name}', sha256=None, extension=None,
                expand=True, **kwargs):
-    """Adds an input file defintion to this appliaction
+    """Adds an input file definition to this application
 
     Defines a new input file.
     An input file must define it's name, and a url where the input can be

--- a/lib/ramble/ramble/language/language_base.py
+++ b/lib/ramble/ramble/language/language_base.py
@@ -114,7 +114,7 @@ class DirectiveMeta(type):
 
         Ramble directives allow you to modify a package while it is being
         defined, e.g. to add version or dependency information.  Directives are
-        one of the key pieces of Ramble's appliaction "language", which is
+        one of the key pieces of Ramble's application "language", which is
         embedded in python.
 
         Here's an example directive:
@@ -143,7 +143,7 @@ class DirectiveMeta(type):
         and that if no directive actually modified it, it will just be an empty
         dict.
 
-        This is just a modular way to add storage attributes to the Appliaction
+        This is just a modular way to add storage attributes to the Application
         class, and it's how Ramble gets information from the applications to
         the core.
 

--- a/lib/ramble/ramble/main.py
+++ b/lib/ramble/ramble/main.py
@@ -366,7 +366,7 @@ def make_argument_parser(**kwargs):
     parser = RambleArgumentParser(
         formatter_class=RambleHelpFormatter, add_help=False,
         description=(
-            "A fleixble benchmark experiment manager."),
+            "A flexible benchmark experiment manager."),
         **kwargs)
 
     # stat names in groups of 7, for nice wrapping.
@@ -513,7 +513,7 @@ def allows_unknown_args(command):
     """Implements really simple argument injection for unknown arguments.
 
     Commands may add an optional argument called "unknown args" to
-    indicate they can handle unknonwn args, and we'll pass the unknown
+    indicate they can handle unknown args, and we'll pass the unknown
     args in.
     """
     info = dict(inspect.getmembers(command))

--- a/lib/ramble/ramble/renderer.py
+++ b/lib/ramble/ramble/renderer.py
@@ -34,7 +34,7 @@ class Renderer(object):
     def render_objects(self, variables, matrices=None):
         """Render objects based on the input variabls and matrices
 
-        Interally collects all matrix and vector variables.
+        Internally collects all matrix and vector variables.
 
         Matrices are processed first.
 
@@ -110,7 +110,7 @@ class Renderer(object):
                     vectors.append(object_variables[var])
                     variable_names.append(var)
 
-                    # Remove the variable, so it's not proccessed as a vector anymore.
+                    # Remove the variable, so it's not processed as a vector anymore.
                     del object_variables[var]
 
                 if last_size == -1:

--- a/lib/ramble/ramble/repository.py
+++ b/lib/ramble/ramble/repository.py
@@ -836,7 +836,7 @@ class Repo(object):
                 sys.modules[ns] = module
 
                 # TODO: DWJ - Do we need this?
-                # Ensure the namespace is an atrribute of its parent,
+                # Ensure the namespace is an attribute of its parent,
                 # if it has not been set by something else already.
                 #
                 # This ensures that we can do things like:

--- a/lib/ramble/ramble/schema/env_vars.py
+++ b/lib/ramble/ramble/schema/env_vars.py
@@ -6,7 +6,7 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-"""Schema for environment varaibles configuration file.
+"""Schema for environment variables configuration file.
 
 .. literalinclude:: _ramble_root/lib/ramble/ramble/schema/env_vars.py
    :lines: 12-

--- a/lib/ramble/ramble/spack_runner.py
+++ b/lib/ramble/ramble/spack_runner.py
@@ -35,7 +35,7 @@ class SpackRunner(object):
     The SpackRunner class is primarily used to manage spack environments
     for executing experiments under.
 
-    This calss provides methods for creating and manaving spack environments,
+    This class provides methods for creating and manaving spack environments,
     and for ensuring required compilers are installed. It also provides a
     method for generating variables that can be used to ensure a spack env
     is loaded within an execution script.

--- a/lib/ramble/ramble/stage.py
+++ b/lib/ramble/ramble/stage.py
@@ -50,7 +50,7 @@ def create_stage_root(path):
 
     err_msg = 'Cannot create stage root {0}: Access to {1} is denied'
 
-    # TODO: (dwjacobsen) Reomve when owner_uid is removed below
+    # TODO: (dwjacobsen) Remove when owner_uid is removed below
     # user_uid = os.getuid()
 
     # Obtain lists of ancestor and descendant paths of the $user node, if any.

--- a/lib/ramble/ramble/success_criteria.py
+++ b/lib/ramble/ramble/success_criteria.py
@@ -23,7 +23,7 @@ class ScopedCriteriaList(object):
      - workload
      - experiment
 
-    To see if success was met, all criteria will be checked and are ANDed together.
+    To see if success was met, all criteria will be checked and are AND-ed together.
     """
 
     _valid_scopes = [

--- a/lib/ramble/ramble/test/cmd/config.py
+++ b/lib/ramble/ramble/test/cmd/config.py
@@ -630,7 +630,7 @@ def test_config_remove_from_workspace(mutable_empty_config, mutable_mock_workspa
 #     config_yaml_v015()
 #     config('update', '-y', 'config')
 #
-#     # Check the entires have been transformed
+#     # Check the entries have been transformed
 #     data = ramble.config.get('config')
 #     check_config_updated(data)
 

--- a/lib/ramble/ramble/test/cmd/software_definitions.py
+++ b/lib/ramble/ramble/test/cmd/software_definitions.py
@@ -11,7 +11,7 @@ from ramble.main import RambleCommand, RambleCommandError
 software_defs = RambleCommand('software-definitions')
 
 
-def test_software_defintions_runs():
+def test_software_definitions_runs():
     software_defs()
 
 

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -982,7 +982,7 @@ ramble:
 def test_reconcretize_in_configs_dir(tmpdir):
     """
     Test multiple concretizations while the configs dir is the cwd do not fail.
-    This catchs a bug that existed when lock files were written incorrectly.
+    This catches a bug that existed when lock files were written incorrectly.
     """
     test_config = """
 ramble:
@@ -1063,7 +1063,7 @@ ramble:
     with open(config_path, 'w+') as f:
         f.write(test_config)
 
-    # Create more tempaltes
+    # Create more templates
     new_templates = []
     for i in range(0, 5):
         new_template = os.path.join(ws1.config_dir, 'test_template.%s' % i)
@@ -1137,7 +1137,7 @@ ramble:
     with open(config_path, 'w+') as f:
         f.write(test_config)
 
-    # Create more tempaltes
+    # Create more temlates
     new_templates = []
     for i in range(0, 5):
         new_template = os.path.join(ws1.config_dir, 'test_template.%s' % i)
@@ -1213,7 +1213,7 @@ ramble:
     with open(config_path, 'w+') as f:
         f.write(test_config)
 
-    # Create more tempaltes
+    # Create more templates
     new_templates = []
     for i in range(0, 5):
         new_template = os.path.join(ws1.config_dir, 'test_template.%s' % i)
@@ -1294,7 +1294,7 @@ ramble:
     with open(config_path, 'w+') as f:
         f.write(test_config)
 
-    # Create more tempaltes
+    # Create more templates
     new_templates = []
     for i in range(0, 5):
         new_template = os.path.join(ws1.config_dir, 'test_template.%s' % i)
@@ -1327,7 +1327,7 @@ ramble:
     fs.mkdirp(remote_archive_path)
 
     config('add', 'config:archive_url:%s/' % remote_archive_path,
-           gloabl_args=['-w', workspace_name])
+           global_args=['-w', workspace_name])
 
     output = workspace('archive', '-t', global_args=['-w', workspace_name])
 

--- a/lib/ramble/ramble/test/conftest.py
+++ b/lib/ramble/ramble/test/conftest.py
@@ -360,10 +360,10 @@ def mock_directive_bundle():
 
 @pytest.fixture
 def clear_directive_functions():
-    """Clear all overidden directive functions for subsequent tests."""
+    """Clear all overridden directive functions for subsequent tests."""
     yield
 
-    # Make sure any directive functions overidden by tests are cleared before
+    # Make sure any directive functions overridden by tests are cleared before
     # proceeding with subsequent tests that may depend on the original
     # functions.
     ramble.directives.DirectiveMeta._directives_to_be_executed = []

--- a/lib/ramble/ramble/test/end_to_end/wrfv4_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/wrfv4_dry_run.py
@@ -185,7 +185,7 @@ licenses:
                 assert "export TEST_VAR=1" in data
                 assert 'unset TEST_VAR' in data
 
-                # Test the expected portions of the exection command exist
+                # Test the expected portions of the execution command exist
                 assert "sed -i -e 's/ start_hour.*/ start_hour" in data
                 assert "sed -i -e 's/ restart .*/ restart" in data
                 assert "mpirun" in data
@@ -204,7 +204,7 @@ licenses:
                 assert "export TEST_VAR=1" in data
                 assert 'unset TEST_VAR' in data
 
-                # Test the expected portions of the exection command exist
+                # Test the expected portions of the execution command exist
                 assert "sed -i -e 's/ start_hour.*/ start_hour" in data
                 assert "sed -i -e 's/ restart .*/ restart" in data
                 assert "mpirun" in data

--- a/lib/ramble/ramble/util/install_cache.py
+++ b/lib/ramble/ramble/util/install_cache.py
@@ -6,7 +6,7 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-"""Provide data structures to assist with cacheing operations"""
+"""Provide data structures to assist with caching operations"""
 
 
 class SetCache:

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -368,7 +368,7 @@ def get_workspace(args, cmd_name, required=False):
     workspace.
 
     Arguments:
-        args (Namespace): argparse namespace wtih command arguments
+        args (Namespace): argparse namespace with command arguments
         cmd_name (str): name of calling command
         required (bool): if ``True``, raise an exception when no workspace
             is found; if ``False``, just return ``None``
@@ -416,7 +416,7 @@ class Workspace(object):
     the entire software stack.
 
     The execute_experiment.tpl file is a template script that
-    contants the blueprints for running each experiment.
+    constants the blueprints for running each experiment.
     There are several ramble language features that can be used
     within the script, to help it render properly for all
     experiments.

--- a/share/ramble/bash/ramble-completion.in
+++ b/share/ramble/bash/ramble-completion.in
@@ -91,7 +91,7 @@ _bash_completion_ramble() {
         list_options=true
     fi
 
-    # In general, when envoking tab completion, the user is not expecting to
+    # In general, when evoking tab completion, the user is not expecting to
     # see optional flags mixed in with subcommands or package names. Tab
     # completion is used by those who are either lazy or just bad at spelling.
     # If someone doesn't remember what flag to use, seeing single letter flags

--- a/share/ramble/cloud-build/ramble-pr-software-conflicts.yaml
+++ b/share/ramble/cloud-build/ramble-pr-software-conflicts.yaml
@@ -34,7 +34,7 @@ steps:
         conflict_err=$$?
 
         if [ $$conflict_err -gt 0 ]; then
-          echo " ***** Conflicts in software defintions detected."
+          echo " ***** Conflicts in software definitions detected."
           error=1
         fi
 

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -91,7 +91,7 @@ _bash_completion_ramble() {
         list_options=true
     fi
 
-    # In general, when envoking tab completion, the user is not expecting to
+    # In general, when evoking tab completion, the user is not expecting to
     # see optional flags mixed in with subcommands or package names. Tab
     # completion is used by those who are either lazy or just bad at spelling.
     # If someone doesn't remember what flag to use, seeing single letter flags

--- a/share/ramble/setup-env.fish
+++ b/share/ramble/setup-env.fish
@@ -227,7 +227,7 @@ function check_rmb_flags -d "check ramble flags for h/V flags"
     # Check if inputs contain h or V flags.
     #
 
-    # combine argument array into single string (space seperated), to be passed
+    # combine argument array into single string (space separated), to be passed
     # to regular expression matching (`string match -r`)
     set -l _a "$argv"
 
@@ -288,7 +288,7 @@ function check_workspace_activate_flags -d "check ramble workspace subcommand fl
     # Check if inputs contain -h/--help, --sh, --csh, or --fish
     #
 
-    # combine argument array into single string (space seperated), to be passed
+    # combine argument array into single string (space separated), to be passed
     # to regular expression matching (`string match -r`)
     set -l _a "$argv"
 
@@ -331,7 +331,7 @@ function check_workspace_deactivate_flags -d "check ramble workspace subcommand 
     # Check if inputs contain --sh, --csh, or --fish
     #
 
-    # combine argument array into single string (space seperated), to be passed
+    # combine argument array into single string (space separated), to be passed
     # to regular expression matching (`string match -r`)
     set -l _a "$argv"
 
@@ -410,7 +410,7 @@ function ramble_runner -d "Runner function for the `ramble` wrapper"
 
         # CASE: ramble subcommand is `workspace`. Here we get the ramble runtime to
         # supply the appropriate shell commands for setting the workspace
-        # varibles. These commands are then run by fish (using the `capture_all`
+        # variables. These commands are then run by fish (using the `capture_all`
         # function, instead of a command substitution).
 
         case "workspace"
@@ -521,7 +521,7 @@ set -l stat $status
 
 
 #
-# Delete temprary global variabels allocated in `allocated_rmb_shared`.
+# Delete temporary global variables allocated in `allocated_rmb_shared`.
 #
 
 delete_rmb_shared
@@ -565,7 +565,7 @@ function ramble_pathadd -d "Add path to specified variable (defaults to PATH)"
     #  -> Notes: [1] (cf. EOF).
     if test -d "$pa_new_path"
 
-        # combine argument array into single string (space seperated), to be
+        # combine argument array into single string (space separated), to be
         # passed to regular expression matching (`string match -r`)
         set -l _a "$pa_oldvalue"
 

--- a/share/ramble/setup-env.sh
+++ b/share/ramble/setup-env.sh
@@ -105,7 +105,7 @@ _ramble_shell_wrapper() {
                 case $_rmb_arg in
                     activate)
                         # Get --sh, --csh, or -h/--help arguments.
-                        # Space needed here becauses regexes start with a space
+                        # Space needed here because regexes start with a space
                         # and `-h` may be the only argument.
                         _a=" $@"
                         # Space needed here to differentiate between `-h`
@@ -126,7 +126,7 @@ _ramble_shell_wrapper() {
                         ;;
                     deactivate)
                         # Get --sh, --csh, or -h/--help arguments.
-                        # Space needed here becauses regexes start with a space
+                        # Space needed here because regexes start with a space
                         # and `-h` may be the only argument.
                         _a=" $@"
                         # Space needed here to differentiate between `--sh`


### PR DESCRIPTION
Hi! I was trying this out today, and I noticed a few typos while browsing the source code. So this pull request will fix all found
typos (for code developed here) and add spell checking to the CI to ensure we catch any for future additions/changes!

There were a handful that were typos in variables or attributes, namely in testing an argument to `config(` and a typo of "global" and then an attribute that was something like "softwre_*" and I fixed them, and  hopefully they are correct in the fixed state.