### PR TITLE
Re-order logger creation to avoid recusrive limit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ google-api-core # for gcs fetch error .execptions
 coverage
 pre-commit
 google-cloud-bigquery
-tqdm # for workspace progress bar


### PR DESCRIPTION
This merge removes the progress bar dependency, as it currently doesn't
work with the way we use loggers.
It also  re-orders some of the logger creation logic to avoid a
recusion limit depth error.
