### PR TITLE
Add command-line control over workspace actions

### DIFF
--- a/lib/ramble/docs/workspace.rst
+++ b/lib/ramble/docs/workspace.rst
@@ -210,6 +210,42 @@ The ``--phases`` argument supports wildcard matching, i.e.:
 Would execute all phases that have then ``_experiments`` suffix.
 
 ^^^^^^^^^^^^^^^^^^^^^
+Filtering Experiments
+^^^^^^^^^^^^^^^^^^^^^
+
+Several of the workspace commands support filtering the experiments they should
+act on. This can be performed using the ``--where`` argument for inclusive
+filtering, or the ``--exclude-where`` argument for exclusive filtering. These
+arguments take a string representing a logical expression, which can use
+variables the experiment would define. If the logical expression evaluates to
+true, the experiment will be included or excluded for action (respectively).
+
+As an example:
+
+.. code-block:: console
+
+   $ ramble workspace setup --where '"{n_ranks}" < 500'
+
+Will only setup experiments that have less than 500 ranks, and:
+
+.. code-block:: console
+
+    $ ramble workspace setup --exclude-shere '"{application_name}" == "hostname"'
+
+Will exclude all experiments from the ``hostname`` application.
+
+The commands that accept these filters are:
+
+.. code-block:: console
+
+    $ ramble workspace analyze
+    $ ramble workspace archive
+    $ ramble workspace mirror
+    $ ramble workspace setup
+
+**NOTE:** The exclusive filter takes precedence over the inclusive filter.
+
+^^^^^^^^^^^^^^^^^^^^^
 Software Environments
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -793,12 +793,12 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         for input_file, input_conf in self._input_fetchers.items():
             mirror_paths = ramble.mirror.mirror_archive_paths(
                 input_conf['fetcher'], os.path.join(self.name, input_file))
-            fetch_dir = os.path.join(workspace._input_mirror_path, self.name)
+            fetch_dir = os.path.join(workspace.input_mirror_path, self.name)
             fs.mkdirp(fetch_dir)
             stage = ramble.stage.InputStage(input_conf['fetcher'], name=input_conf['namespace'],
                                             path=fetch_dir, mirror_paths=mirror_paths, lock=False)
 
-            stage.cache_mirror(workspace._input_mirror_cache, workspace._input_mirror_stats)
+            stage.cache_mirror(workspace.input_mirror_cache, workspace.input_mirror_stats)
 
     def _get_inputs(self, workspace):
         """Download application inputs

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -1173,8 +1173,10 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         tty.debug('fom_vals = %s' % fom_values)
         results['EXPERIMENT_CHAIN'] = self.chain_order.copy()
         if success:
+            self.set_status(status='SUCCESS')
             results['RAMBLE_STATUS'] = 'SUCCESS'
         else:
+            self.set_status(status='FAILED')
             results['RAMBLE_STATUS'] = 'FAILED'
 
         if success or workspace.always_print_foms:

--- a/lib/ramble/ramble/application_types/executable.py
+++ b/lib/ramble/ramble/application_types/executable.py
@@ -25,6 +25,7 @@ class ExecutableApplication(ApplicationBase):
             'get_inputs',
             'make_experiments',
             'write_inventory',
+            'write_status'
         ]
 
         self.application_class = 'ExecutableApplication'

--- a/lib/ramble/ramble/application_types/spack.py
+++ b/lib/ramble/ramble/application_types/spack.py
@@ -56,6 +56,7 @@ class SpackApplication(ApplicationBase):
             'get_inputs',
             'make_experiments',
             'write_inventory',
+            'write_status'
         ]
 
         self._mirror_phases = [

--- a/lib/ramble/ramble/application_types/spack.py
+++ b/lib/ramble/ramble/application_types/spack.py
@@ -61,7 +61,7 @@ class SpackApplication(ApplicationBase):
 
         self._mirror_phases = [
             'mirror_inputs',
-            'create_software_env',
+            'software_create_env',
             'mirror_software'
         ]
 
@@ -325,8 +325,7 @@ class SpackApplication(ApplicationBase):
 
             self.spack_runner.activate()
 
-            mirror_output = self.spack_runner \
-                                .mirror_environment(workspace._software_mirror_path)
+            mirror_output = self.spack_runner.mirror_environment(workspace.software_mirror_path)
 
             present = 0
             added = 0
@@ -347,33 +346,38 @@ class SpackApplication(ApplicationBase):
             if failed_match:
                 failed = int(failed_match.group('num'))
 
-            added_start = len(workspace._software_mirror_stats.new)
+            added_start = len(workspace.software_mirror_stats.new)
             for i in range(added_start, added_start + added):
-                workspace._software_mirror_stats.new[i] = i
+                workspace.software_mirror_stats.new[i] = i
 
-            present_start = len(workspace._software_mirror_stats.present)
+            present_start = len(workspace.software_mirror_stats.present)
             for i in range(present_start, present_start + present):
-                workspace._software_mirror_stats.present[i] = i
+                workspace.software_mirror_stats.present[i] = i
 
-            error_start = len(workspace._software_mirror_stats.errors)
+            error_start = len(workspace.software_mirror_stats.errors)
             for i in range(error_start, error_start + failed):
-                workspace._software_mirror_stats.errors.add(i)
+                workspace.software_mirror_stats.errors.add(i)
 
         except ramble.spack_runner.RunnerError as e:
             with self.logger.force_echo():
                 tty.die(e)
 
-    def _write_inventory(self, workspace):
+    def populate_inventory(self, workspace, force_compute=False, require_exist=False):
         """Add software environment information to hash inventory"""
 
+        env_path = self.expander.env_path
+        self.spack_runner.set_dry_run(workspace.dry_run)
+        self.spack_runner.set_env(env_path, require_exists=False)
+        self.spack_runner.activate()
         self.hash_inventory['software'].append(
             {
                 'name': self.spack_runner.env_path.replace(workspace.root + os.path.sep, ''),
-                'digest': self.spack_runner.inventory_hash()
+                'digest': self.spack_runner.inventory_hash(require_exist)
             }
         )
+        self.spack_runner.deactivate()
 
-        super()._write_inventory(workspace)
+        super().populate_inventory(workspace, force_compute, require_exist)
 
     def _clean_hash_variables(self, workspace, variables):
         """Perform spack specific cleanup of variables before hashing"""

--- a/lib/ramble/ramble/cmd/common/arguments.py
+++ b/lib/ramble/ramble/cmd/common/arguments.py
@@ -98,6 +98,28 @@ def phases():
 
 
 @arg
+def where():
+    return Args(
+        '--where', dest='where',
+        nargs='+',
+        action='append',
+        help='inclusive filter on experiments where the provided logical statement is True',
+        required=False
+    )
+
+
+@arg
+def exclude_where():
+    return Args(
+        '--exclude-where', dest='exclude_where',
+        nargs='+',
+        action='append',
+        help='exclusive filter experiments where the provided logical statement is True',
+        required=False
+    )
+
+
+@arg
 def no_checksum():
     return Args(
         '-n', '--no-checksum', action='store_true', default=False,

--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -258,6 +258,30 @@ class Expander(object):
 
         return str(expanded).lstrip()
 
+    def compute_logical(self, in_str, extra_vars=None):
+        """Compute the logical value by evaluating math contained in a string
+
+        Args:
+            in_str: String representing logical math that should be evaluated
+            extra_vars: Variable definitions to use with highest precedence
+
+        Returns:
+            boolean: True or False, based on the evaluation of in_str
+        """
+
+        evaluated = self.expand_var(in_str, extra_vars=extra_vars, allow_passthrough=False)
+
+        if not isinstance(evaluated, six.string_types):
+            tty.die('Logical compute failed to return a string')
+
+        if evaluated == 'True':
+            return True
+        elif evaluated == 'False':
+            return False
+        else:
+            tty.die(f'When evaluating {in_str}, compute_logical returned a non-boolean '
+                    f'string: "{evaluated}"')
+
     @staticmethod
     def expansion_str(in_str):
         l_delimiter = '{'

--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -258,11 +258,11 @@ class Expander(object):
 
         return str(expanded).lstrip()
 
-    def compute_logical(self, in_str, extra_vars=None):
-        """Compute the logical value by evaluating math contained in a string
+    def evaluate_predicate(self, in_str, extra_vars=None):
+        """Evaluate a predicate by expanding and evaluating math contained in a string
 
         Args:
-            in_str: String representing logical math that should be evaluated
+            in_str: String representing predicate that should be evaluated
             extra_vars: Variable definitions to use with highest precedence
 
         Returns:
@@ -279,7 +279,7 @@ class Expander(object):
         elif evaluated == 'False':
             return False
         else:
-            tty.die(f'When evaluating {in_str}, compute_logical returned a non-boolean '
+            tty.die(f'When evaluating {in_str}, evaluate_predicate returned a non-boolean '
                     f'string: "{evaluated}"')
 
     @staticmethod

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -408,11 +408,7 @@ class ExperimentSet(object):
     def num_filtered_experiments(self, filters):
         """Return the number of filtered experiments in this set"""
 
-        count = 0
-        for _, _, count in self.filtered_experiments(filters):
-            pass
-
-        return count
+        return sum(1 for _ in self.filtered_experiments(filters))
 
     def filtered_experiments(self, filters):
         """Return a filtered set of all experiments based on a logical expression
@@ -428,23 +424,21 @@ class ExperimentSet(object):
             inst: An application instance representing the experiment
         """
 
-        count = 1
-        for exp, inst, _ in self.all_experiments():
+        for exp, inst, idx in self.all_experiments():
             active = True
 
             if filters.include_where:
                 for expression in filters.include_where:
-                    if not inst.expander.compute_logical(expression):
+                    if not inst.expander.evaluate_predicate(expression):
                         active = False
 
             if filters.exclude_where:
                 for expression in filters.exclude_where:
-                    if inst.expander.compute_logical(expression):
+                    if inst.expander.evaluate_predicate(expression):
                         active = False
 
             if active:
-                yield exp, inst, count
-            count += 1
+                yield exp, inst, idx
 
     def add_chained_experiment(self, name, instance):
         if name in self.chained_experiments.keys():

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -378,6 +378,7 @@ class ExperimentSet(object):
             app_inst.set_template(final_context.is_template)
             app_inst.set_chained_experiments(final_context.chained_experiments)
             app_inst.set_modifiers(final_context.modifiers)
+            app_inst.read_status()
             self.experiments[experiment_namespace] = app_inst
             self.experiment_order.append(experiment_namespace)
 

--- a/lib/ramble/ramble/filters.py
+++ b/lib/ramble/ramble/filters.py
@@ -1,0 +1,26 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import itertools
+
+
+class Filters(object):
+    """Object containing filters for limiting various operations in Ramble"""
+
+    def __init__(self, phase_filters=['*'],
+                 include_where_filters=None,
+                 exclude_where_filters=None):
+        """Create a new filter instance"""
+
+        self.phases = phase_filters
+        self.include_where = None
+        self.exclude_where = None
+        if include_where_filters:
+            self.include_where = list(itertools.chain.from_iterable(include_where_filters))
+        if exclude_where_filters:
+            self.exclude_where = list(itertools.chain.from_iterable(exclude_where_filters))

--- a/lib/ramble/ramble/keywords.py
+++ b/lib/ramble/ramble/keywords.py
@@ -43,6 +43,7 @@ class Keywords(object):
         'license_input_dir': key_type.reserved,
         'experiment_name': key_type.reserved,
         'experiment_run_dir': key_type.reserved,
+        'experiment_status': key_type.reserved,
         'log_dir': key_type.reserved,
         'log_file': key_type.reserved,
         'err_file': key_type.reserved,

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -183,7 +183,6 @@ class AnalyzePipeline(Pipeline):
     def _complete(self):
         self.workspace.dump_results(output_formats=self.output_formats)
 
-        # FIXME: this will fire the analyze logic of twice currently
         if self.upload_results:
             ramble.experimental.upload.upload_results(self.workspace.results)
 
@@ -329,7 +328,7 @@ _pipeline_map = {
 
 
 def pipeline_class(name):
-    """Factory for constructing a pipeline instance from its name"""
+    """Factory for determining a pipeline class from its name"""
 
     if name not in _pipeline_map.keys():
         tty.die(f'Pipeline {name} is not valid.\n'

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -1,0 +1,305 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from enum import Enum
+import stat
+import os
+import shutil
+import py.path
+
+import llnl.util.filesystem as fs
+import llnl.util.tty as tty
+from llnl.util.tty.color import cprint
+
+import ramble.config
+import ramble.experiment_set
+import ramble.software_environments
+import ramble.util.hashing
+import ramble.fetch_strategy
+import ramble.stage
+import ramble.workspace
+
+import ramble.experimental.uploader
+
+from ramble.namespace import namespace
+
+import spack.util.spack_json as sjson
+from spack.util.executable import which
+
+
+class Pipeline(object):
+    """Base Class for all pipeline objects"""
+    name = 'base'
+
+    def __init__(self, workspace, filters):
+        """Create a new pipeline instance"""
+        self.filters = filters
+        self.workspace = workspace
+        self.force_inventory = False
+        self.require_inventory = False
+        self.action_string = 'Operating on'
+
+        dt = self.workspace.date_string()
+        log_file = f'{self.name}.{dt}.out'
+        self.log_dir = os.path.join(self.workspace.log_dir,
+                                    f'{self.name}.{dt}')
+        self.log_path = os.path.join(self.workspace.log_dir,
+                                     log_file)
+        fs.mkdirp(self.log_dir)
+
+        self._experiment_set = workspace.build_experiment_set()
+        self._software_environments = ramble.software_environments.SoftwareEnvironments(workspace)
+        self.workspace.software_environments = self._software_environments
+
+    def _validate(self):
+        """Perform validation that this pipeline can be executed"""
+        if not self.workspace.is_concretized():
+            error_message = 'Cannot run %s in a ' % self.name + \
+                            'non-conretized workspace\n' + \
+                            'Run `ramble workspace concretize` on this ' + \
+                            'workspace first.\n' + \
+                            'Then ensure its spack configuration is ' + \
+                            'properly configured.'
+            with self.workspace.logger.force_echo():
+                tty.die(error_message)
+
+    def _prepare(self):
+        """Perform preparation for pipeline execution"""
+        pass
+
+    def _execute(self):
+        """Hook for executing the pipeline"""
+        for exp, app_inst, count in self._experiment_set.filtered_experiments(self.filters):
+            exp_log_path = app_inst.experiment_log_file(self.log_dir)
+            exp_log_stream = open(exp_log_path, 'a+')
+
+            tty.msg(f'    Experiment {count}:',
+                    f'        name: {exp}',
+                    f'        log file: {exp_log_path}')
+
+            for phase in app_inst.get_pipeline_phases(self.name, self.filters.phases):
+                with app_inst.logger(exp_log_stream):
+                    app_inst.run_phase(phase, self.workspace)
+
+    def _complete(self):
+        """Hook for performing pipeline actions after execution is complete"""
+        pass
+
+    def run(self):
+        """Run the full pipeline"""
+        self.log_stream = open(self.log_path, 'a+')
+
+        tty.msg('Streaming details to log:')
+        tty.msg(f'  {self.log_path}')
+        if self.workspace.dry_run:
+            cprint('@*g{      -- DRY-RUN -- DRY-RUN -- DRY-RUN -- DRY-RUN -- DRY-RUN --}')
+
+        experiment_count = self._experiment_set.num_filtered_experiments(self.filters)
+        experiment_total = self._experiment_set.num_experiments()
+        tty.msg(f'  {self.action_string} {experiment_count} out of '
+                f'{experiment_total} experiments:')
+
+        with self.workspace.logger(self.log_stream, echo=self.workspace.dry_run):
+            self._validate()
+            self._prepare()
+
+        self._execute()
+
+        with self.workspace.logger(self.log_stream, echo=self.workspace.dry_run):
+            self._complete()
+
+        self.log_stream.close()
+
+
+class AnalyzePipeline(Pipeline):
+    """Class for the analyze pipeline"""
+
+    name = 'analyze'
+
+    def __init__(self, workspace, filters, output_formats=['text'], upload=False):
+        workspace_success = {
+            namespace.success: ramble.config.config.get_config(namespace.success)
+        }
+
+        workspace.extract_success_criteria('workspace', workspace_success)
+
+        super().__init__(workspace, filters)
+        self.action_string = 'Analyzing'
+        self.output_formats = output_formats
+        self.upload_results = upload
+
+    def _complete(self):
+        self.workspace.dump_results(output_formats=self.output_formats)
+
+        # FIXME: this will fire the analyze logic of twice currently
+        if self.upload_results:
+            ramble.experimental.upload.upload_results(self.workspace.results)
+
+
+class ArchivePipeline(Pipeline):
+    """Class for the archive pipeline"""
+
+    name = 'archive'
+
+    def __init__(self, workspace, filters, create_tar=False, upload_url=None):
+        super().__init__(workspace, filters)
+        self.action_string = 'Archiving'
+        self.create_tar = create_tar
+        self.upload_url = upload_url
+        self.archive_name = None
+
+    def _prepare(self):
+        import glob
+
+        date_str = self.workspace.date_string()
+
+        # Use the basename from the path as the name of the workspace.
+        # If we use `self.workspace.name` we get the path multiple times.
+        self.archive_name = '%s-archive-%s' % (os.path.basename(self.workspace.path), date_str)
+
+        archive_path = os.path.join(self.workspace.archive_dir, self.archive_name)
+        fs.mkdirp(archive_path)
+
+        # Copy current configs
+        archive_configs = os.path.join(self.workspace.latest_archive_path,
+                                       ramble.workspace.workspace_config_path)
+        fs.mkdirp(archive_configs)
+        for root, dirs, files in os.walk(self.workspace.config_dir):
+            for name in files:
+                src = os.path.join(self.workspace.config_dir, root, name)
+                dest = src.replace(self.workspace.config_dir, archive_configs)
+                fs.mkdirp(os.path.dirname(dest))
+                shutil.copyfile(src, dest)
+
+        # Copy current software spack.yamls
+        archive_software = os.path.join(self.workspace.latest_archive_path,
+                                        ramble.workspace.workspace_software_path)
+        fs.mkdirp(archive_software)
+        for file in glob.glob(os.path.join(self.workspace.software_dir, '*', 'spack.yaml')):
+            dest = file.replace(self.workspace.software_dir, archive_software)
+            fs.mkdirp(os.path.dirname(dest))
+            shutil.copyfile(file, dest)
+
+    def _complete(self):
+        if self.create_tar:
+            tar = which('tar', required=True)
+            with py.path.local(self.workspace.archive_dir).as_cwd():
+                tar('-czf', self.archive_name + '.tar.gz', self.archive_name)
+
+            archive_url = self.upload_url if self.upload_url else \
+                ramble.config.get('config:archive_url')
+            archive_url = archive_url.rstrip('/') if archive_url else None
+
+            tty.debug('Archive url: %s' % archive_url)
+
+            if archive_url:
+                tar_path = self.workspace.latest_archive_path + '.tar.gz'
+                remote_tar_path = archive_url + '/' + self.workspace.latest_archive + '.tar.gz'
+                fetcher = ramble.fetch_strategy.URLFetchStrategy(tar_path)
+                fetcher.stage = ramble.stage.DIYStage(self.workspace.latest_archive_path)
+                fetcher.stage.archive_file = tar_path
+                fetcher.archive(remote_tar_path)
+
+
+class MirrorPipeline(Pipeline):
+    """Class for the mirror pipeline"""
+
+    name = 'mirror'
+
+    def __init__(self, workspace, filters, mirror_path=None):
+        super().__init__(workspace, filters)
+        self.action_string = 'Mirroring'
+        self.mirror_path = mirror_path
+
+    def _prepare(self):
+        self.workspace.create_mirror(self.mirror_path)
+
+    def _complete(self):
+        verb = 'updated' if self.workspace.mirror_existed else 'created'
+        tty.msg(
+            "Successfully %s spack software in %s" % (verb, self.workspace.mirror_path),
+            "Archive stats:",
+            "  %-4d already present"  % len(self.workspace.software_mirror_stats.present),
+            "  %-4d added"            % len(self.workspace.software_mirror_stats.new),
+            "  %-4d failed to fetch." % len(self.workspace.software_mirror_stats.errors))
+
+        tty.msg(
+            "Successfully %s inputs in %s" % (verb, self.workspace.mirror_path),
+            "Archive stats:",
+            "  %-4d already present"  % len(self.workspace.input_mirror_stats.present),
+            "  %-4d added"            % len(self.workspace.input_mirror_stats.new),
+            "  %-4d failed to fetch." % len(self.workspace.input_mirror_stats.errors))
+
+        if self.workspace.input_mirror_stats.errors:
+            tty.error("Failed downloads:")
+            tty.colify(s.cformat("{name}") for s in
+                       list(self.workspace.input_mirror_stats.errors))
+            tty.die('Mirroring has errors.')
+
+
+class SetupPipeline(Pipeline):
+    """Class for the setup pipeline"""
+
+    name = 'setup'
+
+    def __init__(self, workspace, filters):
+        super().__init__(workspace, filters)
+        self.force_inventory = True
+        self.require_inventory = True
+        self.action_string = 'Setting up'
+
+    def _prepare(self):
+        experiment_file = open(self.workspace.all_experiments_path, 'w+')
+        experiment_file.write('#!/bin/sh\n')
+        self.workspace.experiments_script = experiment_file
+
+    def _complete(self):
+        for exp, app_inst in sorted(self._experiment_set.all_experiments()):
+            if not app_inst.is_template:
+                self.workspace.hash_inventory['experiments'].append(
+                    {
+                        'name': exp,
+                        'digest': app_inst.experiment_hash,
+                        'contents': app_inst.hash_inventory
+                    }
+                )
+        self.workspace.workspace_hash = \
+            ramble.util.hashing.hash_json(self.workspace.hash_inventory)
+        with open(os.path.join(self.workspace.root,
+                               self.workspace.inventory_file_name), 'w+') as f:
+            sjson.dump(self.workspace.hash_inventory, f)
+
+        with open(os.path.join(self.workspace.root,
+                               self.workspace.hash_file_name), 'w+') as f:
+            f.write(self.workspace.workspace_hash + '\n')
+
+        self.workspace.experiments_script.close()
+        experiment_file_path = os.path.join(self.workspace.root,
+                                            self.workspace.all_experiments_path)
+        os.chmod(experiment_file_path, stat.S_IRWXU | stat.S_IRWXG
+                 | stat.S_IROTH | stat.S_IXOTH)
+
+
+pipelines = Enum('pipelines', ['analyze', 'archive', 'mirror', 'setup'])
+
+_pipeline_map = {
+    pipelines.analyze: AnalyzePipeline,
+    pipelines.archive: ArchivePipeline,
+    pipelines.mirror: MirrorPipeline,
+    pipelines.setup: SetupPipeline
+}
+
+
+def pipeline_class(name):
+    """Factory for constructing a pipeline instance from its name"""
+
+    if name not in _pipeline_map.keys():
+        tty.die(f'Pipeline {name} is not valid.\n'
+                f'Valid pipelines are {_pipeline_map.keys()}')
+
+    return _pipeline_map[name]

--- a/lib/ramble/ramble/success_criteria.py
+++ b/lib/ramble/ramble/success_criteria.py
@@ -175,11 +175,8 @@ class SuccessCriteria(object):
                     }
 
                     comparison_tested = True
-                    expanded = app_inst.expander.expand_var(self.formula,
-                                                            extra_vars=comparison_vars)
-                    tty.debug(f'   Expanded: {expanded}')
-                    if expanded != 'True':
-                        result = False
+                    result = app_inst.expander.compute_logical(self.formula,
+                                                               extra_vars=comparison_vars)
 
             # If fom doesn't match any fom names, fail the comparison
             if not comparison_tested:

--- a/lib/ramble/ramble/success_criteria.py
+++ b/lib/ramble/ramble/success_criteria.py
@@ -175,8 +175,8 @@ class SuccessCriteria(object):
                     }
 
                     comparison_tested = True
-                    result = app_inst.expander.compute_logical(self.formula,
-                                                               extra_vars=comparison_vars)
+                    result = app_inst.expander.evaluate_predicate(self.formula,
+                                                                  extra_vars=comparison_vars)
 
             # If fom doesn't match any fom names, fail the comparison
             if not comparison_tested:

--- a/lib/ramble/ramble/test/cmd/on.py
+++ b/lib/ramble/ramble/test/cmd/on.py
@@ -12,6 +12,8 @@ import pytest
 
 import ramble.workspace
 import ramble.test.cmd.workspace
+import ramble.pipeline
+import ramble.filters
 from ramble.main import RambleCommand
 
 # everything here uses the mock_workspace_path
@@ -45,6 +47,10 @@ def test_execute_nothing(mutable_mock_workspace_path):
     workspace('create', ws_name)
     assert ws_name in workspace('list')
 
+    pipeline_type = ramble.pipeline.pipelines.setup
+    pipeline_class = ramble.pipeline.pipeline_class(pipeline_type)
+    filters = ramble.filters.Filters()
+
     with ramble.workspace.read(ws_name) as ws:
         ramble.test.cmd.workspace.add_basic(ws)
         ramble.test.cmd.workspace.check_basic(ws)
@@ -52,7 +58,8 @@ def test_execute_nothing(mutable_mock_workspace_path):
         ws.concretize()
         assert ws.is_concretized()
 
-        ws.run_pipeline('setup')
+        setup_pipeline = pipeline_class(ws, filters)
+        setup_pipeline.run()
         assert os.path.exists(ws.root + '/all_experiments')
 
         ws.run_experiments()

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -18,6 +18,8 @@ from ramble.software_environments import RambleSoftwareEnvironmentError
 from ramble.main import RambleCommand, RambleCommandError
 from ramble.test.dry_run_helpers import search_files_for_string
 import ramble.config
+import ramble.filters
+import ramble.pipeline
 
 import spack.util.spack_yaml as syaml
 
@@ -464,6 +466,9 @@ def test_setup_nothing():
     ws_name = 'test'
     workspace('create', ws_name)
     assert ws_name in workspace('list')
+    pipeline_type = ramble.pipeline.pipelines.setup
+    pipeline_cls = ramble.pipeline.pipeline_class(pipeline_type)
+    filters = ramble.filters.Filters()
 
     with ramble.workspace.read(ws_name) as ws:
         add_basic(ws)
@@ -472,7 +477,8 @@ def test_setup_nothing():
         ws.concretize()
         assert ws.is_concretized()
 
-        ws.run_pipeline('setup')
+        setup_pipeline = pipeline_cls(ws, filters)
+        setup_pipeline.run()
         assert os.path.exists(ws.root + '/all_experiments')
 
 
@@ -498,6 +504,11 @@ def test_analyze_nothing():
     ws_name = 'test'
     workspace('create', ws_name)
     assert ws_name in workspace('list')
+    setup_type = ramble.pipeline.pipelines.setup
+    setup_cls = ramble.pipeline.pipeline_class(setup_type)
+    analyze_type = ramble.pipeline.pipelines.analyze
+    analyze_cls = ramble.pipeline.pipeline_class(analyze_type)
+    filters = ramble.filters.Filters()
 
     with ramble.workspace.read(ws_name) as ws:
         add_basic(ws)
@@ -506,10 +517,12 @@ def test_analyze_nothing():
         ws.concretize()
         assert ws.is_concretized()
 
-        ws.run_pipeline('setup')
+        setup_pipeline = setup_cls(ws, filters)
+        setup_pipeline.run()
         assert os.path.exists(ws.root + '/all_experiments')
 
-        ws.run_pipeline('analyze')
+        analyze_pipeline = analyze_cls(ws, filters)
+        analyze_pipeline.run()
         check_results(ws)
 
 

--- a/lib/ramble/ramble/test/end_to_end/dryrun_copies_external_env.py
+++ b/lib/ramble/ramble/test/end_to_end/dryrun_copies_external_env.py
@@ -10,6 +10,8 @@ import os
 
 import pytest
 
+import ramble.filters
+import ramble.pipeline
 import ramble.workspace
 import ramble.config
 import ramble.software_environments
@@ -57,6 +59,10 @@ ramble:
         external_spack_env: {env_path}
 """
 
+    setup_type = ramble.pipeline.pipelines.setup
+    setup_cls = ramble.pipeline.pipeline_class(setup_type)
+    filters = ramble.filters.Filters()
+
     workspace_name = 'test_dryrun_copies_external_env'
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
@@ -69,7 +75,8 @@ ramble:
         ws.dry_run = True
         ws._re_read()
 
-        ws.run_pipeline('setup')
+        setup_pipeline = setup_cls(ws, filters)
+        setup_pipeline.run()
 
         env_file = os.path.join(ws.software_dir, 'wrfv4.CONUS_12km', 'spack.yaml')
 

--- a/lib/ramble/ramble/test/end_to_end/dryrun_series_contains_package_paths.py
+++ b/lib/ramble/ramble/test/end_to_end/dryrun_series_contains_package_paths.py
@@ -10,6 +10,8 @@ import os
 
 import pytest
 
+import ramble.filters
+import ramble.pipeline
 import ramble.workspace
 import ramble.config
 import ramble.software_environments
@@ -54,6 +56,10 @@ ramble:
         - zlib
 """
 
+    setup_type = ramble.pipeline.pipelines.setup
+    setup_cls = ramble.pipeline.pipeline_class(setup_type)
+    filters = ramble.filters.Filters()
+
     workspace_name = 'test_dryrun_series_contains_package_paths'
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
@@ -66,7 +72,8 @@ ramble:
         ws.dry_run = True
         ws._re_read()
 
-        ws.run_pipeline('setup')
+        setup_pipeline = setup_cls(ws, filters)
+        setup_pipeline.run()
 
         for test in ['test_1', 'test_2']:
             script = os.path.join(ws.experiment_dir, 'zlib', 'ensure_installed',

--- a/lib/ramble/ramble/test/end_to_end/exclusive_filtered_vector_workloads.py
+++ b/lib/ramble/ramble/test/end_to_end/exclusive_filtered_vector_workloads.py
@@ -1,0 +1,77 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.workspace
+import ramble.config
+import ramble.software_environments
+from ramble.main import RambleCommand
+
+
+# everything here uses the mock_workspace_path
+pytestmark = pytest.mark.usefixtures('mutable_config',
+                                     'mutable_mock_workspace_path')
+
+workspace = RambleCommand('workspace')
+
+
+def test_exclusive_filtered_vector_workloads(mutable_config, mutable_mock_workspace_path):
+    test_config = """
+ramble:
+  variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
+    partition: 'part1'
+    processes_per_node: '16'
+    n_threads: '1'
+  applications:
+    hostname:
+      workloads:
+        '{application_workload}':
+          experiments:
+            simple_test:
+              variables:
+                application_workload: ['parallel' ,'serial', 'local']
+                n_nodes: 1
+  spack:
+    concretized: true
+    packages: {}
+    environments: {}
+"""
+    workspace_name = 'test_exclusive_filtered_vector_workloads'
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+
+        config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+
+        with open(config_path, 'w+') as f:
+            f.write(test_config)
+        ws._re_read()
+
+        workspace('setup', '--dry-run', '--exclude-where', '"{workload_name}" == "serial"',
+                  global_args=['-w', workspace_name])
+        workspace('analyze', '--exclude-where', '"{workload_name}" == "serial"',
+                  global_args=['-w', workspace_name])
+        workspace('archive', '--exclude-where', '"{workload_name}" == "serial"',
+                  global_args=['-w', workspace_name])
+
+        experiment_root = ws.experiment_dir
+        expected_workloads = ['parallel', 'local']
+        for workload in expected_workloads:
+            exp1_dir = os.path.join(experiment_root, 'hostname', workload, 'simple_test')
+            exp1_script = os.path.join(exp1_dir, 'execute_experiment')
+            assert os.path.isfile(exp1_script)
+
+        not_expected_workloads = ['serial']
+        for workload in not_expected_workloads:
+            exp1_dir = os.path.join(experiment_root, 'hostname', workload, 'simple_test')
+            exp1_script = os.path.join(exp1_dir, 'execute_experiment')
+            assert not os.path.isfile(exp1_script)

--- a/lib/ramble/ramble/test/end_to_end/experiment_excludes.py
+++ b/lib/ramble/ramble/test/end_to_end/experiment_excludes.py
@@ -167,6 +167,13 @@ licenses:
                 file_path = os.path.join(software_path, file)
                 assert os.path.exists(file_path)
 
+            # Create mock spack.lock files
+            lock_file = os.path.join(software_path, 'spack.lock')
+            with open(lock_file, 'w+') as f:
+                f.write('{\n')
+                f.write('\t"test_key": "val"\n')
+                f.write('}\n')
+
         expected_experiments = [
             'scaling_2_part1_wrfv4',
             'scaling_4_part1_wrfv4',

--- a/lib/ramble/ramble/test/end_to_end/explicit_zips.py
+++ b/lib/ramble/ramble/test/end_to_end/explicit_zips.py
@@ -155,6 +155,13 @@ licenses:
                 file_path = os.path.join(software_path, file)
                 assert os.path.exists(file_path)
 
+            # Create a mock spack.lock file
+            lock_file = os.path.join(software_path, 'spack.lock')
+            with open(lock_file, 'w+') as f:
+                f.write('{\n')
+                f.write('\t"test_key": "val"\n')
+                f.write('}\n')
+
         expected_experiments = [
             'scaling_1_part1_wrfv4',
             'scaling_2_part1_wrfv4',

--- a/lib/ramble/ramble/test/end_to_end/inclusive_filtered_vector_workloads.py
+++ b/lib/ramble/ramble/test/end_to_end/inclusive_filtered_vector_workloads.py
@@ -1,0 +1,77 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.workspace
+import ramble.config
+import ramble.software_environments
+from ramble.main import RambleCommand
+
+
+# everything here uses the mock_workspace_path
+pytestmark = pytest.mark.usefixtures('mutable_config',
+                                     'mutable_mock_workspace_path')
+
+workspace = RambleCommand('workspace')
+
+
+def test_inclusive_filtered_vector_workloads(mutable_config, mutable_mock_workspace_path):
+    test_config = """
+ramble:
+  variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
+    partition: 'part1'
+    processes_per_node: '16'
+    n_threads: '1'
+  applications:
+    hostname:
+      workloads:
+        '{application_workload}':
+          experiments:
+            simple_test:
+              variables:
+                application_workload: ['parallel' ,'serial', 'local']
+                n_nodes: 1
+  spack:
+    concretized: true
+    packages: {}
+    environments: {}
+"""
+    workspace_name = 'test_inclusive_filtered_vector_workloads'
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+
+        config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+
+        with open(config_path, 'w+') as f:
+            f.write(test_config)
+        ws._re_read()
+
+        workspace('setup', '--dry-run', '--where', '"{workload_name}" == "serial"',
+                  global_args=['-w', workspace_name])
+        workspace('analyze', '--where', '"{workload_name}" == "serial"',
+                  global_args=['-w', workspace_name])
+        workspace('archive', '--where', '"{workload_name}" == "serial"',
+                  global_args=['-w', workspace_name])
+
+        experiment_root = ws.experiment_dir
+        expected_workloads = ['serial']
+        for workload in expected_workloads:
+            exp1_dir = os.path.join(experiment_root, 'hostname', workload, 'simple_test')
+            exp1_script = os.path.join(exp1_dir, 'execute_experiment')
+            assert os.path.isfile(exp1_script)
+
+        not_expected_workloads = ['parallel', 'local']
+        for workload in not_expected_workloads:
+            exp1_dir = os.path.join(experiment_root, 'hostname', workload, 'simple_test')
+            exp1_script = os.path.join(exp1_dir, 'execute_experiment')
+            assert not os.path.isfile(exp1_script)

--- a/lib/ramble/ramble/test/end_to_end/unused_compilers_are_skipped.py
+++ b/lib/ramble/ramble/test/end_to_end/unused_compilers_are_skipped.py
@@ -11,6 +11,8 @@ import glob
 
 import pytest
 
+import ramble.filters
+import ramble.pipeline
 import ramble.workspace
 import ramble.config
 import ramble.software_environments
@@ -64,6 +66,10 @@ ramble:
         - intel
 """
 
+    setup_type = ramble.pipeline.pipelines.setup
+    setup_cls = ramble.pipeline.pipeline_class(setup_type)
+    filters = ramble.filters.Filters()
+
     workspace_name = 'test_unused_compilers_are_skipped'
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
@@ -76,7 +82,8 @@ ramble:
         ws.dry_run = True
         ws._re_read()
 
-        ws.run_pipeline('setup')
+        setup_pipeline = setup_cls(ws, filters)
+        setup_pipeline.run()
 
         required_compiler_str = "gcc@8.5.0"
         unused_gcc9_str = "gcc@9.3.0"

--- a/lib/ramble/ramble/test/end_to_end/wrfv4_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/wrfv4_dry_run.py
@@ -150,6 +150,12 @@ licenses:
                 file_path = os.path.join(software_path, file)
                 assert os.path.exists(file_path)
 
+            lock_file = os.path.join(software_path, 'spack.lock')
+            with open(lock_file, 'w+') as f:
+                f.write('{\n')
+                f.write('\t"test_key": "val"\n')
+                f.write('}\n')
+
         expected_experiments = [
             'scaling_1_part1_wrfv4',
             'scaling_2_part1_wrfv4',

--- a/lib/ramble/ramble/test/mirror_tests.py
+++ b/lib/ramble/ramble/test/mirror_tests.py
@@ -18,6 +18,8 @@ from llnl.util.filesystem import resolve_link_target_relative_to_the_link
 import ramble.mirror
 import ramble.repository
 import ramble.workspace
+import ramble.pipeline
+import ramble.filters
 
 import spack.util.executable
 
@@ -132,6 +134,11 @@ ramble:
     archive_dir = tmpdir_factory.mktemp('mock-archives-dir')
     mirror_dir = tmpdir_factory.mktemp(f'mock-{app_name}-mirror')
 
+    pipeline_type = ramble.pipeline.pipelines.mirror
+
+    mirror_pipeline_cls = ramble.pipeline.pipeline_class(pipeline_type)
+    filters = ramble.filters.Filters()
+
     with archive_dir.as_cwd():
         app_type = ramble.repository.ObjectTypes.applications
         app_class = ramble.repository.paths[app_type].get_obj_class(app_name)('test')
@@ -147,7 +154,9 @@ ramble:
             with open(config_path, 'w+') as f:
                 f.write(test_config)
             workspace._re_read()
-            workspace.create_mirror(str(mirror_dir))
-            workspace.run_pipeline('mirror')
+            mirror_pipeline = mirror_pipeline_cls(workspace,
+                                                  filters,
+                                                  mirror_path=str(mirror_dir))
+            mirror_pipeline.run()
 
         check_mirror(str(mirror_dir), app_name, app_class)

--- a/lib/ramble/ramble/test/workspace_hashing/unsetup_workspace_cannot_analyze.py
+++ b/lib/ramble/ramble/test/workspace_hashing/unsetup_workspace_cannot_analyze.py
@@ -1,0 +1,66 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.application
+import ramble.workspace
+import ramble.config
+import ramble.software_environments
+from ramble.main import RambleCommand, RambleCommandError
+
+
+# everything here uses the mock_workspace_path
+pytestmark = pytest.mark.usefixtures('mutable_config',
+                                     'mutable_mock_workspace_path')
+
+workspace = RambleCommand('workspace')
+
+
+def test_unsetup_workspace_cannot_analyze(mutable_config,
+                                          mutable_mock_workspace_path,
+                                          mock_applications,
+                                          capsys):
+    test_config = """
+ramble:
+  variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
+    partition: 'part1'
+    processes_per_node: '16'
+    n_threads: '1'
+  applications:
+    zlib:
+      workloads:
+        ensure_installed:
+          experiments:
+            simple_test:
+              variables:
+                n_nodes: 1
+              env_vars:
+                set:
+                  MY_VAR: 'TEST'
+  spack:
+    concretized: true
+    packages: {}
+    environments: {}
+"""
+    workspace_name = 'test_unsetup_workspace_cannot_analyze'
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+
+        config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+
+        with open(config_path, 'w+') as f:
+            f.write(test_config)
+        ws._re_read()
+        with pytest.raises(RambleCommandError):
+            output = workspace('analyze', global_args=['-w', workspace_name])
+            assert 'spack.lock file does not exist' in output

--- a/lib/ramble/ramble/test/workspace_hashing/workspace_setup_creates_inventory.py
+++ b/lib/ramble/ramble/test/workspace_hashing/workspace_setup_creates_inventory.py
@@ -63,9 +63,9 @@ ramble:
         workspace('setup', '--dry-run', global_args=['-w', workspace_name])
 
         assert os.path.exists(os.path.join(ws.root,
-                                           ramble.workspace.Workspace._inventory_file_name))
+                                           ramble.workspace.Workspace.inventory_file_name))
         assert os.path.exists(os.path.join(ws.root,
-                                           ramble.workspace.Workspace._hash_file_name))
+                                           ramble.workspace.Workspace.hash_file_name))
         assert os.path.exists(
             os.path.join(ws.experiment_dir,
                          'basic',

--- a/lib/ramble/ramble/workspace/__init__.py
+++ b/lib/ramble/ramble/workspace/__init__.py
@@ -41,6 +41,7 @@ from .workspace import (
     root,
     ramble_workspace_var,
     namespace,
+    workspace_config_path
 )
 
 __all__ = [
@@ -75,4 +76,5 @@ __all__ = [
     'root',
     'ramble_workspace_var',
     'namespace',
+    'workspace_config_path',
 ]

--- a/share/ramble/cloud-build/ramble-pr-unit-tests.yaml
+++ b/share/ramble/cloud-build/ramble-pr-unit-tests.yaml
@@ -65,6 +65,6 @@ steps:
     id: ramble-unit-tests
     entrypoint: /bin/bash
 
-timeout: 600s
+timeout: 900s
 options:
   machineType: N1_HIGHCPU_8

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -645,7 +645,7 @@ _ramble_workspace_activate() {
 }
 
 _ramble_workspace_archive() {
-    RAMBLE_COMPREPLY="-h --help --tar-archive -t --upload-url -u --phases"
+    RAMBLE_COMPREPLY="-h --help --tar-archive -t --upload-url -u --phases --where --exclude-where"
 }
 
 _ramble_workspace_deactivate() {
@@ -666,11 +666,11 @@ _ramble_workspace_concretize() {
 }
 
 _ramble_workspace_setup() {
-    RAMBLE_COMPREPLY="-h --help --dry-run --phases"
+    RAMBLE_COMPREPLY="-h --help --dry-run --phases --where --exclude-where"
 }
 
 _ramble_workspace_analyze() {
-    RAMBLE_COMPREPLY="-h --help -f --formats -u --upload --always-print-foms --phases"
+    RAMBLE_COMPREPLY="-h --help -f --formats -u --upload --always-print-foms --phases --where --exclude-where"
 }
 
 _ramble_workspace_info() {
@@ -682,7 +682,7 @@ _ramble_workspace_edit() {
 }
 
 _ramble_workspace_mirror() {
-    RAMBLE_COMPREPLY="-h --help -d --dry-run --phases"
+    RAMBLE_COMPREPLY="-h --help -d --dry-run --phases --where --exclude-where"
 }
 
 _ramble_workspace_list() {


### PR DESCRIPTION
This merge adds the ability for workspace actions to filter which experiments they should act on within the workspace. This is performed through the `--where` and `--exclude-where` arguments.

Additionally, the logic around pipelines is overhauled in this merge to make it easier to extend and manipulate the pipelines.