### PR TITLE
Allow compilers to be found before trying to install

### DIFF
--- a/lib/ramble/ramble/spack_runner.py
+++ b/lib/ramble/ramble/spack_runner.py
@@ -279,9 +279,13 @@ class SpackRunner(object):
             comp_info_args.extend(['-C', self.env_path])
         comp_info_args.extend(['compiler', 'info', spec])
 
+        if not self.dry_run:
+            self.exe(*self.compiler_find_args)
+
         try:
             self.exe(*comp_info_args, output=os.devnull, error=os.devnull)
             tty.msg(f'{spec} is already an available compiler')
+            return
         except ProcessError:
             args = [
                 'install',


### PR DESCRIPTION
This merge updates install_compiler to try finding external compilers before installing new compilers.