### PR TITLE
Redirect prints from Spack to log file

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -20,6 +20,7 @@ from typing import List
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 import llnl.util.tty.color as color
+import llnl.util.tty.log
 from llnl.util.tty.colify import colified
 
 import spack.util.executable
@@ -105,6 +106,8 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         self.license_path = ''
         self.license_file = ''
         self.license_inc_name = 'license.inc'
+
+        self.logger = llnl.util.tty.log.log_output(echo=False, debug=tty.debug_level())
 
     def copy(self):
         """Deep copy an application instance"""
@@ -278,6 +281,13 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         """Set modifiers for this instance"""
         if modifiers:
             self.modifiers = modifiers.copy()
+
+    def experiment_log_file(self, logs_dir):
+        """Returns an experiment log file path for the given logs directory"""
+        return os.path.join(
+            logs_dir,
+            self.expander.experiment_namespace) + \
+            '.out'
 
     def get_pipeline_phases(self, pipeline, phase_filters=['*']):
         if pipeline not in self._pipelines:

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -430,7 +430,7 @@ def workspace_info(args):
                 header_base = rucolor.nested_4('Variables from')
                 config_vars = ramble.config.config.get('config:variables')
 
-                for exp_name, _ in print_experiment_set.all_experiments():
+                for exp_name, _, _ in print_experiment_set.all_experiments():
                     app_inst = experiment_set.get_experiment(exp_name)
 
                     # Aggregate pipeline phases

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -390,11 +390,15 @@ class ExperimentSet(object):
 
     def all_experiments(self):
         """Iterator over all experiments in this set"""
+        count = 1
+
         for exp, inst in self.experiments.items():
-            yield exp, inst
+            yield exp, inst, count
+            count += 1
 
         for exp, inst in self.chained_experiments.items():
-            yield exp, inst
+            yield exp, inst, count
+            count += 1
 
     def add_chained_experiment(self, name, instance):
         if name in self.chained_experiments.keys():

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -7,6 +7,7 @@
 # except according to those terms.
 
 import os
+import glob
 
 import pytest
 
@@ -15,6 +16,7 @@ import llnl.util.filesystem as fs
 import ramble.workspace
 from ramble.software_environments import RambleSoftwareEnvironmentError
 from ramble.main import RambleCommand, RambleCommandError
+from ramble.test.dry_run_helpers import search_files_for_string
 import ramble.config
 
 import spack.util.spack_yaml as syaml
@@ -669,9 +671,11 @@ ramble:
 
     ws1._re_read()
 
-    output = workspace('setup', '--dry-run', global_args=['-w', workspace_name])
+    workspace('setup', '--dry-run', global_args=['-w', workspace_name])
 
-    assert "Would download file:///tmp/test_file.log" in output
+    out_files = glob.glob(os.path.join(ws1.log_dir, '**', '*.out'), recursive=True)
+
+    assert search_files_for_string(out_files, 'Would download file:///tmp/test_file.log')
     assert os.path.exists(os.path.join(ws1.root, 'experiments',
                                        'basic', 'test_wl',
                                        'test_experiment',
@@ -740,9 +744,11 @@ ramble:
     for exp in expected_experiments:
         assert exp in output
 
-    output = workspace('setup', '--dry-run', global_args=workspace_flags)
+    workspace('setup', '--dry-run', global_args=workspace_flags)
 
-    assert "Would download file:///tmp/test_file.log" in output
+    out_files = glob.glob(os.path.join(ws1.log_dir, '**', '*.out'), recursive=True)
+
+    assert search_files_for_string(out_files, 'Would download file:///tmp/test_file.log')
 
     exp_base = os.path.join(ws1.experiment_dir, 'basic', 'test_wl')
     for exp in expected_experiments:
@@ -794,6 +800,7 @@ ramble:
     output = workspace('setup', '--dry-run',
                        global_args=workspace_flags,
                        fail_on_error=False)
+
     assert "Length mismatch in vector variables in " + \
         "experiment exp_series_{idx}_{n_nodes}_{cells}_{processes_per_node}" in output
 
@@ -1075,12 +1082,13 @@ ramble:
 
     ws1._re_read()
 
-    output = workspace('setup', '--dry-run', global_args=['-w', workspace_name])
+    workspace('setup', '--dry-run', global_args=['-w', workspace_name])
     experiment_dir = os.path.join(ws1.root, 'experiments',
                                   'basic', 'test_wl',
                                   'test_experiment')
+    out_files = glob.glob(os.path.join(ws1.log_dir, '**', '*.out'), recursive=True)
 
-    assert "Would download file:///tmp/test_file.log" in output
+    assert search_files_for_string(out_files, 'Would download file:///tmp/test_file.log')
     assert os.path.exists(os.path.join(experiment_dir,
                                        'execute_experiment'))
 
@@ -1094,7 +1102,7 @@ ramble:
         f = open(new_file, 'w+')
         f.close()
 
-    output = workspace('archive', global_args=['-w', workspace_name])
+    workspace('archive', global_args=['-w', workspace_name])
 
     assert ws1.latest_archive
     assert os.path.exists(ws1.latest_archive_path)
@@ -1149,12 +1157,13 @@ ramble:
 
     ws1._re_read()
 
-    output = workspace('setup', '--dry-run', global_args=['-w', workspace_name])
+    workspace('setup', '--dry-run', global_args=['-w', workspace_name])
     experiment_dir = os.path.join(ws1.root, 'experiments',
                                   'basic', 'test_wl',
                                   'test_experiment')
+    out_files = glob.glob(os.path.join(ws1.log_dir, '**', '*.out'), recursive=True)
 
-    assert "Would download file:///tmp/test_file.log" in output
+    assert search_files_for_string(out_files, 'Would download file:///tmp/test_file.log')
     assert os.path.exists(os.path.join(experiment_dir,
                                        'execute_experiment'))
 
@@ -1168,7 +1177,7 @@ ramble:
         f = open(new_file, 'w+')
         f.close()
 
-    output = workspace('archive', '-t', global_args=['-w', workspace_name])
+    workspace('archive', '-t', global_args=['-w', workspace_name])
 
     assert ws1.latest_archive
     assert os.path.exists(ws1.latest_archive_path)
@@ -1225,12 +1234,13 @@ ramble:
 
     ws1._re_read()
 
-    output = workspace('setup', '--dry-run', global_args=['-w', workspace_name])
+    workspace('setup', '--dry-run', global_args=['-w', workspace_name])
     experiment_dir = os.path.join(ws1.root, 'experiments',
                                   'basic', 'test_wl',
                                   'test_experiment')
+    out_files = glob.glob(os.path.join(ws1.log_dir, '**', '*.out'), recursive=True)
 
-    assert "Would download file:///tmp/test_file.log" in output
+    assert search_files_for_string(out_files, 'Would download file:///tmp/test_file.log')
     assert os.path.exists(os.path.join(experiment_dir,
                                        'execute_experiment'))
 
@@ -1247,8 +1257,8 @@ ramble:
     remote_archive_path = os.path.join(ws1.root, 'archive_backup')
     fs.mkdirp(remote_archive_path)
 
-    output = workspace('archive', '-t', '-u', 'file://' + remote_archive_path,
-                       global_args=['-w', workspace_name])
+    workspace('archive', '-t', '-u', 'file://' + remote_archive_path,
+              global_args=['-w', workspace_name])
 
     assert ws1.latest_archive
     assert os.path.exists(ws1.latest_archive_path)
@@ -1307,12 +1317,13 @@ ramble:
 
     ws1._re_read()
 
-    output = workspace('setup', '--dry-run', global_args=['-w', workspace_name])
+    workspace('setup', '--dry-run', global_args=['-w', workspace_name])
     experiment_dir = os.path.join(ws1.root, 'experiments',
                                   'basic', 'test_wl',
                                   'test_experiment')
+    out_files = glob.glob(os.path.join(ws1.log_dir, '**', '*.out'), recursive=True)
 
-    assert "Would download file:///tmp/test_file.log" in output
+    assert search_files_for_string(out_files, 'Would download file:///tmp/test_file.log')
     assert os.path.exists(os.path.join(experiment_dir,
                                        'execute_experiment'))
 
@@ -1332,7 +1343,7 @@ ramble:
     config('add', 'config:archive_url:%s/' % remote_archive_path,
            global_args=['-w', workspace_name])
 
-    output = workspace('archive', '-t', global_args=['-w', workspace_name])
+    workspace('archive', '-t', global_args=['-w', workspace_name])
 
     assert ws1.latest_archive
     assert os.path.exists(ws1.latest_archive_path)
@@ -1381,9 +1392,11 @@ ramble:
 
     ws1._re_read()
 
-    output = workspace('setup', '--dry-run', global_args=['-w', workspace_name])
+    workspace('setup', '--dry-run', global_args=['-w', workspace_name])
 
-    assert "Would download file:///tmp/test_file.log" in output
+    out_files = glob.glob(os.path.join(ws1.log_dir, '**', '*.out'), recursive=True)
+
+    assert search_files_for_string(out_files, 'Would download file:///tmp/test_file.log')
     assert os.path.exists(os.path.join(ws1.root, 'experiments',
                                        'basic', 'test_wl',
                                        'test_experiment',

--- a/lib/ramble/ramble/test/dry_run_helpers.py
+++ b/lib/ramble/ramble/test/dry_run_helpers.py
@@ -77,3 +77,11 @@ def dry_run_config(section_name, injections, config_path,
 
     with open(config_path, 'w+') as f:
         syaml.dump(ramble_dict, stream=f)
+
+
+def search_files_for_string(file_list, string):
+    for file in file_list:
+        with open(file) as f:
+            if string in f.read():
+                return True
+    return False

--- a/lib/ramble/ramble/test/end_to_end/experiment_excludes.py
+++ b/lib/ramble/ramble/test/end_to_end/experiment_excludes.py
@@ -15,6 +15,7 @@ import ramble.workspace
 import ramble.config
 import ramble.software_environments
 from ramble.main import RambleCommand
+from ramble.test.dry_run_helpers import search_files_for_string
 
 
 # everything here uses the mock_workspace_path
@@ -145,8 +146,12 @@ licenses:
 
         ws1._re_read()
 
-        output = workspace('setup', '--dry-run', global_args=['-w', workspace_name])
-        assert "Would download https://www2.mmm.ucar.edu/wrf/users/benchmark/v422/v42_bench_conus12km.tar.gz" in output
+        workspace('setup', '--dry-run', global_args=['-w', workspace_name])
+
+        out_files = glob.glob(os.path.join(ws1.log_dir, '**', '*.out'), recursive=True)
+
+        assert search_files_for_string(
+            out_files, 'Would download https://www2.mmm.ucar.edu/wrf/users/benchmark/v422/v42_bench_conus12km.tar.gz') # noqa
 
         # Test software directories
         software_dirs = ['wrfv4.CONUS_12km', 'wrfv4-portable.CONUS_12km']
@@ -250,8 +255,7 @@ licenses:
                 f = open(new_file, 'w+')
                 f.close()
 
-        output = workspace('analyze', '-f', 'text',
-                           'json', 'yaml', global_args=['-w', workspace_name])
+        workspace('analyze', '-f', 'text', 'json', 'yaml', global_args=['-w', workspace_name])
         text_simlink_results_files = glob.glob(os.path.join(ws1.root, 'results.latest.txt'))
         text_results_files = glob.glob(os.path.join(ws1.root, 'results*.txt'))
         json_results_files = glob.glob(os.path.join(ws1.root, 'results*.json'))
@@ -270,7 +274,7 @@ licenses:
             assert 'Avg. Max Ratio Time = 0.6' in data
             assert 'Number of timesteps = 5' in data
 
-        output = workspace('archive', global_args=['-w', workspace_name])
+        workspace('archive', global_args=['-w', workspace_name])
 
         assert ws1.latest_archive
         assert os.path.exists(ws1.latest_archive_path)

--- a/lib/ramble/ramble/test/end_to_end/explicit_zips.py
+++ b/lib/ramble/ramble/test/end_to_end/explicit_zips.py
@@ -15,6 +15,7 @@ import ramble.workspace
 import ramble.config
 import ramble.software_environments
 from ramble.main import RambleCommand
+from ramble.test.dry_run_helpers import search_files_for_string
 
 
 # everything here uses the mock_workspace_path
@@ -133,8 +134,12 @@ licenses:
 
         ws1._re_read()
 
-        output = workspace('setup', '--dry-run', global_args=['-w', workspace_name])
-        assert "Would download https://www2.mmm.ucar.edu/wrf/users/benchmark/v422/v42_bench_conus12km.tar.gz" in output
+        workspace('setup', '--dry-run', global_args=['-w', workspace_name])
+
+        out_files = glob.glob(os.path.join(ws1.log_dir, '**', '*.out'), recursive=True)
+
+        assert search_files_for_string(
+            out_files, 'Would download https://www2.mmm.ucar.edu/wrf/users/benchmark/v422/v42_bench_conus12km.tar.gz') # noqa
 
         # Test software directories
         software_dirs = ['wrfv4.CONUS_12km', 'wrfv4-portable.CONUS_12km']
@@ -231,8 +236,8 @@ licenses:
                 f = open(new_file, 'w+')
                 f.close()
 
-        output = workspace('analyze', '-f', 'text',
-                           'json', 'yaml', global_args=['-w', workspace_name])
+        workspace('analyze', '-f', 'text',
+                  'json', 'yaml', global_args=['-w', workspace_name])
         text_simlink_results_files = glob.glob(os.path.join(ws1.root, 'results.latest.txt'))
         text_results_files = glob.glob(os.path.join(ws1.root, 'results*.txt'))
         json_results_files = glob.glob(os.path.join(ws1.root, 'results*.json'))
@@ -251,7 +256,7 @@ licenses:
             assert 'Avg. Max Ratio Time = 0.6' in data
             assert 'Number of timesteps = 5' in data
 
-        output = workspace('archive', global_args=['-w', workspace_name])
+        workspace('archive', global_args=['-w', workspace_name])
 
         assert ws1.latest_archive
         assert os.path.exists(ws1.latest_archive_path)

--- a/lib/ramble/ramble/test/end_to_end/known_applications.py
+++ b/lib/ramble/ramble/test/end_to_end/known_applications.py
@@ -25,7 +25,7 @@ workspace = RambleCommand('workspace')
 
 
 @pytest.mark.long
-def test_known_applications(application):
+def test_known_applications(application, capsys):
     info_cmd = RambleCommand('info')
 
     workload_regex = re.compile(r'Workload: (?P<wl_name>.*)')

--- a/lib/ramble/ramble/test/end_to_end/missing_required_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/missing_required_dry_run.py
@@ -23,7 +23,7 @@ pytestmark = pytest.mark.usefixtures('mutable_config',
 workspace = RambleCommand('workspace')
 
 
-def test_missing_required_dry_run(mutable_config, mutable_mock_workspace_path, capsys):
+def test_missing_required_dry_run(mutable_config, mutable_mock_workspace_path):
     """Tests tty.die at end of ramble.application_types.spack._create_spack_env"""
     test_config = """
 ramble:
@@ -71,10 +71,8 @@ ramble:
         ws._re_read()
 
         with pytest.raises(RambleCommandError):
-            workspace('setup',
-                      '--dry-run',
-                      global_args=['-w', workspace_name])
-
-            captured = capsys.readouterr()
+            captured = workspace('setup',
+                                 '--dry-run',
+                                 global_args=['-w', workspace_name])
 
             assert "Software spec wrf is not defined in environment wrfv3" in captured

--- a/lib/ramble/ramble/test/end_to_end/phase_selection.py
+++ b/lib/ramble/ramble/test/end_to_end/phase_selection.py
@@ -7,6 +7,7 @@
 # except according to those terms.
 
 import os
+import glob
 
 import pytest
 
@@ -14,6 +15,7 @@ import ramble.workspace
 import ramble.config
 import ramble.software_environments
 from ramble.main import RambleCommand
+from ramble.test.dry_run_helpers import search_files_for_string
 
 
 # everything here uses the mock_workspace_path
@@ -144,7 +146,10 @@ licenses:
         assert "Phases for archive pipeline:" in output
         assert "Phases for mirror pipeline:" in output
 
-        output = workspace('setup', '--phases', 'get_*', 'make_*', '--dry-run',
+        workspace('setup', '--phases', 'get_*', 'make_*', '--dry-run',
                            global_args=['-v', '-w', workspace_name])
-        assert 'Executing phase get_inputs' in output
-        assert 'Executing phase make_experiments' in output
+
+        out_files = glob.glob(os.path.join(ws1.log_dir, '**', '*.out'), recursive=True)
+
+        assert search_files_for_string(out_files, 'Executing phase get_inputs')
+        assert search_files_for_string(out_files, 'Executing phase make_experiments')

--- a/lib/ramble/ramble/test/end_to_end/unused_compilers_are_skipped.py
+++ b/lib/ramble/ramble/test/end_to_end/unused_compilers_are_skipped.py
@@ -7,6 +7,7 @@
 # except according to those terms.
 
 import os
+import glob
 
 import pytest
 
@@ -14,6 +15,7 @@ import ramble.workspace
 import ramble.config
 import ramble.software_environments
 from ramble.main import RambleCommand
+from ramble.test.dry_run_helpers import search_files_for_string
 
 
 # everything here uses the mock_workspace_path
@@ -75,12 +77,13 @@ ramble:
         ws._re_read()
 
         ws.run_pipeline('setup')
-        captured = capsys.readouterr()
 
         required_compiler_str = "gcc@8.5.0"
         unused_gcc9_str = "gcc@9.3.0"
         unused_gcc10_str = "gcc@10.1.0"
 
-        assert required_compiler_str in captured.out
-        assert unused_gcc9_str not in captured.out
-        assert unused_gcc10_str not in captured.out
+        out_files = glob.glob(os.path.join(ws.log_dir, '**', '*.out'), recursive=True)
+
+        assert search_files_for_string(out_files, required_compiler_str) is True
+        assert search_files_for_string(out_files, unused_gcc9_str) is False
+        assert search_files_for_string(out_files, unused_gcc10_str) is False

--- a/lib/ramble/ramble/test/end_to_end/wrfv4_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/wrfv4_dry_run.py
@@ -15,6 +15,7 @@ import ramble.workspace
 import ramble.config
 import ramble.software_environments
 from ramble.main import RambleCommand
+from ramble.test.dry_run_helpers import search_files_for_string
 
 
 # everything here uses the mock_workspace_path
@@ -128,8 +129,12 @@ licenses:
 
         ws1._re_read()
 
-        output = workspace('setup', '--dry-run', global_args=['-w', workspace_name])
-        assert "Would download https://www2.mmm.ucar.edu/wrf/users/benchmark/v422/v42_bench_conus12km.tar.gz" in output
+        workspace('setup', '--dry-run', global_args=['-w', workspace_name])
+
+        out_files = glob.glob(os.path.join(ws1.log_dir, '**', '*.out'), recursive=True)
+
+        assert search_files_for_string(
+            out_files, 'Would download https://www2.mmm.ucar.edu/wrf/users/benchmark/v422/v42_bench_conus12km.tar.gz') # noqa
 
         # Test software directories
         software_dirs = ['wrfv4.CONUS_12km', 'wrfv4-portable.CONUS_12km']
@@ -242,8 +247,7 @@ licenses:
             f.write("Dummy data...")
         os.symlink(tmp_results_file, simlink_results_file)
 
-        output = workspace('analyze', '-f', 'text',
-                           'json', 'yaml', global_args=['-w', workspace_name])
+        workspace('analyze', '-f', 'text', 'json', 'yaml', global_args=['-w', workspace_name])
 
         text_results_files = glob.glob(os.path.join(ws1.root, 'results*.txt'))
         json_results_files = glob.glob(os.path.join(ws1.root, 'results*.json'))
@@ -264,7 +268,7 @@ licenses:
                 assert 'Avg. Max Ratio Time = 0.6' in data
                 assert 'Number of timesteps = 5' in data
 
-        output = workspace('archive', global_args=['-w', workspace_name])
+        workspace('archive', global_args=['-w', workspace_name])
 
         assert ws1.latest_archive
         assert os.path.exists(ws1.latest_archive_path)

--- a/lib/ramble/ramble/test/experiment_set.py
+++ b/lib/ramble/ramble/test/experiment_set.py
@@ -582,7 +582,7 @@ def test_experiment_names_match(mutable_mock_workspace_path):
         assert 'basic.test_wl.series1_4_2' in exp_set.experiments.keys()
         assert 'basic.test_wl.series1_12_4' in exp_set.experiments.keys()
 
-        for exp, app in exp_set.all_experiments():
+        for exp, app, _ in exp_set.all_experiments():
             assert exp == app.expander.expand_var('{experiment_namespace}')
 
 

--- a/lib/ramble/ramble/test/modifier_functionality/mock_spack_modifier.py
+++ b/lib/ramble/ramble/test/modifier_functionality/mock_spack_modifier.py
@@ -7,11 +7,13 @@
 # except according to those terms.
 
 import os
+import glob
 
 import pytest
 
-from ramble.test.dry_run_helpers import dry_run_config, SCOPES
+from ramble.test.dry_run_helpers import dry_run_config, search_files_for_string, SCOPES
 import ramble.test.modifier_functionality.modifier_helpers as modifier_helpers
+
 import ramble.workspace
 from ramble.main import RambleCommand
 
@@ -53,11 +55,12 @@ def test_gromacs_dry_run_mock_spack_mod(mutable_mock_workspace_path,
         ws1._re_read()
 
         workspace('concretize', global_args=['-D', ws1.root])
-        output = workspace('setup', '--dry-run', global_args=['-D', ws1.root])
+        workspace('setup', '--dry-run', global_args=['-D', ws1.root])
+        out_files = glob.glob(os.path.join(ws1.log_dir, '**', '*.out'), recursive=True)
 
         expected_str = "with args: ['--reuse', 'mod_compiler@1.1 target=x86_64']"
 
-        assert expected_str in output
+        assert search_files_for_string(out_files, expected_str)
 
         # Test software directories
         software_base_dir = ws1.software_dir

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ google-api-core # for gcs fetch error .execptions
 coverage
 pre-commit
 google-cloud-bigquery
+tqdm # for workspace progress bar


### PR DESCRIPTION
Redirects prints from Spack to a log file to provide a cleaner command line experience for users. Logger wraps everything within the run_pipeline() method in workspace.py, which currently covers workspace setup, analyze, and mirror commands. All of stdout gets redirected into the logfile, unless inside a logger.force_echo() block. Added force_echo() blocks to all errors / tty.die within spack.py to ensure errors get printed to stdout.