### PR TITLE
Allow all language features to be class methods

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -39,6 +39,7 @@ import ramble.util.executable
 import ramble.util.colors as rucolor
 import ramble.util.hashing
 import ramble.util.env
+import ramble.util.directives
 
 from ramble.keywords import keywords
 from ramble.workspace import namespace
@@ -108,41 +109,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         self.close_logger()
         self.build_phase_order()
 
-        self._initialize_directives()
-
-    def _initialize_directives(self):
-        """Create class methods that execute directives
-
-        Wrap each directive, and inject it into this class instance as a class
-        method.
-
-        This allows:
-
-        self.<directive_name>(<directive_args>) to be called. As in:
-
-        self.archive_pattern('*.log')
-
-        Which can be called within `def __init__(self, file_path)` instead of
-        having to call `archive_pattern('*.log')` at the class definition level.
-        """
-        for directive, directive_class in self._directive_classes.items():
-            is_valid_lang = False
-            for lang_class in self._language_classes:
-                if directive_class is lang_class:
-                    is_valid_lang = True
-
-            if not hasattr(self, directive) and is_valid_lang:
-                setattr(self, directive, self.__execute_named_directive(directive))
-
-    def __execute_named_directive(self, name):
-        """Wrap a directive to simplify execution
-
-        Create a wrapper method that executes a directive, to inject the
-        `(self)` argument to simplify use of directives as class methods
-        """
-        def _execute_directive(*args, directive_name=name, **kwargs):
-            self._directive_functions[directive_name](*args, **kwargs)(self)
-        return _execute_directive
+        ramble.util.directives.define_directive_methods(self)
 
     def construct_logger(self, logs_dir):
         """Create and cache logger for this application instance

--- a/lib/ramble/ramble/language/language_base.py
+++ b/lib/ramble/ramble/language/language_base.py
@@ -44,6 +44,8 @@ class DirectiveMeta(type):
     # Set of all known directives
     _directive_names = set()
     _directives_to_be_executed = []
+    _directive_functions = {}
+    _directive_classes = {}
 
     def __new__(cls, name, bases, attr_dict):
         # Initialize the attribute containing the list of directives
@@ -90,6 +92,18 @@ class DirectiveMeta(type):
             # with the directives
             for d in DirectiveMeta._directive_names:
                 setattr(cls, d, {})
+
+            directive_attrs = {
+                '_directive_functions': {},
+                '_directive_classes': {}
+            }
+
+            for attr in directive_attrs.keys():
+                if hasattr(DirectiveMeta, attr):
+                    directive_attrs[attr].update(getattr(DirectiveMeta, attr))
+
+            for attr in directive_attrs.keys():
+                setattr(cls, attr, directive_attrs[attr])
 
             # Lazily execute directives
             for directive in cls._directives_to_be_executed:
@@ -196,6 +210,9 @@ class DirectiveMeta(type):
                 # wrapped function returns same result as original so
                 # that we can nest directives
                 return result
+
+            DirectiveMeta._directive_classes[decorated_function.__name__] = cls
+            DirectiveMeta._directive_functions[decorated_function.__name__] = decorated_function
 
             return _wrapper
 

--- a/lib/ramble/ramble/language/modifier_language.py
+++ b/lib/ramble/ramble/language/modifier_language.py
@@ -35,7 +35,7 @@ def mode(name, description, **kwargs):
     return _execute_mode
 
 
-@modifier_directive('default_modes')
+@modifier_directive(dicts=())
 def default_mode(name, **kwargs):
     """Define a default mode for this modifier.
 
@@ -45,7 +45,7 @@ def default_mode(name, **kwargs):
         if name not in mod.modes:
             raise DirectiveError(f'default_mode directive given an invalid mode for modifier '
                                  f'{mod.name}. Valid modes are {str(list(mod.modes.keys()))}')
-        mod.default_mode = name
+        mod._default_usage_mode = name
 
     return _execute_default_mode
 

--- a/lib/ramble/ramble/modifier.py
+++ b/lib/ramble/ramble/modifier.py
@@ -103,8 +103,8 @@ class ModifierBase(object, metaclass=ModifierMeta):
         """
         if mode:
             self._usage_mode = mode
-        elif hasattr(self, 'default_mode'):
-            self._usage_mode = self.default_mode
+        elif hasattr(self, '_default_usage_mode'):
+            self._usage_mode = self._default_usage_mode
             tty.msg(f'    Using default usage mode {self._usage_mode} on modifier {self.name}')
         else:
             if len(self.modes) > 1 or len(self.modes) == 0:

--- a/lib/ramble/ramble/test/modifier_language.py
+++ b/lib/ramble/ramble/test/modifier_language.py
@@ -26,6 +26,7 @@ func_types = enum.Enum('func_types', ['method', 'directive'])
 def generate_mod_class(base_class):
 
     class GeneratedClass(base_class):
+        _language_classes = base_class._language_classes.copy()
 
         def __init__(self, file_path):
             super().__init__(file_path)

--- a/lib/ramble/ramble/util/directives.py
+++ b/lib/ramble/ramble/util/directives.py
@@ -1,0 +1,60 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+
+def define_directive_methods(obj_inst):
+    """Create class methods that execute directives
+
+    Wrap each directive, and inject it into this class instance as a class
+    method.
+
+    This allows:
+
+    self.<directive_name>(<directive_args>) to be called. As in:
+
+    self.archive_pattern('*.log')
+
+    Which can be called within `def __init__(self, file_path)` instead of
+    having to call `archive_pattern('*.log')` at the class definition level.
+
+    This function requires the object instance to have internal attributes:
+    - '_directive_classes' - Dictionary mapping a directive to the class the
+      directive is defined for
+    - '_directive_functions' - Dictionary mapping a directive to the decorated function
+      that defines the directive
+    - '_language_classes' - A list of classes that language features should be "imported" from
+
+    Both '_directive_classes' and '_directive_functions' are defined for all
+    classes that use the DirectiveMeta meta-class.
+
+    The '_language_classes' attribute is defined in ApplicationBase and ModifierBase.
+    """
+    if not hasattr(obj_inst, "_directive_classes") or \
+            not hasattr(obj_inst, "_directive_functions"):
+        return
+
+    for directive, directive_class in obj_inst._directive_classes.items():
+        is_valid_lang = False
+        if hasattr(obj_inst, "_language_classes"):
+            for lang_class in obj_inst._language_classes:
+                if directive_class is lang_class:
+                    is_valid_lang = True
+
+        if not hasattr(obj_inst, directive) and is_valid_lang:
+            setattr(obj_inst, directive, wrap_named_directive(obj_inst, directive))
+
+
+def wrap_named_directive(obj_inst, name):
+    """Wrap a directive to simplify execution
+
+    Create a wrapper method that executes a directive, to inject the
+    `(self)` argument to simplify use of directives as class methods
+    """
+    def _execute_directive(*args, directive_name=name, **kwargs):
+        obj_inst._directive_functions[directive_name](*args, **kwargs)(obj_inst)
+    return _execute_directive


### PR DESCRIPTION
This merge enables all language feature directives to be called as class methods in addition to directives.

With this functionality, an application definition's init method can be used to define an application using raw python, instead of requiring directives.