### PR TITLE
Implement a custom format parser

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -985,6 +985,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
 
         for template_name, template_conf in workspace.all_templates():
             expand_path = os.path.join(experiment_run_dir, template_name)
+            tty.msg(f'Writing template {template_name} to {expand_path}')
 
             with open(expand_path, 'w+') as f:
                 f.write(self.expander.expand_var(template_conf['contents']))

--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -35,6 +35,12 @@ class ExpansionDelimiter(object):
     right = '}'
 
 
+class VformatDelimiter(object):
+    """Class representing the delimiters for the string.Formatter class"""
+    left = '{'
+    right = '}'
+
+
 class ExpansionNode(object):
     """Class representing a node in a ramble expansion graph"""
 
@@ -145,7 +151,10 @@ class ExpansionNode(object):
                     kw_dict = {'value': self.value}
                     format_str = f'value:{kw_parts[1]}'
                     try:
-                        self.value = formatter.vformat('{' + format_str + '}', [], kw_dict)
+                        self.value = formatter.vformat(VformatDelimiter.left +
+                                                       format_str +
+                                                       VformatDelimiter.right,
+                                                       [], kw_dict)
                         required_passthrough = False
                     except ValueError:
                         self.value += f':{kw_parts[1]}'
@@ -428,7 +437,7 @@ class Expander(object):
                                after expansion
         """
 
-        # tty.debug(f'BEGINNING OF EXPAND_VAR STACK ON {var}')
+        tty.debug(f'BEGINNING OF EXPAND_VAR STACK ON {var}')
         expansions = self._variables
         if extra_vars:
             expansions = self._variables.copy()
@@ -443,7 +452,7 @@ class Expander(object):
                 raise RambleSyntaxError(f'Encountered a passthrough error while expanding {var}\n'
                                         f'{e}')
 
-        # tty.debug(f'END OF EXPAND_VAR STACK {value}')
+        tty.debug(f'END OF EXPAND_VAR STACK {value}')
         return value
 
     def evaluate_predicate(self, in_str, extra_vars=None):
@@ -472,9 +481,7 @@ class Expander(object):
 
     @staticmethod
     def expansion_str(in_str):
-        l_delimiter = '{'
-        r_delimiter = '}'
-        return f'{l_delimiter}{in_str}{r_delimiter}'
+        return f'{ExpansionDelimiter.left}{in_str}{ExpansionDelimiter.right}'
 
     def _partial_expand(self, expansion_vars, in_str, allow_passthrough=True):
         """Perform expansion of a string with some variables
@@ -491,13 +498,11 @@ class Expander(object):
 
         if isinstance(in_str, six.string_types):
             str_graph = ExpansionGraph(in_str)
-            # tty.debug('  Walking expansion graph')
             for node in str_graph.walk():
                 node.define_value(expansion_vars,
                                   allow_passthrough=allow_passthrough,
                                   expansion_func=self._partial_expand,
                                   evaluation_func=self.perform_math_eval)
-                # tty.debug(f'    {node}')
 
             return str(str_graph.root.value)
 

--- a/lib/ramble/ramble/test/expander.py
+++ b/lib/ramble/ramble/test/expander.py
@@ -43,10 +43,14 @@ def exp_dict():
         ('{processes_per_node}', '2'),
         ('{n_nodes}*{processes_per_node}', '4'),
         ('2**4', '16'),
-        ('((((16-10+2)/4)**2)*4)', '16.0'),
+        ('{((((16-10+2)/4)**2)*4)}', '16.0'),
         ('gromacs +blas', 'gromacs +blas'),
         ('range(0, 5)', '[0, 1, 2, 3, 4]'),
+        ('{decimal.06.var}', 'foo'),
         ('{}', '{}'),
+        ('{{n_ranks}+2}', '6'),
+        ('{{n_ranks}*{var{processes_per_node}}:05d}', '00012'),
+        ('{{n_ranks}-1}', '3'),
     ]
 )
 def test_expansions(input, output):
@@ -74,24 +78,6 @@ def test_expand_var_name(input, output):
     expander = ramble.expander.Expander(expansion_vars, None)
 
     assert expander.expand_var_name(input) == output
-
-
-@pytest.mark.parametrize(
-    'input,expected_error,error_string',
-    [
-        ('{decimal.06.var}',
-         ramble.expander.RambleSyntaxError,
-         'Variable names cannot contain decimals'),
-    ]
-)
-def test_failed_expansions(input, expected_error, error_string):
-    expansion_vars = exp_dict()
-
-    expander = ramble.expander.Expander(expansion_vars, None)
-
-    with pytest.raises(expected_error) as e:
-        expander.expand_var(input)
-        assert error_string in e
 
 
 def test_expansion_namespaces():


### PR DESCRIPTION
This merge is a major change to ramble's expander logic. Previously, we relied heavily on Python's f-string format syntax. This causes issues related to formatting template files (like json and yaml), and prevents some usecases (such as in-line variable definitions).

This change adds a custom parser for processing strings while they are being expanded.