### PR TITLE
Add sha256 sums for input_file directives

### DIFF
--- a/var/ramble/repos/builtin/applications/gromacs/application.py
+++ b/var/ramble/repos/builtin/applications/gromacs/application.py
@@ -35,22 +35,28 @@ class Gromacs(SpackApplication):
                '-s {input_path}', use_mpi=True)
 
     input_file('water_gmx50_bare', url='https://ftp.gromacs.org/pub/benchmarks/water_GMX50_bare.tar.gz',
+               sha256='2219c10acb97787f80f6638132bad3ff2ca1e68600eef1bc8b89d9560e74c66a',
                description='')
     input_file('water_bare_hbonds', url='https://ftp.gromacs.org/pub/benchmarks/water_bare_hbonds.tar.gz',
+               sha256='b2e09d30f5c6b00ecf1c13ea6fa715ad132747863ef89f983f6c09a872cf2776',
                description='')
     input_file('lignocellulose',
                url='https://repository.prace-ri.eu/ueabs/GROMACS/1.2/GROMACS_TestCaseB.tar.gz',
+               sha256='8a12db0232465e1d47c6a4eb89f615cdbbdc8fc360a86088b131331bd462f35c',
                description='A model of cellulose and lignocellulosic biomass in an aqueous ' +
                            'solution. This system of 3.3M atoms is inhomogeneous, at ' +
                            'least with GROMACS 4.5. This system uses reaction-field' +
                            'electrostatics instead of PME and therefore should scale well.')
-    input_file('HECBioSim', url='https://github.com/victorusu/GROMACS_Benchmark_Suite/archive/refs/tags/1.0.0.tar.gz',
+    input_file('HECBioSim',
+               url='https://github.com/victorusu/GROMACS_Benchmark_Suite/archive/refs/tags/1.0.0.tar.gz',
+               sha256='9cb2ad61ec2a422fc33578047e7cb2fd2c37ae9a75a6162d662fa2b711e9737f',
                description='https://www.hecbiosim.ac.uk/access-hpc/benchmarks')
 
     # input_file('BenchPEP', url='https://www.mpinat.mpg.de/632210/benchPEP.zip',
     #            description='12M Atoms, Peptides in Water, 2fs time step, all bonds constrained. https://www.mpinat.mpg.de/grubmueller/bench')
 
     input_file('BenchPEP', url='https://www.mpinat.mpg.de/benchPEP.zip',
+               sha256='f11745201dbb9e6a29a39cb016ee8123f6b0f519b250c94660f0a9623e497b22',
                description='12M Atoms, Peptides in Water, 2fs time step, all bonds constrained. https://www.mpinat.mpg.de/grubmueller/bench')
 
     workload('water_gmx50', executables=['pre-process', 'execute-gen'],

--- a/var/ramble/repos/builtin/applications/hpcc/application.py
+++ b/var/ramble/repos/builtin/applications/hpcc/application.py
@@ -39,6 +39,7 @@ class Hpcc(SpackApplication):
     required_package('hpcc')
 
     input_file('hpccinf', url='{config_file}', expand=False,
+               sha256='fe9e5f4118c1b40980e162dc3c52d224fd6287e9706b95bb40ae7dfc96b38622',
                description='Input/Config file for HPCC benchmark')
 
     executable('copy-config', template='cp -R {workload_input_dir}/* {experiment_run_dir}/.', use_mpi=False)

--- a/var/ramble/repos/builtin/applications/lammps/application.py
+++ b/var/ramble/repos/builtin/applications/lammps/application.py
@@ -28,14 +28,19 @@ class Lammps(SpackApplication):
     required_package('lammps')
 
     input_file('leonard-jones', url='https://www.lammps.org/inputs/in.lj.txt', expand=False,
+               sha256='874b4c63b6fcbb6ede76522df19087acf2f49b6bc96794cf0aa3218c66ff7e06',
                description='Atomic fluid. 32k atoms. 100 timesteps. https://www.lammps.org/bench.html#lj')
     input_file('eam', url='https://www.lammps.org/inputs/in.eam.txt', expand=False,
+               sha256='2fa09183c626c34570cc367384fe4c297ab153521adb3ea44ff7e265d451ad75',
                description='Cu metallic solid with embedded atom method potential. 32k atoms. https://www.lammps.org/bench.html#eam')
     input_file('polymer-chain-melt', url='https://www.lammps.org/inputs/in.chain.txt', expand=False,
+               sha256='97676f19d2d791c42415698c354a18b26a3cbe4006cd2161cf8924415d9f7c82',
                description='Bead-spring polymer melt with 100-mer chains and FENE bonds. 32k atoms. 100 timesteps. https://www.lammps.org/bench.html#chain')
     input_file('chute', url='https://www.lammps.org/inputs/in.chute.txt', expand=False,
+               sha256='91e1743cc39365b32757cfb3c76399f5ed8debad0b890cb36ee7bdf47d2dfd2d',
                description='Chute flow of packed granular particles with frictional history potential. 32k atoms. 100 timeteps. https://www.lammps.org/bench.html#chute')
     input_file('rhodo', url='https://www.lammps.org/inputs/in.rhodo.txt', expand=False,
+               sha256='4b6cc70db1b8fe269c48b8e06749f144f400e9a4054bf180ac9b1b9a5a5bb07f',
                description='All-atom rhodopsin protein in solvated lipid bilayer with CHARMM force field, long-range Coulombics via PPPM (particle-particle particle mesh), SHAKE constraints. This model contains counter-ions and a reduced amount of water to make a 32K atom system. 32k atoms. 100 timesteps. https://www.lammps.org/bench.html#rhodo')
 
     executable('copy', template=['cp {input_path} {experiment_run_dir}/input.txt'],

--- a/var/ramble/repos/builtin/applications/namd/application.py
+++ b/var/ramble/repos/builtin/applications/namd/application.py
@@ -30,30 +30,39 @@ class Namd(SpackApplication):
     software_spec('namd', spack_spec='namd@2.14 interface=tcl', compiler='gcc12')
 
     input_file('stmv', url='https://www.ks.uiuc.edu/Research/namd/utilities/stmv.tar.gz',
+               sha256='2ef8beaa22046f2bf4ddc85bb8141391a27041302f101f5302f937d04104ccdd',
                description='STMV (virus) benchmark (1,066,628 atoms, periodic, PME')
 
     input_file('ApoA1', url='https://www.ks.uiuc.edu/Research/namd/utilities/apoa1.tar.gz',
+               sha256='fe30322cc94d93dff6c4e517d28584c48d0d0a1a7b23e2cd74cdb36d03863b22',
                description='ApoA1 benchmark (92,224 atoms, periodic, PME)')
 
     input_file('ATPase', url='https://www.ks.uiuc.edu/Research/namd/utilities/f1atpase.tar.gz',
+               sha256='ec34e31c69a7fc3c1649158bf7dbf20d20fe77520f73d05cbec4e9806b79148d',
                description='ATPase benchmark (327,506 atoms, periodic, PME)')
 
     input_file('20STMV', url='https://www.ks.uiuc.edu/Research/namd/utilities/stmv_sc14.tar.gz',
+               sha256='e166ca309ae614417f1c2da3b0eed139c816666403d552955b04849f703ef719',
                description='20STMV and 210STMV benchmarks from SC14 paper')
 
     input_file('tiny', url='https://www.ks.uiuc.edu/Research/namd/utilities/tiny.tar.gz',
+               sha256='dabf5986456d504a5ba40d3660bb8b6e6bd5d714b413390a733a4f819c1512ec',
                description='tiny benchmark (507 atoms, periodic, PME)')
 
     input_file('interactive_BPTI', url='https://www.ks.uiuc.edu/Research/namd/utilities/bpti_imd.tar.gz',
+               sha256='751ab94d13fc227a3313bc0a323597943fbf1f9a98d88c81086717399d61b8ec',
                description='Interactive BPTI (882 atoms, small)')
 
     input_file('ER-GRE', url='https://www.ks.uiuc.edu/Research/namd/utilities/er-gre.tar.gz',
+               sha256='8aaff093cddf5f28aec9ea65f9bce5853efa4f4346a64477efe0e0cde16740ce',
                description='ER-GRE benchmark (36573 atoms, spherical)')
 
     input_file('decalanin', url='https://www.ks.uiuc.edu/Research/namd/utilities/alanin.tar.gz',
+               sha256='92f8b6f1a55b548d450fe858cde9db901445964ed24639d5aa3667f3fc1ec52c',
                description='decalanin (66 atoms, tiny, ancient)')
 
     input_file('tcl-forces', url='https://www.ks.uiuc.edu/Research/namd/utilities/tclforces.tar.gz',
+               sha256='3daa557c51a41d4f2484aa3b4de7c1d96671da2baa159798ed0d90e638965eee',
                description='Tcl forces (decalanin)')
 
     executable('copy_inputs', 'cp {input_path}/* {experiment_run_dir}/.', use_mpi=False)

--- a/var/ramble/repos/builtin/applications/wrfv3/application.py
+++ b/var/ramble/repos/builtin/applications/wrfv3/application.py
@@ -28,6 +28,7 @@ class Wrfv3(SpackApplication):
     required_package('wrf')
 
     input_file('CONUS_2p5km', url='https://www2.mmm.ucar.edu/wrf/bench/conus2.5km_v3911/bench_2.5km.tar.bz2',
+               sha256='1919a0e0499057c1a570619d069817022bae95b17cf1a52bdaa174f8e8d11508',
                description='2.5 km resolution mesh of the continental United States.')
 
     input_file('CONUS_12km', url='https://www2.mmm.ucar.edu/wrf/bench/conus12km_v3911/bench_12km.tar.bz2',

--- a/var/ramble/repos/builtin/applications/wrfv4/application.py
+++ b/var/ramble/repos/builtin/applications/wrfv4/application.py
@@ -29,9 +29,11 @@ class Wrfv4(SpackApplication):
     required_package('wrf')
 
     input_file('CONUS_2p5km', url='https://www2.mmm.ucar.edu/wrf/users/benchmark/v422/v42_bench_conus2.5km.tar.gz',
+               sha256='dcae9965d1873c1c1e34e21ad653179783302b9a13528ac10fab092b998578f6',
                description='2.5 km resolution mesh of the continental United States.')
 
     input_file('CONUS_12km', url='https://www2.mmm.ucar.edu/wrf/users/benchmark/v422/v42_bench_conus12km.tar.gz',
+               sha256='6a0e87e3401efddc50539e71e5437fd7a5af9228b64cd4837e739737c3706fc3',
                description='12 km resolution mesh of the continental United States.')
 
     executable('cleanup', 'rm -f rsl.* wrfout*', use_mpi=False)


### PR DESCRIPTION
Applications affected gromacs, hpcc, lammps, namd, wrfv3, wrfv4

Enables input file download for ramble workspace mirror