### PR TITLE
Update gcp metadata curl to be silent

### DIFF
--- a/var/ramble/repos/builtin/modifiers/gcp-metadata/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/gcp-metadata/modifier.py
@@ -28,13 +28,13 @@ class GcpMetadata(BasicModifier):
     register_builtin('gcp_metadata_exec')
 
     def gcp_metadata_exec(self):
-        machine_type = 'curl -w "\\n" "http://metadata.google.internal/computeMetadata/v1/instance/machine-type" -H "Metadata-Flavor: Google" >> {log}'
+        machine_type = 'curl -s -w "\\n" "http://metadata.google.internal/computeMetadata/v1/instance/machine-type" -H "Metadata-Flavor: Google" >> {log}'
 
-        image = 'curl -w "\\n" "http://metadata.google.internal/computeMetadata/v1/instance/image" -H "Metadata-Flavor: Google" >> {log}'
+        image = 'curl -s -w "\\n" "http://metadata.google.internal/computeMetadata/v1/instance/image" -H "Metadata-Flavor: Google" >> {log}'
 
-        gid = 'curl -w "=GID\\n" "http://metadata.google.internal/computeMetadata/v1/instance/id" -H "Metadata-Flavor: Google" >> {log}'
+        gid = 'curl -s -w "=GID\\n" "http://metadata.google.internal/computeMetadata/v1/instance/id" -H "Metadata-Flavor: Google" >> {log}'
 
-        ghostname = 'curl -w "\\n" "http://metadata.google.internal/computeMetadata/v1/instance/hostname" -H "Metadata-Flavor: Google" >> {log}'
+        ghostname = 'curl -s -w "\\n" "http://metadata.google.internal/computeMetadata/v1/instance/hostname" -H "Metadata-Flavor: Google" >> {log}'
 
         return [machine_type, image, gid, ghostname]
 


### PR DESCRIPTION
Previously curl would update the user of progress on std out:

```
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    50  100    50    0     0  19004      0 --:--:-- --:--:-- --:--:-- 25000
```