### PR TITLE
Add support to import & upload experiment results

### DIFF
--- a/lib/ramble/ramble/cmd/results.py
+++ b/lib/ramble/ramble/cmd/results.py
@@ -7,89 +7,54 @@
 # except according to those terms.
 
 import llnl.util.tty as tty
+import json
 
-from ramble.config import ConfigError
 import ramble.experimental.uploader
 
-
 description = "take actions on experiment results"
-section = "workspaces"
+section = "results"
 level = "short"
-
-subcommands = [
-    'file_upload',
-]
-
-#: Dictionary mapping subcommand names and aliases to functions
-subcommand_functions = {}
-
-
-def results_file_upload_setup_parser(subparser):
-    subparser.add_argument(
-        'filename', metavar='filename',
-        help='path of file to upload')
-
-
-def results_file_upload(args):
-    """Imports Ramble experiment results from JSON file and uploads them."""
-    imported_results = ramble.experimental.uploader.results_file_import(args.filename)
-
-    if ramble.config.get('config:upload'):
-        # Read upload type and push it there
-        if ramble.config.get('config:upload:type') == 'BigQuery':  # TODO: enum?
-            try:
-                formatted_data = ramble.experimental.uploader.format_data(imported_results)
-            except KeyError:
-                tty.die("Error parsing file: Does not contain valid data.")
-
-            # TODO: strategy object?
-            uploader = ramble.experimental.uploader.BigQueryUploader()
-
-            # Read workspace name from results for uploader, or use default.
-            try:
-                workspace_name = formatted_data[0].workspace_name
-            except KeyError:
-                workspace_name = "Default Workspace"
-
-            uri = ramble.config.get('config:upload:uri')
-            if not uri:
-                tty.die('No upload URI (config:upload:uri) in config.')
-
-            tty.msg('Uploading Results to ' + uri)
-            uploader.perform_upload(uri, workspace_name, formatted_data)
-        else:
-            raise ConfigError("Unknown config:upload:type value")
-
-    else:
-        raise ConfigError("Missing correct conifg:upload parameters")
 
 
 def setup_parser(subparser):
     sp = subparser.add_subparsers(metavar='SUBCOMMAND',
                                   dest='results_command')
 
-    for name in subcommands:
-        if isinstance(name, (list, tuple)):
-            name, aliases = name[0], name[1:]
+    # Upload
+    upload_parser = sp.add_parser('upload', help=results_upload.__doc__)
+    upload_parser.add_argument(
+        'filename', help='path of file to upload')
+
+
+def results_upload(args):
+    """Imports Ramble experiment results from JSON file and uploads them as
+    specified in the upload block of Ramble's config file."""
+    imported_results = import_results_file(args.filename)
+
+    ramble.experimental.uploader.upload_results(imported_results)
+
+
+def import_results_file(filename):
+    """
+    Import Ramble experiment results from a JSON file.
+    """
+    tty.debug("File to import:")
+    tty.debug(filename)
+
+    imported_file = open(filename)
+
+    try:
+        tty.msg("Import file...")
+        parsed_json_file = json.load(imported_file)
+        # Check if data contains an experiment
+        if parsed_json_file.get('experiments'):
+            return parsed_json_file
         else:
-            aliases = []
-
-        # add commands to subcommands dict
-        function_name = 'results_%s' % name
-        function = globals()[function_name]
-        for alias in [name] + aliases:
-            subcommand_functions[alias] = function
-
-        # make a subparser and run the command's setup function on it
-        setup_parser_cmd_name = 'results_%s_setup_parser' % name
-        setup_parser_cmd = globals()[setup_parser_cmd_name]
-
-        subsubparser = sp.add_parser(
-            name, aliases=aliases, help=setup_parser_cmd.__doc__)
-        setup_parser_cmd(subsubparser)
+            tty.die("Error parsing file: Does not contain valid data to upload.")
+    except ValueError:
+        tty.die("Error parsing file: Invalid JSON formatting.")
 
 
 def results(parser, args):
-    """Look for a function called environment_<name> and call it."""
-    action = subcommand_functions[args.results_command]
-    action(args)
+    action = {'upload': results_upload}
+    action[args.results_command](args)

--- a/lib/ramble/ramble/cmd/results.py
+++ b/lib/ramble/ramble/cmd/results.py
@@ -1,0 +1,95 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import llnl.util.tty as tty
+
+from ramble.config import ConfigError
+import ramble.experimental.uploader
+
+
+description = "take actions on experiment results"
+section = "workspaces"
+level = "short"
+
+subcommands = [
+    'file_upload',
+]
+
+#: Dictionary mapping subcommand names and aliases to functions
+subcommand_functions = {}
+
+
+def results_file_upload_setup_parser(subparser):
+    subparser.add_argument(
+        'filename', metavar='filename',
+        help='path of file to upload')
+
+
+def results_file_upload(args):
+    """Imports Ramble experiment results from JSON file and uploads them."""
+    imported_results = ramble.experimental.uploader.results_file_import(args.filename)
+
+    if ramble.config.get('config:upload'):
+        # Read upload type and push it there
+        if ramble.config.get('config:upload:type') == 'BigQuery':  # TODO: enum?
+            try:
+                formatted_data = ramble.experimental.uploader.format_data(imported_results)
+            except KeyError:
+                tty.die("Error parsing file: Does not contain valid data.")
+
+            # TODO: strategy object?
+            uploader = ramble.experimental.uploader.BigQueryUploader()
+
+            # Read workspace name from results for uploader, or use default.
+            try:
+                workspace_name = formatted_data[0].workspace_name
+            except KeyError:
+                workspace_name = "Default Workspace"
+
+            uri = ramble.config.get('config:upload:uri')
+            if not uri:
+                tty.die('No upload URI (config:upload:uri) in config.')
+
+            tty.msg('Uploading Results to ' + uri)
+            uploader.perform_upload(uri, workspace_name, formatted_data)
+        else:
+            raise ConfigError("Unknown config:upload:type value")
+
+    else:
+        raise ConfigError("Missing correct conifg:upload parameters")
+
+
+def setup_parser(subparser):
+    sp = subparser.add_subparsers(metavar='SUBCOMMAND',
+                                  dest='results_command')
+
+    for name in subcommands:
+        if isinstance(name, (list, tuple)):
+            name, aliases = name[0], name[1:]
+        else:
+            aliases = []
+
+        # add commands to subcommands dict
+        function_name = 'results_%s' % name
+        function = globals()[function_name]
+        for alias in [name] + aliases:
+            subcommand_functions[alias] = function
+
+        # make a subparser and run the command's setup function on it
+        setup_parser_cmd_name = 'results_%s_setup_parser' % name
+        setup_parser_cmd = globals()[setup_parser_cmd_name]
+
+        subsubparser = sp.add_parser(
+            name, aliases=aliases, help=setup_parser_cmd.__doc__)
+        setup_parser_cmd(subsubparser)
+
+
+def results(parser, args):
+    """Look for a function called environment_<name> and call it."""
+    action = subcommand_functions[args.results_command]
+    action(args)

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -26,6 +26,7 @@ import ramble.config
 import ramble.workspace
 import ramble.workspace.shell
 import ramble.experiment_set
+import ramble.experimental.uploader
 import ramble.software_environments
 import ramble.util.colors as rucolor
 
@@ -363,7 +364,7 @@ def workspace_analyze(args):
 
     # FIXME: this will fire the analyze logic of twice currently
     if args.upload:
-        ws.upload_results()
+        ramble.experimental.uploader.upload_results(ws.results)
 
 
 def workspace_info_setup_parser(subparser):

--- a/lib/ramble/ramble/experimental/uploader.py
+++ b/lib/ramble/ramble/experimental/uploader.py
@@ -162,6 +162,27 @@ def format_data(data_in):
     return results
 
 
+def results_file_import(filename):
+    """
+    Import Ramble experiment results from a JSON file.
+    """
+    tty.debug("Import file")
+    tty.debug(filename)
+
+    imported_file = open(filename)
+
+    try:
+        tty.msg("Import file...")
+        parsed_json_file = json.load(imported_file)
+        # Check if data contains an experiment
+        if parsed_json_file.get('experiments'):
+            return parsed_json_file
+        else:
+            tty.die("Error parsing file: Does not contain valid data.")
+    except ValueError:
+        tty.die("Error parsing file: Invalid JSON formatting.")
+
+
 class BigQueryUploader(Uploader):
     """Class to handle upload of FOMs to BigQuery
     """
@@ -251,7 +272,7 @@ class BigQueryUploader(Uploader):
         # results = query_job.result()  # Waits for job to complete.
         # return results[0]
 
-    def get_expierment_id(experiment):
+    def get_experiment_id(experiment):
         # get_max_current_id(...) # Warning: dangerous..
 
         # This should be stable per machine/python version, but is not

--- a/lib/ramble/ramble/test/cmd/results.py
+++ b/lib/ramble/ramble/test/cmd/results.py
@@ -1,0 +1,40 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import py
+import pytest
+
+import ramble.paths
+import ramble.cmd.results
+import ramble.experimental.uploader
+
+INPUT_DATA = py.path.local(ramble.paths.test_path).join('data', 'results_upload')
+
+
+@pytest.mark.parametrize(
+    'filename,expected_output',
+    [
+        (
+            py.path.local(INPUT_DATA).join('test1_empty_experiments.json'),
+            'Error parsing file: Does not contain valid data.',
+        ),
+        (
+            py.path.local(INPUT_DATA).join('test2_not_json.txt.json'),
+            'Error parsing file: Invalid JSON formatting.',
+        ),
+        (
+            py.path.local(INPUT_DATA).join('test3_malformed_json.json'),
+            'Error parsing file: Invalid JSON formatting',
+        ),
+    ],
+)
+def test_file_import_rejects_invalid_files(filename, expected_output, capsys):
+    with pytest.raises(SystemExit):
+        ramble.experimental.uploader.results_file_import(filename)
+        captured = capsys.readouterr()
+        assert expected_output in captured

--- a/lib/ramble/ramble/test/cmd/results.py
+++ b/lib/ramble/ramble/test/cmd/results.py
@@ -11,7 +11,6 @@ import pytest
 
 import ramble.paths
 import ramble.cmd.results
-import ramble.experimental.uploader
 
 INPUT_DATA = py.path.local(ramble.paths.test_path).join('data', 'results_upload')
 
@@ -21,7 +20,7 @@ INPUT_DATA = py.path.local(ramble.paths.test_path).join('data', 'results_upload'
     [
         (
             py.path.local(INPUT_DATA).join('test1_empty_experiments.json'),
-            'Error parsing file: Does not contain valid data.',
+            'Error parsing file: Does not contain valid data to upload.',
         ),
         (
             py.path.local(INPUT_DATA).join('test2_not_json.txt.json'),
@@ -35,6 +34,6 @@ INPUT_DATA = py.path.local(ramble.paths.test_path).join('data', 'results_upload'
 )
 def test_file_import_rejects_invalid_files(filename, expected_output, capsys):
     with pytest.raises(SystemExit):
-        ramble.experimental.uploader.results_file_import(filename)
+        ramble.cmd.results.import_results_file(filename)
         captured = capsys.readouterr()
         assert expected_output in captured

--- a/lib/ramble/ramble/test/data/results_upload/test1_empty_experiments.json
+++ b/lib/ramble/ramble/test/data/results_upload/test1_empty_experiments.json
@@ -1,0 +1,4 @@
+{
+  "experiments": [
+  ]
+}

--- a/lib/ramble/ramble/test/data/results_upload/test2_not_json.txt.json
+++ b/lib/ramble/ramble/test/data/results_upload/test2_not_json.txt.json
@@ -1,0 +1,1 @@
+This is not a JSON file.

--- a/lib/ramble/ramble/test/data/results_upload/test3_malformed_json.json
+++ b/lib/ramble/ramble/test/data/results_upload/test3_malformed_json.json
@@ -1,0 +1,113 @@
+
+experiments": [
+  {
+    "name": "gromacs.water_gmx50.pme_single_rank",
+    "EXPERIMENT_CHAIN": [],
+    "RAMBLE_STATUS": "SUCCESS",
+    "RAMBLE_VARIABLES": {
+      "log_dir": "/home/user/gromacs_example/logs",
+      "env_name": "gromacs",
+      "experiments_file": "/home/user/gromacs_example/all_experiments",
+      "processes_per_node": "16",
+      "mpi_command": "mpirun -n 1 -ppn 16",
+      "batch_submit": "/home/user/gromacs_example/experiments/gromacs/water_gmx50/pme_single_rank/execute_experiment",
+      "n_ranks": "1",
+      "n_threads": "1",
+      "size": "0003",
+      "type": "pme",
+      "global_conf_name": "global_conf",
+      "base_name": "None",
+      "workspace_name": "gromacs_example",
+      "application_name": "gromacs",
+      "workload_name": "water_gmx50",
+      "experiment_name": "pme_single_rank",
+      "required_name": "None",
+      "application_namespace": "gromacs",
+      "workload_namespace": "gromacs.water_gmx50",
+      "experiment_namespace": "gromacs.water_gmx50.pme_single_rank",
+      "application_run_dir": "/home/user/gromacs_example/experiments/gromacs",
+      "application_input_dir": "/home/user/gromacs_example/inputs/gromacs",
+      "workload_run_dir": "/home/user/gromacs_example/experiments/gromacs/water_gmx50",
+      "workload_input_dir": "/home/user/gromacs_example/inputs/gromacs/water_gmx50",
+      "experiment_run_dir": "/home/user/gromacs_example/experiments/gromacs/water_gmx50/pme_single_rank",
+      "spack_env": "/home/user/gromacs_example/software/gromacs.water_gmx50",
+      "n_nodes": "1",
+      "experiment_template_name": "pme_single_rank",
+      "log_file": "/home/user/gromacs_example/experiments/gromacs/water_gmx50/pme_single_rank/pme_single_rank.out",
+      "input_path": "/home/user/gromacs_example/inputs/gromacs/water_gmx50/water_gmx50_bare/0003",
+      "water_gmx50_bare": "/home/user/gromacs_example/inputs/gromacs/water_gmx50/water_gmx50_bare",
+      "command": "rm -f \"/home/user/gromacs_example/experiments/gromacs/water_gmx50/pme_single_rank/pme_single_rank.out\"\ntouch \"/home/user/gromacs_example/experiments/gromacs/water_gmx50/pme_single_rank/pme_single_rank.out\"\n. /opt/apps/spack/share/spack/setup-env.sh\nspack env activate /home/user/gromacs_example/software/gromacs.water_gmx50\ngmx_mpi grompp -f /home/user/gromacs_example/inputs/gromacs/water_gmx50/water_gmx50_bare/0003/pme.mdp -c /home/user/gromacs_example/inputs/gromacs/water_gmx50/water_gmx50_bare/0003/conf.gro -p /home/user/gromacs_example/inputs/gromacs/water_gmx50/water_gmx50_bare/0003/topol.top -o exp_input.tpr >> \"/home/user/gromacs_example/experiments/gromacs/water_gmx50/pme_single_rank/pme_single_rank.out\"\nmpirun -n 1 -ppn 16 gmx_mpi mdrun -notunepme -dlb yes -v -resethway -noconfout -nsteps 4000 -s exp_input.tpr >> \"/home/user/gromacs_example/experiments/gromacs/water_gmx50/pme_single_rank/pme_single_rank.out\"",
+      "spack_setup": "",
+      "execute_experiment": "/home/user/gromacs_example/experiments/gromacs/water_gmx50/pme_single_rank/execute_experiment"
+    },
+    "RAMBLE_RAW_VARIABLES": {
+      "log_dir": "/home/user/gromacs_example/logs",
+      "env_name": "{application_name}",
+      "experiments_file": "/home/user/gromacs_example/all_experiments",
+      "processes_per_node": 16,
+      "mpi_command": "mpirun -n {n_ranks} -ppn {processes_per_node}",
+      "batch_submit": "{execute_experiment}",
+      "n_ranks": "1",
+      "n_threads": "1",
+      "size": "0003",
+      "type": "pme",
+      "global_conf_name": "global_conf",
+      "base_name": null,
+      "workspace_name": "gromacs_example",
+      "application_name": "gromacs",
+      "workload_name": "water_gmx50",
+      "experiment_name": "pme_single_rank",
+      "required_name": null,
+      "application_namespace": "gromacs",
+      "workload_namespace": "gromacs.water_gmx50",
+      "experiment_namespace": "gromacs.water_gmx50.pme_single_rank",
+      "application_run_dir": "/home/user/gromacs_example/experiments/{application_name}",
+      "application_input_dir": "/home/user/gromacs_example/inputs/{application_name}",
+      "workload_run_dir": "{application_run_dir}/{workload_name}",
+      "workload_input_dir": "{application_input_dir}/{workload_name}",
+      "experiment_run_dir": "{workload_run_dir}/{experiment_name}",
+      "spack_env": "/home/user/gromacs_example/software/{env_name}.{workload_name}",
+      "n_nodes": 1,
+      "experiment_template_name": "pme_single_rank",
+      "log_file": "{experiment_run_dir}/{experiment_name}.out",
+      "input_path": "{water_gmx50_bare}/{size}",
+      "water_gmx50_bare": "/home/user/gromacs_example/inputs/gromacs/water_gmx50/water_gmx50_bare",
+      "command": "rm -f \"{log_file}\"\ntouch \"{log_file}\"\n. /opt/apps/spack/share/spack/setup-env.sh\nspack env activate /home/user/gromacs_example/software/gromacs.water_gmx50\ngmx_mpi grompp -f /home/user/gromacs_example/inputs/gromacs/water_gmx50/water_gmx50_bare/0003/pme.mdp -c /home/user/gromacs_example/inputs/gromacs/water_gmx50/water_gmx50_bare/0003/conf.gro -p /home/user/gromacs_example/inputs/gromacs/water_gmx50/water_gmx50_bare/0003/topol.top -o exp_input.tpr >> \"/home/user/gromacs_example/experiments/gromacs/water_gmx50/pme_single_rank/pme_single_rank.out\"\nmpirun -n 1 -ppn 16 gmx_mpi mdrun -notunepme -dlb yes -v -resethway -noconfout -nsteps 4000 -s exp_input.tpr >> \"/home/user/gromacs_example/experiments/gromacs/water_gmx50/pme_single_rank/pme_single_rank.out\"",
+      "spack_setup": "",
+      "execute_experiment": "/home/user/gromacs_example/experiments/gromacs/water_gmx50/pme_single_rank/execute_experiment"
+    },
+    "CONTEXTS": [
+      {
+        "name": "null",
+        "foms": [
+          {
+            "value": "42.556",
+            "units": "s",
+            "name": "Core Time"
+          },
+          {
+            "value": "21.280",
+            "units": "s",
+            "name": "Wall Time"
+          },
+          {
+            "value": "200.0",
+            "units": "%",
+            "name": "Percent Core Time"
+          },
+          {
+            "value": "16.249",
+            "units": "ns/day",
+            "name": "Nanosecs per day"
+          },
+          {
+            "value": "1.477",
+            "units": "hours/ns",
+            "name": "Hours per nanosec"
+          }
+        ]
+      }
+    ]
+  }
+]
+}

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -33,8 +33,6 @@ import ramble.success_criteria
 import ramble.keywords
 import ramble.software_environments
 from ramble.mirror import MirrorStats
-from ramble.config import ConfigError
-import ramble.experimental.uploader
 
 import spack.util.spack_yaml as syaml
 import spack.util.spack_json as sjson
@@ -1066,27 +1064,6 @@ class Workspace(object):
         with open(out_file, 'w+') as f:
             sjson.dump(self.results, f)
         return out_file
-
-    def upload_results(self):
-        if ramble.config.get('config:upload'):
-            # Read upload type and push it there
-            if ramble.config.get('config:upload:type') == 'BigQuery':  # TODO: enum?
-                formatted_data = ramble.experimental.uploader.format_data(self.results)
-
-                # TODO: strategy object?
-                uploader = ramble.experimental.uploader.BigQueryUploader()
-
-                uri = ramble.config.get('config:upload:uri')
-                if not uri:
-                    tty.die('No upload URI (config:upload:uri) in config.')
-
-                tty.msg('Uploading Results to ' + uri)
-                uploader.perform_upload(uri, self.name, formatted_data)
-            else:
-                raise ConfigError("Unknown config:upload:type value")
-
-        else:
-            raise ConfigError("Missing correct conifg:upload parameters")
 
     def default_results(self):
         res = {}

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -600,16 +600,16 @@ _ramble_results() {
     then
         RAMBLE_COMPREPLY="-h --help"
     else
-        RAMBLE_COMPREPLY="file_upload"
+        RAMBLE_COMPREPLY="upload"
     fi
 }
 
-_ramble_results_file_upload() {
+_ramble_results_upload() {
     if $list_options
     then
         RAMBLE_COMPREPLY="-h --help"
     else
-        RAMBLE=""
+        RAMBLE_COMREPLY=""
     fi
 }
 

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -267,7 +267,7 @@ _ramble() {
     then
         RAMBLE_COMPREPLY="-h --help -H --all-help --color -c --config -C --config-scope -d --debug --timestamp --pdb -w --workspace -D --workspace-dir -W --no-workspace --use-workspace-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -p --profile --sorted-profile --lines -v --verbose --stacktrace -V --version --print-shell-vars"
     else
-        RAMBLE_COMPREPLY="attributes clean commands config debug edit flake8 help info license list mirror mods on repo software-definitions unit-test workspace"
+        RAMBLE_COMPREPLY="attributes clean commands config debug edit flake8 help info license list mirror mods on repo results software-definitions unit-test workspace"
     fi
 }
 
@@ -592,6 +592,24 @@ _ramble_repo_rm() {
         RAMBLE_COMPREPLY="-h --help --scope -t --type"
     else
         _repos
+    fi
+}
+
+_ramble_results() {
+    if $list_options
+    then
+        RAMBLE_COMPREPLY="-h --help"
+    else
+        RAMBLE_COMPREPLY="file_upload"
+    fi
+}
+
+_ramble_results_file_upload() {
+    if $list_options
+    then
+        RAMBLE_COMPREPLY="-h --help"
+    else
+        RAMBLE=""
     fi
 }
 


### PR DESCRIPTION
Adds 'results' module with support to import Ramble experiment results from a JSON file and upload them to BigQuery.