### PR TITLE
Update FOMs to expand fom_name (LHS) using groups (RHS)

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -174,7 +174,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
 
         if hasattr(self, 'maintainers'):
             out_str.append('\n')
-            out_str.append(section_title("Maintainers:\n"))
+            out_str.append(rucolor.section_title("Maintainers:\n"))
             out_str.append(colified(self.maintainers, tty=True))
             out_str.append('\n')
 
@@ -975,28 +975,32 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                         fom_conf = foms[fom]
                         fom_match = fom_conf['regex'].match(line)
 
-                        if fom_match and \
-                                (fom_conf['group'] in
-                                 fom_conf['regex'].groupindex):
-                            tty.debug(' --- Matched fom %s' % fom)
-                            fom_contexts = []
-                            if fom_conf['contexts']:
-                                for context in fom_conf['contexts']:
-                                    context_name = active_contexts[context] \
-                                        if context in active_contexts \
-                                        else 'null'
-                                    fom_contexts.append(context_name)
-                            else:
-                                fom_contexts.append('null')
+                        if fom_match:
+                            fom_vars = {}
+                            for k, v in fom_match.groupdict().items():
+                                fom_vars[k] = v
+                            fom_name = self.expander.expand_var(fom, extra_vars=fom_vars)
 
-                            for context in fom_contexts:
-                                if context not in fom_values:
-                                    fom_values[context] = {}
-                                fom_val = fom_match.group(fom_conf['group'])
-                                fom_values[context][fom] = {
-                                    'value': fom_val,
-                                    'units': fom_conf['units']
-                                }
+                            if fom_conf['group'] in fom_conf['regex'].groupindex:
+                                tty.debug(' --- Matched fom %s' % fom_name)
+                                fom_contexts = []
+                                if fom_conf['contexts']:
+                                    for context in fom_conf['contexts']:
+                                        context_name = active_contexts[context] \
+                                            if context in active_contexts \
+                                            else 'null'
+                                        fom_contexts.append(context_name)
+                                else:
+                                    fom_contexts.append('null')
+
+                                for context in fom_contexts:
+                                    if context not in fom_values:
+                                        fom_values[context] = {}
+                                    fom_val = fom_match.group(fom_conf['group'])
+                                    fom_values[context][fom_name] = {
+                                        'value': fom_val,
+                                        'units': fom_conf['units']
+                                    }
 
         exp_ns = self.expander.experiment_namespace
         results = {'name': exp_ns}

--- a/lib/ramble/ramble/test/end_to_end/expanded_fom_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/expanded_fom_dry_run.py
@@ -1,0 +1,86 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+import glob
+
+import pytest
+
+import ramble.workspace
+import ramble.config
+import ramble.software_environments
+from ramble.main import RambleCommand
+
+
+# everything here uses the mock_workspace_path
+pytestmark = pytest.mark.usefixtures('mutable_config',
+                                     'mutable_mock_workspace_path')
+
+workspace = RambleCommand('workspace')
+
+
+def test_expanded_foms_dry_run(mutable_config,
+                               mutable_mock_workspace_path,
+                               mock_applications):
+    test_config = """
+ramble:
+  variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
+    n_threads: '1'
+  applications:
+    expanded_foms:
+      workloads:
+        test_wl:
+          experiments:
+            single_exp:
+              variables:
+                n_nodes: 1
+                n_ranks: 1
+  spack:
+    concretized: false
+    packages: {}
+    environments: {}
+"""
+
+    workspace_name = 'test_end_to_end_expanded_foms'
+    with ramble.workspace.create(workspace_name) as ws1:
+        ws1.write()
+
+        config_path = os.path.join(ws1.config_dir, ramble.workspace.config_file_name)
+
+        with open(config_path, 'w+') as f:
+            f.write(test_config)
+
+        # Write a command template
+        with open(os.path.join(ws1.config_dir, 'full_command.tpl'), 'w+') as f:
+            f.write('{command}')
+
+        ws1._re_read()
+
+        ws1.concretize()
+        output = workspace('setup', '--dry-run', global_args=['-w', workspace_name])
+
+        # Create fake figures of merit.
+        expected_expansions = ['MPI', 'test1', '123']
+
+        exp_dir = os.path.join(ws1.root, 'experiments', 'expanded_foms', 'test_wl', 'single_exp')
+        fom_out_file = os.path.join(exp_dir, 'single_exp.out')
+        with open(fom_out_file, 'w+') as f:
+            for expected in expected_expansions:
+                f.write(f'Collect FOM {expected} = 567.8 seconds\n')
+
+        ws1._re_read()
+        output = workspace('analyze', global_args=['-w', workspace_name])
+        print(output)
+
+        text_results_files = glob.glob(os.path.join(ws1.root, 'results*.txt'))
+        with open(text_results_files[0], 'r') as f:
+            data = f.read()
+            for expected in expected_expansions:
+                assert f'test_fom {expected} = 567.8' in data

--- a/var/ramble/repos/builtin.mock/applications/expanded_foms/application.py
+++ b/var/ramble/repos/builtin.mock/applications/expanded_foms/application.py
@@ -1,0 +1,34 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.appkit import *
+
+
+class ExpandedFoms(ExecutableApplication):
+    name = "expanded-Foms"
+
+    executable('foo', 'bar', use_mpi=False)
+
+    input_file('input', url='file:///tmp/test_file.log',
+               description='Not a file', extension='.log')
+
+    workload('test_wl', executables=['foo'], input='input')
+
+    workload_variable('my_var', default='1.0',
+                      description='Example var',
+                      workload='test_wl')
+
+    archive_pattern('{experiment_run_dir}/archive_test.*')
+
+    figure_of_merit('test_fom {var}',
+                    fom_regex=r'Collect FOM (?P<var>\w+)\s=\s(?P<test>[0-9]+\.[0-9]+) seconds',
+                    log_file='{log_file}',
+                    group_name='test', units='s')
+
+    success_criteria('Run', mode='string',
+                     match=r'Collect', file='{log_file}')


### PR DESCRIPTION
This change allows FOM names to be expanded based on regex groups, eg:

```
figure_of_merit('MPI_{func}', fom_regex=r'\s*MPI_(?P<func>\w+).* ...)
```

Could create `MPI_bcast` if func=bcast