### PR TITLE
Add support for explicit zips

### DIFF
--- a/lib/ramble/docs/workspace_config.rst
+++ b/lib/ramble/docs/workspace_config.rst
@@ -197,6 +197,7 @@ to create a list. With this functionality, the example above could be re-written
                   variables:
                     n_ranks: '1'
 
+
 .. _ramble-matrix-logic:
 
 ^^^^^^^^^^^^^^^^^^
@@ -270,6 +271,57 @@ while the second is a 1x4 matrix. All matrices are required to have the same
 number of elements, as they are flattened and zipped together. In this case,
 there would be 4 experiments, each defined by a unique
 ``(processes_per_node, partition, n_nodes)`` tuple.
+
+
+.. _ramble-explicit-zips:
+
+
+^^^^^^^^^^^^^^^^^^^^^^^
+Explicit Variable Zips:
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Ramble's worksapce config contains syntax for defining explicit variable zips.
+These zips are named grouping of variables that are related and should be
+iterated over together when generating experiments.
+
+Zips consume list variables and generate a named grouping, which can be
+consumed by matrices just as list variables would be.
+
+Below is an example showing how to define explicit zips:
+
+.. code-block:: yaml
+   :linenos:
+
+    ramble:
+      variables:
+        mpi_command: 'mpirun -n {n_ranks}'
+        batch_submit: '{execute_experiment}'
+        n_ranks: '{n_nodes}*{processes_per_node}'
+      applications:
+        hostname:
+          variables:
+            n_threads: '1'
+          workloads:
+            serial:
+              variables:
+                processes_per_node: ['16', '32']
+                partition: ['part1', 'part2']
+                n_nodes: ['1', '2', '3', '4']
+              experiments:
+                test_exp_{n_nodes}_{processes_per_node}:
+                  variables:
+                    n_ranks: '1'
+                  zips:
+                    partition_defs:
+                    - partition
+                    - processes_per_node
+                  matrices:
+                  - partition_defs
+                  - n_nodes
+
+
+Which would result in eight experiments, crossing the ``n_nodes`` variable with
+the zip of ``partition`` and ``processes_per_node``.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Environment Variable Control:

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -403,8 +403,9 @@ def workspace_info(args):
         for workload, experiments, workload_vars, workload_env_vars, workload_internals, \
                 workload_template, workload_chained_exps, workload_mods \
                 in ws.all_workloads(workloads):
-            for exp, _, exp_vars, exp_env_vars, exp_matrices, exp_internals, exp_template, \
-                    exp_chained_exps, exp_mods in ws.all_experiments(experiments):
+            for exp, _, exp_vars, exp_env_vars, exp_zips, exp_matrices, exp_internals, \
+                    exp_template, exp_chained_exps, exp_mods \
+                    in ws.all_experiments(experiments):
                 print_experiment_set = ramble.experiment_set.ExperimentSet(ws)
                 print_experiment_set.set_application_context(app, app_vars,
                                                              app_env_vars, app_internals,
@@ -417,6 +418,7 @@ def workspace_info(args):
                 print_experiment_set.set_experiment_context(exp,
                                                             exp_vars,
                                                             exp_env_vars,
+                                                            exp_zips,
                                                             exp_matrices,
                                                             exp_internals,
                                                             exp_template,

--- a/lib/ramble/ramble/namespace.py
+++ b/lib/ramble/ramble/namespace.py
@@ -28,6 +28,7 @@ class namespace:
 
     # For rendering objects
     variables = 'variables'
+    zips = 'zips'
     matrices = 'matrices'
     matrix = 'matrix'
 

--- a/lib/ramble/ramble/schema/applications.py
+++ b/lib/ramble/ramble/schema/applications.py
@@ -24,6 +24,19 @@ import ramble.schema.licenses
 import ramble.schema.modifiers
 
 
+zip_def = {
+    'type': 'array',
+    'default': [],
+    'items': {'type': 'string'}
+}
+
+zips_def = {
+    'type': 'object',
+    'default': {},
+    'properties': {},
+    'additionalProperties': zip_def
+}
+
 matrix_def = {
     'type': 'array',
     'default': [],
@@ -111,6 +124,7 @@ properties = {
                                             'properties': union_dicts(
                                                 sub_props,
                                                 {
+                                                    'zips': zips_def,
                                                     'matrix': matrix_def,
                                                     'matrices': matrices_def,
                                                     'success_criteria': success_list_def,

--- a/lib/ramble/ramble/schema/spack.py
+++ b/lib/ramble/ramble/schema/spack.py
@@ -40,6 +40,7 @@ properties = {
                             'default': None,
                         },
                         'variables': ramble.schema.variables.variables_def,
+                        'zips': ramble.schema.applications.zips_def,
                         'matrix': ramble.schema.applications.matrix_def,
                         'matrices': ramble.schema.applications.matrices_def,
                     },
@@ -64,6 +65,7 @@ properties = {
                             'default': []
                         },
                         'variables': ramble.schema.variables.variables_def,
+                        'zips': ramble.schema.applications.zips_def,
                         'matrix': ramble.schema.applications.matrix_def,
                         'matrices': ramble.schema.applications.matrices_def,
                     },

--- a/lib/ramble/ramble/software_environments.py
+++ b/lib/ramble/ramble/software_environments.py
@@ -95,10 +95,14 @@ class SoftwareEnvironments(object):
                 self._raw_packages[pkg_template] = pkg_info
                 self._package_map[pkg_template] = []
                 pkg_vars = workspace_vars.copy()
+                pkg_zips = {}
                 pkg_matrices = []
 
                 if namespace.variables in pkg_info:
                     pkg_vars.update(pkg_info[namespace.variables])
+
+                if namespace.zips in pkg_info:
+                    pkg_zips = pkg_info[namespace.zips].copy()
 
                 if namespace.matrices in pkg_info:
                     pkg_matrices = pkg_info[namespace.matrices].copy()
@@ -108,7 +112,7 @@ class SoftwareEnvironments(object):
 
                 pkg_vars['package_name'] = pkg_template
 
-                for rendered_vars in pkg_renderer.render_objects(pkg_vars, pkg_matrices):
+                for rendered_vars in pkg_renderer.render_objects(pkg_vars, pkg_zips, pkg_matrices):
                     final_name = expander.expand_var_name('package_name',
                                                           extra_vars=rendered_vars)
                     self._packages[final_name] = {}
@@ -131,12 +135,16 @@ class SoftwareEnvironments(object):
         if namespace.environments in self.spack_dict:
             for env_template, env_info in self.spack_dict[namespace.environments].items():
                 env_vars = workspace_vars.copy()
+                env_zips = {}
                 env_matrices = []
                 self._raw_environments[env_template] = env_info
                 self._environment_map[env_template] = []
 
                 if namespace.variables in env_info:
                     env_vars.update(env_info[namespace.variables])
+
+                if namespace.zips in env_info:
+                    env_zips = env_info[namespace.zips].copy()
 
                 if namespace.matrices in env_info:
                     env_matrices = env_info[namespace.matrices].copy()
@@ -146,7 +154,7 @@ class SoftwareEnvironments(object):
 
                 env_vars['environment_name'] = env_template
 
-                for rendered_vars in env_renderer.render_objects(env_vars, env_matrices):
+                for rendered_vars in env_renderer.render_objects(env_vars, env_zips, env_matrices):
                     final_name = expander.expand_var_name('environment_name',
                                                           extra_vars=rendered_vars)
                     self._environment_map[env_template].append(final_name)

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -882,12 +882,12 @@ ramble:
     workspace_flags = ['-w', workspace_name]
 
     output = workspace('info', global_args=workspace_flags, fail_on_error=False)
-    assert "variable foo has not been defined yet" in output
+    assert "variable or zip foo has not been defined yet" in output
 
     output = workspace('setup', '--dry-run',
                        global_args=workspace_flags,
                        fail_on_error=False)
-    assert "variable foo has not been defined yet" in output
+    assert "variable or zip foo has not been defined yet" in output
 
 
 def test_non_vector_var_matrices_workspace():

--- a/lib/ramble/ramble/test/end_to_end/explicit_zips.py
+++ b/lib/ramble/ramble/test/end_to_end/explicit_zips.py
@@ -1,0 +1,271 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+import glob
+
+import pytest
+
+import ramble.workspace
+import ramble.config
+import ramble.software_environments
+from ramble.main import RambleCommand
+
+
+# everything here uses the mock_workspace_path
+pytestmark = pytest.mark.usefixtures('mutable_config',
+                                     'mutable_mock_workspace_path')
+
+workspace = RambleCommand('workspace')
+
+
+def test_wrfv4_explicit_zips(mutable_config, mutable_mock_workspace_path):
+    test_config = """
+ramble:
+  variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
+    partition: ['part1', 'part2']
+    processes_per_node: ['16', '36']
+    n_ranks: '{processes_per_node}*{n_nodes}'
+    n_threads: '1'
+  applications:
+    wrfv4:
+      variables:
+        env_name: ['wrfv4', 'wrfv4-portable']
+      workloads:
+        CONUS_12km:
+          experiments:
+            scaling_{n_nodes}_{partition}_{env_name}:
+              success_criteria:
+              - name: 'timing'
+                mode: 'string'
+                match: '.*Timing for main.*'
+                file: '{experiment_run_dir}/rsl.out.0000'
+              env_vars:
+                set:
+                  OMP_NUM_THREADS: '{n_threads}'
+                  TEST_VAR: '1'
+                append:
+                - var-separator: ', '
+                  vars:
+                    TEST_VAR: 'add_var'
+                - paths:
+                    TEST_VAR: 'new_path'
+                prepend:
+                - paths:
+                    TEST_VAR: 'pre_path'
+                unset:
+                - TEST_VAR
+              variables:
+                n_nodes: ['1', '2', '4', '8', '16']
+              zips:
+                partitions:
+                - partition
+                - processes_per_node
+              matrix:
+              - n_nodes
+              - env_name
+              - partitions
+  spack:
+    concretized: true
+    packages:
+      gcc:
+        spack_spec: gcc@8.5.0
+      intel-mpi:
+        spack_spec: intel-mpi@2018.4.274
+        compiler: gcc
+      wrfv4:
+        spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf
+        compiler: gcc
+      wrfv4-portable:
+        spack_spec: 'wrf@4.2 build_type=dm+sm compile_type=em_real
+          nesting=basic ~chem ~pnetcdf target=x86_64'
+        compiler: gcc
+    environments:
+      wrfv4:
+        packages:
+        - wrfv4
+        - intel-mpi
+      wrfv4-portable:
+        packages:
+        - wrfv4-portable
+        - intel-mpi
+"""
+
+    test_licenses = """
+licenses:
+  wrfv4:
+    set:
+      WRF_LICENSE: port@server
+"""
+
+    workspace_name = 'test_end_to_end_wrfv4'
+    with ramble.workspace.create(workspace_name) as ws1:
+        ws1.write()
+
+        config_path = os.path.join(ws1.config_dir, ramble.workspace.config_file_name)
+        license_path = os.path.join(ws1.config_dir, 'licenses.yaml')
+
+        aux_software_path = os.path.join(ws1.config_dir,
+                                         ramble.workspace.auxiliary_software_dir_name)
+        aux_software_files = ['packages.yaml', 'my_test.sh']
+
+        with open(config_path, 'w+') as f:
+            f.write(test_config)
+
+        with open(license_path, 'w+') as f:
+            f.write(test_licenses)
+
+        for file in aux_software_files:
+            file_path = os.path.join(aux_software_path, file)
+            with open(file_path, 'w+') as f:
+                f.write('')
+
+        # Write a command template
+        with open(os.path.join(ws1.config_dir, 'full_command.tpl'), 'w+') as f:
+            f.write('{command}')
+
+        ws1._re_read()
+
+        output = workspace('setup', '--dry-run', global_args=['-w', workspace_name])
+        assert "Would download https://www2.mmm.ucar.edu/wrf/users/benchmark/v422/v42_bench_conus12km.tar.gz" in output
+
+        # Test software directories
+        software_dirs = ['wrfv4.CONUS_12km', 'wrfv4-portable.CONUS_12km']
+        software_base_dir = os.path.join(ws1.root, ramble.workspace.workspace_software_path)
+        assert os.path.exists(software_base_dir)
+        for software_dir in software_dirs:
+            software_path = os.path.join(software_base_dir, software_dir)
+            assert os.path.exists(software_path)
+
+            spack_file = os.path.join(software_path, 'spack.yaml')
+            assert os.path.exists(spack_file)
+            for file in aux_software_files:
+                file_path = os.path.join(software_path, file)
+                assert os.path.exists(file_path)
+
+        expected_experiments = [
+            'scaling_1_part1_wrfv4',
+            'scaling_2_part1_wrfv4',
+            'scaling_4_part1_wrfv4',
+            'scaling_8_part1_wrfv4',
+            'scaling_16_part1_wrfv4',
+            'scaling_1_part2_wrfv4',
+            'scaling_2_part2_wrfv4',
+            'scaling_4_part2_wrfv4',
+            'scaling_8_part2_wrfv4',
+            'scaling_16_part2_wrfv4',
+            'scaling_1_part1_wrfv4-portable',
+            'scaling_2_part1_wrfv4-portable',
+            'scaling_4_part1_wrfv4-portable',
+            'scaling_8_part1_wrfv4-portable',
+            'scaling_16_part1_wrfv4-portable',
+            'scaling_1_part2_wrfv4-portable',
+            'scaling_2_part2_wrfv4-portable',
+            'scaling_4_part2_wrfv4-portable',
+            'scaling_8_part2_wrfv4-portable',
+            'scaling_16_part2_wrfv4-portable'
+        ]
+
+        # Test experiment directories
+        for exp in expected_experiments:
+            exp_dir = os.path.join(ws1.root, 'experiments', 'wrfv4', 'CONUS_12km', exp)
+            assert os.path.isdir(exp_dir)
+            assert os.path.exists(os.path.join(exp_dir, 'execute_experiment'))
+            assert os.path.exists(os.path.join(exp_dir, 'full_command'))
+
+            with open(os.path.join(exp_dir, 'full_command'), 'r') as f:
+                data = f.read()
+                # Test the license exists
+                assert "export WRF_LICENSE=port@server" in data
+
+                # Test the required environment variables exist
+                assert 'export OMP_NUM_THREADS="1"' in data
+                assert "export TEST_VAR=1" in data
+                assert 'unset TEST_VAR' in data
+
+                # Test the expected portions of the execution command exist
+                assert "sed -i -e 's/ start_hour.*/ start_hour" in data
+                assert "sed -i -e 's/ restart .*/ restart" in data
+                assert "mpirun" in data
+                assert "wrf.exe" in data
+
+                # Test the run script has a reference to the experiment log file
+                assert os.path.join(exp_dir, f'{exp}.out') in data
+
+            with open(os.path.join(exp_dir, 'execute_experiment'), 'r') as f:
+                data = f.read()
+                # Test the license exists
+                assert "export WRF_LICENSE=port@server" in data
+
+                # Test the required environment variables exist
+                assert 'export OMP_NUM_THREADS="1"' in data
+                assert "export TEST_VAR=1" in data
+                assert 'unset TEST_VAR' in data
+
+                # Test the expected portions of the execution command exist
+                assert "sed -i -e 's/ start_hour.*/ start_hour" in data
+                assert "sed -i -e 's/ restart .*/ restart" in data
+                assert "mpirun" in data
+                assert "wrf.exe" in data
+
+                # Test the run script has a reference to the experiment log file
+                assert os.path.join(exp_dir, f'{exp}.out') in data
+
+                # Test that spack is used
+                assert "spack env activate" in data
+
+            # Create fake figures of merit.
+            with open(os.path.join(exp_dir, 'rsl.out.0000'), 'w+') as f:
+                for i in range(1, 6):
+                    f.write(f'Timing for main {i}{i}.{i}\n')
+                f.write('wrf: SUCCESS COMPLETE WRF\n')
+
+            # Create files that match archive patterns
+            for i in range(0, 5):
+                new_name = 'rsl.error.000%s' % i
+                new_file = os.path.join(exp_dir, new_name)
+
+                f = open(new_file, 'w+')
+                f.close()
+
+        output = workspace('analyze', '-f', 'text',
+                           'json', 'yaml', global_args=['-w', workspace_name])
+        text_simlink_results_files = glob.glob(os.path.join(ws1.root, 'results.latest.txt'))
+        text_results_files = glob.glob(os.path.join(ws1.root, 'results*.txt'))
+        json_results_files = glob.glob(os.path.join(ws1.root, 'results*.json'))
+        yaml_results_files = glob.glob(os.path.join(ws1.root, 'results*.yaml'))
+        assert len(text_simlink_results_files) == 1
+        assert len(text_results_files) == 2
+        assert len(json_results_files) == 2
+        assert len(yaml_results_files) == 2
+
+        with open(text_results_files[0], 'r') as f:
+            data = f.read()
+            assert 'Average Timestep Time = 3.3 s' in data
+            assert 'Cumulative Timestep Time = 16.5 s' in data
+            assert 'Minimum Timestep Time = 1.1 s' in data
+            assert 'Maximum Timestep Time = 5.5 s' in data
+            assert 'Avg. Max Ratio Time = 0.6' in data
+            assert 'Number of timesteps = 5' in data
+
+        output = workspace('archive', global_args=['-w', workspace_name])
+
+        assert ws1.latest_archive
+        assert os.path.exists(ws1.latest_archive_path)
+
+        for exp in expected_experiments:
+            exp_dir = os.path.join(ws1.latest_archive_path, 'experiments',
+                                   'wrfv4', 'CONUS_12km', exp)
+            assert os.path.isdir(exp_dir)
+            assert os.path.exists(os.path.join(exp_dir, 'execute_experiment'))
+            assert os.path.exists(os.path.join(exp_dir, 'full_command'))
+            assert os.path.exists(os.path.join(exp_dir, 'rsl.out.0000'))
+            for i in range(0, 5):
+                assert os.path.exists(os.path.join(exp_dir, f'rsl.error.000{i}'))

--- a/lib/ramble/ramble/test/experiment_set.py
+++ b/lib/ramble/ramble/test/experiment_set.py
@@ -55,7 +55,7 @@ def test_single_experiment_in_set(mutable_mock_workspace_path):
 
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
-        exp_set.set_experiment_context(exp_name, exp_vars, None, None, None, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, None, None, None, None, None)
         exp_set.build_experiment_chains()
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
@@ -93,7 +93,7 @@ def test_vector_experiment_in_set(mutable_mock_workspace_path):
 
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
-        exp_set.set_experiment_context(exp_name, exp_vars, None, None, None, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, None, None, None, None, None)
         exp_set.build_experiment_chains()
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
@@ -133,7 +133,7 @@ def test_nonunique_vector_errors(mutable_mock_workspace_path, capsys):
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         with pytest.raises(SystemExit):
-            exp_set.set_experiment_context(exp_name, exp_vars, None, None, None, None, None)
+            exp_set.set_experiment_context(exp_name, exp_vars, None, None, None, None, None, None)
             captured = capsys.readouterr()
             assert "is not unique." in captured
 
@@ -170,7 +170,7 @@ def test_zipped_vector_experiments(mutable_mock_workspace_path):
 
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
-        exp_set.set_experiment_context(exp_name, exp_vars, None, None, None, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, None, None, None, None, None)
         exp_set.build_experiment_chains()
 
         assert 'basic.test_wl.series1_4_2' in exp_set.experiments.keys()
@@ -213,7 +213,8 @@ def test_matrix_experiments(mutable_mock_workspace_path):
 
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
-        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, None, exp_matrices, None,
+                                       None, None)
         exp_set.build_experiment_chains()
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
@@ -256,7 +257,8 @@ def test_matrix_multiplication_experiments(mutable_mock_workspace_path):
 
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
-        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, None, exp_matrices, None,
+                                       None, None)
         exp_set.build_experiment_chains()
 
         assert 'basic.test_wl.series1_2' in exp_set.experiments.keys()
@@ -303,7 +305,8 @@ def test_matrix_vector_experiments(mutable_mock_workspace_path):
 
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
-        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, None, exp_matrices, None,
+                                       None, None)
         exp_set.build_experiment_chains()
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
@@ -349,7 +352,8 @@ def test_multi_matrix_experiments(mutable_mock_workspace_path):
 
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
-        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, None, exp_matrices, None,
+                                       None, None)
         exp_set.build_experiment_chains()
 
         assert 'basic.test_wl.series1_4_2' in exp_set.experiments.keys()
@@ -395,7 +399,7 @@ def test_matrix_undefined_var_errors(mutable_mock_workspace_path, capsys):
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
 
         with pytest.raises(SystemExit):
-            exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices,
+            exp_set.set_experiment_context(exp_name, exp_vars, None, None, exp_matrices,
                                            None, None, None)
             captured = capsys.readouterr()
             assert "variable foo has not been defined yet." in captured
@@ -438,7 +442,8 @@ def test_experiment_names_match(mutable_mock_workspace_path):
 
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
-        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, None, exp_matrices, None,
+                                       None, None)
         exp_set.build_experiment_chains()
 
         assert 'basic.test_wl.series1_4_2' in exp_set.experiments.keys()
@@ -489,8 +494,8 @@ def test_cross_experiment_variable_references(mutable_mock_workspace_path):
 
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
-        exp_set.set_experiment_context(exp1_name, exp1_vars, None, None, None, None, None)
-        exp_set.set_experiment_context(exp2_name, exp2_vars, None, None, None, None, None)
+        exp_set.set_experiment_context(exp1_name, exp1_vars, None, None, None, None, None, None)
+        exp_set.set_experiment_context(exp2_name, exp2_vars, None, None, None, None, None, None)
         exp_set.build_experiment_chains()
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
@@ -533,7 +538,7 @@ def test_cross_experiment_missing_experiment_errors(mutable_mock_workspace_path)
 
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
-        exp_set.set_experiment_context(exp1_name, exp1_vars, None, None, None, None, None)
+        exp_set.set_experiment_context(exp1_name, exp1_vars, None, None, None, None, None, None)
         exp_set.build_experiment_chains()
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
@@ -581,7 +586,8 @@ def test_n_ranks_correct_defaults(mutable_mock_workspace_path):
 
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
-        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, None, exp_matrices, None,
+                                       None, None)
         exp_set.build_experiment_chains()
 
         assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
@@ -623,7 +629,8 @@ def test_n_nodes_correct_defaults(mutable_mock_workspace_path):
 
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
-        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_matrices, None, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, None, exp_matrices, None,
+                                       None, None)
         exp_set.build_experiment_chains()
 
         assert 'basic.test_wl.series1_4_2' in exp_set.experiments.keys()
@@ -663,7 +670,7 @@ def test_processes_per_node_correct_defaults(mutable_mock_workspace_path):
 
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
-        exp_set.set_experiment_context(exp_name, exp_vars, None, None, None, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, None, None, None, None, None)
         exp_set.build_experiment_chains()
 
         assert 'basic.test_wl.series1_4_2' in exp_set.experiments.keys()
@@ -773,7 +780,7 @@ def test_reserved_keywords_error_in_experiment(mutable_mock_workspace_path, var,
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         with pytest.raises(ramble.experiment_set.RambleVariableDefinitionError):
-            exp_set.set_experiment_context(exp_name, exp_vars, None, None, None, None, None)
+            exp_set.set_experiment_context(exp_name, exp_vars, None, None, None, None, None, None)
             captured = capsys.readouterr()
             assert "In experiment basic.test_wl.series1_{n_ranks}_{processes_per_node}" in captured
             assert f"{var}" in captured
@@ -821,7 +828,7 @@ def test_missing_required_keyword_errors(mutable_mock_workspace_path, var, capsy
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
         with pytest.raises(ramble.experiment_set.RambleVariableDefinitionError):
-            exp_set.set_experiment_context(exp_name, exp_vars, None, None, None, None, None)
+            exp_set.set_experiment_context(exp_name, exp_vars, None, None, None, None, None, None)
             captured = capsys.readouterr()
             assert f'Required key "{var}" is not defined' in captured.err
             assert 'One or more required keys are not defined within an experiment.' \
@@ -879,8 +886,9 @@ def test_chained_experiments_populate_new_experiments(mutable_mock_workspace_pat
 
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
-        exp_set.set_experiment_context(exp1_name, exp1_vars, None, None, None, None, None)
-        exp_set.set_experiment_context(exp2_name, exp2_vars, None, None, None, None, exp2_chains)
+        exp_set.set_experiment_context(exp1_name, exp1_vars, None, None, None, None, None, None)
+        exp_set.set_experiment_context(exp2_name, exp2_vars, None, None, None, None, None,
+                                       exp2_chains)
         exp_set.build_experiment_chains()
 
         assert 'basic.test_wl.series2_4' in \
@@ -941,8 +949,9 @@ def test_chained_experiment_has_correct_directory(mutable_mock_workspace_path, c
 
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
-        exp_set.set_experiment_context(exp1_name, exp1_vars, None, None, None, None, None)
-        exp_set.set_experiment_context(exp2_name, exp2_vars, None, None, None, None, exp2_chains)
+        exp_set.set_experiment_context(exp1_name, exp1_vars, None, None, None, None, None, None)
+        exp_set.set_experiment_context(exp2_name, exp2_vars, None, None, None, None, None,
+                                       exp2_chains)
         exp_set.build_experiment_chains()
 
         parent_name = 'basic.test_wl.series2_4'
@@ -1002,8 +1011,9 @@ def test_chained_cycle_errors(mutable_mock_workspace_path, capsys):
 
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
-        exp_set.set_experiment_context(exp1_name, exp1_vars, None, None, None, None, None)
-        exp_set.set_experiment_context(exp2_name, exp2_vars, None, None, None, None, exp2_chains)
+        exp_set.set_experiment_context(exp1_name, exp1_vars, None, None, None, None, None, None)
+        exp_set.set_experiment_context(exp2_name, exp2_vars, None, None, None, None, None,
+                                       exp2_chains)
         with pytest.raises(ChainCycleDetectedError):
             exp_set.build_experiment_chains()
             captured = capsys.readouterr
@@ -1053,8 +1063,9 @@ def test_chained_invalid_order_errors(mutable_mock_workspace_path, capsys):
 
         exp_set.set_application_context(app_name, app_vars, None, None, None, None)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
-        exp_set.set_experiment_context(exp1_name, exp1_vars, None, None, None, None, None)
-        exp_set.set_experiment_context(exp2_name, exp2_vars, None, None, None, None, exp2_chains)
+        exp_set.set_experiment_context(exp1_name, exp1_vars, None, None, None, None, None, None)
+        exp_set.set_experiment_context(exp2_name, exp2_vars, None, None, None, None, None,
+                                       exp2_chains)
         with pytest.raises(InvalidChainError):
             exp_set.build_experiment_chains()
             captured = capsys.readouterr
@@ -1121,7 +1132,7 @@ def test_modifiers_set_correctly(mutable_mock_workspace_path, capsys):
 
         exp_set.set_application_context(app_name, app_vars, None, None, None, None, app_mods)
         exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None, wl_mods)
-        exp_set.set_experiment_context(exp1_name, exp1_vars, None, None, None,
+        exp_set.set_experiment_context(exp1_name, exp1_vars, None, None, None, None,
                                        None, None, exp1_mods)
 
         assert 'basic.test_wl.test1' in exp_set.experiments
@@ -1133,3 +1144,366 @@ def test_modifiers_set_correctly(mutable_mock_workspace_path, capsys):
             assert mod_def['name'] in expected_modifiers
             expected_modifiers.remove(mod_def['name'])
         assert len(expected_modifiers) == 0
+
+
+def test_explicit_zips_work(mutable_mock_workspace_path):
+    workspace('create', 'test')
+
+    assert 'test' in workspace('list')
+
+    with ramble.workspace.read('test') as ws:
+        exp_set = ramble.experiment_set.ExperimentSet(ws)
+
+        app_name = 'basic'
+        app_vars = {
+            'app_var1': '1',
+            'app_var2': '2',
+            'n_ranks': '{processes_per_node}*{n_nodes}',
+            'mpi_command': '',
+            'batch_submit': ''
+        }
+
+        wl_name = 'test_wl'
+        wl_vars = {
+            'wl_var1': '1',
+            'wl_var2': '2',
+            'processes_per_node': '2'
+        }
+        exp_name = 'series1_{n_ranks}'
+        exp_vars = {
+            'exp_var1': '1',
+            'exp_var2': '2',
+            'n_nodes': ['2', '4']
+        }
+
+        exp_zips = {
+            'test_zip': ['n_nodes']
+        }
+
+        exp_set.set_application_context(app_name, app_vars, None, None, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_zips, None, None,
+                                       None, None, None)
+        exp_set.build_experiment_chains()
+
+        assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
+        assert 'basic.test_wl.series1_8' in exp_set.experiments.keys()
+
+
+def test_explicit_zips_in_matrix(mutable_mock_workspace_path):
+    workspace('create', 'test')
+
+    assert 'test' in workspace('list')
+
+    with ramble.workspace.read('test') as ws:
+        exp_set = ramble.experiment_set.ExperimentSet(ws)
+
+        app_name = 'basic'
+        app_vars = {
+            'app_var1': '1',
+            'app_var2': '2',
+            'n_ranks': '{processes_per_node}*{n_nodes}',
+            'mpi_command': '',
+            'batch_submit': ''
+        }
+
+        wl_name = 'test_wl'
+        wl_vars = {
+            'wl_var1': '1',
+            'wl_var2': '2',
+            'processes_per_node': '2'
+        }
+        exp_name = 'series1_{n_ranks}_{exp_var1}'
+        exp_vars = {
+            'exp_var1': ['1', 'a', '3'],
+            'exp_var2': ['2', 'b', '4'],
+            'n_nodes': ['2', '4']
+        }
+
+        exp_matrices = [['test_zip']]
+
+        exp_zips = {
+            'test_zip': ['exp_var1', 'exp_var2']
+        }
+
+        exp_set.set_application_context(app_name, app_vars, None, None, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_zips, exp_matrices, None,
+                                       None, None, None)
+        exp_set.build_experiment_chains()
+
+        assert 'basic.test_wl.series1_4_1' in exp_set.experiments.keys()
+        assert 'basic.test_wl.series1_4_a' in exp_set.experiments.keys()
+        assert 'basic.test_wl.series1_4_3' in exp_set.experiments.keys()
+        assert 'basic.test_wl.series1_8_1' in exp_set.experiments.keys()
+        assert 'basic.test_wl.series1_8_a' in exp_set.experiments.keys()
+        assert 'basic.test_wl.series1_8_3' in exp_set.experiments.keys()
+
+
+def test_explicit_zips_unconsumed(mutable_mock_workspace_path):
+    workspace('create', 'test')
+
+    assert 'test' in workspace('list')
+
+    with ramble.workspace.read('test') as ws:
+        exp_set = ramble.experiment_set.ExperimentSet(ws)
+
+        app_name = 'basic'
+        app_vars = {
+            'app_var1': '1',
+            'app_var2': '2',
+            'n_ranks': '{processes_per_node}*{n_nodes}',
+            'mpi_command': '',
+            'batch_submit': ''
+        }
+
+        wl_name = 'test_wl'
+        wl_vars = {
+            'wl_var1': '1',
+            'wl_var2': '2',
+            'processes_per_node': '2'
+        }
+        exp_name = 'series1_{n_ranks}_{exp_var1}'
+        exp_vars = {
+            'exp_var1': ['1', 'a', '3'],
+            'exp_var2': ['2', 'b', '4'],
+            'n_nodes': ['2', '4']
+        }
+
+        exp_matrices = [['n_nodes']]
+
+        exp_zips = {
+            'test_zip': ['exp_var1', 'exp_var2']
+        }
+
+        exp_set.set_application_context(app_name, app_vars, None, None, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_zips, exp_matrices, None,
+                                       None, None, None)
+        exp_set.build_experiment_chains()
+
+        assert 'basic.test_wl.series1_4_1' in exp_set.experiments.keys()
+        assert 'basic.test_wl.series1_4_a' in exp_set.experiments.keys()
+        assert 'basic.test_wl.series1_4_3' in exp_set.experiments.keys()
+        assert 'basic.test_wl.series1_8_1' in exp_set.experiments.keys()
+        assert 'basic.test_wl.series1_8_a' in exp_set.experiments.keys()
+        assert 'basic.test_wl.series1_8_3' in exp_set.experiments.keys()
+
+
+def test_single_var_explicit_zip(mutable_mock_workspace_path):
+    workspace('create', 'test')
+
+    assert 'test' in workspace('list')
+
+    with ramble.workspace.read('test') as ws:
+        exp_set = ramble.experiment_set.ExperimentSet(ws)
+
+        app_name = 'basic'
+        app_vars = {
+            'app_var1': '1',
+            'app_var2': '2',
+            'n_ranks': '{processes_per_node}*{n_nodes}',
+            'mpi_command': '',
+            'batch_submit': ''
+        }
+
+        wl_name = 'test_wl'
+        wl_vars = {
+            'wl_var1': '1',
+            'wl_var2': '2',
+            'processes_per_node': '2'
+        }
+        exp_name = 'series1_{n_ranks}'
+        exp_vars = {
+            'exp_var1': '1',
+            'exp_var2': '2',
+            'n_nodes': ['2', '4']
+        }
+
+        exp_zips = {
+            'test_zip': ['n_nodes'],
+        }
+
+        exp_set.set_application_context(app_name, app_vars, None, None, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
+        exp_set.set_experiment_context(exp_name, exp_vars, None, exp_zips, None, None,
+                                       None, None, None)
+        exp_set.build_experiment_chains()
+
+        assert 'basic.test_wl.series1_4' in exp_set.experiments.keys()
+        assert 'basic.test_wl.series1_8' in exp_set.experiments.keys()
+
+
+def test_zip_undefined_var_errors(mutable_mock_workspace_path, capsys):
+    workspace('create', 'test')
+
+    assert 'test' in workspace('list')
+
+    with ramble.workspace.read('test') as ws:
+        exp_set = ramble.experiment_set.ExperimentSet(ws)
+
+        app_name = 'basic'
+        app_vars = {
+            'app_var1': '1',
+            'app_var2': '2',
+            'n_ranks': '{processes_per_node}*{n_nodes}',
+            'mpi_command': '',
+            'batch_submit': ''
+        }
+
+        wl_name = 'test_wl'
+        wl_vars = {
+            'wl_var1': '1',
+            'wl_var2': '2',
+            'processes_per_node': '2'
+        }
+        exp_name = 'series1_{n_ranks}'
+        exp_vars = {
+            'exp_var1': '1',
+            'exp_var2': '2',
+            'n_nodes': ['2', '4']
+        }
+
+        exp_zips = {
+            'test_zip': ['foo'],
+        }
+
+        exp_set.set_application_context(app_name, app_vars, None, None, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
+        with pytest.raises(SystemExit):
+            exp_set.set_experiment_context(exp_name, exp_vars, None, exp_zips, None, None,
+                                           None, None, None)
+            captured = capsys.readouterr()
+            assert "An undefined variable foo is defined in zip test_zip" in captured
+
+
+def test_zip_multi_use_var_errors(mutable_mock_workspace_path, capsys):
+    workspace('create', 'test')
+
+    assert 'test' in workspace('list')
+
+    with ramble.workspace.read('test') as ws:
+        exp_set = ramble.experiment_set.ExperimentSet(ws)
+
+        app_name = 'basic'
+        app_vars = {
+            'app_var1': '1',
+            'app_var2': '2',
+            'n_ranks': '{processes_per_node}*{n_nodes}',
+            'mpi_command': '',
+            'batch_submit': ''
+        }
+
+        wl_name = 'test_wl'
+        wl_vars = {
+            'wl_var1': '1',
+            'wl_var2': '2',
+            'processes_per_node': '2'
+        }
+        exp_name = 'series1_{n_ranks}'
+        exp_vars = {
+            'exp_var1': '1',
+            'exp_var2': '2',
+            'n_nodes': ['2', '4']
+        }
+
+        exp_zips = {
+            'test_zip1': ['n_nodes'],
+            'test_zip2': ['n_nodes'],
+        }
+
+        exp_set.set_application_context(app_name, app_vars, None, None, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
+        with pytest.raises(SystemExit):
+            exp_set.set_experiment_context(exp_name, exp_vars, None, exp_zips, None, None,
+                                           None, None, None)
+            captured = capsys.readouterr()
+            assert 'Variable n_nodes is used across multiple zips' in captured
+
+
+def test_zip_non_list_var_errors(mutable_mock_workspace_path, capsys):
+    workspace('create', 'test')
+
+    assert 'test' in workspace('list')
+
+    with ramble.workspace.read('test') as ws:
+        exp_set = ramble.experiment_set.ExperimentSet(ws)
+
+        app_name = 'basic'
+        app_vars = {
+            'app_var1': '1',
+            'app_var2': '2',
+            'n_ranks': '{processes_per_node}*{n_nodes}',
+            'mpi_command': '',
+            'batch_submit': ''
+        }
+
+        wl_name = 'test_wl'
+        wl_vars = {
+            'wl_var1': '1',
+            'wl_var2': '2',
+            'processes_per_node': '2'
+        }
+        exp_name = 'series1_{n_ranks}'
+        exp_vars = {
+            'exp_var1': '1',
+            'exp_var2': '2',
+            'n_nodes': ['2', '4']
+        }
+
+        exp_zips = {
+            'test_zip': ['exp_var1'],
+        }
+
+        exp_set.set_application_context(app_name, app_vars, None, None, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
+        with pytest.raises(SystemExit):
+            exp_set.set_experiment_context(exp_name, exp_vars, None, exp_zips, None, None,
+                                           None, None, None)
+            captured = capsys.readouterr()
+            assert 'Variable exp_var1 in zip test_zip does not refer to a vector' in captured
+
+
+def test_zip_variable_lengths_errors(mutable_mock_workspace_path, capsys):
+    workspace('create', 'test')
+
+    assert 'test' in workspace('list')
+
+    with ramble.workspace.read('test') as ws:
+        exp_set = ramble.experiment_set.ExperimentSet(ws)
+
+        app_name = 'basic'
+        app_vars = {
+            'app_var1': '1',
+            'app_var2': '2',
+            'n_ranks': '{processes_per_node}*{n_nodes}',
+            'mpi_command': '',
+            'batch_submit': ''
+        }
+
+        wl_name = 'test_wl'
+        wl_vars = {
+            'wl_var1': '1',
+            'wl_var2': '2',
+            'processes_per_node': '2'
+        }
+        exp_name = 'series1_{n_ranks}'
+        exp_vars = {
+            'exp_var1': '1',
+            'exp_var2': ['2'],
+            'n_nodes': ['2', '4']
+        }
+
+        exp_zips = {
+            'test_zip': ['n_nodes', 'exp_var2'],
+        }
+
+        exp_set.set_application_context(app_name, app_vars, None, None, None, None)
+        exp_set.set_workload_context(wl_name, wl_vars, None, None, None, None)
+        with pytest.raises(SystemExit):
+            exp_set.set_experiment_context(exp_name, exp_vars, None, exp_zips, None, None,
+                                           None, None, None)
+            captured = capsys.readouterr()
+            assert 'Variable exp_var2 in zip test_zip' in captured
+            assert 'has a length of 1 which differs from' in captured
+            assert 'the current max of 2' in captured

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -742,12 +742,13 @@ class Workspace(object):
                                                     workload_template, workload_chained_exps,
                                                     workload_mods)
 
-                for experiment, _, exp_vars, exp_env_vars, exp_matrices, exp_ints, \
+                for experiment, _, exp_vars, exp_env_vars, exp_zips, exp_matrices, exp_ints, \
                         exp_template, exp_chained_exps, exp_mods \
                         in self.all_experiments(experiments):
                     experiment_set.set_experiment_context(experiment,
                                                           exp_vars,
                                                           exp_env_vars,
+                                                          exp_zips,
                                                           exp_matrices,
                                                           exp_ints,
                                                           exp_template,
@@ -908,6 +909,7 @@ class Workspace(object):
             experiment_template = False
             experiment_chained_experiments = None
             experiment_modifiers = None
+            experiment_zips = None
 
             if namespace.variables in contents:
                 experiment_vars = contents[namespace.variables]
@@ -929,6 +931,9 @@ class Workspace(object):
 
             self.extract_success_criteria('experiment', contents)
 
+            if namespace.zips in contents:
+                experiment_zips = contents[namespace.zips]
+
             matrices = []
             if 'matrix' in contents:
                 matrices.append(contents['matrix'])
@@ -948,7 +953,7 @@ class Workspace(object):
                         matrices.append(matrix)
 
             yield experiment, contents, experiment_vars, \
-                experiment_env_vars, matrices, experiment_internals, \
+                experiment_env_vars, experiment_zips, matrices, experiment_internals, \
                 experiment_template, experiment_chained_experiments, \
                 experiment_modifiers
 


### PR DESCRIPTION
This merge adds support for explicit zips, which are a new feature in defining experiments. Zips are named groups of variables with the same length, and can be consumed as a dimension of a matrix.

This merge adds tests, and documentation to support this feature.