### PR TITLE
Fix typo in lib/ramble/ramble/language/application_language.py

### DIFF
--- a/lib/ramble/ramble/language/application_language.py
+++ b/lib/ramble/ramble/language/application_language.py
@@ -45,7 +45,7 @@ examples
 
 class ApplicationMeta(ramble.language.shared_language.SharedMeta):
     _directive_names = set()
-    _diretives_to_be_executed = []
+    _directives_to_be_executed = []
 
 
 application_directive = ApplicationMeta.directive

--- a/lib/ramble/ramble/language/modifier_language.py
+++ b/lib/ramble/ramble/language/modifier_language.py
@@ -14,7 +14,7 @@ from ramble.language.language_base import DirectiveError
 
 class ModifierMeta(ramble.language.shared_language.SharedMeta):
     _directive_names = set()
-    _diretives_to_be_executed = []
+    _directives_to_be_executed = []
 
 
 modifier_directive = ModifierMeta.directive

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -33,7 +33,7 @@ inherit from the SharedMeta class.
 
 class SharedMeta(ramble.language.language_base.DirectiveMeta):
     _directive_names = set()
-    _diretives_to_be_executed = []
+    _directives_to_be_executed = []
 
 
 # shared_directive = ramble.language.language_base.DirectiveMeta.directive


### PR DESCRIPTION
Small typo correction.