### PR TITLE
Add a prepare_analysis phase / hook to modifiers and applications

### DIFF
--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -70,6 +70,9 @@ class Expander(object):
         self._workload_run_dir = None
         self._experiment_run_dir = None
 
+    def copy(self):
+        return Expander(self._variables.copy(), self._experiment_set)
+
     @property
     def application_name(self):
         if not self._application_name:

--- a/lib/ramble/ramble/success_criteria.py
+++ b/lib/ramble/ramble/success_criteria.py
@@ -58,7 +58,7 @@ class ScopedCriteriaList(object):
         self.validate_scope(scope)
         exists = self.find_criteria(name)
         if exists:
-            tty.die(f'Criteria {name} is not unique.')
+            tty.die(f'Success criteria {name} is not unique.')
 
         self.criteria[scope].append(SuccessCriteria(name, mode, *args, **kwargs))
 

--- a/lib/ramble/ramble/test/dry_run_helpers.py
+++ b/lib/ramble/ramble/test/dry_run_helpers.py
@@ -14,7 +14,7 @@ SCOPES = Enum('SCOPES', ['workspace', 'application', 'workload', 'experiment'])
 
 
 def dry_run_config(section_name, injections, config_path,
-                   app_name, wl_name):
+                   app_name, wl_name, batch_cmd='batch_submit'):
     """Creates a new configuration with modifiers injected
 
     Input argument injections is a list of tuples. Each tuple has two
@@ -43,7 +43,7 @@ def dry_run_config(section_name, injections, config_path,
 
     ws_var_dict = test_dict['variables']
     ws_var_dict['mpi_command'] = 'mpirun -n {n_ranks} -ppn {processes_per_node}'
-    ws_var_dict['batch_submit'] = 'batch_submit {execute_experiment}'
+    ws_var_dict['batch_submit'] = f'{batch_cmd} {{execute_experiment}}'
     ws_var_dict['processes_per_node'] = '16'
     ws_var_dict['n_ranks'] = '{processes_per_node}*{n_nodes}'
     ws_var_dict['n_threads'] = '1'

--- a/lib/ramble/ramble/test/modifier_functionality/modifier_prepare_analysis.py
+++ b/lib/ramble/ramble/test/modifier_functionality/modifier_prepare_analysis.py
@@ -1,0 +1,67 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+import re
+
+import pytest
+
+from ramble.test.dry_run_helpers import dry_run_config, SCOPES
+import ramble.test.modifier_functionality.modifier_helpers as modifier_helpers
+
+import ramble.workspace
+from ramble.main import RambleCommand
+
+config = RambleCommand('config')
+workspace = RambleCommand('workspace')
+on_cmd = RambleCommand('on')
+
+
+@pytest.mark.parametrize(
+    'scope',
+    [
+        SCOPES.workspace,
+        SCOPES.application,
+        SCOPES.workload,
+        SCOPES.experiment,
+    ]
+)
+def test_basic_dry_run_mock_prepare_analysis_mod(mutable_mock_workspace_path,
+                                                 mock_applications,
+                                                 mock_modifiers,
+                                                 scope):
+    workspace_name = 'test_basic_dry_run_mock_prepare_analysis_mod'
+
+    test_modifiers = [
+        (scope, modifier_helpers.named_modifier('prepare-analysis'))
+    ]
+
+    with ramble.workspace.create(workspace_name) as ws1:
+        ws1.write()
+
+        config_path = os.path.join(ws1.config_dir, ramble.workspace.config_file_name)
+
+        dry_run_config('modifiers', test_modifiers, config_path,
+                       'basic', 'working_wl', batch_cmd='')
+
+        ws1._re_read()
+        ws_args = ['-D', ws1.root]
+
+        workspace('concretize', global_args=ws_args)
+        workspace('setup', global_args=ws_args)
+        on_cmd(global_args=ws_args)
+        workspace('analyze', global_args=ws_args)
+
+        expected_regex = re.compile('.*This test worked')
+        found_str = False
+        with open(os.path.join(ws1.root, 'results.latest.txt'), 'r') as f:
+            for line in f.readlines():
+                if expected_regex.match(line):
+                    found_str = True
+
+        assert found_str

--- a/var/ramble/repos/builtin.mock/applications/basic/application.py
+++ b/var/ramble/repos/builtin.mock/applications/basic/application.py
@@ -14,12 +14,14 @@ class Basic(ExecutableApplication):
 
     executable('foo', 'bar', use_mpi=False)
     executable('bar', 'baz', use_mpi=True)
+    executable('echo', 'echo "0.25 seconds"', use_mpi=False)
 
     input_file('input', url='file:///tmp/test_file.log',
                description='Not a file', extension='.log')
 
     workload('test_wl', executable='foo', input='input')
     workload('test_wl2', executable='bar', input='input')
+    workload('working_wl', executable='echo')
 
     workload_variable('my_var', default='1.0',
                       description='Example var',

--- a/var/ramble/repos/builtin.mock/modifiers/prepare-analysis/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/prepare-analysis/modifier.py
@@ -1,0 +1,27 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.modkit import *  # noqa: F403
+
+
+class PrepareAnalysis(BasicModifier):
+    """Define a modifier that defines a prepare_analysis hook"""
+    name = "prepare-analysis"
+
+    tags('test')
+
+    mode('test', description='This is a test mode')
+
+    _log_file = '{experiment_run_dir}/.prepare_analysis_hook_data'
+
+    figure_of_merit('test-fom', fom_regex='Test fom = (?P<fom>.*)', log_file=_log_file,
+                    units='', group_name='fom')
+
+    def _prepare_analysis(self, workspace):
+        with open(self.expander.expand_var(self._log_file), 'w+') as f:
+            f.write('Test fom = This test worked')


### PR DESCRIPTION
This merge adds a hook in modifier definitions to perform work before figures of merit can be extracted. Additionally, this merge adds a phase to applications called prepare_analysis, which currently does nothing but we will transition to having analyze_experiments become extract_analysis.