### PR TITLE
Allow workloads to be templatized

### DIFF
--- a/lib/ramble/docs/workspace_config.rst
+++ b/lib/ramble/docs/workspace_config.rst
@@ -305,6 +305,33 @@ Would result in roughly the following bash commands:
     export PATH=prepend_path:$PATH:app_path
     unset LD_LIBRARY_PATH
 
+^^^^^^^^^^^^^^^^^^^^^^
+Templatized Workloads:
+^^^^^^^^^^^^^^^^^^^^^^
+
+As previously shown, variables can be defined using lists or matrices. In addition to
+controlling several aspects of experiments, list and matrix variables can be used to
+replicate an experiment across workloads.
+
+.. code-block:: yaml
+
+    ramble:
+      applications:
+        hostname:
+          variables:
+            application_workloads: ['parallel', 'serial', 'local']
+          workloads:
+            '{application_workloads}':
+              experiments:
+                test_exp:
+                  variables:
+                    n_ranks: '1'
+
+In the above example, we use the ``application_workloads`` variable to define
+the names of the workloads we'd like to generate experiments for. Any variable
+can be used to define the name of the workloads, except those reserved by
+Ramble. These can be seen in the reserved variables section below.
+
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Cross Experiment Variable References:
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -714,6 +714,17 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                 template_name)
             self.variables[template_name] = expand_path
 
+    def _validate_experiment(self):
+        """Perform validation of an experiment before performing actions with it
+
+        This function is an entry point to validate various aspects of an
+        experiment definition before it is used. It is expected to raise errors
+        when validation fails.
+        """
+        if self.expander.workload_name not in self.workloads:
+            raise ApplicationError(f'Workload {self.expander.workload_name} is not defined '
+                                   f'as a workload of application {self.name}.')
+
     def add_expand_vars(self, workspace):
         """Add application specific expansion variables
 
@@ -723,6 +734,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         - spack_setup: set to an empty string, so spack applications can override this
         """
         if not self._vars_are_expanded:
+            self._validate_experiment()
             executables = self._get_executables()
             self._set_input_path()
             self._set_default_experiment_variables()

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -385,7 +385,8 @@ class ExperimentSet(object):
 
         for context in self._contexts:
             var_name = f'{context.name}_name'
-            context_variables[var_name] = self._context_names[context]
+            if self._context_names[context] not in context_variables:
+                context_variables[var_name] = self._context_names[context]
 
         # Set namespaces
         context_variables['application_namespace'] = self.application_namespace
@@ -444,9 +445,9 @@ class ExperimentSet(object):
 
             tty.debug('   Final name: %s' % final_exp_name)
 
-            if final_exp_name in rendered_experiments:
-                tty.die('Experiment %s is not unique.' % final_exp_name)
-            rendered_experiments.add(final_exp_name)
+            if experiment_namespace in rendered_experiments:
+                tty.die('Experiment %s is not unique.' % experiment_namespace)
+            rendered_experiments.add(experiment_namespace)
 
             try:
                 self.keywords.check_required_keys(experiment_vars)

--- a/lib/ramble/ramble/test/end_to_end/vector_workloads.py
+++ b/lib/ramble/ramble/test/end_to_end/vector_workloads.py
@@ -1,0 +1,66 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.workspace
+import ramble.config
+import ramble.software_environments
+from ramble.main import RambleCommand
+
+
+# everything here uses the mock_workspace_path
+pytestmark = pytest.mark.usefixtures('mutable_config',
+                                     'mutable_mock_workspace_path')
+
+workspace = RambleCommand('workspace')
+
+
+def test_vector_workloads(mutable_config, mutable_mock_workspace_path):
+    test_config = """
+ramble:
+  variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
+    partition: 'part1'
+    processes_per_node: '16'
+    n_threads: '1'
+  applications:
+    hostname:
+      workloads:
+        '{application_workload}':
+          experiments:
+            simple_test:
+              variables:
+                application_workload: ['parallel' ,'serial', 'local']
+                n_nodes: 1
+  spack:
+    concretized: true
+    packages: {}
+    environments: {}
+"""
+    workspace_name = 'test_vector_workloads'
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+
+        config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+
+        with open(config_path, 'w+') as f:
+            f.write(test_config)
+        ws._re_read()
+
+        workspace('setup', '--dry-run', global_args=['-w', workspace_name])
+
+        experiment_root = ws.experiment_dir
+        expected_workloads = ['parallel', 'serial', 'local']
+        for workload in expected_workloads:
+            exp1_dir = os.path.join(experiment_root, 'hostname', workload, 'simple_test')
+            exp1_script = os.path.join(exp1_dir, 'execute_experiment')
+            assert os.path.isfile(exp1_script)


### PR DESCRIPTION
This merge allows the name of workloads to be templatized. This allows variables that are vectors or matrices to be used for the name of workloads that experiments should be generated from.