### PR TITLE
Add missing namd_flags workload variable

### DIFF
--- a/var/ramble/repos/builtin/applications/namd/application.py
+++ b/var/ramble/repos/builtin/applications/namd/application.py
@@ -86,6 +86,13 @@ class Namd(SpackApplication):
                  inputs=[wl_def[0]])
 
         workload_variable(
+            'namd_flags',
+            default='+ppn {processes_per_node} +setcpuaffinity',
+            description='Flags for running NAMD',
+            workloads=[wl_def[0]]
+        )
+
+        workload_variable(
             'input_path',
             default=Expander.expansion_str(wl_def[0]),
             description=f'Path to the {wl_def[0]} inputs',


### PR DESCRIPTION
This merge adds a missing workload variable to the NAMD application definition.