### PR TITLE
Add success criteria to modifier definitions

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -1086,11 +1086,19 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         # Add the application defined criteria
         criteria_list.flush_scope('application_definition')
 
-        for criteria, conf in self.success_criteria.items():
-            if conf['mode'] == 'string':
-                criteria_list.add_criteria('application_definition', criteria,
-                                           conf['mode'], re.compile(conf['match']),
-                                           conf['file'])
+        success_lists = [
+            ('application_definition', self.success_criteria),
+        ]
+
+        for mod in self._modifier_instances:
+            success_lists.append(('modifier_definition', mod.success_criteria))
+
+        for success_scope, success_list in success_lists:
+            for criteria, conf in success_list.items():
+                if conf['mode'] == 'string':
+                    criteria_list.add_criteria(success_scope, criteria,
+                                               conf['mode'], re.compile(conf['match']),
+                                               conf['file'])
 
         criteria_list.add_criteria(scope='application_definition',
                                    name='_application_function',

--- a/lib/ramble/ramble/language/modifier_language.py
+++ b/lib/ramble/ramble/language/modifier_language.py
@@ -6,6 +6,8 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+import llnl.util.tty as tty
+
 import ramble.language.language_base
 from ramble.language.language_base import DirectiveError
 
@@ -215,6 +217,47 @@ def required_package(name):
             mod.required_packages[name] = True
 
     return _execute_required_package
+
+
+@modifier_directive('success_criteria')
+def success_criteria(name, mode, match=None, file='{log_file}',
+                     fom_name=None, fom_context='null', formula=None):
+    """Defines a success criteria that will be applied to experiments using this modifier
+
+    Adds a new success criteria to this modifier definition.
+
+    These will be checked during the analyze step to see if a job exited properly.
+
+    Arguments:
+      name: The name of this success criteria
+      mode: The type of success criteria that will be validated
+            Valid values are: 'string', 'application_function', and 'fom_comparison'
+      match: For mode='string'. Value to check indicate success (if found, it
+             would mark success)
+      file: For mode='string'. File success criteria should be located in
+      fom_name: For mode='fom_comparison'. Name of fom for a criteria.
+                Accepts globbing.
+      fom_context: For mode='fom_comparison'. Context the fom is contained
+                   in. Accepts globbing.
+      formula: For mode='fom_comparison'. Formula to use to evaluate success.
+               '{value}' keyword is set as the value of the FOM.
+    """
+
+    def _execute_success_criteria(mod):
+        valid_modes = ramble.success_criteria.SuccessCriteria._valid_modes
+        if mode not in valid_modes:
+            tty.die(f'Mode {mode} is not valid. Valid values are {valid_modes}')
+
+        mod.success_criteria[name] = {
+            'mode': mode,
+            'match': match,
+            'file': file,
+            'fom_name': fom_name,
+            'fom_context': fom_context,
+            'formula': formula,
+        }
+
+    return _execute_success_criteria
 
 
 @modifier_directive('builtins')

--- a/lib/ramble/ramble/success_criteria.py
+++ b/lib/ramble/ramble/success_criteria.py
@@ -29,6 +29,7 @@ class ScopedCriteriaList(object):
 
     _valid_scopes = [
         'application_definition',
+        'modifier_definition',
         'workspace',
         'application',
         'workload',
@@ -39,6 +40,7 @@ class ScopedCriteriaList(object):
         'workload': ['workload', 'experiment'],
         'application': ['application', 'workload', 'experiment'],
         'workspace': ['workspace', 'application', 'workload', 'experiment'],
+        'modifier_definition': ['modifier_definition'],
         'application_definition': ['application_definition']
     }
 

--- a/lib/ramble/ramble/test/modifier_language.py
+++ b/lib/ramble/ramble/test/modifier_language.py
@@ -43,6 +43,7 @@ def test_modifier_type_features(mod_class):
     assert hasattr(test_mod, 'software_specs')
     assert hasattr(test_mod, 'default_compilers')
     assert hasattr(test_mod, 'required_packages')
+    assert hasattr(test_mod, 'success_criteria')
     assert hasattr(test_mod, 'builtins')
     assert hasattr(test_mod, 'executable_modifiers')
     assert hasattr(test_mod, 'env_var_modifications')

--- a/lib/ramble/ramble/test/success_criteria/success_modifiers.py
+++ b/lib/ramble/ramble/test/success_criteria/success_modifiers.py
@@ -1,0 +1,79 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.workspace
+import ramble.config
+import ramble.software_environments
+import ramble.namespace
+from ramble.main import RambleCommand
+from ramble.test.dry_run_helpers import dry_run_config, SCOPES
+
+
+# everything here uses the mock_workspace_path
+pytestmark = pytest.mark.usefixtures('mutable_config',
+                                     'mutable_mock_workspace_path')
+
+workspace = RambleCommand('workspace')
+
+
+@pytest.mark.parametrize(
+    'value,result',
+    [
+        ('1.0 seconds\nExperiment status: SUCCESS', 'SUCCESS'),
+        ('1.0 seconds\nExperiment status: FAILED', 'FAILED'),
+        ('1.0 seconds\nExperiment status: FAILED', 'FAILED'),
+    ]
+)
+@pytest.mark.parametrize(
+    'scope',
+    [
+        SCOPES.workspace,
+        SCOPES.application,
+        SCOPES.workload,
+        SCOPES.experiment,
+    ]
+)
+def test_success_modifier(mutable_config,
+                          mutable_mock_workspace_path,
+                          mock_applications,
+                          mock_modifiers,
+                          value, result,
+                          scope):
+
+    modifier = [
+        (scope, {'name': 'success-criteria'}),
+    ]
+
+    workspace_name = 'test_success_modifier'
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+
+        config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+
+        dry_run_config('modifiers', modifier, config_path,
+                       'basic', 'test_wl')
+        ws._re_read()
+
+        workspace('concretize', global_args=['-w', workspace_name])
+        workspace('setup', '--dry-run',  global_args=['-w', workspace_name])
+
+        # Write mock output data:
+        result_path = os.path.join(ws.experiment_dir, 'basic', 'test_wl',
+                                   'test_exp', 'test_exp.out')
+        with open(result_path, 'w+') as f:
+            f.write(value)
+
+        workspace('analyze', global_args=['-w', workspace_name])
+
+        with open(os.path.join(ws.root, 'results.latest.txt'), 'r') as f:
+            data = f.read()
+            assert result in data

--- a/var/ramble/repos/builtin.mock/modifiers/success-criteria/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/success-criteria/modifier.py
@@ -1,0 +1,25 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.modkit import *  # noqa: F403
+
+
+class SuccessCriteria(BasicModifier):
+    """Define a modifier with a success criteria"""
+    name = "success-criteria"
+
+    mode('test', description='This is a test mode')
+
+    success_criteria('status', mode='string', match='.*Experiment status: SUCCESS', file='{log_file}')
+
+    variable_modification('experiment_status', modification='Experiment status: SUCCESS', method='set', mode='test')
+
+    register_builtin('echo_status', required=True)
+
+    def echo_status(self):
+        return ['echo "Experiment status: {experiment_status}" >> {log_file}']


### PR DESCRIPTION
This merge allows modifiers to define success criteria. This allows modifiers to define additional success criteria that augment an experiment's list of success criteria, and can be more closely tied to output from the modifier.