### PR TITLE
Add support for variables to be defined as ranges

### DIFF
--- a/lib/ramble/docs/workspace_config.rst
+++ b/lib/ramble/docs/workspace_config.rst
@@ -172,6 +172,30 @@ There are two notable aspects of this config file are:
 All lists defined within any experiment namespace are required to be the same
 length. They are zipped together, and iterated over to generate unique experiments.
 
+In addition to accepting explicit lists, Ramble supports using
+`python's range function<https://docs.python.org/3/library/functions.html#func-range>`
+to create a list. With this functionality, the example above could be re-written as:
+
+.. code-block:: yaml
+
+    ramble:
+      variables:
+        mpi_command: 'mpirun -n {n_ranks}'
+        batch_submit: '{execute_experiment}'
+        processes_per_node: '16'
+        n_ranks: '{n_nodes}*{processes_per_node}'
+      applications:
+        hostname:
+          variables:
+            n_threads: '1'
+          workloads:
+            serial:
+              variables:
+                n_nodes: 'range(1, 5)'
+              experiments:
+                test_exp_{n_nodes}:
+                  variables:
+                    n_ranks: '1'
 
 .. _ramble-matrix-logic:
 

--- a/lib/ramble/ramble/renderer.py
+++ b/lib/ramble/ramble/renderer.py
@@ -11,6 +11,7 @@ import itertools
 import llnl.util.tty as tty
 
 import ramble.error
+import ramble.expander
 
 
 class Renderer(object):
@@ -57,7 +58,14 @@ class Renderer(object):
         Returns:
           A single object definition, through a yield
         """
-        object_variables = variables.copy()
+        object_variables = {}
+        expander = ramble.expander.Expander(variables, None)
+
+        # Expand all variables that generate lists
+        for name, unexpanded in variables.items():
+            value = expander.expand_lists(unexpanded)
+            object_variables[name] = value
+
         new_objects = []
         matrix_objects = []
 

--- a/lib/ramble/ramble/test/expander.py
+++ b/lib/ramble/ramble/test/expander.py
@@ -44,6 +44,7 @@ def exp_dict():
         ('2**4', '16'),
         ('((((16-10+2)/4)**2)*4)', '16.0'),
         ('gromacs +blas', 'gromacs +blas'),
+        ('range(0, 5)', '[0, 1, 2, 3, 4]')
     ]
 )
 def test_expansions(input, output):


### PR DESCRIPTION
This merge adds support for:

```
variables:
  n_ranks: 'range(0, 10)'
```

Which will generate the equivalent list from running this code in python.