### PR TITLE
Fix fetch fallback when mirrors are GCS buckets

### DIFF
--- a/lib/ramble/ramble/stage.py
+++ b/lib/ramble/ramble/stage.py
@@ -467,6 +467,11 @@ class InputStage(object):
                 errors.append('Fetching from {0} failed.'.format(fetcher))
                 tty.debug(e)
                 continue
+            except spack.util.web.SpackWebError as e:
+                errors.append('Fetching from {0} failed.'.format(fetcher))
+                tty.debug(e)
+                continue
+
         else:
             print_errors(errors)
 


### PR DESCRIPTION
This merge adds fallback logic to mirror fetching when a mirror is a GCS bucket. Previously, the exception that was thrown was not properly excepted, leading to a fail in a mirror fetch to fail the entire fetch even if a valid URL was provided in the input.