### PR TITLE
Add default mode capability to modifiers

### DIFF
--- a/lib/ramble/docs/configuration_files.rst
+++ b/lib/ramble/docs/configuration_files.rst
@@ -321,7 +321,7 @@ experiments ramble generates. Its format is as follows:
 
     modifiers:
     - name: <modifier_name>
-      mode: <mode_for_modifier> # Optional if modifier only has one mode
+      mode: <mode_for_modifier> # Optional if modifier only has one mode or if default_mode is set
       on_executable: # Defaults to '*', follows glob syntax
       - list of
       - executables to apply

--- a/lib/ramble/ramble/language/modifier_language.py
+++ b/lib/ramble/ramble/language/modifier_language.py
@@ -35,6 +35,21 @@ def mode(name, description, **kwargs):
     return _execute_mode
 
 
+@modifier_directive('default_modes')
+def default_mode(name, **kwargs):
+    """Define a default mode for this modifier.
+
+    The default mode will be used if modifier mode is not specified in an experiment."""
+
+    def _execute_default_mode(mod):
+        if name not in mod.modes:
+            raise DirectiveError(f'default_mode directive given an invalid mode for modifier '
+                                 f'{mod.name}. Valid modes are {str(list(mod.modes.keys()))}')
+        mod.default_mode = name
+
+    return _execute_default_mode
+
+
 @modifier_directive('variable_modifications')
 def variable_modification(name, modification, method='set', mode=None, modes=None, **kwargs):
     """Define a new variable modification for a mode in this modifier.

--- a/lib/ramble/ramble/modifier.py
+++ b/lib/ramble/ramble/modifier.py
@@ -66,6 +66,9 @@ class ModifierBase(object, metaclass=ModifierMeta):
         """
         if mode:
             self._usage_mode = mode
+        elif hasattr(self, 'default_mode'):
+            self._usage_mode = self.default_mode
+            tty.msg(f'    Using default usage mode {self._usage_mode} on modifier {self.name}')
         else:
             if len(self.modes) > 1 or len(self.modes) == 0:
                 raise InvalidModeError('Cannot auto determine usage '

--- a/lib/ramble/ramble/test/modifier_functionality/mock_modifier_dry_run.py
+++ b/lib/ramble/ramble/test/modifier_functionality/mock_modifier_dry_run.py
@@ -41,7 +41,7 @@ def test_gromacs_dry_run_mock_mods(mutable_mock_workspace_path,
     ]
 
     expected_failures = {
-        'multiple-modes': {'error': InvalidModeError, 'msg': 'Cannot auto determine'},
+        'multiple-modes-no-default': {'error': InvalidModeError, 'msg': 'Cannot auto determine'},
         'invalid-builtin-injection': {'error': DirectiveError,
                                       'msg': 'has an invalid injection method of'},
     }

--- a/var/ramble/repos/builtin.mock/modifiers/multiple-modes-no-default/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/multiple-modes-no-default/modifier.py
@@ -9,9 +9,9 @@
 from ramble.modkit import *  # noqa: F403
 
 
-class MultipleModes(BasicModifier):
-    """Define modifier with no variable modifications"""
-    name = "multiple-modes"
+class MultipleModesNoDefault(BasicModifier):
+    """Define modifier with multiple modes and no default mode"""
+    name = "multiple-modes-no-default"
 
     tags('test')
 

--- a/var/ramble/repos/builtin.mock/modifiers/multiple-modes-with-default/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/multiple-modes-with-default/modifier.py
@@ -1,0 +1,22 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.modkit import *  # noqa: F403
+
+
+class MultipleModesWithDefault(BasicModifier):
+    """Define modifier with multiple modes and a default mode"""
+    name = "multiple-modes-with-default"
+
+    tags('test')
+
+    mode('test_mode1', description='This is the first test mode')
+
+    mode('test_mode2', description='This is the second test mode')
+
+    default_mode('test_mode2')

--- a/var/ramble/repos/builtin/modifiers/gcp-metadata/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/gcp-metadata/modifier.py
@@ -22,6 +22,8 @@ class GcpMetadata(BasicModifier):
     maintainers('rfbgo')
 
     mode('standard', description='Standard execution mode')
+    default_mode('standard')
+
     variable_modification('log', '{experiment_run_dir}/gcp-metadata.log', method='set', modes=['standard'])
     archive_pattern('{log}')
 

--- a/var/ramble/repos/builtin/modifiers/intel-aps/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/intel-aps/modifier.py
@@ -23,6 +23,7 @@ class IntelAps(SpackModifier):
     maintainers('douglasjacobsen')
 
     mode('mpi', description='Mode for collecting mpi statistics')
+    default_mode('mpi')
 
     variable_modification('aps_log_dir', 'aps_{executable_name}_results_dir',
                           method='set', modes=['mpi'])

--- a/var/ramble/repos/builtin/modifiers/lscpu/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/lscpu/modifier.py
@@ -23,6 +23,7 @@ class Lscpu(BasicModifier):
     maintainers('douglasjacobsen')
 
     mode('standard', description='Standard execution mode for lscpu')
+    default_mode('standard')
 
     variable_modification('lscpu_log', '{experiment_run_dir}/lscpu_output.log', method='set', modes=['standard'])
 


### PR DESCRIPTION
Adds default_mode to modifier definitions. Previously, if a mod with more than 1 mode was used and mode was not explicitly set, the experiment would error. Now, if the mod has a default mode, that will be used.