### PR TITLE
Fix WRF FOM time calculation

### DIFF
--- a/lib/ramble/ramble/test/end_to_end/experiment_excludes.py
+++ b/lib/ramble/ramble/test/end_to_end/experiment_excludes.py
@@ -239,7 +239,7 @@ licenses:
             # Create fake figures of merit.
             with open(os.path.join(exp_dir, 'rsl.out.0000'), 'w+') as f:
                 for i in range(1, 6):
-                    f.write(f'Timing for main {i}{i}.{i}\n')
+                    f.write(f'Timing for main: time 2019-11-27_00:00:00 on domain 1: {i}{i}.{i}\n')
                 f.write('wrf: SUCCESS COMPLETE WRF\n')
 
             # Create files that match archive patterns
@@ -263,10 +263,10 @@ licenses:
 
         with open(text_results_files[0], 'r') as f:
             data = f.read()
-            assert 'Average Timestep Time = 3.3 s' in data
-            assert 'Cumulative Timestep Time = 16.5 s' in data
-            assert 'Minimum Timestep Time = 1.1 s' in data
-            assert 'Maximum Timestep Time = 5.5 s' in data
+            assert 'Average Timestep Time = 33.3 s' in data
+            assert 'Cumulative Timestep Time = 166.5 s' in data
+            assert 'Minimum Timestep Time = 11.1 s' in data
+            assert 'Maximum Timestep Time = 55.5 s' in data
             assert 'Avg. Max Ratio Time = 0.6' in data
             assert 'Number of timesteps = 5' in data
 

--- a/lib/ramble/ramble/test/end_to_end/explicit_zips.py
+++ b/lib/ramble/ramble/test/end_to_end/explicit_zips.py
@@ -220,7 +220,7 @@ licenses:
             # Create fake figures of merit.
             with open(os.path.join(exp_dir, 'rsl.out.0000'), 'w+') as f:
                 for i in range(1, 6):
-                    f.write(f'Timing for main {i}{i}.{i}\n')
+                    f.write(f'Timing for main: time 2019-11-27_00:00:00 on domain 1: {i}{i}.{i}\n')
                 f.write('wrf: SUCCESS COMPLETE WRF\n')
 
             # Create files that match archive patterns
@@ -244,10 +244,10 @@ licenses:
 
         with open(text_results_files[0], 'r') as f:
             data = f.read()
-            assert 'Average Timestep Time = 3.3 s' in data
-            assert 'Cumulative Timestep Time = 16.5 s' in data
-            assert 'Minimum Timestep Time = 1.1 s' in data
-            assert 'Maximum Timestep Time = 5.5 s' in data
+            assert 'Average Timestep Time = 33.3 s' in data
+            assert 'Cumulative Timestep Time = 166.5 s' in data
+            assert 'Minimum Timestep Time = 11.1 s' in data
+            assert 'Maximum Timestep Time = 55.5 s' in data
             assert 'Avg. Max Ratio Time = 0.6' in data
             assert 'Number of timesteps = 5' in data
 

--- a/lib/ramble/ramble/test/end_to_end/wrfv4_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/wrfv4_dry_run.py
@@ -223,7 +223,7 @@ licenses:
             # Create fake figures of merit.
             with open(os.path.join(exp_dir, 'rsl.out.0000'), 'w+') as f:
                 for i in range(1, 6):
-                    f.write(f'Timing for main {i}{i}.{i}\n')
+                    f.write(f'Timing for main: time 2019-11-27_00:00:00 on domain 1: {i}{i}.{i}\n')
                 f.write('wrf: SUCCESS COMPLETE WRF\n')
 
             # Create files that match archive patterns
@@ -257,10 +257,10 @@ licenses:
         for text_result in text_results_files:
             with open(text_result, 'r') as f:
                 data = f.read()
-                assert 'Average Timestep Time = 3.3 s' in data
-                assert 'Cumulative Timestep Time = 16.5 s' in data
-                assert 'Minimum Timestep Time = 1.1 s' in data
-                assert 'Maximum Timestep Time = 5.5 s' in data
+                assert 'Average Timestep Time = 33.3 s' in data
+                assert 'Cumulative Timestep Time = 166.5 s' in data
+                assert 'Minimum Timestep Time = 11.1 s' in data
+                assert 'Maximum Timestep Time = 55.5 s' in data
                 assert 'Avg. Max Ratio Time = 0.6' in data
                 assert 'Number of timesteps = 5' in data
 

--- a/var/ramble/repos/builtin/applications/wrfv3/application.py
+++ b/var/ramble/repos/builtin/applications/wrfv3/application.py
@@ -99,7 +99,7 @@ class Wrfv3(SpackApplication):
                                            'rsl.out.*'))
 
         if file_list:
-            timing_regex = re.compile(r'Timing for main.*(?P<main_time>[0-9]+\.[0-9]*).*')
+            timing_regex = re.compile(r'Timing for main.*:\s+(?P<main_time>[0-9]+\.[0-9]*).*')
             avg_time = 0.0
             min_time = float('inf')
             max_time = float('-inf')

--- a/var/ramble/repos/builtin/applications/wrfv4/application.py
+++ b/var/ramble/repos/builtin/applications/wrfv4/application.py
@@ -105,7 +105,7 @@ class Wrfv4(SpackApplication):
                                            'rsl.out.*'))
 
         if file_list:
-            timing_regex = re.compile(r'Timing for main.*(?P<main_time>[0-9]+\.[0-9]*).*')
+            timing_regex = re.compile(r'Timing for main.*:\s+(?P<main_time>[0-9]+\.[0-9]*).*')
             avg_time = 0.0
             min_time = float('inf')
             max_time = float('-inf')


### PR DESCRIPTION
Previously the way the greedy regex was written caused the numbers in the FOM to be improperly extracted (some of the leading numbers were being eaten by the non group portion of the regex)

This PR makes the regex more specific and allows the numbers to extracted as expected, fixing the odd performance data we were getting 