### PR TITLE
Fix spack using auxiliary software when installing compilers

### DIFF
--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -26,6 +26,8 @@ supported_math_operators = {
     ast.And: operator.and_, ast.Or: operator.or_
 }
 
+formatter = string.Formatter()
+
 
 class ExpansionDict(dict):
     def __missing__(self, key):
@@ -274,12 +276,16 @@ class Expander(object):
         """
 
         exp_dict = ExpansionDict()
+        exp_positional = []
         if isinstance(in_str, six.string_types):
-            for kw in self._all_keywords(in_str):
-                if kw in expansion_vars:
-                    exp_dict[kw] = \
-                        self._partial_expand(expansion_vars,
-                                             expansion_vars[kw])
+            for tup in formatter.parse(in_str):
+                kw = tup[1]
+                if kw is not None:
+                    if len(kw) > 0 and kw in expansion_vars:
+                        exp_dict[kw] = self._partial_expand(expansion_vars,
+                                                            expansion_vars[kw])
+                    elif len(kw) == 0:
+                        exp_positional.append('{}')
 
             passthrough_vars = {}
             for kw, val in exp_dict.items():
@@ -300,7 +306,30 @@ class Expander(object):
             exp_dict.update(passthrough_vars)
 
             try:
-                return in_str.format_map(exp_dict)
+                return formatter.vformat(in_str, exp_positional, exp_dict)
+            except IndexError as e:
+                if allow_passthrough:
+                    return in_str
+
+                tty.debug('Index error when parsing:\n')
+                tty.debug(in_str)
+                tty.debug(e)
+                raise RambleSyntaxError('Error occurred while parsing an expansion string.')
+            except KeyError as e:
+                tty.debug('Invalid variable name encountered')
+                tty.debug(e)
+                raise RambleSyntaxError('Expansion failed on:\n'
+                                        f'{in_str}\n'
+                                        'Which contains an invalid variable name')
+            except ValueError as e:
+                return in_str
+                tty.debug('JSON/YAML dict syntax should not be manually escaped.')
+                tty.debug('   {} will be automatically escaped')
+                tty.debug('   {{}} raises a syntax error')
+                tty.debug(e)
+                raise RambleSyntaxError('Expansion failed on:\n'
+                                        f'{in_str}\n'
+                                        'JSON/YAML dict syntax should not be manually escaped')
             except AttributeError:
                 tty.debug(f'Error encountered while trying to expand variable {in_str}')
                 tty.debug(f'Expansion dict was: {exp_dict}')

--- a/lib/ramble/ramble/test/expander.py
+++ b/lib/ramble/ramble/test/expander.py
@@ -45,7 +45,8 @@ def exp_dict():
         ('2**4', '16'),
         ('((((16-10+2)/4)**2)*4)', '16.0'),
         ('gromacs +blas', 'gromacs +blas'),
-        ('range(0, 5)', '[0, 1, 2, 3, 4]')
+        ('range(0, 5)', '[0, 1, 2, 3, 4]'),
+        ('{}', '{}'),
     ]
 )
 def test_expansions(input, output):


### PR DESCRIPTION
Previously, when installing compilers, spack would not use any of the config files in `$workspace/configs/auxiliary_software_files` meaning if a custom compiler is defined, it would be ignored.

This fix makes the following changes:
- Spack env is generated before installing compilers
- Spack env dir is added as a config scope when installing compilers
- More advanced usage of string.Formatter to detect positional arguments
- Split create_spack_env into create_spack_env (which only creates the env) and concretize_spack_env, to perform the concretization (both happened in create_spack_env before)