### PR TITLE
Convert spack version to use git and import

### DIFF
--- a/lib/ramble/ramble/main.py
+++ b/lib/ramble/ramble/main.py
@@ -116,16 +116,29 @@ def get_version():
 
     The commit sha is only added when available.
     """
-    import spack.util.git
     version = ramble.ramble_version
-    git_path = os.path.join(ramble.paths.prefix, ".git")
+    git_hash = get_git_hash(path=ramble.paths.prefix)
+
+    if git_hash:
+        version += f' ({git_hash})'
+
+    return version
+
+
+def get_git_hash(path=ramble.paths.prefix):
+    """Get get hash from a path
+
+    Outputs '<git commit sha>'.
+    """
+    import spack.util.git
+    git_path = os.path.join(path, ".git")
     if os.path.exists(git_path):
         git = spack.util.git.git()
         if not git:
-            return version
+            return
         rev = git(
             "-C",
-            ramble.paths.prefix,
+            path,
             "rev-parse",
             "HEAD",
             output=str,
@@ -133,12 +146,12 @@ def get_version():
             fail_on_error=False,
         )
         if git.returncode != 0:
-            return version
+            return
         match = re.match(r"[a-f\d]{7,}$", rev)
         if match:
-            version += " ({0})".format(match.group(0))
+            return match.group(0)
 
-    return version
+    return
 
 
 def index_commands():

--- a/lib/ramble/ramble/spack_runner.py
+++ b/lib/ramble/ramble/spack_runner.py
@@ -98,8 +98,25 @@ class SpackRunner(object):
 
     def get_version(self):
         """Get spack's version"""
-        version_args = ['-V']
-        return self.exe(*version_args, output=str).strip()
+        from ramble.main import get_git_hash
+        import importlib.util
+
+        version_spec = importlib.util.spec_from_file_location(
+            'spack_version',
+            os.path.join(self.spack_dir,
+                         'lib', 'spack',
+                         'spack', '__init__.py')
+        )
+        version_mod = importlib.util.module_from_spec(version_spec)
+        version_spec.loader.exec_module(version_mod)
+
+        spack_version = version_mod.spack_version
+        spack_hash = get_git_hash(path=self.spack_dir)
+
+        if spack_hash:
+            spack_version += f' ({spack_hash})'
+
+        return spack_version
 
     def set_dry_run(self, dry_run=False):
         """


### PR DESCRIPTION
This merge changes the spack version string printing to use git and a python import instead of trying to run spack commands directly.

This fixes a regression in testing introduced with the workspace hashing merge