### PR TITLE
repository.py: remove irrelevant warning case

### DIFF
--- a/lib/ramble/ramble/repository.py
+++ b/lib/ramble/ramble/repository.py
@@ -270,7 +270,9 @@ class FastObjectChecker(Mapping):
 
             # Warn about invalid names that look like objects.
             if not nm.valid_module_name(obj_name):
-                if not obj_name.startswith('.'):
+                if not obj_name.startswith('.') and not any(
+                        obj_name == obj_info['config'] for obj_info in type_definitions.values()
+                ):
                     tty.warn(f'Skipping {self.object_type} '
                              f'at {obj_dir}. "{obj_name}" is not '
                              'a valid Ramble module name.')


### PR DESCRIPTION
When the repository is set up with `subdirectory: ""`, we get constant warnings that `repo.yaml` (or `modifiers_repo.yaml`)  is not a valid module name.

This PR skips the warning in that case.