### PR TITLE
Fix an invalid lookup where spack variables are None

### DIFF
--- a/lib/ramble/ramble/software_environments.py
+++ b/lib/ramble/ramble/software_environments.py
@@ -88,7 +88,8 @@ class SoftwareEnvironments(object):
 
         workspace_vars = self._workspace.get_workspace_vars().copy()
 
-        if namespace.variables in self.spack_dict:
+        if namespace.variables in self.spack_dict and \
+                self.spack_dict[namespace.variables] is not None:
             workspace_vars.update(self.spack_dict[namespace.variables])
 
         if namespace.packages in self.spack_dict:


### PR DESCRIPTION
Previously, if the variables attribute within the spack dictionary are not defined, they are set to None. This caused an error when updating workspace variables while building software environments.