### PR TITLE
Add support for package manager configs, and remove spack module generation

### DIFF
--- a/lib/ramble/ramble/application_types/spack.py
+++ b/lib/ramble/ramble/application_types/spack.py
@@ -71,6 +71,12 @@ class SpackApplication(ApplicationBase):
     def _long_print(self):
         out_str = super()._long_print()
 
+        if hasattr(self, 'package_manager_configs'):
+            out_str.append('\n')
+            out_str.append(section_title('Package Manager Configs:\n'))
+            for name, config in self.package_manager_configs.items():
+                out_str.append(f'\t{name} = {config}\n')
+
         for group in self._spec_groups:
             if hasattr(self, group[0]):
                 out_str.append('\n')
@@ -134,6 +140,14 @@ class SpackApplication(ApplicationBase):
             return
         else:
             workspace.add_to_cache(cache_tupl)
+
+        package_manager_config_dicts = [self.package_manager_configs]
+        for mod_inst in self._modifier_instances:
+            package_manager_config_dicts.append(mod_inst.package_manager_configs)
+
+        for config_dict in package_manager_config_dicts:
+            for _, config in config_dict.items():
+                self.spack_runner.add_config(config)
 
         try:
             self.spack_runner.set_dry_run(workspace.dry_run)

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -154,6 +154,21 @@ def software_spec(name, spack_spec, compiler_spec=None, compiler=None):
     return _execute_software_spec
 
 
+@shared_directive('package_manager_configs')
+def package_manager_config(name, config, **kwargs):
+    """Defines a config option to set within a package manager
+
+    Define a new config which will be passed to a package manager. The
+    resulting experiment instance will pass the config to the package manager,
+    which will control the logic of applying it.
+    """
+
+    def _execute_package_manager_config(obj):
+        obj.package_manager_configs[name] = config
+
+    return _execute_package_manager_config
+
+
 @shared_directive('required_packages')
 def required_package(name):
     """Defines a new spack package that is required for this object

--- a/lib/ramble/ramble/modifier.py
+++ b/lib/ramble/ramble/modifier.py
@@ -130,6 +130,12 @@ class ModifierBase(object, metaclass=ModifierMeta):
             out_str.append(rucolor.section_title('Executable Modifiers:\n'))
             out_str.append('\t' + colified(self.executable_modifiers.keys(), tty=True) + '\n')
 
+        if hasattr(self, 'package_manager_configs'):
+            out_str.append(rucolor.section_title('Package Manager Configs:\n'))
+            for name, config in self.package_manager_configs.items():
+                out_str.append(f'\t{name} = {config}\n')
+            out_str.append('\n')
+
         if hasattr(self, 'default_compilers'):
             out_str.append(rucolor.section_title('Default Compilers:\n'))
             for comp_name, comp_def in self.default_compilers.items():

--- a/lib/ramble/ramble/spack_runner.py
+++ b/lib/ramble/ramble/spack_runner.py
@@ -569,29 +569,6 @@ class SpackRunner(object):
         else:
             self._dry_run_print(args)
 
-        for mod_type in ['tcl', 'lmod']:
-            args = [
-                'module',
-                mod_type,
-                'refresh',
-                '-y'
-            ]
-
-            if not self.dry_run:
-                self.exe(*args)
-            else:
-                self._dry_run_print(args)
-
-        args = [
-            'env',
-            'loads'
-        ]
-
-        if not self.dry_run:
-            self.exe(*args)
-        else:
-            self._dry_run_print(args)
-
         self.installed = True
 
     def get_package_path(self, package_spec):

--- a/lib/ramble/ramble/test/application_language.py
+++ b/lib/ramble/ramble/test/application_language.py
@@ -32,6 +32,7 @@ def test_application_type_features(app_class):
     assert hasattr(test_app, 'software_specs')
     assert hasattr(test_app, 'required_packages')
     assert hasattr(test_app, 'maintainers')
+    assert hasattr(test_app, 'package_manager_configs')
 
 
 def add_workload(app_inst, wl_num=1):

--- a/lib/ramble/ramble/test/cmd/info.py
+++ b/lib/ramble/ramble/test/cmd/info.py
@@ -78,7 +78,25 @@ def test_spack_info_software(app_query):
         'Tags:',
         'spack_spec =',
         'compiler =',
+    )
 
+    out = info(app_query)
+
+    for field in expected_fields:
+        assert field in out
+
+
+@pytest.mark.parametrize('app_query', [
+    'zlib-configs',
+])
+def test_mock_spack_info_software(mock_applications, app_query):
+    expected_fields = (
+        'Description:',
+        'Setup Pipeline Phases:',
+        'Analyze Pipeline Phases:',
+        'Tags:',
+        'Package Manager Configs:',
+        'spack_spec =',
     )
 
     out = info(app_query)

--- a/lib/ramble/ramble/test/cmd/mods.py
+++ b/lib/ramble/ramble/test/cmd/mods.py
@@ -16,7 +16,7 @@ mods = RambleCommand('mods')
 def check_info(output):
     expected_sections = ['Tags', 'Mode', 'Builtin Executables',
                          'Executable Modifiers', 'Default Compilers',
-                         'Software Specs']
+                         'Software Specs', 'Package Manager Configs']
 
     for section in expected_sections:
         assert section in output

--- a/lib/ramble/ramble/test/end_to_end/package_manager_config.py
+++ b/lib/ramble/ramble/test/end_to_end/package_manager_config.py
@@ -1,0 +1,71 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.workspace
+import ramble.config
+import ramble.software_environments
+from ramble.main import RambleCommand
+
+
+pytestmark = pytest.mark.usefixtures('mutable_config',
+                                     'mutable_mock_workspace_path')
+
+workspace = RambleCommand('workspace')
+
+
+def test_package_manager_config_zlib(mock_applications):
+    test_config = """
+ramble:
+  variables:
+    mpi_command: ''
+    batch_submit: 'batch_submit {execute_experiment}'
+    processes_per_node: '1'
+    n_ranks: '1'
+  applications:
+    zlib-configs:
+      workloads:
+        ensure_installed:
+          experiments:
+            test:
+              variables: {}
+  spack:
+    concretized: true
+    packages:
+      zlib:
+        spack_spec: 'zlib'
+    environments:
+      zlib-configs:
+        packages:
+        - zlib
+"""
+
+    workspace_name = 'test_package_manager_config_zlib'
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+
+        config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+
+        with open(config_path, 'w+') as f:
+            f.write(test_config)
+        ws._re_read()
+
+        workspace('setup', '--dry-run', global_args=['-w', workspace_name])
+
+        spack_yaml = os.path.join(ws.software_dir, 'zlib-configs.ensure_installed',
+                                  'spack.yaml')
+
+        assert os.path.isfile(spack_yaml)
+
+        with open(spack_yaml, 'r') as f:
+            data = f.read()
+            assert 'config:' in data
+            assert 'debug: true' in data

--- a/lib/ramble/ramble/test/modifier_functionality/mock_modifier_spack_configs.py
+++ b/lib/ramble/ramble/test/modifier_functionality/mock_modifier_spack_configs.py
@@ -1,0 +1,63 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+from ramble.test.dry_run_helpers import dry_run_config, SCOPES
+import ramble.test.modifier_functionality.modifier_helpers as modifier_helpers
+import ramble.workspace
+from ramble.main import RambleCommand
+
+workspace = RambleCommand('workspace')
+
+
+@pytest.mark.parametrize(
+    'scope',
+    [
+        SCOPES.workspace,
+        SCOPES.application,
+        SCOPES.workload,
+        SCOPES.experiment,
+    ]
+)
+def test_gromacs_mock_spack_config_mod(mutable_mock_workspace_path,
+                                       mutable_applications,
+                                       mock_modifiers,
+                                       scope):
+    workspace_name = 'test_gromacs_mock_spack_config_mod'
+
+    test_modifiers = [
+        (scope, modifier_helpers.named_modifier('spack-mod')),
+    ]
+
+    with ramble.workspace.create(workspace_name) as ws1:
+        ws1.write()
+
+        config_path = os.path.join(ws1.config_dir, ramble.workspace.config_file_name)
+
+        dry_run_config('modifiers', test_modifiers, config_path, 'gromacs', 'water_bare')
+
+        ws1._re_read()
+
+        workspace('concretize', global_args=['-D', ws1.root])
+        workspace('setup', '--dry-run', global_args=['-D', ws1.root])
+        exp_script = os.path.join(ws1.experiment_dir, 'gromacs', 'water_bare',
+                                  'test_exp', 'execute_experiment')
+
+        assert os.path.isfile(exp_script)
+
+        spack_yaml = os.path.join(ws1.software_dir, 'gromacs.water_bare',
+                                  'spack.yaml')
+        assert os.path.isfile(spack_yaml)
+
+        with open(spack_yaml, 'r') as f:
+            data = f.read()
+
+            assert 'debug: true' in data

--- a/lib/ramble/ramble/test/modifier_language.py
+++ b/lib/ramble/ramble/test/modifier_language.py
@@ -48,6 +48,7 @@ def test_modifier_type_features(mod_class):
     assert hasattr(test_mod, 'executable_modifiers')
     assert hasattr(test_mod, 'env_var_modifications')
     assert hasattr(test_mod, 'maintainers')
+    assert hasattr(test_mod, 'package_manager_configs')
 
 
 def add_mode(mod_inst, mode_num=1):

--- a/lib/ramble/ramble/test/spack_runner.py
+++ b/lib/ramble/ramble/test/spack_runner.py
@@ -120,7 +120,6 @@ def test_env_install(tmpdir, capsys):
 
         captured = capsys.readouterr()
         assert "with args: ['install'" in captured.out
-        assert "with args: ['env', 'loads']" in captured.out
 
         sr.deactivate()
 

--- a/var/ramble/repos/builtin.mock/applications/zlib-configs/application.py
+++ b/var/ramble/repos/builtin.mock/applications/zlib-configs/application.py
@@ -1,0 +1,28 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.appkit import *
+
+
+class ZlibConfigs(SpackApplication):
+    name = "zlib-configs"
+
+    software_spec('zlib', spack_spec='zlib')
+
+    executable('list_lib', 'ls {zlib}/lib', use_mpi=False)
+
+    workload('ensure_installed', executable='list_lib')
+
+    package_manager_config('enable_debug', 'config:debug:true')
+
+    figure_of_merit('zlib_installed',
+                    fom_regex=r'(?P<lib_name>libz.so.*)', group_name='lib_name',
+                    units='')
+
+    success_criteria('zlib_installed', mode='string',
+                     match=r'libz.so', file='{log_file}')

--- a/var/ramble/repos/builtin.mock/modifiers/spack-mod/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/spack-mod/modifier.py
@@ -17,6 +17,8 @@ class SpackMod(SpackModifier):
 
     mode('default', description='This is the default mode for the spack-mod')
 
+    package_manager_config('enable_debug', 'config:debug:true')
+
     default_compiler('mod_compiler',
                      spack_spec='mod_compiler@1.1 target=x86_64',
                      compiler_spec='mod_compiler@1.1')


### PR DESCRIPTION
This merge adds a new directive (package_manager_config) which can be used within an application to define a config which the package manager should set within the environment generated for the application's experiments.

Additionally, this commit removes the generation of module files from spack, as it's no longer needed and can be controlled through other mechanisms (such as this new directive).