### PR TITLE
Add explicit support for deprecated ast.Str

### DIFF
--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -404,6 +404,11 @@ class Expander(object):
             return self._ast_constant(node)
         elif isinstance(node, ast.Name):
             return self._ast_name(node)
+        # TODO: Remove when we drop support for 3.6
+        # DEPRECATED: Remove due to python 3.8
+        # See: https://docs.python.org/3/library/ast.html#node-classes
+        elif isinstance(node, ast.Str):
+            return node.s
         elif isinstance(node, ast.Attribute):
             return self._ast_attr(node)
         elif isinstance(node, ast.Compare):


### PR DESCRIPTION
This merge adds support for ast.Str, which was removed after python 3.8. This addition allows Ramble to support older python distributions.