### PR TITLE
Fix issue where `ramble clean -a` could leave us in a bad state

### DIFF
--- a/lib/ramble/ramble/fetch_strategy.py
+++ b/lib/ramble/ramble/fetch_strategy.py
@@ -377,6 +377,12 @@ class URLFetchStrategy(FetchStrategy):
             save_file = self.stage.save_filename
         tty.msg('Fetching {0}'.format(url))
 
+        # Check if we're about to try and open a broken simlink, and if so
+        # remove that file to avoid a bad situation where a file "exists" but
+        # cannot be opened (warning: this is not atomic)
+        if os.path.islink(save_file) and not os.path.exists(save_file):
+            os.unlink(save_file)
+
         # Run urllib but grab the mime type from the http headers
         try:
             url, headers, response = ramble.util.web.read_from_url(url)


### PR DESCRIPTION
Previously if you ran `ramble clean -a` we would try fetch from a broken simlink, which would cause an error and exit

This PR detects that use case and unlinks the simlink before continuing as normal