### PR TITLE
Remap hypen based args to underscore named functions

### DIFF
--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -654,6 +654,12 @@ def workspace_mirror(args):
 subcommand_functions = {}
 
 
+def sanitize_arg_name(base_name):
+    """Allow function names to be remaped (eg `-` to `_`) """
+    formatted_name = base_name.replace('-', '_')
+    return formatted_name
+
+
 def setup_parser(subparser):
     sp = subparser.add_subparsers(metavar='SUBCOMMAND',
                                   dest='workspace_command')
@@ -665,13 +671,14 @@ def setup_parser(subparser):
             aliases = []
 
         # add commands to subcommands dict
-        function_name = 'workspace_%s' % name
+        function_name = sanitize_arg_name('workspace_%s' % name)
+
         function = globals()[function_name]
         for alias in [name] + aliases:
             subcommand_functions[alias] = function
 
         # make a subparser and run the command's setup function on it
-        setup_parser_cmd_name = 'workspace_%s_setup_parser' % name
+        setup_parser_cmd_name = sanitize_arg_name('workspace_%s_setup_parser' % name)
         setup_parser_cmd = globals()[setup_parser_cmd_name]
 
         subsubparser = sp.add_parser(


### PR DESCRIPTION
This PR allows for args which have dashes in, eg:

```
 $ ramble workspace -h
usage: ramble workspace [-h] SUBCOMMAND ...

manage experiment workspaces

positional arguments:
  SUBCOMMAND
    activate   Set the current workspace
    ...
    test-dash
```

```
 $ ramble workspace test-dash
Works
```
(code maps the function it looks up to call from `workspace_test-dash` (invalid python) to `workspace_test_dash`) 

Only caveat is that if someone adds the same arg with an underscore it will collide.. but that is probably a really bad idea and we decided we wanted dashes not underscores in the first place