### PR TITLE
Reduce prints to screen

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -348,9 +348,9 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
             tty.debug(f'{self.name} is a template. Skipping phases')
             return
 
-        if hasattr(self, '_%s' % phase):
-            tty.msg('    Executing phase ' + phase)
-            phase_func = getattr(self, '_%s' % phase)
+        if hasattr(self, f'_{phase}'):
+            tty.verbose('    Executing phase ' + phase)
+            phase_func = getattr(self, f'_{phase}')
             phase_func(workspace)
 
     def _get_env_set_commands(self, var_conf, var_set, shell='sh'):

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1228,7 +1228,7 @@ class Workspace(object):
         experiment_set = self.build_experiment_set()
 
         for exp, app_inst in experiment_set.all_experiments():
-            tty.debug('On experiment: %s' % exp)
+            tty.msg(f'    Configuring experiment {exp}')
             for phase in app_inst.get_pipeline_phases(pipeline):
                 app_inst.run_phase(phase, self)
 


### PR DESCRIPTION
When executing workspace pipelines, prints the experiment name and changes phase name to verbose mode to reduce prints to screen.