### PR TITLE
Add application instances as an input to executable modifiers

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -699,7 +699,8 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                 for mod in self._modifier_instances:
                     if mod.applies_to_executable(executable):
                         pre_cmd, post_cmd = mod.apply_executable_modifiers(executable,
-                                                                           base_command)
+                                                                           base_command,
+                                                                           app_inst=self)
                         pre_commands.extend(pre_cmd)
                         post_commands.extend(post_cmd)
 

--- a/lib/ramble/ramble/language/modifier_language.py
+++ b/lib/ramble/ramble/language/modifier_language.py
@@ -324,7 +324,7 @@ def executable_modifier(name):
 
       executable_modifier('write_exec_name')
 
-      def write_exec_name(self, executable_name, executable):
+      def write_exec_name(self, executable_name, executable, app_inst=None):
         prepend_execs = []
         append_execs = [ExecutableCommand(
             template='echo "{executable_name}"',

--- a/lib/ramble/ramble/modifier.py
+++ b/lib/ramble/ramble/modifier.py
@@ -220,13 +220,13 @@ class ModifierBase(object, metaclass=ModifierMeta):
 
         return apply
 
-    def apply_executable_modifiers(self, executable_name, executable):
+    def apply_executable_modifiers(self, executable_name, executable, app_inst=None):
         pre_execs = []
         post_execs = []
         for exec_mod in self.executable_modifiers:
             mod_func = getattr(self, exec_mod)
 
-            pre_exec, post_exec = mod_func(executable_name, executable)
+            pre_exec, post_exec = mod_func(executable_name, executable, app_inst=app_inst)
 
             pre_execs.extend(pre_exec)
             post_execs.extend(post_exec)

--- a/var/ramble/repos/builtin/modifiers/intel-aps/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/intel-aps/modifier.py
@@ -37,7 +37,7 @@ class IntelAps(SpackModifier):
 
     executable_modifier('aps_summary')
 
-    def aps_summary(self, executable_name, executable):
+    def aps_summary(self, executable_name, executable, app_inst=None):
         from ramble.util.executable import CommandExecutable
 
         pre_exec = []


### PR DESCRIPTION
This merge adds application instances to the executable modifier interface. This allows executable modifiers to query internals about hte application instance they are modifying executables for. This means executable modifiers can perform conditional actions based on the variables of the experiment.