### PR TITLE
Fix issue preventing spack specs from passing through expander

### DIFF
--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -365,6 +365,8 @@ class Expander(object):
             left_eval = self.eval_math(node.left)
             right_eval = self.eval_math(node.right)
             op = supported_math_operators[type(node.op)]
+            if isinstance(left_eval, six.string_types) or isinstance(right_eval, six.string_types):
+                raise SyntaxError('Unsupported operand type in binary operator')
             return op(left_eval, right_eval)
         except TypeError:
             raise SyntaxError('Unsupported operand type in binary operator')
@@ -378,6 +380,8 @@ class Expander(object):
         """
         try:
             operand = self.eval_math(node.operand)
+            if isinstance(operand, six.string_types):
+                raise SyntaxError('Unsupported operand type in unary operator')
             op = supported_math_operators[type(node.op)]
             return op(operand)
         except TypeError:

--- a/lib/ramble/ramble/test/expander.py
+++ b/lib/ramble/ramble/test/expander.py
@@ -6,6 +6,8 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+import pytest
+
 import ramble.expander
 
 
@@ -29,21 +31,27 @@ def exp_dict():
     }
 
 
-def test_expansions():
+@pytest.mark.parametrize(
+    'input,output',
+    [
+        ('{var1}', '3'),
+        ('{var2}', '3'),
+        ('{var3}', '3'),
+        ('{application_name}', 'foo'),
+        ('{n_nodes}', '2'),
+        ('{processes_per_node}', '2'),
+        ('{n_nodes}*{processes_per_node}', '4'),
+        ('2**4', '16'),
+        ('((((16-10+2)/4)**2)*4)', '16.0'),
+        ('gromacs +blas', 'gromacs +blas'),
+    ]
+)
+def test_expansions(input, output):
     expansion_vars = exp_dict()
 
     expander = ramble.expander.Expander(expansion_vars, None)
 
-    assert expander.expand_var('{var1}') == '3'
-    assert expander.expand_var('{var2}') == '3'
-    assert expander.expand_var('{var3}') == '3'
-    assert expander.expand_var('{application_name}') == 'foo'
-
-    assert expander.expand_var('{n_nodes}') == '2'
-    assert expander.expand_var('{processes_per_node}') == '2'
-    assert expander.expand_var('{n_nodes}*{processes_per_node}') == '4'
-    assert expander.expand_var('2**4') == '16'
-    assert expander.expand_var('((((16-10+2)/4)**2)*4)') == '16.0'
+    assert expander.expand_var(input) == output
 
 
 def test_expansion_namespaces():


### PR DESCRIPTION
Previously, spack specs with variants (i.e. `gromacs +blas`) would be evaluated by the expander as string operations. The result would be `gromacsblas`, instead of properly unmodifing the string.

This merge fixes this issue and adds a test to ensure it works in the future.