### PR TITLE
Fix typo in pipeline.py

### DIFF
--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -186,7 +186,7 @@ class AnalyzePipeline(Pipeline):
         self.workspace.dump_results(output_formats=self.output_formats)
 
         if self.upload_results:
-            ramble.experimental.upload.upload_results(self.workspace.results)
+            ramble.experimental.uploader.upload_results(self.workspace.results)
 
 
 class ArchivePipeline(Pipeline):


### PR DESCRIPTION
Found a typo while trying `ramble workspace analyze -u`