### PR TITLE
Add support for phase selections

### DIFF
--- a/lib/ramble/docs/workspace.rst
+++ b/lib/ramble/docs/workspace.rst
@@ -179,6 +179,35 @@ To perform a light-weight test version of this, one can use:
 
 Which will create experiments, but it won't download or install anything.
 
+^^^^^^^^^^^^^^^
+Phase Selection
+^^^^^^^^^^^^^^^
+
+Some workflows would benefit from more fine-grained control of the phases that
+are executed by Ramble. A good example is that sometimes one only wants to run
+the ``make_experiments`` phase of a workspace instead of all of the phases.
+
+The ``ramble workspace setup`` command has a ``--phases`` argument, which can
+take phase filters which will be used to down-select the phases which should be
+executed.
+
+As an example:
+
+.. code-block:: console
+
+    $ ramble workspace setup --phases make_experiments
+
+Would execute only the ``make_experiments`` phase of all experiments that have
+this phase.
+
+The ``--phases`` argument supports wildcard matching, i.e.:
+
+.. code-block:: console
+
+    $ ramble workspace setup --phases *_experiments
+
+Would execute all phases that have then ``_experiments`` suffix.
+
 ^^^^^^^^^^^^^^^^^^^^^
 Software Environments
 ^^^^^^^^^^^^^^^^^^^^^

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -56,6 +56,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
     _builtin_required_key = 'required'
     _workload_exec_key = 'executables'
     _inventory_file_name = 'ramble_inventory.json'
+    _pipelines = ['analyze', 'archive', 'mirror', 'setup']
 
     #: Lists of strings which contains GitHub usernames of attributes.
     #: Do not include @ here in order not to unnecessarily ping the users.
@@ -64,8 +65,6 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
 
     def __init__(self, file_path):
         super().__init__()
-
-        self._pipelines = ['setup', 'analyze', 'archive', 'mirror']
         self._setup_phases = ['license_includes']
         self._analyze_phases = ['analyze_experiments']
         self._archive_phases = ['archive_experiments']
@@ -281,12 +280,18 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
             self.modifiers = modifiers.copy()
 
     def get_pipeline_phases(self, pipeline, phase_filters=['*']):
+        if pipeline not in self._pipelines:
+            tty.die(f'Requested pipeline {pipeline} is not valid.\n',
+                    f'\tAvailable pipelinese are {self._pipelines}')
+
         phases = []
         if hasattr(self, f'_{pipeline}_phases'):
             for phase in getattr(self, f'_{pipeline}_phases'):
                 for phase_filter in phase_filters:
                     if fnmatch.fnmatch(phase, phase_filter):
                         phases.append(phase)
+        else:
+            tty.die(f'Pipeline {pipeline} is not defined in application {self.name}')
 
         return phases
 

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -14,6 +14,7 @@ import six
 import textwrap
 import string
 import shutil
+import fnmatch
 from typing import List
 
 import llnl.util.filesystem as fs
@@ -64,6 +65,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
     def __init__(self, file_path):
         super().__init__()
 
+        self._pipelines = ['setup', 'analyze', 'archive', 'mirror']
         self._setup_phases = ['license_includes']
         self._analyze_phases = ['analyze_experiments']
         self._archive_phases = ['archive_experiments']
@@ -278,10 +280,14 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         if modifiers:
             self.modifiers = modifiers.copy()
 
-    def get_pipeline_phases(self, pipeline):
+    def get_pipeline_phases(self, pipeline, phase_filters=['*']):
         phases = []
-        if hasattr(self, '_%s_phases' % pipeline):
-            phases = getattr(self, '_%s_phases' % pipeline).copy()
+        if hasattr(self, f'_{pipeline}_phases'):
+            for phase in getattr(self, f'_{pipeline}_phases'):
+                for phase_filter in phase_filters:
+                    if fnmatch.fnmatch(phase, phase_filter):
+                        phases.append(phase)
+
         return phases
 
     def _short_print(self):

--- a/lib/ramble/ramble/application_types/spack.py
+++ b/lib/ramble/ramble/application_types/spack.py
@@ -46,11 +46,12 @@ class SpackApplication(ApplicationBase):
 
     def __init__(self, file_path):
         super().__init__(file_path)
+
         self._setup_phases += [
-            'create_spack_env',
-            'install_compilers',
-            'concretize_spack_env',
-            'install_software',
+            'software_create_env',
+            'software_install_requested_compilers',
+            'software_configure',
+            'software_install',
             'define_package_paths',
             'get_inputs',
             'make_experiments',
@@ -59,7 +60,7 @@ class SpackApplication(ApplicationBase):
 
         self._mirror_phases = [
             'mirror_inputs',
-            'create_spack_env',
+            'create_software_env',
             'mirror_software'
         ]
 
@@ -88,7 +89,7 @@ class SpackApplication(ApplicationBase):
 
         return ''.join(out_str)
 
-    def _install_compilers(self, workspace):
+    def _software_install_requested_compilers(self, workspace):
         """Install compilers an application uses"""
 
         # See if we cached this already, and if so return
@@ -120,7 +121,7 @@ class SpackApplication(ApplicationBase):
         except ramble.spack_runner.RunnerError as e:
             tty.die(e)
 
-    def _create_spack_env(self, workspace):
+    def _software_create_env(self, workspace):
         """Create the spack environment for this experiment
 
         Extract all specs this experiment uses, and write the spack environment
@@ -191,7 +192,7 @@ class SpackApplication(ApplicationBase):
         except ramble.spack_runner.RunnerError as e:
             tty.die(e)
 
-    def _concretize_spack_env(self, workspace):
+    def _software_configure(self, workspace):
         """Concretize the spack environment for this experiment
 
         Perform spack's concretize step on the software environment generated
@@ -223,7 +224,7 @@ class SpackApplication(ApplicationBase):
         except ramble.spack_runner.RunnerError as e:
             tty.die(e)
 
-    def _install_software(self, workspace):
+    def _software_install(self, workspace):
         """Install application's software using spack"""
 
         # See if we cached this already, and if so return

--- a/lib/ramble/ramble/cmd/common/arguments.py
+++ b/lib/ramble/ramble/cmd/common/arguments.py
@@ -86,6 +86,18 @@ def repo_type():
 
 
 @arg
+def phases():
+    return Args(
+        '--phases', dest='phases',
+        nargs='+',
+        default=['*'],
+        help='select phases to execute when performing setup. ' +
+             'Phase names support globbing',
+        required=False
+    )
+
+
+@arg
 def no_checksum():
     return Args(
         '-n', '--no-checksum', action='store_true', default=False,

--- a/lib/ramble/ramble/test/end_to_end/phase_selection.py
+++ b/lib/ramble/ramble/test/end_to_end/phase_selection.py
@@ -1,0 +1,150 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.workspace
+import ramble.config
+import ramble.software_environments
+from ramble.main import RambleCommand
+
+
+# everything here uses the mock_workspace_path
+pytestmark = pytest.mark.usefixtures('mutable_config',
+                                     'mutable_mock_workspace_path')
+
+workspace = RambleCommand('workspace')
+
+
+@pytest.fixture(scope='function')
+def enable_verbose():
+    import llnl.util.tty
+    old_setting = llnl.util.tty._verbose
+    llnl.util.tty._verbose = True
+    yield
+    llnl.util.tty._verbose = old_setting
+
+
+def test_workspace_phase_selection(mutable_config, mutable_mock_workspace_path, enable_verbose):
+    test_config = """
+ramble:
+  variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
+    partition: ['part1', 'part2']
+    processes_per_node: ['16', '36']
+    n_ranks: '{processes_per_node}*{n_nodes}'
+    n_threads: '1'
+  applications:
+    wrfv4:
+      variables:
+        env_name: ['wrfv4', 'wrfv4-portable']
+      workloads:
+        CONUS_12km:
+          experiments:
+            scaling_{n_nodes}_{partition}_{env_name}:
+              success_criteria:
+              - name: 'timing'
+                mode: 'string'
+                match: '.*Timing for main.*'
+                file: '{experiment_run_dir}/rsl.out.0000'
+              env_vars:
+                set:
+                  OMP_NUM_THREADS: '{n_threads}'
+                  TEST_VAR: '1'
+                append:
+                - var-separator: ', '
+                  vars:
+                    TEST_VAR: 'add_var'
+                - paths:
+                    TEST_VAR: 'new_path'
+                prepend:
+                - paths:
+                    TEST_VAR: 'pre_path'
+                unset:
+                - TEST_VAR
+              variables:
+                n_nodes: ['1', '2', '4', '8', '16']
+              matrix:
+              - n_nodes
+              - env_name
+  spack:
+    concretized: true
+    packages:
+      gcc:
+        spack_spec: gcc@8.5.0
+      intel-mpi:
+        spack_spec: intel-mpi@2018.4.274
+        compiler: gcc
+      wrfv4:
+        spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf
+        compiler: gcc
+      wrfv4-portable:
+        spack_spec: 'wrf@4.2 build_type=dm+sm compile_type=em_real
+          nesting=basic ~chem ~pnetcdf target=x86_64'
+        compiler: gcc
+    environments:
+      wrfv4:
+        packages:
+        - wrfv4
+        - intel-mpi
+      wrfv4-portable:
+        packages:
+        - wrfv4-portable
+        - intel-mpi
+"""
+
+    test_licenses = """
+licenses:
+  wrfv4:
+    set:
+      WRF_LICENSE: port@server
+"""
+
+    workspace_name = 'test_end_to_end_wrfv4'
+    with ramble.workspace.create(workspace_name) as ws1:
+        ws1.write()
+
+        config_path = os.path.join(ws1.config_dir, ramble.workspace.config_file_name)
+        license_path = os.path.join(ws1.config_dir, 'licenses.yaml')
+
+        aux_software_path = os.path.join(ws1.config_dir,
+                                         ramble.workspace.auxiliary_software_dir_name)
+        aux_software_files = ['packages.yaml', 'my_test.sh']
+
+        with open(config_path, 'w+') as f:
+            f.write(test_config)
+
+        with open(license_path, 'w+') as f:
+            f.write(test_licenses)
+
+        for file in aux_software_files:
+            file_path = os.path.join(aux_software_path, file)
+            with open(file_path, 'w+') as f:
+                f.write('')
+
+        # Write a command template
+        with open(os.path.join(ws1.config_dir, 'full_command.tpl'), 'w+') as f:
+            f.write('{command}')
+
+        ws1._re_read()
+
+        output = workspace('info', global_args=['-w', workspace_name])
+        assert "Phases for setup pipeline:" in output
+        assert "get_inputs" in output
+        assert "make_experiments" in output
+        assert "Phases for analyze pipeline:" in output
+        assert "Phases for archive pipeline:" in output
+        assert "Phases for mirror pipeline:" in output
+
+        output = workspace('setup', '--phases', 'get_*', 'make_*', '--dry-run',
+                           global_args=['-v', '-w', workspace_name])
+        assert 'Executing phase get_inputs' in output
+        assert 'Executing phase make_experiments' in output

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1215,7 +1215,7 @@ class Workspace(object):
         self._input_mirror_cache = ramble.caches.MirrorCache(self._input_mirror_path)
         self._software_mirror_cache = ramble.caches.MirrorCache(self._software_mirror_path)
 
-    def run_pipeline(self, pipeline):
+    def run_pipeline(self, pipeline, phases='*'):
         all_experiments_file = None
         experiment_set = ramble.experiment_set.ExperimentSet(self)
         self.software_environments = \
@@ -1244,7 +1244,7 @@ class Workspace(object):
 
         for exp, app_inst in experiment_set.all_experiments():
             tty.msg(f'    Configuring experiment {exp}')
-            for phase in app_inst.get_pipeline_phases(pipeline):
+            for phase in app_inst.get_pipeline_phases(pipeline, phases):
                 app_inst.run_phase(phase, self)
 
         if pipeline == 'setup':

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -645,7 +645,7 @@ _ramble_workspace_activate() {
 }
 
 _ramble_workspace_archive() {
-    RAMBLE_COMPREPLY="-h --help --tar-archive -t --upload-url -u"
+    RAMBLE_COMPREPLY="-h --help --tar-archive -t --upload-url -u --phases"
 }
 
 _ramble_workspace_deactivate() {
@@ -666,11 +666,11 @@ _ramble_workspace_concretize() {
 }
 
 _ramble_workspace_setup() {
-    RAMBLE_COMPREPLY="-h --help --dry-run"
+    RAMBLE_COMPREPLY="-h --help --dry-run --phases"
 }
 
 _ramble_workspace_analyze() {
-    RAMBLE_COMPREPLY="-h --help -f --formats -u --upload --always-print-foms"
+    RAMBLE_COMPREPLY="-h --help -f --formats -u --upload --always-print-foms --phases"
 }
 
 _ramble_workspace_info() {
@@ -682,7 +682,7 @@ _ramble_workspace_edit() {
 }
 
 _ramble_workspace_mirror() {
-    RAMBLE_COMPREPLY="-h --help -d --dry-run"
+    RAMBLE_COMPREPLY="-h --help -d --dry-run --phases"
 }
 
 _ramble_workspace_list() {


### PR DESCRIPTION
This merge adds support for workspace commands to define which phases of their pipeline they should execute.

As an example:

```
ramble workspace setup --phases *software*
```
will execute only phases that contain the string `software` in their names.

Additionally, `ramble workspace info` is updated to print all of the phases any experiment within the workspace will execute.