### PR TITLE
Add `config edit` and util.editor unit tests

### DIFF
--- a/lib/ramble/ramble/cmd/config.py
+++ b/lib/ramble/ramble/cmd/config.py
@@ -18,7 +18,7 @@ import ramble.config
 import ramble.workspace
 
 import spack.util.spack_yaml as syaml
-from spack.util.editor import editor
+import ramble.util.editor
 
 description = "get and set configuration options"
 section = "config"
@@ -102,6 +102,7 @@ def setup_parser(subparser):
 
 def _get_scope_and_section(args):
     """Extract config scope and section from arguments."""
+    tty.debug(f' Args = {str(args)}')
     scope = args.scope
     section = getattr(args, 'section', None)
     path = getattr(args, 'path', None)
@@ -179,7 +180,7 @@ def config_edit(args):
         if not os.path.isdir(os.path.dirname(config_file)):
             fs.mkdirp(os.path.dirname(config_file))
 
-        editor(config_file)
+        return ramble.util.editor.editor(config_file)
 
 
 def config_list(args):

--- a/lib/ramble/ramble/test/cmd/config.py
+++ b/lib/ramble/ramble/test/cmd/config.py
@@ -721,3 +721,30 @@ def check_config_updated(data):
     assert isinstance(data['install_tree'], dict)
     assert data['install_tree']['root'] == '/fake/path'
     assert data['install_tree']['projections'] == {'all': '{name}-{version}'}
+
+
+@pytest.fixture(scope='function')
+def mock_editor(monkeypatch):
+    def _editor(*args, **kwargs):
+        return True
+
+    monkeypatch.setattr('ramble.util.editor.editor', _editor)
+
+
+def section_args(section_name):
+    class TestArgs(object):
+        scope = None
+        section = section_name
+        config_command = 'edit'
+        print_file = False
+
+    return TestArgs()
+
+
+def test_config_edit_file(mutable_config, config_section, mock_editor):
+    import ramble.cmd.config
+    import ramble.util.editor
+
+    args = section_args(config_section)
+
+    assert ramble.cmd.config.config_edit(args)

--- a/lib/ramble/ramble/test/conftest.py
+++ b/lib/ramble/ramble/test/conftest.py
@@ -592,3 +592,16 @@ def pytest_generate_tests(metafunc):
             all_modifiers.append(mod_name)
 
         metafunc.parametrize("mock_modifier", all_modifiers)
+
+    if 'config_section' in metafunc.fixturenames:
+        from ramble.main import RambleCommand
+        config_cmd = RambleCommand('config')
+
+        all_sections = []
+        config_sections = config_cmd('list').split(' ')
+
+        for section_str in config_sections:
+            if section_str != '':
+                all_sections.append(section_str.strip())
+
+        metafunc.parametrize('config_section', all_sections)

--- a/lib/ramble/ramble/test/util/editor.py
+++ b/lib/ramble/ramble/test/util/editor.py
@@ -1,0 +1,137 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+import sys
+
+import pytest
+
+from llnl.util.filesystem import set_executable
+
+import ramble.util.editor as ed
+
+pytestmark = [pytest.mark.usefixtures('working_env'),
+              pytest.mark.skipif(sys.platform == 'win32',
+                                 reason="editor not implemented on windows")]
+
+
+def _make_exe(tmpdir_factory, name, contents=None):
+    if sys.platform == "win32":
+        name += '.exe'
+    path = str(tmpdir_factory.mktemp('%s_exe' % name).join(name))
+    if contents is not None:
+        with open(path, 'w') as f:
+            f.write('#!/bin/sh\n%s\n' % contents)
+        set_executable(path)
+    return path
+
+
+@pytest.fixture(scope='session')
+def good_exe(tmpdir_factory):
+    return _make_exe(tmpdir_factory, 'good', 'exit 0')
+
+
+@pytest.fixture(scope='session')
+def bad_exe(tmpdir_factory):
+    return _make_exe(tmpdir_factory, 'bad', 'exit 1')
+
+
+@pytest.fixture(scope='session')
+def nosuch_exe(tmpdir_factory):
+    return _make_exe(tmpdir_factory, 'nosuch')
+
+
+@pytest.fixture(scope='session')
+def vim_exe(tmpdir_factory):
+    return _make_exe(tmpdir_factory, 'vim', 'exit 0')
+
+
+def test_find_exe_from_env_var(good_exe):
+    os.environ['EDITOR'] = good_exe
+    assert ed._find_exe_from_env_var('EDITOR') == (good_exe, [good_exe])
+
+
+def test_find_exe_from_env_var_with_args(good_exe):
+    os.environ['EDITOR'] = good_exe + ' a b c'
+    assert ed._find_exe_from_env_var('EDITOR') == (
+        good_exe, [good_exe, 'a', 'b', 'c'])
+
+
+def test_find_exe_from_env_var_bad_path(nosuch_exe):
+    os.environ['EDITOR'] = nosuch_exe
+    assert ed._find_exe_from_env_var('FOO') == (None, [])
+
+
+def test_find_exe_from_env_var_no_editor():
+    if 'FOO' in os.environ:
+        os.environ.unset('FOO')
+    assert ed._find_exe_from_env_var('FOO') == (None, [])
+
+
+def test_editor_visual(good_exe):
+    os.environ['VISUAL'] = good_exe
+
+    def assert_exec(exe, args):
+        assert exe == good_exe
+        assert args == [good_exe, '/path/to/file']
+
+    ed.editor('/path/to/file', _exec_func=assert_exec)
+
+
+def test_editor_visual_bad(good_exe, bad_exe):
+    os.environ['VISUAL'] = bad_exe
+    os.environ['EDITOR'] = good_exe
+
+    def assert_exec(exe, args):
+        if exe == bad_exe:
+            raise OSError()
+
+        assert exe == good_exe
+        assert args == [good_exe, '/path/to/file']
+
+    ed.editor('/path/to/file', _exec_func=assert_exec)
+
+
+def test_editor_no_visual(good_exe):
+    if 'VISUAL' in os.environ:
+        del os.environ['VISUAL']
+    os.environ['EDITOR'] = good_exe
+
+    def assert_exec(exe, args):
+        assert exe == good_exe
+        assert args == [good_exe, '/path/to/file']
+
+    ed.editor('/path/to/file', _exec_func=assert_exec)
+
+
+def test_editor_no_visual_with_args(good_exe):
+    if 'VISUAL' in os.environ:
+        del os.environ['VISUAL']
+
+    # editor has extra args in the var (e.g., emacs -nw)
+    os.environ['EDITOR'] = good_exe + ' -nw --foo'
+
+    def assert_exec(exe, args):
+        assert exe == good_exe
+        assert args == [good_exe, '-nw', '--foo', '/path/to/file']
+
+    ed.editor('/path/to/file', _exec_func=assert_exec)
+
+
+def test_editor_both_bad(nosuch_exe, vim_exe):
+    os.environ['VISUAL'] = nosuch_exe
+    os.environ['EDITOR'] = nosuch_exe
+
+    os.environ['PATH'] = '%s%s%s' % (
+        os.path.dirname(vim_exe), os.pathsep, os.environ['PATH'])
+
+    def assert_exec(exe, args):
+        assert exe == vim_exe
+        assert args == [vim_exe, '/path/to/file']
+
+    ed.editor('/path/to/file', _exec_func=assert_exec)


### PR DESCRIPTION
This merge adds unit tests to exercise the `config edit` command, to help identify errors with any of the config sections.

Additionally, tests for util/editor are ported over from Spack.