### PR TITLE
Raise an error when variable names contain decimals

### DIFF
--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -299,7 +299,14 @@ class Expander(object):
                         passthrough_vars[kw] = '{' + kw + '}'
             exp_dict.update(passthrough_vars)
 
-            return in_str.format_map(exp_dict)
+            try:
+                return in_str.format_map(exp_dict)
+            except AttributeError:
+                tty.debug(f'Error encountered while trying to expand variable {in_str}')
+                tty.debug(f'Expansion dict was: {exp_dict}')
+                raise RambleSyntaxError(f'Expansion failed on variable {in_str}',
+                                        'Variable names cannot contain decimals.')
+
         return in_str
 
     def eval_math(self, node):

--- a/lib/ramble/ramble/test/expander.py
+++ b/lib/ramble/ramble/test/expander.py
@@ -28,6 +28,7 @@ def exp_dict():
         'var1': '{var2}',
         'var2': '{var3}',
         'var3': '3',
+        'decimal.06.var': 'foo',
     }
 
 
@@ -53,6 +54,24 @@ def test_expansions(input, output):
     expander = ramble.expander.Expander(expansion_vars, None)
 
     assert expander.expand_var(input) == output
+
+
+@pytest.mark.parametrize(
+    'input,expected_error,error_string',
+    [
+        ('{decimal.06.var}',
+         ramble.expander.RambleSyntaxError,
+         'Variable names cannot contain decimals'),
+    ]
+)
+def test_failed_expansions(input, expected_error, error_string):
+    expansion_vars = exp_dict()
+
+    expander = ramble.expander.Expander(expansion_vars, None)
+
+    with pytest.raises(expected_error) as e:
+        expander.expand_var(input)
+        assert error_string in e
 
 
 def test_expansion_namespaces():


### PR DESCRIPTION
This merge adds an exception that explains variable names cannot contain decimals when variable names are used that contain decimals.

A test is added to ensure this exception is raised properly.