### PR TITLE
Allow variables to be specified in spack config section

### DIFF
--- a/lib/ramble/ramble/schema/spack.py
+++ b/lib/ramble/ramble/schema/spack.py
@@ -24,6 +24,7 @@ properties = {
                 'type': 'boolean',
                 'default': False
             },
+            'variables': ramble.schema.variables.variables_def,
             'packages': {
                 'type': 'object',
                 'additionalProperties': {


### PR DESCRIPTION
Previously, the `variables` attribute was not added to the spack schema. This prevented variables from being defined in standard spack config sections.

This merge adds `variables` to the spack schema.