### PR TITLE
Add `expand_var_name` function to expander

### DIFF
--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -71,24 +71,21 @@ class Expander(object):
     @property
     def application_name(self):
         if not self._application_name:
-            var = self.expansion_str(self._keywords.application_name)
-            self._application_name = self.expand_var(var)
+            self._application_name = self.expand_var_name(self._keywords.application_name)
 
         return self._application_name
 
     @property
     def workload_name(self):
         if not self._workload_name:
-            var = self.expansion_str(self._keywords.workload_name)
-            self._workload_name = self.expand_var(var)
+            self._workload_name = self.expand_var_name(self._keywords.workload_name)
 
         return self._workload_name
 
     @property
     def experiment_name(self):
         if not self._experiment_name:
-            var = self.expansion_str(self._keywords.experiment_name)
-            self._experiment_name = self.expand_var(var)
+            self._experiment_name = self.expand_var_name(self._keywords.experiment_name)
 
         return self._experiment_name
 
@@ -128,40 +125,36 @@ class Expander(object):
     @property
     def application_input_dir(self):
         if not self._application_input_dir:
-            var = self.expansion_str(self._keywords.application_input_dir)
-            self._application_input_dir = self.expand_var(var)
+            self._application_input_dir = \
+                self.expand_var_name(self._keywords.application_input_dir)
 
         return self._application_input_dir
 
     @property
     def workload_input_dir(self):
         if not self._workload_input_dir:
-            var = self.expansion_str(self._keywords.workload_input_dir)
-            self._workload_input_dir = self.expand_var(var)
+            self._workload_input_dir = self.expand_var_name(self._keywords.workload_input_dir)
 
         return self._workload_input_dir
 
     @property
     def application_run_dir(self):
         if not self._application_run_dir:
-            var = self.expansion_str(self._keywords.application_run_dir)
-            self._application_run_dir = self.expand_var(var)
+            self._application_run_dir = self.expand_var_name(self._keywords.application_run_dir)
 
         return self._application_run_dir
 
     @property
     def workload_run_dir(self):
         if not self._workload_run_dir:
-            var = self.expansion_str(self._keywords.workload_run_dir)
-            self._workload_run_dir = self.expand_var(var)
+            self._workload_run_dir = self.expand_var_name(self._keywords.workload_run_dir)
 
         return self._workload_run_dir
 
     @property
     def experiment_run_dir(self):
         if not self._experiment_run_dir:
-            var = self.expansion_str(self._keywords.experiment_run_dir)
-            self._experiment_run_dir = self.expand_var(var)
+            self._experiment_run_dir = self.expand_var_name(self._keywords.experiment_run_dir)
 
         return self._experiment_run_dir
 
@@ -190,6 +183,23 @@ class Expander(object):
             return var
         except SyntaxError:
             return var
+
+    def expand_var_name(self, var_name, extra_vars=None, allow_passthrough=True):
+        """Convert a variable name to an expansion string, and expand it
+
+        Take a variable name (var) and convert it to an expansion string by
+        calling the expansion_str function. Pass the expansion string into
+        expand_var, and return the result.
+
+        Args:
+            var_name: String name of variable to expand
+            extra_vars: Variable definitions to use with highest precedence
+            allow_passthrough: Whether the string is allowed to have keywords
+                               after expansion
+        """
+        return self.expand_var(self.expansion_str(var_name),
+                               extra_vars=extra_vars,
+                               allow_passthrough=allow_passthrough)
 
     def expand_var(self, var, extra_vars=None, allow_passthrough=True):
         """Perform expansion of a string

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -428,10 +428,10 @@ class ExperimentSet(object):
 
             expander = ramble.expander.Expander(experiment_vars, self)
             self._compute_mpi_vars(expander, experiment_vars)
-            final_app_name = expander.expand_var(
-                Expander.expansion_str(self.keywords.application_name), allow_passthrough=False)
-            final_wl_name = expander.expand_var(
-                Expander.expansion_str(self.keywords.workload_name), allow_passthrough=False)
+            final_app_name = expander.expand_var_name(self.keywords.application_name,
+                                                      allow_passthrough=False)
+            final_wl_name = expander.expand_var_name(self.keywords.workload_name,
+                                                     allow_passthrough=False)
             final_exp_name = expander.expand_var(experiment_template_name, allow_passthrough=False)
 
             experiment_vars[self.keywords.experiment_template_name] = experiment_template_name

--- a/lib/ramble/ramble/software_environments.py
+++ b/lib/ramble/ramble/software_environments.py
@@ -109,9 +109,8 @@ class SoftwareEnvironments(object):
                 pkg_vars['package_name'] = pkg_template
 
                 for rendered_vars in pkg_renderer.render_objects(pkg_vars, pkg_matrices):
-                    expansion_str = expander.expansion_str('package_name')
-                    final_name = expander.expand_var(expansion_str,
-                                                     extra_vars=rendered_vars)
+                    final_name = expander.expand_var_name('package_name',
+                                                          extra_vars=rendered_vars)
                     self._packages[final_name] = {}
                     self._package_map[pkg_template].append(final_name)
 
@@ -148,9 +147,8 @@ class SoftwareEnvironments(object):
                 env_vars['environment_name'] = env_template
 
                 for rendered_vars in env_renderer.render_objects(env_vars, env_matrices):
-                    expansion_str = expander.expansion_str('environment_name')
-                    final_name = expander.expand_var(expansion_str,
-                                                     extra_vars=rendered_vars)
+                    final_name = expander.expand_var_name('environment_name',
+                                                          extra_vars=rendered_vars)
                     self._environment_map[env_template].append(final_name)
 
                     self._environments[final_name] = {}

--- a/lib/ramble/ramble/test/expander.py
+++ b/lib/ramble/ramble/test/expander.py
@@ -58,6 +58,25 @@ def test_expansions(input, output):
 
 
 @pytest.mark.parametrize(
+    'input,output',
+    [
+        ('application_name', 'foo'),
+        ('workload_name', 'bar'),
+        ('experiment_name', 'baz'),
+        ('var1', '3'),
+        ('var2', '3'),
+        ('var3', '3'),
+    ]
+)
+def test_expand_var_name(input, output):
+    expansion_vars = exp_dict()
+
+    expander = ramble.expander.Expander(expansion_vars, None)
+
+    assert expander.expand_var_name(input) == output
+
+
+@pytest.mark.parametrize(
     'input,expected_error,error_string',
     [
         ('{decimal.06.var}',


### PR DESCRIPTION
This merge adds a new function to the expander `expand_var_name` which takes a variable name as a string, converts it to an expansion string (currently '{var_name}') and then expands that.