### PR TITLE
Fix typo from PR #165

### DIFF
--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -293,7 +293,7 @@ class Expander(object):
                     except SyntaxError:
                         pass
                 elif not allow_passthrough:
-                    tty.deubg(f'Expansion stack errors: attempted to expand "{kw}" = "{val}"')
+                    tty.debug(f'Expansion stack errors: attempted to expand "{kw}" = "{val}"')
                 else:
                     for kw in self._all_keywords(val):
                         passthrough_vars[kw] = '{' + kw + '}'


### PR DESCRIPTION
Found a small typo while running `ramble -d workspace setup`

Change `tty.deubg` to `tty.debug` in lib/ramble/ramble/expander.py:296