### PR TITLE
Allow input files path to be expanded

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -776,7 +776,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
             workload = self.workloads[workload_name]
 
             for input_file in workload['inputs']:
-                input_conf = self.inputs[input_file]
+                input_conf = self.inputs[input_file].copy()
 
                 # Expand input value as it may be a var
                 expanded_url = self.expander.expand_var(input_conf['url'])

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -748,8 +748,8 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         if not self._vars_are_expanded:
             self._validate_experiment()
             executables = self._get_executables()
-            self._set_input_path()
             self._set_default_experiment_variables()
+            self._set_input_path()
             self._inject_commands(executables)
             # ---------------------------------------------------------------------------------
             # TODO (dwj): Remove this after we validate that 'spack_setup' is not in templates.
@@ -777,6 +777,10 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
 
             for input_file in workload['inputs']:
                 input_conf = self.inputs[input_file]
+
+                # Expand input value as it may be a var
+                expanded_url = self.expander.expand_var(input_conf['url'])
+                input_conf['url'] = expanded_url
 
                 fetcher = ramble.fetch_strategy.URLFetchStrategy(**input_conf)
 

--- a/lib/ramble/ramble/test/mirror_tests.py
+++ b/lib/ramble/ramble/test/mirror_tests.py
@@ -135,6 +135,7 @@ ramble:
     with archive_dir.as_cwd():
         app_type = ramble.repository.ObjectTypes.applications
         app_class = ramble.repository.paths[app_type].get_obj_class(app_name)('test')
+        app_class.set_variables(None, None)
         create_archive(archive_dir, app_class)
 
         # Create workspace


### PR DESCRIPTION
Previously the url for an application `input_file` could not be a variable. Something like:

```
input_file('CONUS_12km', url='{my_input}', ...)
workload_variable('my_input', default='https://url/to/resource'
```

Would not work. This PR enables expansion of the url