### PR TITLE
Remove some spack env logic from vendored spack

### DIFF
--- a/lib/ramble/spack/util/path.py
+++ b/lib/ramble/spack/util/path.py
@@ -205,14 +205,8 @@ def substitute_config_variables(path):
     replaced if there is an active environment, and should only be used in
     environment yaml files.
     """
-    import spack.environment as ev  # break circular
     _replacements = replacements()
-    env = ev.active_environment()
-    if env:
-        _replacements.update({'env': env.path})
-    else:
-        # If a previous invocation added env, remove it
-        _replacements.pop('env', None)
+    _replacements.pop('env', None)
 
     # Look up replacements
     def repl(match):


### PR DESCRIPTION
This merge fixes an issue where spack tries to look up an active environment. However, since this is spack inside Ramble, there is never an active environment. This causes errors in older versions of python, so we are temporarily removing it. This should be resolved in the future by updating the vendored version of spack.