### PR TITLE
Add config option to disable passthrough

### DIFF
--- a/lib/ramble/ramble/config.py
+++ b/lib/ramble/ramble/config.py
@@ -119,6 +119,7 @@ configuration_paths = (
 config_defaults = {
     'config': {
         'debug': False,
+        'disable_passthrough': False,
         'connect_timeout': 10,
         'verify_ssl': True,
         'checksum': True,

--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -437,6 +437,12 @@ class Expander(object):
                                after expansion
         """
 
+        passthrough_setting = allow_passthrough
+
+        # If disable_passthrough is set, override allow_passthrough from caller
+        if ramble.config.get('config:disable_passthrough'):
+            passthrough_setting = False
+
         tty.debug(f'BEGINNING OF EXPAND_VAR STACK ON {var}')
         expansions = self._variables
         if extra_vars:
@@ -446,9 +452,9 @@ class Expander(object):
         try:
             value = self._partial_expand(expansions,
                                          str(var),
-                                         allow_passthrough=allow_passthrough).lstrip()
+                                         allow_passthrough=passthrough_setting).lstrip()
         except RamblePassthroughError as e:
-            if not allow_passthrough:
+            if not passthrough_setting:
                 raise RambleSyntaxError(f'Encountered a passthrough error while expanding {var}\n'
                                         f'{e}')
 

--- a/lib/ramble/ramble/main.py
+++ b/lib/ramble/ramble/main.py
@@ -410,6 +410,9 @@ def make_argument_parser(**kwargs):
         help="write out debug messages "
              "(more d's for more verbosity: -d, -dd, -ddd, etc.)")
     parser.add_argument(
+        '--disable-passthrough', action='store_true',
+        help="disable passthrough of expansion variables for debugging")
+    parser.add_argument(
         '--timestamp', action='store_true',
         help="Add a timestamp to tty output")
     parser.add_argument(
@@ -505,6 +508,10 @@ def setup_main_options(args):
         if args.locks is False:
             spack.util.lock.check_lock_safety(ramble.paths.prefix)
         ramble.config.set('config:locks', args.locks, scope='command_line')
+
+    # override disable_passthrough configuration if passed on command line
+    if args.disable_passthrough:
+        ramble.config.set('config:disable_passthrough', True, scope='command_line')
 
     if args.mock:
         import spack.util.spack_yaml as syaml

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -265,7 +265,7 @@ complete -o bashdefault -o default -F _bash_completion_ramble ramble
 _ramble() {
     if $list_options
     then
-        RAMBLE_COMPREPLY="-h --help -H --all-help --color -c --config -C --config-scope -d --debug --timestamp --pdb -w --workspace -D --workspace-dir -W --no-workspace --use-workspace-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -p --profile --sorted-profile --lines -v --verbose --stacktrace -V --version --print-shell-vars"
+        RAMBLE_COMPREPLY="-h --help -H --all-help --color -c --config -C --config-scope -d --debug --disable-passthrough --timestamp --pdb -w --workspace -D --workspace-dir -W --no-workspace --use-workspace-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -p --profile --sorted-profile --lines -v --verbose --stacktrace -V --version --print-shell-vars"
     else
         RAMBLE_COMPREPLY="attributes clean commands config debug edit flake8 help info license list mirror mods on repo results software-definitions unit-test workspace"
     fi


### PR DESCRIPTION
Add a config option to disable passthrough of unexpanded variables to assist with debugging.