### PR TITLE
add space between mpi command and template command

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -554,7 +554,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
 
                 if command_config['mpi']:
                     exec_vars['mpi_command'] = \
-                        self.expander.expand_var('{mpi_command} ')
+                        self.expander.expand_var('{mpi_command}') + ' '
                 else:
                     exec_vars['mpi_command'] = ''
 
@@ -565,21 +565,21 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                 else:
                     exec_vars['redirect'] = ''
 
+                mpi_cmd = exec_vars['mpi_command']
+                redirect = exec_vars['redirect']
                 if isinstance(command_config['template'], list):
                     for part in command_config['template']:
-                        command_part = '{mpi_command}%s{redirect}' % \
-                            part
+                        command_part = f'{mpi_cmd}{part}{redirect}'
                         command.append(self.expander.expand_var(command_part,
                                                                 exec_vars))
                 elif isinstance(command_config['template'],
                                 six.string_types):
-                    command_part = '{mpi_command}%s{redirect}' % \
-                        command_config['template']
+                    command_part = f'{mpi_cmd}{command_config["template"]}{redirect}'
                     command.append(self.expander.expand_var(command_part,
                                                             exec_vars))
                 else:
                     app_err = 'Unsupported template type in executable '
-                    app_err += '%s' % executable
+                    app_err += f'{executable}'
                     raise ApplicationError(app_err)
 
                 del self.variables['executable_name']


### PR DESCRIPTION
This will fix a bug reported in #159 where there is a space missing between the MPI command and the template command! I've added padding on both sides, and this fixes the error:

```bash
$ cat experiments/hostname/parallel/test/execute_experiment 
```
```bash
# This is a template execution script for
# running the execute pipeline.
#
# Variables surrounded by curly braces will be expanded
# when generating a specific execution script.
# Some example variables are:
#   - experiment_run_dir (Will be replaced with the experiment directory)
#   - command (Will be replaced with the command to run the experiment)
#   - log_dir (Will be replaced with the logs directory)
#   - experiment_name (Will be replaced with the name of the experiment)
#   - workload_run_dir (Will be replaced with the directory of the workload
#   - application_name (Will be repalced with the name of the application)
#   - n_nodes (Will be replaced with the required number of nodes)
#   Any experiment parameters will be available as variables as well.

cd "/home/flux/test_workspace/experiments/hostname/parallel/test"

rm -f "/home/flux/test_workspace/experiments/hostname/parallel/test/test.out"
touch "/home/flux/test_workspace/experiments/hostname/parallel/test/test.out"
export OMP_NUM_THREADS="1";
mpirun /usr/bin/time hostname  &> "/home/flux/test_workspace/experiments/hostname/parallel/test/test.out"
```

Note before the last line was `mpirun /usr/bin/time` and it produced an error.