### PR TITLE
Intel MKL-optimized HPL

### DIFF
--- a/var/ramble/repos/builtin/applications/hpl/application.py
+++ b/var/ramble/repos/builtin/applications/hpl/application.py
@@ -17,119 +17,179 @@ class Hpl(SpackApplication):
 
     maintainers('douglasjacobsen', 'dodecatheon')
 
-    tags('benchmark-app', 'mini-app', 'benchmark')
+    tags('benchmark-app', 'benchmark', 'linpack')
 
     default_compiler('gcc9', spack_spec='gcc@9.3.0')
 
-    software_spec('impi2018', spack_spec='intel-mpi@2018.4.274')
+    software_spec('impi_2018', spack_spec='intel-mpi@2018.4.274')
 
-    software_spec('hpl',
-                  spack_spec='hpl@2.3 +openmp',
-                  compiler='gcc9')
+    software_spec('hpl', spack_spec='hpl@2.3 +openmp', compiler='gcc9')
 
     required_package('hpl')
 
     executable('execute', 'xhpl', use_mpi=True)
 
     workload('standard', executables=['execute'])
+    workload('calculator', executables=['execute'])
 
-    workload_variable('output_file', default='HPL.out      output file name (if any)',
+    workload_variable('output_file',
+                      default='{:13} output file name (if any)'.format('HPL.out'),
                       description='Output file name (if any)',
                       workloads=['standard'])
-    workload_variable('device_out', default='6            device out (6=stdout,7=stderr,file)',
+    workload_variable('device_out',
+                      default='{:13} device out (6=stdout,7=stderr,file)'.format('6'),
                       description='Output device',
                       workloads=['standard'])
-    workload_variable('N-Ns', default='4            # of problems sizes (N)',
+    workload_variable('N-Ns',
+                      default='{:13} Number of problems sizes (N)'.format('4'),
                       description='Number of problems sizes',
                       workloads=['standard'])
-    workload_variable('Ns', default='29 30 34 35  Ns',
+    workload_variable('Ns',
+                      default='{:13} Ns'.format('29 30 34 35'),
                       description='Problem sizes',
                       workloads=['standard'])
-    workload_variable('N-NBs', default='4            # of NBs',
+    workload_variable('N-NBs',
+                      default='{:13} Number of NBs'.format('4'),
                       description='Number of NBs',
                       workloads=['standard'])
-    workload_variable('NBs', default='1 2 3 4      NBs',
+    workload_variable('NBs',
+                      default='{:13} NBs'.format('1 2 3 4'),
                       description='NB values',
                       workloads=['standard'])
-    workload_variable('PMAP', default='0            PMAP process mapping (0=Row-,1=Column-major)',
+    workload_variable('PMAP',
+                      default='{:13} PMAP process mapping (0=Row-,1=Column-major)'.format('0'),
                       description='PMAP Process mapping. (0=Row-, 1=Column-Major)',
                       workloads=['standard'])
-    workload_variable('N-Grids', default='3            # of process grids (P x Q)',
+    workload_variable('N-Grids',
+                      default='{:13} Number of process grids (P x Q)'.format('3'),
                       description='Number of process grids (P x Q)',
                       workloads=['standard'])
-    workload_variable('Ps', default='2 1 4        Ps',
+    workload_variable('Ps',
+                      default='{:13} Ps'.format('2 1 4'),
                       description='P values',
                       workloads=['standard'])
-    workload_variable('Qs', default='2 4 1        Qs',
+    workload_variable('Qs',
+                      default='{:13} Qs'.format('2 4 1'),
                       description='Q values',
                       workloads=['standard'])
-    workload_variable('threshold', default='16.0         threshold',
+    workload_variable('threshold',
+                      default='{:13} threshold'.format('16.0'),
                       description='Residual threshold',
                       workloads=['standard'])
-    workload_variable('NPFACTS', default='3            # of panel fact',
+    workload_variable('NPFACTs',
+                      default='{:13} Number of PFACTs, panel fact'.format('3'),
                       description='Number of PFACTs',
                       workloads=['standard'])
-    workload_variable('PFACTS', default='0 1 2        PFACTs (0=left, 1=Crout, 2=Right)',
+    workload_variable('PFACTs',
+                      default='{:13} PFACTs (0=left, 1=Crout, 2=Right)'.format('0 1 2'),
                       description='PFACT Values',
                       workloads=['standard'])
-    workload_variable('N-NBMINs', default='2            # of recursive stopping criterium',
+    workload_variable('N-NBMINs',
+                      default='{:13} Number of NBMINs, recursive stopping criteria'.format('2'),
                       description='Number of NBMINs',
                       workloads=['standard'])
-    workload_variable('NBMINs', default='2 4          NBMINs (>= 1)',
+    workload_variable('NBMINs',
+                      default='{:13} NBMINs (>= 1)'.format('2 4'),
                       description='NBMIN values',
                       workloads=['standard'])
-    workload_variable('N-NDIVs', default='1            # of panels in recursion',
+    workload_variable('N-NDIVs',
+                      default='{:13} Number of NDIVs, panels in recursion'.format('1'),
                       description='Number of NDIVs',
                       workloads=['standard'])
-    workload_variable('NDIVs', default='2            NDIVs',
+    workload_variable('NDIVs',
+                      default='{:13} NDIVs'.format('2'),
                       description='NDIV values',
                       workloads=['standard'])
-    workload_variable('N-RFACTs', default='3            # of recursive panel fact.',
+    workload_variable('N-RFACTs',
+                      default='{:13} Number of RFACTs, recursive panel fact.'.format('3'),
                       description='Number of RFACTs',
                       workloads=['standard'])
-    workload_variable('RFACTs', default='0 1 2        RFACTs (0=left, 1=Crout, 2=Right)',
+    workload_variable('RFACTs',
+                      default='{:13} RFACTs (0=left, 1=Crout, 2=Right)'.format('0 1 2'),
                       description='RFACT values',
                       workloads=['standard'])
-    workload_variable('N-BCASTs', default='1            # of broadcast',
+    workload_variable('N-BCASTs',
+                      default='{:13} Number of BCASTs, broadcast'.format('1'),
                       description='Number of BCASTs',
                       workloads=['standard'])
-    workload_variable('BCASTs', default='0            BCASTs (0=1rg,1=1rM,2=2rg,3=2rM,4=Lng,5=LnM)',
+    workload_variable('BCASTs',
+                      default='{:13} BCASTs (0=1rg,1=1rM,2=2rg,3=2rM,4=Lng,5=LnM)'.format('0'),
                       description='BCAST values',
                       workloads=['standard'])
-    workload_variable('N-DEPTHs', default='1            # of lookahead depth',
+    workload_variable('N-DEPTHs',
+                      default='{:13} Number of DEPTHs, lookahead depth'.format('1'),
                       description='Number of DEPTHs',
                       workloads=['standard'])
-    workload_variable('DEPTHs', default='0            DEPTHs (>=0)',
+    workload_variable('DEPTHs',
+                      default='{:13} DEPTHs (>=0)'.format('0'),
                       description='DEPTH values',
                       workloads=['standard'])
-    workload_variable('SWAP', default='2            SWAP (0=bin-exch,1=long,2=mix)',
+    workload_variable('SWAP',
+                      default='{:13} SWAP (0=bin-exch,1=long,2=mix)'.format('2'),
                       description='Swapping algorithm',
                       workloads=['standard'])
-    workload_variable('swapping_threshold', default='64           swapping threshold',
+    workload_variable('swapping_threshold',
+                      default='{:13} swapping threshold'.format('64'),
                       description='Swapping threshold',
                       workloads=['standard'])
-    workload_variable('L1', default='0            L1 in (0=transposed,1=no-transposed) form',
+    workload_variable('L1',
+                      default='{:13} L1 in (0=transposed,1=no-transposed) form'.format('0'),
                       description='Storage for upper triangular portion of columns',
                       workloads=['standard'])
-    workload_variable('U', default='0            U  in (0=transposed,1=no-transposed) form',
+    workload_variable('U',
+                      default='{:13} U  in (0=transposed,1=no-transposed) form'.format('0'),
                       description='Storage for the rows of U',
                       workloads=['standard'])
-    workload_variable('Equilibration', default='1            Equilibration (0=no,1=yes)',
+    workload_variable('Equilibration',
+                      default='{:13} Equilibration (0=no,1=yes)'.format('1'),
                       description='Determines if equilibration should be enabled or disabled.',
                       workloads=['standard'])
-    workload_variable('mem_alignment', default='8            memory alignment in double (> 0)',
+    workload_variable('mem_alignment',
+                      default='{:13} memory alignment in double (> 0)'.format('8'),
                       description='Sets the alignment in doubles for memory addresses',
                       workloads=['standard'])
 
-    workload('calculator', executables=['execute'])
+    # calculator workload-specific variables:
 
-    workload_variable('memory_per_node', default='128',
+    workload_variable('percent_mem', default='85',
+                      description='Percent of memory to use (default 85)',
+                      workloads=['calculator'])
+
+    workload_variable('memory_per_node',
+                      default='240',
                       description='Memory per node in GB',
                       workloads=['calculator'])
 
-    workload_variable('block_size', default='224',
+    workload_variable('block_size', default='384',
                       description='Size of each block',
                       workloads=['calculator'])
+
+    workload_variable('pfact',
+                      default='0',
+                      description='PFACT for optimized calculator',
+                      workloads=['calculator'])
+
+    workload_variable('nbmin',
+                      default='2',
+                      description='NBMIN for optimized calculator',
+                      workloads=['calculator'])
+
+    workload_variable('rfact',
+                      default='0',
+                      description='RFACT for optimized calculator',
+                      workloads=['calculator'])
+
+    workload_variable('bcast',
+                      default='0',
+                      description='BCAST for optimized calculator',
+                      workloads=['calculator'])
+
+    workload_variable('depth',
+                      default='0',
+                      description='DEPTH for optimized calculator',
+                      workloads=['calculator'])
+
+    # FoMs:
 
     figure_of_merit('Time', log_file='{experiment_run_dir}/{experiment_name}.out',
                     fom_regex=r'.*\s+(?P<N>[0-9]+)\s+(?P<NB>[0-9]+)\s+(?P<P>[0-9]+)\s+(?P<Q>[0-9]+)\s+(?P<time>[0-9]+\.[0-9]+)\s+(?P<gflops>[0-9].*)\n',
@@ -142,55 +202,114 @@ class Hpl(SpackApplication):
 
     figure_of_merit_context('problem-name', regex=r'.*\s+(?P<N>[0-9]+)\s+(?P<NB>[0-9]+)\s+(?P<P>[0-9]+)\s+(?P<Q>[0-9]+)\s+(?P<time>[0-9]+\.[0-9]+)\s+(?P<gflops>[0-9].*)\n', output_format='{N}-{NB}-{P}-{Q}')
 
+    # Integer sqrt
+    def _isqrt(self, n):
+        if n < 0:
+            raise Exception
+        elif n < 2:
+            return (n)
+        else:
+            lo = self._isqrt(n >> 2) << 1
+            hi = lo + 1
+            if ((hi * hi) > n):
+                return (lo)
+            else:
+                return (hi)
+
     def _calculate_values(self, workspace, expander):
         if expander.workload_name == 'calculator':
-            memoryPerNode = int(expander.expand_var('{memory_per_node}'))
+            # Find the best P and Q whose product is the number of available
+            # cores, with P less than Q
             nNodes = int(expander.expand_var('{n_nodes}'))
             processesPerNode = int(expander.expand_var('{processes_per_node}'))
-            blockSize = int(expander.expand_var('{block_size}'))
-
-            targetProblemSize = 0.80 * int(math.sqrt((memoryPerNode
-                                           * nNodes * 1024 * 1024 * 1024)
-                                           / 8))
-            nBlocks = int(targetProblemSize / blockSize)
-            nBlocks = nBlocks if (nBlocks % 2 == 0) else nBlocks - 1
-            problemSize = blockSize * nBlocks
 
             totalCores = nNodes * processesPerNode
-            sqrtCores = int(math.sqrt(totalCores))
 
-            bestDist = totalCores - 1
-            bestP = 1
+            bestP = self._isqrt(totalCores)
+            while ((totalCores % bestP) > 0):     # stops at 1 because any int % 1 = 0
+                bestP -= 1
 
-            for i in range(2, sqrtCores):
-                if totalCores % i == 0:
-                    testDist = totalCores - i
-                    if testDist < bestDist:
-                        bestDist = testDist
-                        bestP = i
+            bestQ = totalCores // bestP
 
-            bestQ = int(totalCores / bestP)
+            # Find LCM(P,Q)
+            P = int(bestP)
+            Q = int(bestQ)
+            lcmPQ = Q             # Q is always the larger of P and Q
+            while ((lcmPQ % P) > 0):
+                lcmPQ += Q
+
+            # HPL maintainers recommend basing the target problem size on
+            # the square root of 80% of total memory in words.
+            memoryPerNode = int(expander.expand_var('{memory_per_node}'))
+            memFraction = int(expander.expand_var('{percent_mem}')) / 100
+            blockSize = int(expander.expand_var('{block_size}'))
+            one_gb_mem_in_words = (1 << 30) / 8
+
+            fullMemWords = nNodes * memoryPerNode * one_gb_mem_in_words
+
+            targetProblemSize = math.sqrt(fullMemWords * memFraction)
+
+            # Ensure that N is divisible by NB * LCM(P,Q)
+            problemSize = int(targetProblemSize)
+            problemSize -= (problemSize % blockSize)
+            nBlocks = problemSize // blockSize
+            nBlocks -= nBlocks % lcmPQ
+            problemSize = blockSize * nBlocks
+            usedPercentage = int(problemSize**2 / fullMemWords * 100)
 
             for var, config in self.workload_variables['standard'].items():
                 self.variables[var] = config['default']
 
-            self.variables['N-Ns'] = '1'
-            self.variables['Ns'] = int(problemSize)
-            self.variables['N-NBs'] = '1'
-            self.variables['NBs'] = blockSize
-            self.variables['N-Grids'] = '1'
-            self.variables['Ps'] = int(bestP)
-            self.variables['Qs'] = int(bestQ)
-            self.variables['NPFACTS'] = '1'
-            self.variables['PFACTS'] = '2'
-            self.variables['N-NBMINs'] = '1'
-            self.variables['NBMINs'] = '4'
-            self.variables['N-RFACTs'] = '1'
-            self.variables['RFACTs'] = '1'
-            self.variables['N-BCASTs'] = '1'
-            self.variables['BCASTs'] = '1'
-            self.variables['N-DEPTHs'] = '1'
-            self.variables['DEPTHs'] = '1'
+            pfact = expander.expand_var('{pfact}')
+            nbmin = expander.expand_var('{nbmin}')
+            rfact = expander.expand_var('{rfact}')
+            bcast = expander.expand_var('{bcast}')
+            depth = expander.expand_var('{depth}')
+
+            self.variables['N-Ns'] = '{:13} Number of problems sizes (N)'.format('1')  # vs 4
+
+            # Calculated:
+            self.variables['Ns'] = ("{:<13} Ns (= {}% of "
+                                    "total available memory)").format(int(problemSize),
+                                                                      usedPercentage)
+            self.variables['N-NBs'] = '{:13} Number of NBs'.format('1')  # vs 4
+
+            # Calculated:
+            self.variables['NBs'] = "{:<13} NBs".format(blockSize)  # calculated, vs 4 samples
+
+            self.variables['N-Grids'] = ('{:13} Number of Grids,'
+                                         'process grids (P x Q)').format('1')  # vs 3
+            # Calculated:
+            self.variables['Ps'] = "{:<13} Ps".format(int(bestP))
+
+            # Calculated:
+            self.variables['Qs'] = "{:<13} Qs".format(int(bestQ))
+
+            self.variables['NPFACTs'] = '{:13} Number of PFACTs, panel fact'.format('1')  # vs 3
+
+            # ramble.yaml configurable
+            self.variables['PFACTs'] = '{:13} PFACT Values (0=left, 1=Crout, 2=Right)'.format(pfact)  # vs 0 1 2
+
+            self.variables['N-NBMINs'] = '{:13} Number of NBMINs, recursive stopping criteria'.format('1')  # vs 2
+
+            # ramble.yaml configurable
+            self.variables['NBMINs'] = '{:13} NBMINs (>= 1)'.format(nbmin)  # vs '2 4'
+
+            self.variables['N-RFACTs'] = '{:13} Number of RFACTS, recursive panel fact.'.format('1')  # vs '3'
+
+            # ramble.yaml configurable
+            self.variables['RFACTs'] = '{:13} RFACTs (0=left, 1=Crout, 2=Right)'.format(rfact)  # vs '0 1 2'
+
+            self.variables['N-BCASTs'] = '{:13} Number of BCASTs, broadcast'.format('1')
+
+            # ramble.yaml configurable
+            self.variables['BCASTs'] = ('{:13} BCASTs (0=1rg,1=1rM,2=2rg,3=2rM,4=Lng,'
+                                        '5=LnM,6=MKL BPUSH,7=AMD Hybrid Panel)').format(bcast)  # vs '0'
+
+            self.variables['N-DEPTHs'] = '{:13} Number of DEPTHs, lookahead depth'.format('1')
+
+            # ramble.yaml configurable
+            self.variables['DEPTHs'] = '{:13} DEPTHs (>=0)'.format(depth)  # vs '0'
 
     def _make_experiments(self, workspace):
         super()._make_experiments(workspace)
@@ -199,8 +318,8 @@ class Hpl(SpackApplication):
         input_path = self.expander.expand_var('{experiment_run_dir}/HPL.dat')
 
         settings = ['output_file', 'device_out', 'N-Ns', 'Ns', 'N-NBs', 'NBs',
-                    'PMAP', 'N-Grids', 'Ps', 'Qs', 'threshold', 'NPFACTS',
-                    'PFACTS', 'N-NBMINs', 'NBMINs', 'N-NDIVs', 'NDIVs', 'N-RFACTs',
+                    'PMAP', 'N-Grids', 'Ps', 'Qs', 'threshold', 'NPFACTs',
+                    'PFACTs', 'N-NBMINs', 'NBMINs', 'N-NDIVs', 'NDIVs', 'N-RFACTs',
                     'RFACTs', 'N-BCASTs', 'BCASTs', 'N-DEPTHs', 'DEPTHs', 'SWAP',
                     'swapping_threshold', 'L1', 'U', 'Equilibration',
                     'mem_alignment']
@@ -211,3 +330,6 @@ class Hpl(SpackApplication):
 
             for setting in settings:
                 f.write(self.expander.expand_var('{' + setting + '}') + '\n')
+
+            # Write some documentation at the bottom of the input file:
+            f.write('##### This line (no. 32) is ignored (it serves as a separator). ######')

--- a/var/ramble/repos/builtin/applications/hpl/application.py
+++ b/var/ramble/repos/builtin/applications/hpl/application.py
@@ -11,6 +11,10 @@ from ramble.appkit import *
 import math
 
 
+def pad_value(val, desc):
+    return ('{:<14}'.format(val) + desc)
+
+
 class Hpl(SpackApplication):
     '''Define HPL application'''
     name = 'hpl'
@@ -33,119 +37,119 @@ class Hpl(SpackApplication):
     workload('calculator', executables=['execute'])
 
     workload_variable('output_file',
-                      default='{:13} output file name (if any)'.format('HPL.out'),
+                      default=pad_value('HPL.out', 'output file name (if any)'),
                       description='Output file name (if any)',
                       workloads=['standard'])
     workload_variable('device_out',
-                      default='{:13} device out (6=stdout,7=stderr,file)'.format('6'),
+                      default=pad_value('6', 'device out (6=stdout,7=stderr,file)'),
                       description='Output device',
                       workloads=['standard'])
     workload_variable('N-Ns',
-                      default='{:13} Number of problems sizes (N)'.format('4'),
+                      default=pad_value('4', 'Number of problems sizes (N)'),
                       description='Number of problems sizes',
                       workloads=['standard'])
     workload_variable('Ns',
-                      default='{:13} Ns'.format('29 30 34 35'),
+                      default=pad_value('29 30 34 35', 'Ns'),
                       description='Problem sizes',
                       workloads=['standard'])
     workload_variable('N-NBs',
-                      default='{:13} Number of NBs'.format('4'),
+                      default=pad_value('4', 'Number of NBs'),
                       description='Number of NBs',
                       workloads=['standard'])
     workload_variable('NBs',
-                      default='{:13} NBs'.format('1 2 3 4'),
+                      default=pad_value('1 2 3 4', 'NBs'),
                       description='NB values',
                       workloads=['standard'])
     workload_variable('PMAP',
-                      default='{:13} PMAP process mapping (0=Row-,1=Column-major)'.format('0'),
+                      default=pad_value('0', 'PMAP process mapping (0=Row-,1=Column-major)'),
                       description='PMAP Process mapping. (0=Row-, 1=Column-Major)',
                       workloads=['standard'])
     workload_variable('N-Grids',
-                      default='{:13} Number of process grids (P x Q)'.format('3'),
+                      default=pad_value('3', 'Number of process grids (P x Q)'),
                       description='Number of process grids (P x Q)',
                       workloads=['standard'])
     workload_variable('Ps',
-                      default='{:13} Ps'.format('2 1 4'),
+                      default=pad_value('2 1 4', 'Ps'),
                       description='P values',
                       workloads=['standard'])
     workload_variable('Qs',
-                      default='{:13} Qs'.format('2 4 1'),
+                      default=pad_value('2 4 1', 'Qs'),
                       description='Q values',
                       workloads=['standard'])
     workload_variable('threshold',
-                      default='{:13} threshold'.format('16.0'),
+                      default=pad_value('16.0', 'threshold'),
                       description='Residual threshold',
                       workloads=['standard'])
     workload_variable('NPFACTs',
-                      default='{:13} Number of PFACTs, panel fact'.format('3'),
+                      default=pad_value('3', 'Number of PFACTs, panel fact'),
                       description='Number of PFACTs',
                       workloads=['standard'])
     workload_variable('PFACTs',
-                      default='{:13} PFACTs (0=left, 1=Crout, 2=Right)'.format('0 1 2'),
+                      default=pad_value('0 1 2', 'PFACTs (0=left, 1=Crout, 2=Right)'),
                       description='PFACT Values',
                       workloads=['standard'])
     workload_variable('N-NBMINs',
-                      default='{:13} Number of NBMINs, recursive stopping criteria'.format('2'),
+                      default=pad_value('2', 'Number of NBMINs, recursive stopping criteria'),
                       description='Number of NBMINs',
                       workloads=['standard'])
     workload_variable('NBMINs',
-                      default='{:13} NBMINs (>= 1)'.format('2 4'),
+                      default=pad_value('2 4', 'NBMINs (>= 1)'),
                       description='NBMIN values',
                       workloads=['standard'])
     workload_variable('N-NDIVs',
-                      default='{:13} Number of NDIVs, panels in recursion'.format('1'),
+                      default=pad_value('1', 'Number of NDIVs, panels in recursion'),
                       description='Number of NDIVs',
                       workloads=['standard'])
     workload_variable('NDIVs',
-                      default='{:13} NDIVs'.format('2'),
+                      default=pad_value('2', 'NDIVs'),
                       description='NDIV values',
                       workloads=['standard'])
     workload_variable('N-RFACTs',
-                      default='{:13} Number of RFACTs, recursive panel fact.'.format('3'),
+                      default=pad_value('3', 'Number of RFACTs, recursive panel fact.'),
                       description='Number of RFACTs',
                       workloads=['standard'])
     workload_variable('RFACTs',
-                      default='{:13} RFACTs (0=left, 1=Crout, 2=Right)'.format('0 1 2'),
+                      default=pad_value('0 1 2', 'RFACTs (0=left, 1=Crout, 2=Right)'),
                       description='RFACT values',
                       workloads=['standard'])
     workload_variable('N-BCASTs',
-                      default='{:13} Number of BCASTs, broadcast'.format('1'),
+                      default=pad_value('1', 'Number of BCASTs, broadcast'),
                       description='Number of BCASTs',
                       workloads=['standard'])
     workload_variable('BCASTs',
-                      default='{:13} BCASTs (0=1rg,1=1rM,2=2rg,3=2rM,4=Lng,5=LnM)'.format('0'),
+                      default=pad_value('0', 'BCASTs (0=1rg,1=1rM,2=2rg,3=2rM,4=Lng,5=LnM)'),
                       description='BCAST values',
                       workloads=['standard'])
     workload_variable('N-DEPTHs',
-                      default='{:13} Number of DEPTHs, lookahead depth'.format('1'),
+                      default=pad_value('1', 'Number of DEPTHs, lookahead depth'),
                       description='Number of DEPTHs',
                       workloads=['standard'])
     workload_variable('DEPTHs',
-                      default='{:13} DEPTHs (>=0)'.format('0'),
+                      default=pad_value('0', 'DEPTHs (>=0)'),
                       description='DEPTH values',
                       workloads=['standard'])
     workload_variable('SWAP',
-                      default='{:13} SWAP (0=bin-exch,1=long,2=mix)'.format('2'),
+                      default=pad_value('2', 'SWAP (0=bin-exch,1=long,2=mix)'),
                       description='Swapping algorithm',
                       workloads=['standard'])
     workload_variable('swapping_threshold',
-                      default='{:13} swapping threshold'.format('64'),
+                      default=pad_value('64', 'swapping threshold'),
                       description='Swapping threshold',
                       workloads=['standard'])
     workload_variable('L1',
-                      default='{:13} L1 in (0=transposed,1=no-transposed) form'.format('0'),
+                      default=pad_value('0', 'L1 in (0=transposed,1=no-transposed) form'),
                       description='Storage for upper triangular portion of columns',
                       workloads=['standard'])
     workload_variable('U',
-                      default='{:13} U  in (0=transposed,1=no-transposed) form'.format('0'),
+                      default=pad_value('0', 'U  in (0=transposed,1=no-transposed) form'),
                       description='Storage for the rows of U',
                       workloads=['standard'])
     workload_variable('Equilibration',
-                      default='{:13} Equilibration (0=no,1=yes)'.format('1'),
+                      default=pad_value('1', 'Equilibration (0=no,1=yes)'),
                       description='Determines if equilibration should be enabled or disabled.',
                       workloads=['standard'])
     workload_variable('mem_alignment',
-                      default='{:13} memory alignment in double (> 0)'.format('8'),
+                      default=pad_value('8', 'memory alignment in double (> 0)'),
                       description='Sets the alignment in doubles for memory addresses',
                       workloads=['standard'])
 
@@ -155,8 +159,7 @@ class Hpl(SpackApplication):
                       description='Percent of memory to use (default 85)',
                       workloads=['calculator'])
 
-    workload_variable('memory_per_node',
-                      default='240',
+    workload_variable('memory_per_node', default='240',
                       description='Memory per node in GB',
                       workloads=['calculator'])
 
@@ -164,28 +167,23 @@ class Hpl(SpackApplication):
                       description='Size of each block',
                       workloads=['calculator'])
 
-    workload_variable('pfact',
-                      default='0',
+    workload_variable('pfact', default='0',
                       description='PFACT for optimized calculator',
                       workloads=['calculator'])
 
-    workload_variable('nbmin',
-                      default='2',
+    workload_variable('nbmin', default='2',
                       description='NBMIN for optimized calculator',
                       workloads=['calculator'])
 
-    workload_variable('rfact',
-                      default='0',
+    workload_variable('rfact', default='0',
                       description='RFACT for optimized calculator',
                       workloads=['calculator'])
 
-    workload_variable('bcast',
-                      default='0',
+    workload_variable('bcast', default='0',
                       description='BCAST for optimized calculator',
                       workloads=['calculator'])
 
-    workload_variable('depth',
-                      default='0',
+    workload_variable('depth', default='0',
                       description='DEPTH for optimized calculator',
                       workloads=['calculator'])
 
@@ -240,9 +238,9 @@ class Hpl(SpackApplication):
 
             # HPL maintainers recommend basing the target problem size on
             # the square root of 80% of total memory in words.
-            memoryPerNode = int(expander.expand_var('{memory_per_node}'))
-            memFraction = int(expander.expand_var('{percent_mem}')) / 100
-            blockSize = int(expander.expand_var('{block_size}'))
+            memoryPerNode = int(expander.expand_var(expander.expansion_str('memory_per_node')))
+            memFraction = int(expander.expand_var(expander.expansion_str('percent_mem'))) / 100
+            blockSize = int(expander.expand_var(expander.expansion_str('block_size')))
             one_gb_mem_in_words = (1 << 30) / 8
 
             fullMemWords = nNodes * memoryPerNode * one_gb_mem_in_words
@@ -266,50 +264,45 @@ class Hpl(SpackApplication):
             bcast = expander.expand_var(expander.expansion_str('bcast'))
             depth = expander.expand_var(expander.expansion_str('depth'))
 
-            self.variables['N-Ns'] = '{:13} Number of problems sizes (N)'.format('1')  # vs 4
+            self.variables['N-Ns'] = pad_value('1', 'Number of problems sizes (N)')  # vs 4
 
             # Calculated:
-            self.variables['Ns'] = ("{:<13} Ns (= {}% of "
-                                    "total available memory)").format(int(problemSize),
-                                                                      usedPercentage)
-            self.variables['N-NBs'] = '{:13} Number of NBs'.format('1')  # vs 4
+            self.variables['Ns'] = pad_value(int(problemSize),
+                                                  f"Ns (= {usedPercentage}% of total available memory)")
+
+            self.variables['N-NBs'] = pad_value('1', 'Number of NBs')  # vs 4
 
             # Calculated:
-            self.variables['NBs'] = "{:<13} NBs".format(blockSize)  # calculated, vs 4 samples
+            self.variables['NBs'] = pad_value(blockSize, "NBs")  # calculated, vs 4 samples
 
-            self.variables['N-Grids'] = ('{:13} Number of Grids,'
-                                         'process grids (P x Q)').format('1')  # vs 3
-            # Calculated:
-            self.variables['Ps'] = "{:<13} Ps".format(int(bestP))
+            self.variables['N-Grids'] = pad_value('1', 'Number of Grids, process grids (P x Q)')  # vs 3
 
             # Calculated:
-            self.variables['Qs'] = "{:<13} Qs".format(int(bestQ))
+            self.variables['Ps'] = pad_value(int(bestP), "Ps")
 
-            self.variables['NPFACTs'] = '{:13} Number of PFACTs, panel fact'.format('1')  # vs 3
+            # Calculated:
+            self.variables['Qs'] = pad_value(int(bestQ), "Qs")
 
-            # ramble.yaml configurable
-            self.variables['PFACTs'] = '{:13} PFACT Values (0=left, 1=Crout, 2=Right)'.format(pfact)  # vs 0 1 2
-
-            self.variables['N-NBMINs'] = '{:13} Number of NBMINs, recursive stopping criteria'.format('1')  # vs 2
+            self.variables['NPFACTs'] = pad_value('1', 'Number of PFACTs, panel fact')  # vs 3
 
             # ramble.yaml configurable
-            self.variables['NBMINs'] = '{:13} NBMINs (>= 1)'.format(nbmin)  # vs '2 4'
+            self.variables['PFACTs'] = pad_value(pfact, 'PFACT Values (0=left, 1=Crout, 2=Right)')  # vs 0 1 2
 
-            self.variables['N-RFACTs'] = '{:13} Number of RFACTS, recursive panel fact.'.format('1')  # vs '3'
-
-            # ramble.yaml configurable
-            self.variables['RFACTs'] = '{:13} RFACTs (0=left, 1=Crout, 2=Right)'.format(rfact)  # vs '0 1 2'
-
-            self.variables['N-BCASTs'] = '{:13} Number of BCASTs, broadcast'.format('1')
+            self.variables['N-NBMINs'] = pad_value('1', 'Number of NBMINs, recursive stopping criteria')  # vs 2
 
             # ramble.yaml configurable
-            self.variables['BCASTs'] = ('{:13} BCASTs (0=1rg,1=1rM,2=2rg,3=2rM,4=Lng,'
-                                        '5=LnM,6=MKL BPUSH,7=AMD Hybrid Panel)').format(bcast)  # vs '0'
+            self.variables['NBMINs'] = pad_value(nbmin, 'NBMINs (>= 1)')  # vs '2 4'
 
-            self.variables['N-DEPTHs'] = '{:13} Number of DEPTHs, lookahead depth'.format('1')
+            self.variables['N-RFACTs'] = pad_value('1', 'Number of RFACTS, recursive panel fact.')  # vs '3'
 
             # ramble.yaml configurable
-            self.variables['DEPTHs'] = '{:13} DEPTHs (>=0)'.format(depth)  # vs '0'
+            self.variables['RFACTs'] = pad_value(rfact, 'RFACTs (0=left, 1=Crout, 2=Right)')  # vs '0 1 2'
+
+            # ramble.yaml configurable
+            self.variables['BCASTs'] = pad_value(bcast, 'BCASTs (0=1rg,1=1rM,2=2rg,3=2rM,4=Lng,5=LnM,6=MKL BPUSH,7=AMD Hybrid Panel)')  # vs '0'
+
+            # ramble.yaml configurable
+            self.variables['DEPTHs'] = pad_value(depth, 'DEPTHs (>=0)')  # vs '0'
 
     def _make_experiments(self, workspace):
         super()._make_experiments(workspace)
@@ -329,7 +322,10 @@ class Hpl(SpackApplication):
             f.write('Innovative Computing Laboratory, University of Tennessee\n')
 
             for setting in settings:
-                f.write(self.expander.expand_var('{' + setting + '}') + '\n')
+                # This gets around an issue in expander where trailing comments
+                # after '#' are not printed
+                hash_replace_str = self.expander.expand_var(self.expander.expansion_str(setting)).replace('Number', '#')
+                f.write(hash_replace_str + '\n')
 
             # Write some documentation at the bottom of the input file:
             f.write('##### This line (no. 32) is ignored (it serves as a separator). ######')

--- a/var/ramble/repos/builtin/applications/hpl/application.py
+++ b/var/ramble/repos/builtin/applications/hpl/application.py
@@ -260,11 +260,11 @@ class Hpl(SpackApplication):
             for var, config in self.workload_variables['standard'].items():
                 self.variables[var] = config['default']
 
-            pfact = expander.expand_var('{pfact}')
-            nbmin = expander.expand_var('{nbmin}')
-            rfact = expander.expand_var('{rfact}')
-            bcast = expander.expand_var('{bcast}')
-            depth = expander.expand_var('{depth}')
+            pfact = expander.expand_var(expander.expansion_str('pfact'))
+            nbmin = expander.expand_var(expander.expansion_str('nbmin'))
+            rfact = expander.expand_var(expander.expansion_str('rfact'))
+            bcast = expander.expand_var(expander.expansion_str('bcast'))
+            depth = expander.expand_var(expander.expansion_str('depth'))
 
             self.variables['N-Ns'] = '{:13} Number of problems sizes (N)'.format('1')  # vs 4
 

--- a/var/ramble/repos/builtin/applications/hpl/application.py
+++ b/var/ramble/repos/builtin/applications/hpl/application.py
@@ -268,7 +268,7 @@ class Hpl(SpackApplication):
 
             # Calculated:
             self.variables['Ns'] = pad_value(int(problemSize),
-                                                  f"Ns (= {usedPercentage}% of total available memory)")
+                                             f"Ns (= {usedPercentage}% of total available memory)")
 
             self.variables['N-NBs'] = pad_value('1', 'Number of NBs')  # vs 4
 

--- a/var/ramble/repos/builtin/applications/intel-hpl/application.py
+++ b/var/ramble/repos/builtin/applications/intel-hpl/application.py
@@ -8,27 +8,176 @@
 
 from ramble.appkit import *
 
-from ramble.app.builtin.hpl import Hpl as HplApplication
+import math
 
 
-class IntelHpl(HplApplication):
+class IntelHpl(SpackApplication):
     '''Define HPL application using Intel MKL optimized binary from intel-oneapi-mpi package'''
     name = 'intel-hpl'
 
     maintainers('dodecatheon')
 
-    tags('optimized', 'intel', 'mkl')
+    tags('benchmark-app', 'benchmark', 'linpack', 'optimized', 'intel', 'mkl')
 
     default_compiler('gcc9', spack_spec='gcc@9.5.0')
     software_spec('imkl_2023p1', spack_spec='intel-oneapi-mkl@2023.1.0 threads=openmp')
     software_spec('impi_2018', spack_spec='intel-mpi@2018.4.274')
 
-    # Note that 'hpl' is required by the Hpl class
     required_package('intel-oneapi-mkl')
 
     executable('execute',
                '{intel-oneapi-mkl}/mkl/latest/benchmarks/mp_linpack/xhpl_intel64_dynamic',
                use_mpi=True)
+
+    workload('standard', executables=['execute'])
+    workload('calculator', executables=['execute'])
+
+    workload_variable('output_file',
+                      default='{:13} output file name (if any)'.format('HPL.out'),
+                      description='Output file name (if any)',
+                      workloads=['standard'])
+    workload_variable('device_out',
+                      default='{:13} device out (6=stdout,7=stderr,file)'.format('6'),
+                      description='Output device',
+                      workloads=['standard'])
+    workload_variable('N-Ns',
+                      default='{:13} Number of problems sizes (N)'.format('4'),
+                      description='Number of problems sizes',
+                      workloads=['standard'])
+    workload_variable('Ns',
+                      default='{:13} Ns'.format('29 30 34 35'),
+                      description='Problem sizes',
+                      workloads=['standard'])
+    workload_variable('N-NBs',
+                      default='{:13} Number of NBs'.format('4'),
+                      description='Number of NBs',
+                      workloads=['standard'])
+    workload_variable('NBs',
+                      default='{:13} NBs'.format('1 2 3 4'),
+                      description='NB values',
+                      workloads=['standard'])
+    workload_variable('PMAP',
+                      default='{:13} PMAP process mapping (0=Row-,1=Column-major)'.format('0'),
+                      description='PMAP Process mapping. (0=Row-, 1=Column-Major)',
+                      workloads=['standard'])
+    workload_variable('N-Grids',
+                      default='{:13} Number of process grids (P x Q)'.format('3'),
+                      description='Number of process grids (P x Q)',
+                      workloads=['standard'])
+    workload_variable('Ps',
+                      default='{:13} Ps'.format('2 1 4'),
+                      description='P values',
+                      workloads=['standard'])
+    workload_variable('Qs',
+                      default='{:13} Qs'.format('2 4 1'),
+                      description='Q values',
+                      workloads=['standard'])
+    workload_variable('threshold',
+                      default='{:13} threshold'.format('16.0'),
+                      description='Residual threshold',
+                      workloads=['standard'])
+    workload_variable('NPFACTs',
+                      default='{:13} Number of PFACTs, panel fact'.format('3'),
+                      description='Number of PFACTs',
+                      workloads=['standard'])
+    workload_variable('PFACTs',
+                      default='{:13} PFACTs (0=left, 1=Crout, 2=Right)'.format('0 1 2'),
+                      description='PFACT Values',
+                      workloads=['standard'])
+    workload_variable('N-NBMINs',
+                      default='{:13} Number of NBMINs, recursive stopping criteria'.format('2'),
+                      description='Number of NBMINs',
+                      workloads=['standard'])
+    workload_variable('NBMINs',
+                      default='{:13} NBMINs (>= 1)'.format('2 4'),
+                      description='NBMIN values',
+                      workloads=['standard'])
+    workload_variable('N-NDIVs',
+                      default='{:13} Number of NDIVs, panels in recursion'.format('1'),
+                      description='Number of NDIVs',
+                      workloads=['standard'])
+    workload_variable('NDIVs',
+                      default='{:13} NDIVs'.format('2'),
+                      description='NDIV values',
+                      workloads=['standard'])
+    workload_variable('N-RFACTs',
+                      default='{:13} Number of RFACTs, recursive panel fact.'.format('3'),
+                      description='Number of RFACTs',
+                      workloads=['standard'])
+    workload_variable('RFACTs',
+                      default='{:13} RFACTs (0=left, 1=Crout, 2=Right)'.format('0 1 2'),
+                      description='RFACT values',
+                      workloads=['standard'])
+    workload_variable('N-BCASTs',
+                      default='{:13} Number of BCASTs, broadcast'.format('1'),
+                      description='Number of BCASTs',
+                      workloads=['standard'])
+    workload_variable('BCASTs',
+                      default='{:13} BCASTs (0=1rg,1=1rM,2=2rg,3=2rM,4=Lng,5=LnM)'.format('0'),
+                      description='BCAST values',
+                      workloads=['standard'])
+    workload_variable('N-DEPTHs',
+                      default='{:13} Number of DEPTHs, lookahead depth'.format('1'),
+                      description='Number of DEPTHs',
+                      workloads=['standard'])
+    workload_variable('DEPTHs',
+                      default='{:13} DEPTHs (>=0)'.format('0'),
+                      description='DEPTH values',
+                      workloads=['standard'])
+    workload_variable('SWAP',
+                      default='{:13} SWAP (0=bin-exch,1=long,2=mix)'.format('2'),
+                      description='Swapping algorithm',
+                      workloads=['standard'])
+    workload_variable('swapping_threshold',
+                      default='{:13} swapping threshold'.format('64'),
+                      description='Swapping threshold',
+                      workloads=['standard'])
+    workload_variable('L1',
+                      default='{:13} L1 in (0=transposed,1=no-transposed) form'.format('0'),
+                      description='Storage for upper triangular portion of columns',
+                      workloads=['standard'])
+    workload_variable('U',
+                      default='{:13} U  in (0=transposed,1=no-transposed) form'.format('0'),
+                      description='Storage for the rows of U',
+                      workloads=['standard'])
+    workload_variable('Equilibration',
+                      default='{:13} Equilibration (0=no,1=yes)'.format('1'),
+                      description='Determines if equilibration should be enabled or disabled.',
+                      workloads=['standard'])
+    workload_variable('mem_alignment',
+                      default='{:13} memory alignment in double (> 0)'.format('8'),
+                      description='Sets the alignment in doubles for memory addresses',
+                      workloads=['standard'])
+
+    # calculator workload-specific variables:
+
+    workload_variable('percent_mem', default='85',
+                      description='Percent of memory to use (default 85)',
+                      workloads=['calculator'])
+
+    workload_variable('memory_per_node',
+                      default='240',
+                      description='Memory per node in GB',
+                      workloads=['calculator'])
+
+    workload_variable('block_size', default='384',
+                      description='Size of each block',
+                      workloads=['calculator'])
+
+    workload_variable('pfact',
+                      default='0',
+                      description='PFACT for optimized calculator',
+                      workloads=['calculator'])
+
+    workload_variable('nbmin',
+                      default='2',
+                      description='NBMIN for optimized calculator',
+                      workloads=['calculator'])
+
+    workload_variable('rfact',
+                      default='0',
+                      description='RFACT for optimized calculator',
+                      workloads=['calculator'])
 
     # Redefine default bcast to 6 for the MKL-optimized case
     workload_variable('bcast',
@@ -36,12 +185,152 @@ class IntelHpl(HplApplication):
                       description='BCAST for Intel MKL optimized calculator',
                       workloads=['calculator'])
 
-    # overload the inherited method to correct required_packages
-    def _inject_required_builtins(self):
-        # Do inherited stuff to inject the stuff coming from directives
-        # above and in parent classes.
-        super()._inject_required_builtins()
+    workload_variable('depth',
+                      default='0',
+                      description='DEPTH for optimized calculator',
+                      workloads=['calculator'])
 
-        # Now ensure that hpl is no longer required
-        if 'hpl' in self.required_packages.keys():
-            self.required_packages.pop('hpl')
+    # FoMs:
+
+    figure_of_merit('Time', log_file='{experiment_run_dir}/{experiment_name}.out',
+                    fom_regex=r'.*\s+(?P<N>[0-9]+)\s+(?P<NB>[0-9]+)\s+(?P<P>[0-9]+)\s+(?P<Q>[0-9]+)\s+(?P<time>[0-9]+\.[0-9]+)\s+(?P<gflops>[0-9].*)\n',
+                    group_name='time', units='s', contexts=['problem-name'])
+
+    figure_of_merit('GFlops', log_file='{experiment_run_dir}/{experiment_name}.out',
+                    fom_regex=r'.*\s+(?P<N>[0-9]+)\s+(?P<NB>[0-9]+)\s+(?P<P>[0-9]+)\s+(?P<Q>[0-9]+)\s+(?P<time>[0-9]+\.[0-9]+)\s+(?P<gflops>[0-9].*)\n',
+                    group_name='gflops', units='GFLOP/s',
+                    contexts=['problem-name'])
+
+    figure_of_merit_context('problem-name', regex=r'.*\s+(?P<N>[0-9]+)\s+(?P<NB>[0-9]+)\s+(?P<P>[0-9]+)\s+(?P<Q>[0-9]+)\s+(?P<time>[0-9]+\.[0-9]+)\s+(?P<gflops>[0-9].*)\n', output_format='{N}-{NB}-{P}-{Q}')
+
+    # Integer sqrt
+    def _isqrt(self, n):
+        if n < 0:
+            raise Exception
+        elif n < 2:
+            return (n)
+        else:
+            lo = self._isqrt(n >> 2) << 1
+            hi = lo + 1
+            if ((hi * hi) > n):
+                return (lo)
+            else:
+                return (hi)
+
+    def _calculate_values(self, workspace, expander):
+        if expander.workload_name == 'calculator':
+            # Find the best P and Q whose product is the number of available
+            # cores, with P less than Q
+            nNodes = int(expander.expand_var('{n_nodes}'))
+            processesPerNode = int(expander.expand_var('{processes_per_node}'))
+
+            totalCores = nNodes * processesPerNode
+
+            bestP = self._isqrt(totalCores)
+            while ((totalCores % bestP) > 0):     # stops at 1 because any int % 1 = 0
+                bestP -= 1
+
+            bestQ = totalCores // bestP
+
+            # Find LCM(P,Q)
+            P = int(bestP)
+            Q = int(bestQ)
+            lcmPQ = Q             # Q is always the larger of P and Q
+            while ((lcmPQ % P) > 0):
+                lcmPQ += Q
+
+            # HPL maintainers recommend basing the target problem size on
+            # the square root of 80% of total memory in words.
+            memoryPerNode = int(expander.expand_var('{memory_per_node}'))
+            memFraction = int(expander.expand_var('{percent_mem}')) / 100
+            blockSize = int(expander.expand_var('{block_size}'))
+            one_gb_mem_in_words = (1 << 30) / 8
+
+            fullMemWords = nNodes * memoryPerNode * one_gb_mem_in_words
+
+            targetProblemSize = math.sqrt(fullMemWords * memFraction)
+
+            # Ensure that N is divisible by NB * LCM(P,Q)
+            problemSize = int(targetProblemSize)
+            problemSize -= (problemSize % blockSize)
+            nBlocks = problemSize // blockSize
+            nBlocks -= nBlocks % lcmPQ
+            problemSize = blockSize * nBlocks
+            usedPercentage = int(problemSize**2 / fullMemWords * 100)
+
+            for var, config in self.workload_variables['standard'].items():
+                self.variables[var] = config['default']
+
+            pfact = expander.expand_var('{pfact}')
+            nbmin = expander.expand_var('{nbmin}')
+            rfact = expander.expand_var('{rfact}')
+            bcast = expander.expand_var('{bcast}')
+            depth = expander.expand_var('{depth}')
+
+            self.variables['N-Ns'] = '{:13} Number of problems sizes (N)'.format('1')  # vs 4
+
+            # Calculated:
+            self.variables['Ns'] = ("{:<13} Ns (= {}% of "
+                                    "total available memory)").format(int(problemSize),
+                                                                      usedPercentage)
+            self.variables['N-NBs'] = '{:13} Number of NBs'.format('1')  # vs 4
+
+            # Calculated:
+            self.variables['NBs'] = "{:<13} NBs".format(blockSize)  # calculated, vs 4 samples
+
+            self.variables['N-Grids'] = ('{:13} Number of Grids,'
+                                         'process grids (P x Q)').format('1')  # vs 3
+            # Calculated:
+            self.variables['Ps'] = "{:<13} Ps".format(int(bestP))
+
+            # Calculated:
+            self.variables['Qs'] = "{:<13} Qs".format(int(bestQ))
+
+            self.variables['NPFACTs'] = '{:13} Number of PFACTs, panel fact'.format('1')  # vs 3
+
+            # ramble.yaml configurable
+            self.variables['PFACTs'] = '{:13} PFACT Values (0=left, 1=Crout, 2=Right)'.format(pfact)  # vs 0 1 2
+
+            self.variables['N-NBMINs'] = '{:13} Number of NBMINs, recursive stopping criteria'.format('1')  # vs 2
+
+            # ramble.yaml configurable
+            self.variables['NBMINs'] = '{:13} NBMINs (>= 1)'.format(nbmin)  # vs '2 4'
+
+            self.variables['N-RFACTs'] = '{:13} Number of RFACTS, recursive panel fact.'.format('1')  # vs '3'
+
+            # ramble.yaml configurable
+            self.variables['RFACTs'] = '{:13} RFACTs (0=left, 1=Crout, 2=Right)'.format(rfact)  # vs '0 1 2'
+
+            self.variables['N-BCASTs'] = '{:13} Number of BCASTs, broadcast'.format('1')
+
+            # ramble.yaml configurable
+            self.variables['BCASTs'] = ('{:13} BCASTs (0=1rg,1=1rM,2=2rg,3=2rM,4=Lng,'
+                                        '5=LnM,6=MKL BPUSH,7=AMD Hybrid Panel)').format(bcast)  # vs '0'
+
+            self.variables['N-DEPTHs'] = '{:13} Number of DEPTHs, lookahead depth'.format('1')
+
+            # ramble.yaml configurable
+            self.variables['DEPTHs'] = '{:13} DEPTHs (>=0)'.format(depth)  # vs '0'
+
+    def _make_experiments(self, workspace):
+        super()._make_experiments(workspace)
+        self._calculate_values(workspace, self.expander)
+
+        input_path = self.expander.expand_var('{experiment_run_dir}/HPL.dat')
+
+        settings = ['output_file', 'device_out', 'N-Ns', 'Ns', 'N-NBs', 'NBs',
+                    'PMAP', 'N-Grids', 'Ps', 'Qs', 'threshold', 'NPFACTs',
+                    'PFACTs', 'N-NBMINs', 'NBMINs', 'N-NDIVs', 'NDIVs', 'N-RFACTs',
+                    'RFACTs', 'N-BCASTs', 'BCASTs', 'N-DEPTHs', 'DEPTHs', 'SWAP',
+                    'swapping_threshold', 'L1', 'U', 'Equilibration',
+                    'mem_alignment']
+
+        with open(input_path, 'w+') as f:
+            f.write('    HPLinpack benchmark input file\n')
+            f.write('Innovative Computing Laboratory, University of Tennessee\n')
+
+            for setting in settings:
+                f.write(self.expander.expand_var('{' + setting + '}') + '\n')
+
+            # Write some documentation at the bottom of the input file:
+            f.write('##### This line (no. 32) is ignored (it serves as a separator). ######')

--- a/var/ramble/repos/builtin/applications/intel-hpl/application.py
+++ b/var/ramble/repos/builtin/applications/intel-hpl/application.py
@@ -19,7 +19,7 @@ class IntelHpl(SpackApplication):
 
     tags('benchmark-app', 'benchmark', 'linpack', 'optimized', 'intel', 'mkl')
 
-    default_compiler('gcc9', spack_spec='gcc@9.5.0')
+    default_compiler('gcc9', spack_spec='gcc@9.3.0')
     software_spec('imkl_2023p1', spack_spec='intel-oneapi-mkl@2023.1.0 threads=openmp')
     software_spec('impi_2018', spack_spec='intel-mpi@2018.4.274')
 

--- a/var/ramble/repos/builtin/applications/intel-hpl/application.py
+++ b/var/ramble/repos/builtin/applications/intel-hpl/application.py
@@ -269,7 +269,7 @@ class IntelHpl(SpackApplication):
 
             # Calculated:
             self.variables['Ns'] = pad_value(int(problemSize),
-                                                  f"Ns (= {usedPercentage}% of total available memory)")
+                                             f"Ns (= {usedPercentage}% of total available memory)")
 
             self.variables['N-NBs'] = pad_value('1', 'Number of NBs')  # vs 4
 

--- a/var/ramble/repos/builtin/applications/intel-hpl/application.py
+++ b/var/ramble/repos/builtin/applications/intel-hpl/application.py
@@ -11,6 +11,10 @@ from ramble.appkit import *
 import math
 
 
+def pad_value(val, desc):
+    return ('{:<14}'.format(val) + desc)
+
+
 class IntelHpl(SpackApplication):
     '''Define HPL application using Intel MKL optimized binary from intel-oneapi-mpi package'''
     name = 'intel-hpl'
@@ -33,119 +37,119 @@ class IntelHpl(SpackApplication):
     workload('calculator', executables=['execute'])
 
     workload_variable('output_file',
-                      default='{:13} output file name (if any)'.format('HPL.out'),
+                      default=pad_value('HPL.out', 'output file name (if any)'),
                       description='Output file name (if any)',
                       workloads=['standard'])
     workload_variable('device_out',
-                      default='{:13} device out (6=stdout,7=stderr,file)'.format('6'),
+                      default=pad_value('6', 'device out (6=stdout,7=stderr,file)'),
                       description='Output device',
                       workloads=['standard'])
     workload_variable('N-Ns',
-                      default='{:13} Number of problems sizes (N)'.format('4'),
+                      default=pad_value('4', 'Number of problems sizes (N)'),
                       description='Number of problems sizes',
                       workloads=['standard'])
     workload_variable('Ns',
-                      default='{:13} Ns'.format('29 30 34 35'),
+                      default=pad_value('29 30 34 35', 'Ns'),
                       description='Problem sizes',
                       workloads=['standard'])
     workload_variable('N-NBs',
-                      default='{:13} Number of NBs'.format('4'),
+                      default=pad_value('4', 'Number of NBs'),
                       description='Number of NBs',
                       workloads=['standard'])
     workload_variable('NBs',
-                      default='{:13} NBs'.format('1 2 3 4'),
+                      default=pad_value('1 2 3 4', 'NBs'),
                       description='NB values',
                       workloads=['standard'])
     workload_variable('PMAP',
-                      default='{:13} PMAP process mapping (0=Row-,1=Column-major)'.format('0'),
+                      default=pad_value('0', 'PMAP process mapping (0=Row-,1=Column-major)'),
                       description='PMAP Process mapping. (0=Row-, 1=Column-Major)',
                       workloads=['standard'])
     workload_variable('N-Grids',
-                      default='{:13} Number of process grids (P x Q)'.format('3'),
+                      default=pad_value('3', 'Number of process grids (P x Q)'),
                       description='Number of process grids (P x Q)',
                       workloads=['standard'])
     workload_variable('Ps',
-                      default='{:13} Ps'.format('2 1 4'),
+                      default=pad_value('2 1 4', 'Ps'),
                       description='P values',
                       workloads=['standard'])
     workload_variable('Qs',
-                      default='{:13} Qs'.format('2 4 1'),
+                      default=pad_value('2 4 1', 'Qs'),
                       description='Q values',
                       workloads=['standard'])
     workload_variable('threshold',
-                      default='{:13} threshold'.format('16.0'),
+                      default=pad_value('16.0', 'threshold'),
                       description='Residual threshold',
                       workloads=['standard'])
     workload_variable('NPFACTs',
-                      default='{:13} Number of PFACTs, panel fact'.format('3'),
+                      default=pad_value('3', 'Number of PFACTs, panel fact'),
                       description='Number of PFACTs',
                       workloads=['standard'])
     workload_variable('PFACTs',
-                      default='{:13} PFACTs (0=left, 1=Crout, 2=Right)'.format('0 1 2'),
+                      default=pad_value('0 1 2', 'PFACTs (0=left, 1=Crout, 2=Right)'),
                       description='PFACT Values',
                       workloads=['standard'])
     workload_variable('N-NBMINs',
-                      default='{:13} Number of NBMINs, recursive stopping criteria'.format('2'),
+                      default=pad_value('2', 'Number of NBMINs, recursive stopping criteria'),
                       description='Number of NBMINs',
                       workloads=['standard'])
     workload_variable('NBMINs',
-                      default='{:13} NBMINs (>= 1)'.format('2 4'),
+                      default=pad_value('2 4', 'NBMINs (>= 1)'),
                       description='NBMIN values',
                       workloads=['standard'])
     workload_variable('N-NDIVs',
-                      default='{:13} Number of NDIVs, panels in recursion'.format('1'),
+                      default=pad_value('1', 'Number of NDIVs, panels in recursion'),
                       description='Number of NDIVs',
                       workloads=['standard'])
     workload_variable('NDIVs',
-                      default='{:13} NDIVs'.format('2'),
+                      default=pad_value('2', 'NDIVs'),
                       description='NDIV values',
                       workloads=['standard'])
     workload_variable('N-RFACTs',
-                      default='{:13} Number of RFACTs, recursive panel fact.'.format('3'),
+                      default=pad_value('3', 'Number of RFACTs, recursive panel fact.'),
                       description='Number of RFACTs',
                       workloads=['standard'])
     workload_variable('RFACTs',
-                      default='{:13} RFACTs (0=left, 1=Crout, 2=Right)'.format('0 1 2'),
+                      default=pad_value('0 1 2', 'RFACTs (0=left, 1=Crout, 2=Right)'),
                       description='RFACT values',
                       workloads=['standard'])
     workload_variable('N-BCASTs',
-                      default='{:13} Number of BCASTs, broadcast'.format('1'),
+                      default=pad_value('1', 'Number of BCASTs, broadcast'),
                       description='Number of BCASTs',
                       workloads=['standard'])
     workload_variable('BCASTs',
-                      default='{:13} BCASTs (0=1rg,1=1rM,2=2rg,3=2rM,4=Lng,5=LnM)'.format('0'),
+                      default=pad_value('0', 'BCASTs (0=1rg,1=1rM,2=2rg,3=2rM,4=Lng,5=LnM)'),
                       description='BCAST values',
                       workloads=['standard'])
     workload_variable('N-DEPTHs',
-                      default='{:13} Number of DEPTHs, lookahead depth'.format('1'),
+                      default=pad_value('1', 'Number of DEPTHs, lookahead depth'),
                       description='Number of DEPTHs',
                       workloads=['standard'])
     workload_variable('DEPTHs',
-                      default='{:13} DEPTHs (>=0)'.format('0'),
+                      default=pad_value('0', 'DEPTHs (>=0)'),
                       description='DEPTH values',
                       workloads=['standard'])
     workload_variable('SWAP',
-                      default='{:13} SWAP (0=bin-exch,1=long,2=mix)'.format('2'),
+                      default=pad_value('2', 'SWAP (0=bin-exch,1=long,2=mix)'),
                       description='Swapping algorithm',
                       workloads=['standard'])
     workload_variable('swapping_threshold',
-                      default='{:13} swapping threshold'.format('64'),
+                      default=pad_value('64', 'swapping threshold'),
                       description='Swapping threshold',
                       workloads=['standard'])
     workload_variable('L1',
-                      default='{:13} L1 in (0=transposed,1=no-transposed) form'.format('0'),
+                      default=pad_value('0', 'L1 in (0=transposed,1=no-transposed) form'),
                       description='Storage for upper triangular portion of columns',
                       workloads=['standard'])
     workload_variable('U',
-                      default='{:13} U  in (0=transposed,1=no-transposed) form'.format('0'),
+                      default=pad_value('0', 'U  in (0=transposed,1=no-transposed) form'),
                       description='Storage for the rows of U',
                       workloads=['standard'])
     workload_variable('Equilibration',
-                      default='{:13} Equilibration (0=no,1=yes)'.format('1'),
+                      default=pad_value('1', 'Equilibration (0=no,1=yes)'),
                       description='Determines if equilibration should be enabled or disabled.',
                       workloads=['standard'])
     workload_variable('mem_alignment',
-                      default='{:13} memory alignment in double (> 0)'.format('8'),
+                      default=pad_value('8', 'memory alignment in double (> 0)'),
                       description='Sets the alignment in doubles for memory addresses',
                       workloads=['standard'])
 
@@ -155,8 +159,7 @@ class IntelHpl(SpackApplication):
                       description='Percent of memory to use (default 85)',
                       workloads=['calculator'])
 
-    workload_variable('memory_per_node',
-                      default='240',
+    workload_variable('memory_per_node', default='240',
                       description='Memory per node in GB',
                       workloads=['calculator'])
 
@@ -164,29 +167,24 @@ class IntelHpl(SpackApplication):
                       description='Size of each block',
                       workloads=['calculator'])
 
-    workload_variable('pfact',
-                      default='0',
+    workload_variable('pfact', default='0',
                       description='PFACT for optimized calculator',
                       workloads=['calculator'])
 
-    workload_variable('nbmin',
-                      default='2',
+    workload_variable('nbmin', default='2',
                       description='NBMIN for optimized calculator',
                       workloads=['calculator'])
 
-    workload_variable('rfact',
-                      default='0',
+    workload_variable('rfact', default='0',
                       description='RFACT for optimized calculator',
                       workloads=['calculator'])
 
     # Redefine default bcast to 6 for the MKL-optimized case
-    workload_variable('bcast',
-                      default='6',
+    workload_variable('bcast', default='6',
                       description='BCAST for Intel MKL optimized calculator',
                       workloads=['calculator'])
 
-    workload_variable('depth',
-                      default='0',
+    workload_variable('depth', default='0',
                       description='DEPTH for optimized calculator',
                       workloads=['calculator'])
 
@@ -241,9 +239,9 @@ class IntelHpl(SpackApplication):
 
             # HPL maintainers recommend basing the target problem size on
             # the square root of 80% of total memory in words.
-            memoryPerNode = int(expander.expand_var('{memory_per_node}'))
-            memFraction = int(expander.expand_var('{percent_mem}')) / 100
-            blockSize = int(expander.expand_var('{block_size}'))
+            memoryPerNode = int(expander.expand_var(expander.expansion_str('memory_per_node')))
+            memFraction = int(expander.expand_var(expander.expansion_str('percent_mem'))) / 100
+            blockSize = int(expander.expand_var(expander.expansion_str('block_size')))
             one_gb_mem_in_words = (1 << 30) / 8
 
             fullMemWords = nNodes * memoryPerNode * one_gb_mem_in_words
@@ -267,50 +265,45 @@ class IntelHpl(SpackApplication):
             bcast = expander.expand_var(expander.expansion_str('bcast'))
             depth = expander.expand_var(expander.expansion_str('depth'))
 
-            self.variables['N-Ns'] = '{:13} Number of problems sizes (N)'.format('1')  # vs 4
+            self.variables['N-Ns'] = pad_value('1', 'Number of problems sizes (N)')  # vs 4
 
             # Calculated:
-            self.variables['Ns'] = ("{:<13} Ns (= {}% of "
-                                    "total available memory)").format(int(problemSize),
-                                                                      usedPercentage)
-            self.variables['N-NBs'] = '{:13} Number of NBs'.format('1')  # vs 4
+            self.variables['Ns'] = pad_value(int(problemSize),
+                                                  f"Ns (= {usedPercentage}% of total available memory)")
+
+            self.variables['N-NBs'] = pad_value('1', 'Number of NBs')  # vs 4
 
             # Calculated:
-            self.variables['NBs'] = "{:<13} NBs".format(blockSize)  # calculated, vs 4 samples
+            self.variables['NBs'] = pad_value(blockSize, "NBs")  # calculated, vs 4 samples
 
-            self.variables['N-Grids'] = ('{:13} Number of Grids,'
-                                         'process grids (P x Q)').format('1')  # vs 3
-            # Calculated:
-            self.variables['Ps'] = "{:<13} Ps".format(int(bestP))
+            self.variables['N-Grids'] = pad_value('1', 'Number of Grids, process grids (P x Q)')  # vs 3
 
             # Calculated:
-            self.variables['Qs'] = "{:<13} Qs".format(int(bestQ))
+            self.variables['Ps'] = pad_value(int(bestP), "Ps")
 
-            self.variables['NPFACTs'] = '{:13} Number of PFACTs, panel fact'.format('1')  # vs 3
+            # Calculated:
+            self.variables['Qs'] = pad_value(int(bestQ), "Qs")
 
-            # ramble.yaml configurable
-            self.variables['PFACTs'] = '{:13} PFACT Values (0=left, 1=Crout, 2=Right)'.format(pfact)  # vs 0 1 2
-
-            self.variables['N-NBMINs'] = '{:13} Number of NBMINs, recursive stopping criteria'.format('1')  # vs 2
+            self.variables['NPFACTs'] = pad_value('1', 'Number of PFACTs, panel fact')  # vs 3
 
             # ramble.yaml configurable
-            self.variables['NBMINs'] = '{:13} NBMINs (>= 1)'.format(nbmin)  # vs '2 4'
+            self.variables['PFACTs'] = pad_value(pfact, 'PFACT Values (0=left, 1=Crout, 2=Right)')  # vs 0 1 2
 
-            self.variables['N-RFACTs'] = '{:13} Number of RFACTS, recursive panel fact.'.format('1')  # vs '3'
-
-            # ramble.yaml configurable
-            self.variables['RFACTs'] = '{:13} RFACTs (0=left, 1=Crout, 2=Right)'.format(rfact)  # vs '0 1 2'
-
-            self.variables['N-BCASTs'] = '{:13} Number of BCASTs, broadcast'.format('1')
+            self.variables['N-NBMINs'] = pad_value('1', 'Number of NBMINs, recursive stopping criteria')  # vs 2
 
             # ramble.yaml configurable
-            self.variables['BCASTs'] = ('{:13} BCASTs (0=1rg,1=1rM,2=2rg,3=2rM,4=Lng,'
-                                        '5=LnM,6=MKL BPUSH,7=AMD Hybrid Panel)').format(bcast)  # vs '0'
+            self.variables['NBMINs'] = pad_value(nbmin, 'NBMINs (>= 1)')  # vs '2 4'
 
-            self.variables['N-DEPTHs'] = '{:13} Number of DEPTHs, lookahead depth'.format('1')
+            self.variables['N-RFACTs'] = pad_value('1', 'Number of RFACTS, recursive panel fact.')  # vs '3'
 
             # ramble.yaml configurable
-            self.variables['DEPTHs'] = '{:13} DEPTHs (>=0)'.format(depth)  # vs '0'
+            self.variables['RFACTs'] = pad_value(rfact, 'RFACTs (0=left, 1=Crout, 2=Right)')  # vs '0 1 2'
+
+            # ramble.yaml configurable
+            self.variables['BCASTs'] = pad_value(bcast, 'BCASTs (0=1rg,1=1rM,2=2rg,3=2rM,4=Lng,5=LnM,6=MKL BPUSH,7=AMD Hybrid Panel)')  # vs '0'
+
+            # ramble.yaml configurable
+            self.variables['DEPTHs'] = pad_value(depth, 'DEPTHs (>=0)')  # vs '0'
 
     def _make_experiments(self, workspace):
         super()._make_experiments(workspace)
@@ -330,7 +323,10 @@ class IntelHpl(SpackApplication):
             f.write('Innovative Computing Laboratory, University of Tennessee\n')
 
             for setting in settings:
-                f.write(self.expander.expand_var('{' + setting + '}') + '\n')
+                # This gets around an issue in expander where trailing comments
+                # after '#' are not printed
+                hash_replace_str = self.expander.expand_var(self.expander.expansion_str(setting)).replace('Number', '#')
+                f.write(hash_replace_str + '\n')
 
             # Write some documentation at the bottom of the input file:
             f.write('##### This line (no. 32) is ignored (it serves as a separator). ######')

--- a/var/ramble/repos/builtin/applications/intel-hpl/application.py
+++ b/var/ramble/repos/builtin/applications/intel-hpl/application.py
@@ -1,0 +1,47 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.appkit import *
+
+from ramble.app.builtin.hpl import Hpl as HplApplication
+
+
+class IntelHpl(HplApplication):
+    '''Define HPL application using Intel MKL optimized binary from intel-oneapi-mpi package'''
+    name = 'intel-hpl'
+
+    maintainers('dodecatheon')
+
+    tags('optimized', 'intel', 'mkl')
+
+    default_compiler('gcc9', spack_spec='gcc@9.5.0')
+    software_spec('imkl_2023p1', spack_spec='intel-oneapi-mkl@2023.1.0 threads=openmp')
+    software_spec('impi_2018', spack_spec='intel-mpi@2018.4.274')
+
+    # Note that 'hpl' is required by the Hpl class
+    required_package('intel-oneapi-mkl')
+
+    executable('execute',
+               '{intel-oneapi-mkl}/mkl/latest/benchmarks/mp_linpack/xhpl_intel64_dynamic',
+               use_mpi=True)
+
+    # Redefine default bcast to 6 for the MKL-optimized case
+    workload_variable('bcast',
+                      default='6',
+                      description='BCAST for Intel MKL optimized calculator',
+                      workloads=['calculator'])
+
+    # overload the inherited method to correct required_packages
+    def _inject_required_builtins(self):
+        # Do inherited stuff to inject the stuff coming from directives
+        # above and in parent classes.
+        super()._inject_required_builtins()
+
+        # Now ensure that hpl is no longer required
+        if 'hpl' in self.required_packages.keys():
+            self.required_packages.pop('hpl')

--- a/var/ramble/repos/builtin/applications/intel-hpl/application.py
+++ b/var/ramble/repos/builtin/applications/intel-hpl/application.py
@@ -261,11 +261,11 @@ class IntelHpl(SpackApplication):
             for var, config in self.workload_variables['standard'].items():
                 self.variables[var] = config['default']
 
-            pfact = expander.expand_var('{pfact}')
-            nbmin = expander.expand_var('{nbmin}')
-            rfact = expander.expand_var('{rfact}')
-            bcast = expander.expand_var('{bcast}')
-            depth = expander.expand_var('{depth}')
+            pfact = expander.expand_var(expander.expansion_str('pfact'))
+            nbmin = expander.expand_var(expander.expansion_str('nbmin'))
+            rfact = expander.expand_var(expander.expansion_str('rfact'))
+            bcast = expander.expand_var(expander.expansion_str('bcast'))
+            depth = expander.expand_var(expander.expansion_str('depth'))
 
             self.variables['N-Ns'] = '{:13} Number of problems sizes (N)'.format('1')  # vs 4
 


### PR DESCRIPTION
Uses provided binary from intel-oneapi-mkl spack package

calculator workload modified to correctly calculate N based on 80% of available memory, with P and Q based on 2 procs per node.

To change memory usage, e.g. for testing, set percent_mem for workload calculator in ramble.yaml.