### PR TITLE
Add a custom logger to ramble

### DIFF
--- a/lib/ramble/ramble/appkit.py
+++ b/lib/ramble/ramble/appkit.py
@@ -14,7 +14,6 @@ Everything in this module is automatically imported into Ramble application file
 
 import llnl.util.filesystem
 from llnl.util.filesystem import *
-import llnl.util.tty as tty
 
 from ramble.application import ApplicationBase
 from ramble.application_types.executable import ExecutableApplication
@@ -24,5 +23,9 @@ from ramble.spec import Spec
 import ramble.language.application_language
 from ramble.language.application_language import *
 from ramble.language.shared_language import *
+from ramble.util.logger import logger
+
+# Import new logger as tty to preserve old behavior
+from ramble.util.logger import logger as tty
 
 from ramble.schema.types import OUTPUT_CAPTURE

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -18,9 +18,7 @@ import fnmatch
 from typing import List
 
 import llnl.util.filesystem as fs
-import llnl.util.tty as tty
 import llnl.util.tty.color as color
-import llnl.util.tty.log
 from llnl.util.tty.colify import colified
 
 import spack.util.executable
@@ -33,6 +31,7 @@ import ramble.stage
 import ramble.mirror
 import ramble.fetch_strategy
 import ramble.expander
+import ramble.keywords
 import ramble.repository
 import ramble.modifier
 import ramble.util.executable
@@ -40,7 +39,7 @@ import ramble.util.colors as rucolor
 import ramble.util.hashing
 import ramble.util.env
 import ramble.util.directives
-import ramble.keywords
+import ramble.util.logger
 
 from ramble.workspace import namespace
 
@@ -108,42 +107,9 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         self.license_file = ''
         self.license_inc_name = 'license.inc'
 
-        self.close_logger()
         self.build_phase_order()
 
         ramble.util.directives.define_directive_methods(self)
-
-    def construct_logger(self, logs_dir):
-        """Create and cache logger for this application instance
-
-
-        Using the input argument, logs_dir, construct a log path for this
-        application instance. Using that path, construct a logger instance that
-        will redirect output into that location.
-
-        When called multiple times, closes previously opened loggers, and
-        creates a new one each time.
-
-        Args:
-            logs_dir: Base directory for logs to exist in.
-        Returns:
-            log_path: Absolute path to log file that logger is writing to
-            logger: Logger instance to control writing
-        """
-        if hasattr(self, 'logger') and self.logger is not None:
-            self.close_logger()
-
-        log_path = self.experiment_log_file(logs_dir)
-        self.logger_file = log_path
-        self.logger = llnl.util.tty.log.log_output(log_path,
-                                                   echo=False,
-                                                   debug=tty.debug_level())
-
-    def close_logger(self):
-        """Close and destroy logger instances"""
-
-        self.logger_file = None
-        self.logger = None
 
     def copy(self):
         """Deep copy an application instance"""
@@ -378,8 +344,8 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
 
     def get_pipeline_phases(self, pipeline, phase_filters=['*']):
         if pipeline not in self._pipelines:
-            tty.die(f'Requested pipeline {pipeline} is not valid.\n',
-                    f'\tAvailable pipelinese are {self._pipelines}')
+            ramble.util.logger.logger.die(f'Requested pipeline {pipeline} is not valid.\n',
+                                          f'\tAvailable pipelinese are {self._pipelines}')
 
         phases = set()
         if hasattr(self, f'_{pipeline}_phases'):
@@ -388,7 +354,9 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                     if fnmatch.fnmatch(phase, phase_filter):
                         phases.add(phase)
         else:
-            tty.die(f'Pipeline {pipeline} is not defined in application {self.name}')
+            ramble.util.logger.logger.die(
+                f'Pipeline {pipeline} is not defined in application {self.name}'
+            )
 
         include_phase_deps = ramble.config.get('config:include_phase_dependencies')
         if include_phase_deps:
@@ -469,11 +437,11 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         self._inject_required_modifier_builtins()
         self.add_expand_vars(workspace)
         if self.is_template:
-            tty.debug(f'{self.name} is a template. Skipping phases')
+            ramble.util.logger.logger.debug(f'{self.name} is a template. Skipping phases')
             return
 
         if hasattr(self, f'_{phase}'):
-            tty.msg(f'  Executing phase {phase}')
+            ramble.util.logger.logger.msg(f'  Executing phase {phase}')
             for mod_inst in self._modifier_instances:
                 mod_inst.run_phase_hook(workspace, phase)
             phase_func = getattr(self, f'_{phase}')
@@ -950,7 +918,9 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
 
                 workspace.add_to_cache(input_tuple)
             else:
-                tty.msg('DRY-RUN: Would download %s' % input_conf['fetcher'].url)
+                ramble.util.logger.logger.msg(
+                    f'DRY-RUN: Would download {input_conf["fetcher"].url}'
+                )
 
     def _prepare_license_path(self, workspace):
         self.license_path = os.path.join(workspace.shared_license_dir, self.name)
@@ -961,7 +931,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
     register_phase('license_includes', pipeline='setup')
 
     def _license_includes(self, workspace):
-        tty.debug("Writing License Includes")
+        ramble.util.logger.logger.debug("Writing License Includes")
         self._prepare_license_path(workspace)
 
         action_funcs = ramble.util.env.action_funcs
@@ -1001,7 +971,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
 
         for template_name, template_conf in workspace.all_templates():
             expand_path = os.path.join(experiment_run_dir, template_name)
-            tty.msg(f'Writing template {template_name} to {expand_path}')
+            ramble.util.logger.logger.msg(f'Writing template {template_name} to {expand_path}')
 
             with open(expand_path, 'w+') as f:
                 f.write(self.expander.expand_var(template_conf['contents']))
@@ -1218,14 +1188,14 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
 
             # Start with no active contexts in a file.
             active_contexts = {}
-            tty.debug('Reading log file: %s' % file)
+            ramble.util.logger.logger.debug('Reading log file: %s' % file)
 
             with open(file, 'r') as f:
                 for line in f.readlines():
-                    tty.debug(f'Line: {line}')
+                    ramble.util.logger.logger.debug(f'Line: {line}')
 
                     for criteria in file_conf['success_criteria']:
-                        tty.debug('Looking for criteria %s' % criteria)
+                        ramble.util.logger.logger.debug('Looking for criteria %s' % criteria)
                         criteria_obj = criteria_list.find_criteria(criteria)
                         if criteria_obj.passed(line, self):
                             criteria_obj.mark_found()
@@ -1238,9 +1208,10 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                             context_name = \
                                 format_context(context_match,
                                                context_conf['format'])
-                            tty.debug('Line was: %s' % line)
-                            tty.debug(' Context match %s -- %s' %
-                                      (context, context_name))
+                            ramble.util.logger.logger.debug('Line was: %s' % line)
+                            ramble.util.logger.logger.debug(
+                                f' Context match {context} -- {context_name}'
+                            )
 
                             active_contexts[context] = context_name
 
@@ -1248,7 +1219,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                                 fom_values[context_name] = {}
 
                     for fom in file_conf['foms']:
-                        tty.debug(f'  Testing for fom {fom}')
+                        ramble.util.logger.logger.debug(f'  Testing for fom {fom}')
                         fom_conf = foms[fom]
                         fom_match = fom_conf['regex'].match(line)
 
@@ -1259,7 +1230,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                             fom_name = self.expander.expand_var(fom, extra_vars=fom_vars)
 
                             if fom_conf['group'] in fom_conf['regex'].groupindex:
-                                tty.debug(' --- Matched fom %s' % fom_name)
+                                ramble.util.logger.logger.debug(' --- Matched fom %s' % fom_name)
                                 fom_contexts = []
                                 if fom_conf['contexts']:
                                     for context in fom_conf['contexts']:
@@ -1297,7 +1268,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                     success = True
         success = success and criteria_list.passed()
 
-        tty.debug('fom_vals = %s' % fom_values)
+        ramble.util.logger.logger.debug('fom_vals = %s' % fom_values)
         results['EXPERIMENT_CHAIN'] = self.chain_order.copy()
         if success:
             self.set_status(status='SUCCESS')
@@ -1359,7 +1330,9 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
             ('application_definition', self.success_criteria),
         ]
 
-        tty.debug(f' Number of modifiers are: {len(self._modifier_instances)}')
+        ramble.util.logger.logger.debug(
+            f' Number of modifiers are: {len(self._modifier_instances)}'
+        )
         for mod in self._modifier_instances:
             success_lists.append(('modifier_definition', mod.success_criteria))
 
@@ -1411,8 +1384,8 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                 files[log_path] = self._new_file_dict()
 
             if log_path in files:
-                tty.debug('Log = %s' % log_path)
-                tty.debug('Conf = %s' % conf)
+                ramble.util.logger.logger.debug('Log = %s' % log_path)
+                ramble.util.logger.logger.debug('Conf = %s' % conf)
                 if conf['contexts']:
                     files[log_path]['contexts'].extend(conf['contexts'])
                 files[log_path]['foms'].append(fom)

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -1188,7 +1188,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
 
             # Start with no active contexts in a file.
             active_contexts = {}
-            ramble.util.logger.logger.debug('Reading log file: %s' % file)
+            ramble.util.logger.logger.debug(f'Reading log file: {file}')
 
             with open(file, 'r') as f:
                 for line in f.readlines():

--- a/lib/ramble/ramble/application_types/spack.py
+++ b/lib/ramble/ramble/application_types/spack.py
@@ -14,7 +14,7 @@ from ramble.language.shared_language import register_builtin
 from ramble.application import ApplicationBase, ApplicationError
 import ramble.spack_runner
 import ramble.keywords
-import ramble.util.logger
+from ramble.util.logger import logger
 
 header_color = '@*b'
 level1_color = '@*g'
@@ -90,7 +90,7 @@ class SpackApplication(ApplicationBase):
 
         cache_tupl = ('spack-compilers', env_path)
         if workspace.check_cache(cache_tupl):
-            ramble.util.logger.logger.debug('{} already in cache.'.format(cache_tupl))
+            logger.debug('{} already in cache.'.format(cache_tupl))
             return
         else:
             workspace.add_to_cache(cache_tupl)
@@ -104,13 +104,13 @@ class SpackApplication(ApplicationBase):
             for pkg_name in workspace.software_environments.get_env_packages(app_context):
                 pkg_spec = workspace.software_environments.get_spec(pkg_name)
                 if 'compiler' in pkg_spec:
-                    ramble.util.logger.logger.msg('Installing compilers')
-                    ramble.util.logger.logger.debug(f'Compilers: {pkg_spec["compiler"]}')
+                    logger.msg('Installing compilers')
+                    logger.debug(f'Compilers: {pkg_spec["compiler"]}')
                     comp_spec = workspace.software_environments.get_spec(pkg_spec['compiler'])
                     self.spack_runner.install_compiler(comp_spec['spack_spec'])
 
         except ramble.spack_runner.RunnerError as e:
-            ramble.util.logger.logger.die(e)
+            logger.die(e)
 
     register_phase('software_create_env', pipeline='mirror')
     register_phase('software_create_env', pipeline='setup')
@@ -122,7 +122,7 @@ class SpackApplication(ApplicationBase):
         file for it.
         """
 
-        ramble.util.logger.logger.msg('Creating Spack environment')
+        logger.msg('Creating Spack environment')
 
         # See if we cached this already, and if so return
         env_path = self.expander.env_path
@@ -131,7 +131,7 @@ class SpackApplication(ApplicationBase):
 
         cache_tupl = ('spack-env', env_path)
         if workspace.check_cache(cache_tupl):
-            ramble.util.logger.logger.debug('{} already in cache.'.format(cache_tupl))
+            logger.debug('{} already in cache.'.format(cache_tupl))
             return
         else:
             workspace.add_to_cache(cache_tupl)
@@ -175,23 +175,23 @@ class SpackApplication(ApplicationBase):
             added_packages = set(self.spack_runner.added_packages())
             for pkg in self.required_packages.keys():
                 if pkg not in added_packages:
-                    ramble.util.logger.logger.die(f'Software spec {pkg} is not defined '
-                                                  f'in environment {env_context}, but is '
-                                                  f'required by the {self.name} application '
-                                                  'definition')
+                    logger.die(f'Software spec {pkg} is not defined '
+                               f'in environment {env_context}, but is '
+                               f'required by the {self.name} application '
+                               'definition')
 
             for mod_inst in self._modifier_instances:
                 for pkg in mod_inst.required_packages.keys():
                     if pkg not in added_packages:
-                        ramble.util.logger.logger.die(f'Software spec {pkg} is not defined '
-                                                      f'in environment {env_context}, but is '
-                                                      f'required by the {mod_inst.name} modifier '
-                                                      'definition')
+                        logger.die(f'Software spec {pkg} is not defined '
+                                   f'in environment {env_context}, but is '
+                                   f'required by the {mod_inst.name} modifier '
+                                   'definition')
 
             self.spack_runner.deactivate()
 
         except ramble.spack_runner.RunnerError as e:
-            ramble.util.logger.logger.die(e)
+            logger.die(e)
 
     register_phase('software_configure', pipeline='setup',
                    depends_on=['software_create_env', 'software_install_requested_compilers'])
@@ -203,14 +203,14 @@ class SpackApplication(ApplicationBase):
         for  this experiment.
         """
 
-        ramble.util.logger.logger.msg('Concretizing Spack environment')
+        logger.msg('Concretizing Spack environment')
 
         # See if we cached this already, and if so return
         env_path = self.expander.env_path
 
         cache_tupl = ('concretize-env', env_path)
         if workspace.check_cache(cache_tupl):
-            ramble.util.logger.logger.debug('{} already in cache.'.format(cache_tupl))
+            logger.debug('{} already in cache.'.format(cache_tupl))
             return
         else:
             workspace.add_to_cache(cache_tupl)
@@ -226,7 +226,7 @@ class SpackApplication(ApplicationBase):
                 self.spack_runner.concretize()
 
         except ramble.spack_runner.RunnerError as e:
-            ramble.util.logger.logger.die(e)
+            logger.die(e)
 
     register_phase('software_install', pipeline='setup',
                    depends_on=['software_configure'])
@@ -239,7 +239,7 @@ class SpackApplication(ApplicationBase):
 
         cache_tupl = ('spack-install', env_path)
         if workspace.check_cache(cache_tupl):
-            ramble.util.logger.logger.debug('{} already in cache.'.format(cache_tupl))
+            logger.debug('{} already in cache.'.format(cache_tupl))
             return
         else:
             workspace.add_to_cache(cache_tupl)
@@ -248,12 +248,12 @@ class SpackApplication(ApplicationBase):
             self.spack_runner.set_dry_run(workspace.dry_run)
             self.spack_runner.set_env(env_path)
 
-            ramble.util.logger.logger.msg('Installing software')
+            logger.msg('Installing software')
 
             self.spack_runner.activate()
             self.spack_runner.install()
         except ramble.spack_runner.RunnerError as e:
-            ramble.util.logger.logger.die(e)
+            logger.die(e)
 
     register_phase('define_package_paths', pipeline='setup',
                    depends_on=['software_install'])
@@ -277,7 +277,7 @@ class SpackApplication(ApplicationBase):
         wrf@4.2.2
         """
 
-        ramble.util.logger.logger.msg('Defining Spack variables')
+        logger.msg('Defining Spack variables')
 
         try:
             self.spack_runner.set_dry_run(workspace.dry_run)
@@ -294,7 +294,7 @@ class SpackApplication(ApplicationBase):
                 self.variables[spack_pkg_name] = package_path
 
         except ramble.spack_runner.RunnerError as e:
-            ramble.util.logger.logger.die(e)
+            logger.die(e)
 
     register_phase('mirror_software', pipeline='mirror', depends_on=['software_create_env'])
 
@@ -302,7 +302,7 @@ class SpackApplication(ApplicationBase):
         """Mirror software source for this experiment using spack"""
         import re
 
-        ramble.util.logger.logger.msg('Mirroring software')
+        logger.msg('Mirroring software')
 
         # See if we cached this already, and if so return
         env_path = self.expander.env_path
@@ -311,7 +311,7 @@ class SpackApplication(ApplicationBase):
 
         cache_tupl = ('spack-mirror', env_path)
         if workspace.check_cache(cache_tupl):
-            ramble.util.logger.logger.debug('{} already in cache.'.format(cache_tupl))
+            logger.debug('{} already in cache.'.format(cache_tupl))
             return
         else:
             workspace.add_to_cache(cache_tupl)
@@ -356,7 +356,7 @@ class SpackApplication(ApplicationBase):
                 workspace.software_mirror_stats.errors.add(i)
 
         except ramble.spack_runner.RunnerError as e:
-            ramble.util.logger.logger.die(e)
+            logger.die(e)
 
     register_phase('push_to_spack_cache', pipeline='pushtocache', depends_on=[])
 
@@ -365,7 +365,7 @@ class SpackApplication(ApplicationBase):
         env_path = self.expander.env_path
         cache_tupl = ('push-to-cache', env_path)
         if workspace.check_cache(cache_tupl):
-            ramble.util.logger.logger.debug('{} already pushed, skipping'.format(cache_tupl))
+            logger.debug('{} already pushed, skipping'.format(cache_tupl))
             return
         else:
             workspace.add_to_cache(cache_tupl)
@@ -379,7 +379,7 @@ class SpackApplication(ApplicationBase):
 
             self.spack_runner.deactivate()
         except ramble.spack_runner.RunnerError as e:
-            ramble.util.logger.logger.die(e)
+            logger.die(e)
 
     def populate_inventory(self, workspace, force_compute=False, require_exist=False):
         """Add software environment information to hash inventory"""

--- a/lib/ramble/ramble/application_types/spack.py
+++ b/lib/ramble/ramble/application_types/spack.py
@@ -9,13 +9,12 @@
 import os
 import six
 
-import llnl.util.tty as tty
-
 from ramble.language.application_language import register_phase
 from ramble.language.shared_language import register_builtin
 from ramble.application import ApplicationBase, ApplicationError
 import ramble.spack_runner
 import ramble.keywords
+import ramble.util.logger
 
 header_color = '@*b'
 level1_color = '@*g'
@@ -91,7 +90,7 @@ class SpackApplication(ApplicationBase):
 
         cache_tupl = ('spack-compilers', env_path)
         if workspace.check_cache(cache_tupl):
-            tty.debug('{} already in cache.'.format(cache_tupl))
+            ramble.util.logger.logger.debug('{} already in cache.'.format(cache_tupl))
             return
         else:
             workspace.add_to_cache(cache_tupl)
@@ -105,14 +104,13 @@ class SpackApplication(ApplicationBase):
             for pkg_name in workspace.software_environments.get_env_packages(app_context):
                 pkg_spec = workspace.software_environments.get_spec(pkg_name)
                 if 'compiler' in pkg_spec:
-                    tty.msg('Installing compilers')
-                    tty.debug(f'Compilers: {pkg_spec["compiler"]}')
+                    ramble.util.logger.logger.msg('Installing compilers')
+                    ramble.util.logger.logger.debug(f'Compilers: {pkg_spec["compiler"]}')
                     comp_spec = workspace.software_environments.get_spec(pkg_spec['compiler'])
                     self.spack_runner.install_compiler(comp_spec['spack_spec'])
 
         except ramble.spack_runner.RunnerError as e:
-            with self.logger.force_echo():
-                tty.die(e)
+            ramble.util.logger.logger.die(e)
 
     register_phase('software_create_env', pipeline='mirror')
     register_phase('software_create_env', pipeline='setup')
@@ -124,7 +122,7 @@ class SpackApplication(ApplicationBase):
         file for it.
         """
 
-        tty.msg('Creating Spack environment')
+        ramble.util.logger.logger.msg('Creating Spack environment')
 
         # See if we cached this already, and if so return
         env_path = self.expander.env_path
@@ -133,7 +131,7 @@ class SpackApplication(ApplicationBase):
 
         cache_tupl = ('spack-env', env_path)
         if workspace.check_cache(cache_tupl):
-            tty.debug('{} already in cache.'.format(cache_tupl))
+            ramble.util.logger.logger.debug('{} already in cache.'.format(cache_tupl))
             return
         else:
             workspace.add_to_cache(cache_tupl)
@@ -177,26 +175,23 @@ class SpackApplication(ApplicationBase):
             added_packages = set(self.spack_runner.added_packages())
             for pkg in self.required_packages.keys():
                 if pkg not in added_packages:
-                    with self.logger.force_echo():
-                        tty.die(f'Software spec {pkg} is not defined '
-                                f'in environment {env_context}, but is required '
-                                f'to by the {self.name} application '
-                                'definition')
+                    ramble.util.logger.logger.die(f'Software spec {pkg} is not defined '
+                                                  f'in environment {env_context}, but is '
+                                                  f'required by the {self.name} application '
+                                                  'definition')
 
             for mod_inst in self._modifier_instances:
                 for pkg in mod_inst.required_packages.keys():
                     if pkg not in added_packages:
-                        with self.logger.force_echo():
-                            tty.die(f'Software spec {pkg} is not defined '
-                                    f'in environment {env_context}, but is required '
-                                    f'to by the {mod_inst.name} modifier '
-                                    'definition')
+                        ramble.util.logger.logger.die(f'Software spec {pkg} is not defined '
+                                                      f'in environment {env_context}, but is '
+                                                      f'required by the {mod_inst.name} modifier '
+                                                      'definition')
 
             self.spack_runner.deactivate()
 
         except ramble.spack_runner.RunnerError as e:
-            with self.logger.force_echo():
-                tty.die(e)
+            ramble.util.logger.logger.die(e)
 
     register_phase('software_configure', pipeline='setup',
                    depends_on=['software_create_env', 'software_install_requested_compilers'])
@@ -208,14 +203,14 @@ class SpackApplication(ApplicationBase):
         for  this experiment.
         """
 
-        tty.msg('Concretizing Spack environment')
+        ramble.util.logger.logger.msg('Concretizing Spack environment')
 
         # See if we cached this already, and if so return
         env_path = self.expander.env_path
 
         cache_tupl = ('concretize-env', env_path)
         if workspace.check_cache(cache_tupl):
-            tty.debug('{} already in cache.'.format(cache_tupl))
+            ramble.util.logger.logger.debug('{} already in cache.'.format(cache_tupl))
             return
         else:
             workspace.add_to_cache(cache_tupl)
@@ -231,8 +226,7 @@ class SpackApplication(ApplicationBase):
                 self.spack_runner.concretize()
 
         except ramble.spack_runner.RunnerError as e:
-            with self.logger.force_echo():
-                tty.die(e)
+            ramble.util.logger.logger.die(e)
 
     register_phase('software_install', pipeline='setup',
                    depends_on=['software_configure'])
@@ -245,7 +239,7 @@ class SpackApplication(ApplicationBase):
 
         cache_tupl = ('spack-install', env_path)
         if workspace.check_cache(cache_tupl):
-            tty.debug('{} already in cache.'.format(cache_tupl))
+            ramble.util.logger.logger.debug('{} already in cache.'.format(cache_tupl))
             return
         else:
             workspace.add_to_cache(cache_tupl)
@@ -254,13 +248,12 @@ class SpackApplication(ApplicationBase):
             self.spack_runner.set_dry_run(workspace.dry_run)
             self.spack_runner.set_env(env_path)
 
-            tty.msg('Installing software')
+            ramble.util.logger.logger.msg('Installing software')
 
             self.spack_runner.activate()
             self.spack_runner.install()
         except ramble.spack_runner.RunnerError as e:
-            with self.logger.force_echo():
-                tty.die(e)
+            ramble.util.logger.logger.die(e)
 
     register_phase('define_package_paths', pipeline='setup',
                    depends_on=['software_install'])
@@ -284,7 +277,7 @@ class SpackApplication(ApplicationBase):
         wrf@4.2.2
         """
 
-        tty.msg('Defining Spack variables')
+        ramble.util.logger.logger.msg('Defining Spack variables')
 
         try:
             self.spack_runner.set_dry_run(workspace.dry_run)
@@ -301,8 +294,7 @@ class SpackApplication(ApplicationBase):
                 self.variables[spack_pkg_name] = package_path
 
         except ramble.spack_runner.RunnerError as e:
-            with self.logger.force_echo():
-                tty.die(e)
+            ramble.util.logger.logger.die(e)
 
     register_phase('mirror_software', pipeline='mirror', depends_on=['software_create_env'])
 
@@ -310,7 +302,7 @@ class SpackApplication(ApplicationBase):
         """Mirror software source for this experiment using spack"""
         import re
 
-        tty.msg('Mirroring software')
+        ramble.util.logger.logger.msg('Mirroring software')
 
         # See if we cached this already, and if so return
         env_path = self.expander.env_path
@@ -319,7 +311,7 @@ class SpackApplication(ApplicationBase):
 
         cache_tupl = ('spack-mirror', env_path)
         if workspace.check_cache(cache_tupl):
-            tty.debug('{} already in cache.'.format(cache_tupl))
+            ramble.util.logger.logger.debug('{} already in cache.'.format(cache_tupl))
             return
         else:
             workspace.add_to_cache(cache_tupl)
@@ -364,8 +356,7 @@ class SpackApplication(ApplicationBase):
                 workspace.software_mirror_stats.errors.add(i)
 
         except ramble.spack_runner.RunnerError as e:
-            with self.logger.force_echo():
-                tty.die(e)
+            ramble.util.logger.logger.die(e)
 
     register_phase('push_to_spack_cache', pipeline='pushtocache', depends_on=[])
 
@@ -374,7 +365,7 @@ class SpackApplication(ApplicationBase):
         env_path = self.expander.env_path
         cache_tupl = ('push-to-cache', env_path)
         if workspace.check_cache(cache_tupl):
-            tty.debug('{} already pushed, skipping'.format(cache_tupl))
+            ramble.util.logger.logger.debug('{} already pushed, skipping'.format(cache_tupl))
             return
         else:
             workspace.add_to_cache(cache_tupl)
@@ -388,8 +379,7 @@ class SpackApplication(ApplicationBase):
 
             self.spack_runner.deactivate()
         except ramble.spack_runner.RunnerError as e:
-            with self.logger.force_echo():
-                tty.die(e)
+            ramble.util.logger.logger.die(e)
 
     def populate_inventory(self, workspace, force_compute=False, require_exist=False):
         """Add software environment information to hash inventory"""

--- a/lib/ramble/ramble/cmd/__init__.py
+++ b/lib/ramble/ramble/cmd/__init__.py
@@ -20,7 +20,7 @@ import ramble.config
 import ramble.error
 import ramble.paths
 import ramble.workspace
-import ramble.util.logger
+from ramble.util.logger import logger
 
 import spack.extensions
 import spack.util.string
@@ -109,7 +109,7 @@ def get_module(cmd_name):
     require_cmd_name(cmd_name)
     pname = python_name(cmd_name)
 
-    ramble.util.logger.logger.debug(f'Getting module for command {cmd_name}')
+    logger.debug(f'Getting module for command {cmd_name}')
 
     try:
         # Try to import the command from the built-in directory
@@ -117,7 +117,7 @@ def get_module(cmd_name):
         module = __import__(module_name,
                             fromlist=[pname, SETUP_PARSER, DESCRIPTION],
                             level=0)
-        ramble.util.logger.logger.debug(f'Imported {pname} from built-in commands')
+        logger.debug(f'Imported {pname} from built-in commands')
     except ImportError:
         try:
             module = spack.extensions.get_module(cmd_name)
@@ -129,7 +129,7 @@ def get_module(cmd_name):
     attr_setdefault(module, DESCRIPTION, "")
 
     if not hasattr(module, pname):
-        ramble.util.logger.logger.die(
+        logger.die(
             f"Command module {module.__name__} ({module.__file__}) must define function '{pname}'."
         )
 
@@ -231,7 +231,7 @@ def require_active_workspace(cmd_name):
     if ws:
         return ws
     else:
-        ramble.util.logger.logger.die(
+        logger.die(
             f'`ramble {cmd_name}` requires a workspace',
             'activate a workspace first:',
             '    ramble workspace activate WRKSPC',

--- a/lib/ramble/ramble/cmd/__init__.py
+++ b/lib/ramble/ramble/cmd/__init__.py
@@ -130,7 +130,7 @@ def get_module(cmd_name):
 
     if not hasattr(module, pname):
         ramble.util.logger.logger.die(
-            f"Command module {module.__name__} (module.__file__) must define function '{pname}'."
+            f"Command module {module.__name__} ({module.__file__}) must define function '{pname}'."
         )
 
     return module

--- a/lib/ramble/ramble/cmd/__init__.py
+++ b/lib/ramble/ramble/cmd/__init__.py
@@ -13,7 +13,6 @@ import re
 import argparse
 import ruamel.yaml as yaml
 
-import llnl.util.tty as tty
 from llnl.util.lang import attr_setdefault
 from llnl.util.filesystem import join_path
 
@@ -21,6 +20,7 @@ import ramble.config
 import ramble.error
 import ramble.paths
 import ramble.workspace
+import ramble.util.logger
 
 import spack.extensions
 import spack.util.string
@@ -109,7 +109,7 @@ def get_module(cmd_name):
     require_cmd_name(cmd_name)
     pname = python_name(cmd_name)
 
-    tty.debug('Getting module for command {}'.format(cmd_name))
+    ramble.util.logger.logger.debug(f'Getting module for command {cmd_name}')
 
     try:
         # Try to import the command from the built-in directory
@@ -117,7 +117,7 @@ def get_module(cmd_name):
         module = __import__(module_name,
                             fromlist=[pname, SETUP_PARSER, DESCRIPTION],
                             level=0)
-        tty.debug('Imported {0} from built-in commands'.format(pname))
+        ramble.util.logger.logger.debug(f'Imported {pname} from built-in commands')
     except ImportError:
         try:
             module = spack.extensions.get_module(cmd_name)
@@ -129,8 +129,9 @@ def get_module(cmd_name):
     attr_setdefault(module, DESCRIPTION, "")
 
     if not hasattr(module, pname):
-        tty.die("Command module %s (%s) must define function '%s'." %
-                (module.__name__, module.__file__, pname))
+        ramble.util.logger.logger.die(
+            f"Command module {module.__name__} (module.__file__) must define function '{pname}'."
+        )
 
     return module
 
@@ -230,12 +231,12 @@ def require_active_workspace(cmd_name):
     if ws:
         return ws
     else:
-        tty.die(
-            '`ramble %s` requires a workspace' % cmd_name,
+        ramble.util.logger.logger.die(
+            f'`ramble {cmd_name}` requires a workspace',
             'activate a workspace first:',
             '    ramble workspace activate WRKSPC',
             'or use:',
-            '    ramble -w WRKSPC %s ...' % cmd_name)
+            f'    ramble -w WRKSPC {cmd_name} ...')
 
 
 def find_workspace(args):

--- a/lib/ramble/ramble/cmd/attributes.py
+++ b/lib/ramble/ramble/cmd/attributes.py
@@ -15,7 +15,7 @@ import llnl.util.tty.color as color
 from llnl.util.tty.colify import colify
 
 import ramble.repository
-import ramble.util.logger
+from ramble.util.logger import logger
 
 description = "get information about object attributes"
 section = "developer"
@@ -176,9 +176,7 @@ def attributes(parser, args):
 
     if args.by_attribute:
         if not args.object_or_attr:
-            ramble.util.logger.logger.die(
-                "ramble attributes --by-attribute requires an attribute or --all"
-            )
+            logger.die("ramble attributes --by-attribute requires an attribute or --all")
 
         objects = union_values(attributes_to_objects(args.object_or_attr,
                                                      attr_name=attr_name,
@@ -188,7 +186,7 @@ def attributes(parser, args):
 
     else:
         if not args.object_or_attr:
-            ramble.util.logger.logger.die("ramble attributes requires an object or --all")
+            logger.die("ramble attributes requires an object or --all")
 
         users = union_values(objects_to_attributes(args.object_or_attr,
                                                    attr_name=attr_name,

--- a/lib/ramble/ramble/cmd/attributes.py
+++ b/lib/ramble/ramble/cmd/attributes.py
@@ -11,11 +11,11 @@ from __future__ import print_function
 import argparse
 from collections import defaultdict
 
-import llnl.util.tty as tty
 import llnl.util.tty.color as color
 from llnl.util.tty.colify import colify
 
 import ramble.repository
+import ramble.util.logger
 
 description = "get information about object attributes"
 section = "developer"
@@ -176,7 +176,9 @@ def attributes(parser, args):
 
     if args.by_attribute:
         if not args.object_or_attr:
-            tty.die("ramble attributes --by-attribute requires an attribute or --all")
+            ramble.util.logger.logger.die(
+                "ramble attributes --by-attribute requires an attribute or --all"
+            )
 
         objects = union_values(attributes_to_objects(args.object_or_attr,
                                                      attr_name=attr_name,
@@ -186,7 +188,7 @@ def attributes(parser, args):
 
     else:
         if not args.object_or_attr:
-            tty.die("ramble attributes requires an object or --all")
+            ramble.util.logger.logger.die("ramble attributes requires an object or --all")
 
         users = union_values(objects_to_attributes(args.object_or_attr,
                                                    attr_name=attr_name,

--- a/lib/ramble/ramble/cmd/clean.py
+++ b/lib/ramble/ramble/cmd/clean.py
@@ -11,12 +11,11 @@ import argparse
 import os
 import shutil
 
-import llnl.util.tty as tty
-
 import ramble.caches
 import ramble.config
 import ramble.repository
 import ramble.stage
+import ramble.util.logger
 from ramble.paths import lib_path, var_path
 
 description = "remove temporary files and/or downloaded archives"
@@ -53,24 +52,24 @@ def clean(parser, args):
         args.downloads = True
 
     if args.downloads:
-        tty.msg('Removing cached downloads')
+        ramble.util.logger.logger.msg('Removing cached downloads')
         ramble.caches.fetch_cache.destroy()
 
     if args.misc_cache:
-        tty.msg('Removing cached information on repositories')
+        ramble.util.logger.logger.msg('Removing cached information on repositories')
         ramble.caches.misc_cache.destroy()
 
     if args.python_cache:
-        tty.msg('Removing python cache files')
+        ramble.util.logger.logger.msg('Removing python cache files')
         for directory in [lib_path, var_path]:
             for root, dirs, files in os.walk(directory):
                 for f in files:
                     if f.endswith('.pyc') or f.endswith('.pyo'):
                         fname = os.path.join(root, f)
-                        tty.debug('Removing {0}'.format(fname))
+                        ramble.util.logger.logger.debug(f'Removing {fname}')
                         os.remove(fname)
                 for d in dirs:
                     if d == '__pycache__':
                         dname = os.path.join(root, d)
-                        tty.debug('Removing {0}'.format(dname))
+                        ramble.util.logger.logger.debug(f'Removing {dname}')
                         shutil.rmtree(dname)

--- a/lib/ramble/ramble/cmd/clean.py
+++ b/lib/ramble/ramble/cmd/clean.py
@@ -15,7 +15,7 @@ import ramble.caches
 import ramble.config
 import ramble.repository
 import ramble.stage
-import ramble.util.logger
+from ramble.util.logger import logger
 from ramble.paths import lib_path, var_path
 
 description = "remove temporary files and/or downloaded archives"
@@ -52,24 +52,24 @@ def clean(parser, args):
         args.downloads = True
 
     if args.downloads:
-        ramble.util.logger.logger.msg('Removing cached downloads')
+        logger.msg('Removing cached downloads')
         ramble.caches.fetch_cache.destroy()
 
     if args.misc_cache:
-        ramble.util.logger.logger.msg('Removing cached information on repositories')
+        logger.msg('Removing cached information on repositories')
         ramble.caches.misc_cache.destroy()
 
     if args.python_cache:
-        ramble.util.logger.logger.msg('Removing python cache files')
+        logger.msg('Removing python cache files')
         for directory in [lib_path, var_path]:
             for root, dirs, files in os.walk(directory):
                 for f in files:
                     if f.endswith('.pyc') or f.endswith('.pyo'):
                         fname = os.path.join(root, f)
-                        ramble.util.logger.logger.debug(f'Removing {fname}')
+                        logger.debug(f'Removing {fname}')
                         os.remove(fname)
                 for d in dirs:
                     if d == '__pycache__':
                         dname = os.path.join(root, d)
-                        ramble.util.logger.logger.debug(f'Removing {dname}')
+                        logger.debug(f'Removing {dname}')
                         shutil.rmtree(dname)

--- a/lib/ramble/ramble/cmd/commands.py
+++ b/lib/ramble/ramble/cmd/commands.py
@@ -23,7 +23,7 @@ from llnl.util.tty.colify import colify
 import ramble.cmd
 import ramble.main
 import ramble.paths
-import ramble.util.logger
+from ramble.util.logger import logger
 from ramble.main import section_descriptions
 
 
@@ -257,12 +257,12 @@ def _commands(parser, args):
 
     # check header first so we don't open out files unnecessarily
     if args.header and not os.path.exists(args.header):
-        ramble.util.logger.logger.die(f"No such file: '{args.header}'")
+        logger.die(f"No such file: '{args.header}'")
 
     # if we're updating an existing file, only write output if a command
     # or the header is newer than the file.
     if args.update:
-        ramble.util.logger.logger.msg(f'Generating file: {args.update}')
+        logger.msg(f'Generating file: {args.update}')
         with open(args.update, 'w+') as f:
             prepend_header(args, f)
             formatter(args, f)
@@ -293,7 +293,7 @@ def commands(parser, args):
         if args.format != 'names' or any([
                 args.aliases, args.update, args.header
         ]):
-            ramble.util.logger.logger.die("--update-completion can only be specified alone.")
+            logger.die("--update-completion can only be specified alone.")
 
         # this runs the command multiple times with different arguments
         return update_completion(parser, args)

--- a/lib/ramble/ramble/cmd/commands.py
+++ b/lib/ramble/ramble/cmd/commands.py
@@ -15,7 +15,6 @@ import re
 import sys
 
 import llnl.util.filesystem as fs
-import llnl.util.tty as tty
 from llnl.util.argparsewriter import (
     ArgparseWriter, ArgparseRstWriter, ArgparseCompletionWriter
 )
@@ -24,6 +23,7 @@ from llnl.util.tty.colify import colify
 import ramble.cmd
 import ramble.main
 import ramble.paths
+import ramble.util.logger
 from ramble.main import section_descriptions
 
 
@@ -257,12 +257,12 @@ def _commands(parser, args):
 
     # check header first so we don't open out files unnecessarily
     if args.header and not os.path.exists(args.header):
-        tty.die("No such file: '%s'" % args.header)
+        ramble.util.logger.logger.die(f"No such file: '{args.header}'")
 
     # if we're updating an existing file, only write output if a command
     # or the header is newer than the file.
     if args.update:
-        tty.msg('Generating file: %s' % args.update)
+        ramble.util.logger.logger.msg(f'Generating file: {args.update}')
         with open(args.update, 'w+') as f:
             prepend_header(args, f)
             formatter(args, f)
@@ -293,7 +293,7 @@ def commands(parser, args):
         if args.format != 'names' or any([
                 args.aliases, args.update, args.header
         ]):
-            tty.die("--update-completion can only be specified alone.")
+            ramble.util.logger.logger.die("--update-completion can only be specified alone.")
 
         # this runs the command multiple times with different arguments
         return update_completion(parser, args)

--- a/lib/ramble/ramble/cmd/common/__init__.py
+++ b/lib/ramble/ramble/cmd/common/__init__.py
@@ -9,7 +9,7 @@
 import llnl.util.tty.color as color
 
 import ramble.paths
-import ramble.util.logger
+from ramble.util.logger import logger
 
 
 def shell_init_instructions(cmd, equivalent):
@@ -49,4 +49,4 @@ def shell_init_instructions(cmd, equivalent):
         msg += ["  " + equivalent]
 
     msg += ['']
-    ramble.util.logger.logger.error(*msg)
+    logger.error(*msg)

--- a/lib/ramble/ramble/cmd/common/__init__.py
+++ b/lib/ramble/ramble/cmd/common/__init__.py
@@ -6,10 +6,10 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-import llnl.util.tty as tty
 import llnl.util.tty.color as color
 
 import ramble.paths
+import ramble.util.logger
 
 
 def shell_init_instructions(cmd, equivalent):
@@ -49,4 +49,4 @@ def shell_init_instructions(cmd, equivalent):
         msg += ["  " + equivalent]
 
     msg += ['']
-    tty.error(*msg)
+    ramble.util.logger.logger.error(*msg)

--- a/lib/ramble/ramble/cmd/common/list.py
+++ b/lib/ramble/ramble/cmd/common/list.py
@@ -20,7 +20,7 @@ from llnl.util.tty.colify import colify
 
 import ramble.repository
 import ramble.cmd.common.arguments as arguments
-import ramble.util.logger
+from ramble.util.logger import logger
 
 if sys.version_info > (3, 1):
     from html import escape  # novm
@@ -81,7 +81,7 @@ def name_only(objs, out, object_type):
     obj_def = ramble.repository.type_definitions[object_type]
     indent = 0
     if out.isatty():
-        ramble.util.logger.logger.msg(f'{len(objs)} {obj_def["dir_name"]}')
+        logger.msg(f'{len(objs)} {obj_def["dir_name"]}')
     colify(objs, indent=indent, output=out)
 
 
@@ -261,10 +261,10 @@ def perform_list(args, object_type):
         if os.path.exists(args.update):
             if os.path.getmtime(args.update) > \
                     ramble.repository.paths[object_type].last_mtime():
-                ramble.util.logger.logger.msg(f'File is up to date: {args.update}')
+                logger.msg(f'File is up to date: {args.update}')
                 return
 
-        ramble.util.logger.logger.msg(f'Updating file: {args.update}')
+        logger.msg(f'Updating file: {args.update}')
         with open(args.update, 'w') as f:
             formatter(sorted_objects, f, object_type)
 

--- a/lib/ramble/ramble/cmd/common/list.py
+++ b/lib/ramble/ramble/cmd/common/list.py
@@ -16,11 +16,11 @@ import re
 import sys
 import math
 
-import llnl.util.tty as tty
 from llnl.util.tty.colify import colify
 
 import ramble.repository
 import ramble.cmd.common.arguments as arguments
+import ramble.util.logger
 
 if sys.version_info > (3, 1):
     from html import escape  # novm
@@ -81,7 +81,7 @@ def name_only(objs, out, object_type):
     obj_def = ramble.repository.type_definitions[object_type]
     indent = 0
     if out.isatty():
-        tty.msg(f'{len(objs)} {obj_def["dir_name"]}')
+        ramble.util.logger.logger.msg(f'{len(objs)} {obj_def["dir_name"]}')
     colify(objs, indent=indent, output=out)
 
 
@@ -261,10 +261,10 @@ def perform_list(args, object_type):
         if os.path.exists(args.update):
             if os.path.getmtime(args.update) > \
                     ramble.repository.paths[object_type].last_mtime():
-                tty.msg('File is up to date: %s' % args.update)
+                ramble.util.logger.logger.msg(f'File is up to date: {args.update}')
                 return
 
-        tty.msg('Updating file: %s' % args.update)
+        ramble.util.logger.logger.msg(f'Updating file: {args.update}')
         with open(args.update, 'w') as f:
             formatter(sorted_objects, f, object_type)
 

--- a/lib/ramble/ramble/cmd/config.py
+++ b/lib/ramble/ramble/cmd/config.py
@@ -274,8 +274,8 @@ def config_update(args):
             if scope.name == 'system':
                 skip_system_scope = True
                 msg = ('Not enough permissions to write to "system" scope. '
-                       'Skipping update at that location [cfg={0}]')
-                ramble.util.logger.logger.warn(msg.format(cfg_file))
+                       f'Skipping update at that location [cfg={cfg_file}]')
+                ramble.util.logger.logger.warn(msg)
                 continue
             cannot_overwrite.append((scope, cfg_file))
 

--- a/lib/ramble/ramble/cmd/config.py
+++ b/lib/ramble/ramble/cmd/config.py
@@ -17,6 +17,7 @@ import llnl.util.tty as tty
 import ramble.cmd.common.arguments
 import ramble.config
 import ramble.workspace
+import ramble.util.logger
 
 import spack.util.spack_yaml as syaml
 import ramble.util.editor
@@ -103,7 +104,7 @@ def setup_parser(subparser):
 
 def _get_scope_and_section(args):
     """Extract config scope and section from arguments."""
-    tty.debug(f' Args = {str(args)}')
+    ramble.util.logger.logger.debug(f' Args = {str(args)}')
     scope = args.scope
     section = getattr(args, 'section', None)
     path = getattr(args, 'path', None)
@@ -144,11 +145,15 @@ def config_get(args):
             with open(config_file) as f:
                 print(f.read())
         else:
-            tty.die('workspace has no %s file' % ramble.workspace.config_file_name)
+            ramble.util.logger.logger.die(
+                f'workspace has no {ramble.workspace.config_file_name} file'
+            )
 
     else:
-        tty.die('`ramble config get` requires a section argument '
-                'or an active workspace.')
+        ramble.util.logger.logger.die(
+            '`ramble config get` requires a section argument '
+            'or an active workspace.'
+        )
 
 
 def config_blame(args):
@@ -171,8 +176,10 @@ def config_edit(args):
         # If we aren't editing a ramble.yaml file, get config path from scope.
         scope, section = _get_scope_and_section(args)
         if not scope and not section:
-            tty.die('`ramble config edit` requires a section argument '
-                    'or an active workspace.')
+            ramble.util.logger.logger.die(
+                '`ramble config edit` requires a section argument '
+                'or an active workspace.'
+            )
         config_file = ramble.config.config.get_config_filename(scope, section)
 
     if args.print_file:
@@ -197,7 +204,7 @@ def config_add(args):
 
     This is a stateful operation that edits the config files."""
     if not (args.file or args.path):
-        tty.error("No changes requested. Specify a file or value.")
+        ramble.util.logger.logger.error("No changes requested. Specify a file or value.")
         setup_parser.add_parser.print_help()
         exit(1)
 
@@ -268,7 +275,7 @@ def config_update(args):
                 skip_system_scope = True
                 msg = ('Not enough permissions to write to "system" scope. '
                        'Skipping update at that location [cfg={0}]')
-                tty.warn(msg.format(cfg_file))
+                ramble.util.logger.logger.warn(msg.format(cfg_file))
                 continue
             cannot_overwrite.append((scope, cfg_file))
 
@@ -279,7 +286,7 @@ def config_update(args):
         msg += ('\nEither ensure that you have sufficient permissions to '
                 'modify these files or do not include these scopes in the '
                 'update.')
-        tty.die(msg)
+        ramble.util.logger.logger.die(msg)
 
     if skip_system_scope:
         updates = [x for x in updates if x.name != 'system']
@@ -287,7 +294,7 @@ def config_update(args):
     # Report if there are no updates to be done
     if not updates:
         msg = 'No updates needed for "{0}" section.'
-        tty.msg(msg.format(args.section))
+        ramble.util.logger.logger.msg(msg.format(args.section))
         return
 
     proceed = True
@@ -303,11 +310,11 @@ def config_update(args):
                 'that are older than this version may not be able to read '
                 'them. Ramble stores backups of the updated files which can '
                 'be retrieved with "ramble config revert"')
-        tty.msg(msg)
+        ramble.util.logger.logger.msg(msg)
         proceed = tty.get_yes_or_no('Do you want to proceed?', default=False)
 
     if not proceed:
-        tty.die('Operation aborted.')
+        ramble.util.logger.logger.die('Operation aborted.')
 
     # Get a function to update the format
     update_fn = ramble.config.ensure_latest_format_fn(args.section)
@@ -327,7 +334,7 @@ def config_update(args):
             args.section, data, scope=scope.name, force=True
         )
         msg = 'File "{0}" updated [backup={1}]'
-        tty.msg(msg.format(cfg_file, bkp_file))
+        ramble.util.logger.logger.msg(msg.format(cfg_file, bkp_file))
 
 
 def _can_revert_update(scope_dir, cfg_file, bkp_file):
@@ -371,7 +378,7 @@ def config_revert(args):
             msg += '\t[scope={0.scope}, cfg={0.cfg}, bkp={0.bkp}]\n'.format(e)
         msg += ('\nEither ensure to have the right permissions before retrying'
                 ' or be more specific on the scope to revert.')
-        tty.die(msg)
+        ramble.util.logger.logger.die(msg)
 
     proceed = True
     if not args.yes_to_all:
@@ -380,17 +387,17 @@ def config_revert(args):
         for entry in to_be_restored:
             msg += '\t[scope={0.scope}, bkp={0.bkp}]\n'.format(entry)
         msg += 'This operation cannot be undone.'
-        tty.msg(msg)
+        ramble.util.logger.logger.msg(msg)
         proceed = tty.get_yes_or_no('Do you want to proceed?', default=False)
 
     if not proceed:
-        tty.die('Operation aborted.')
+        ramble.util.logger.logger.die('Operation aborted.')
 
     for _, cfg_file, bkp_file in to_be_restored:
         shutil.copy(bkp_file, cfg_file)
         os.unlink(bkp_file)
         msg = 'File "{0}" reverted to old state'
-        tty.msg(msg.format(cfg_file))
+        ramble.util.logger.logger.msg(msg.format(cfg_file))
 
 
 def config(parser, args):

--- a/lib/ramble/ramble/cmd/edit.py
+++ b/lib/ramble/ramble/cmd/edit.py
@@ -9,11 +9,10 @@
 import glob
 import os
 
-import llnl.util.tty as tty
-
 import ramble.cmd
 import ramble.paths
 import ramble.repository
+import ramble.util.logger
 
 from spack.util.editor import editor
 
@@ -42,12 +41,15 @@ def edit_application(name, repo_path, namespace):
 
     if os.path.exists(path):
         if not os.path.isfile(path):
-            tty.die("Something is wrong. '{0}' is not a file!".format(path))
+            ramble.util.logger.logger.die(f"Something is wrong. '{path}' is not a file!")
         if not os.access(path, os.R_OK):
-            tty.die("Insufficient permissions on '%s'!" % path)
+            ramble.util.logger.logger.die(f"Insufficient permissions on '{path}'!")
     else:
-        tty.die("No package for '{0}' was found.".format(name),
-                "  Use `spack create` to create a new package")
+        # TODO: Update this once a `ramble create` command exists
+        ramble.util.logger.logger.die(
+            f"No application for '{name}' was found."
+            # "  Use `ramble create` to create a new application"
+        )
 
     editor(path)
 
@@ -115,10 +117,9 @@ def edit(parser, args):
                     m += ' Please specify a suffix. Files are:\n\n'
                     for f in files:
                         m += '        ' + os.path.basename(f) + '\n'
-                    tty.die(m)
+                    ramble.util.logger.logger.die(m)
                 if not files:
-                    tty.die("No file for '{0}' was found in {1}".format(name,
-                                                                        path))
+                    ramble.util.logger.logger.die(f"No file for '{name}' was found in {path}")
                 path = files[0]  # already confirmed only one entry in files
 
         editor(path)

--- a/lib/ramble/ramble/cmd/edit.py
+++ b/lib/ramble/ramble/cmd/edit.py
@@ -12,7 +12,7 @@ import os
 import ramble.cmd
 import ramble.paths
 import ramble.repository
-import ramble.util.logger
+from ramble.util.logger import logger
 
 from spack.util.editor import editor
 
@@ -41,12 +41,12 @@ def edit_application(name, repo_path, namespace):
 
     if os.path.exists(path):
         if not os.path.isfile(path):
-            ramble.util.logger.logger.die(f"Something is wrong. '{path}' is not a file!")
+            logger.die(f"Something is wrong. '{path}' is not a file!")
         if not os.access(path, os.R_OK):
-            ramble.util.logger.logger.die(f"Insufficient permissions on '{path}'!")
+            logger.die(f"Insufficient permissions on '{path}'!")
     else:
         # TODO: Update this once a `ramble create` command exists
-        ramble.util.logger.logger.die(
+        logger.die(
             f"No application for '{name}' was found."
             # "  Use `ramble create` to create a new application"
         )
@@ -117,9 +117,9 @@ def edit(parser, args):
                     m += ' Please specify a suffix. Files are:\n\n'
                     for f in files:
                         m += '        ' + os.path.basename(f) + '\n'
-                    ramble.util.logger.logger.die(m)
+                    logger.die(m)
                 if not files:
-                    ramble.util.logger.logger.die(f"No file for '{name}' was found in {path}")
+                    logger.die(f"No file for '{name}' was found in {path}")
                 path = files[0]  # already confirmed only one entry in files
 
         editor(path)

--- a/lib/ramble/ramble/cmd/license.py
+++ b/lib/ramble/ramble/cmd/license.py
@@ -12,7 +12,7 @@ import re
 from collections import defaultdict
 
 import ramble.paths
-import ramble.util.logger
+from ramble.util.logger import logger
 from spack.util.executable import which
 
 description = 'list and check license headers on files in ramble'
@@ -140,7 +140,7 @@ def _check_license(lines, path):
                 # out of date.
                 if i == 0:
                     if not re.search(strict_date, line):
-                        ramble.util.logger.logger.debug(f'{path}: copyright date mismatch')
+                        logger.debug(f'{path}: copyright date mismatch')
                 found.append(i)
 
     if len(found) == len(license_lines) and found == list(sorted(found)):
@@ -188,9 +188,9 @@ def verify(args):
             license_errors.add_error(error)
 
     if license_errors.has_errors():
-        ramble.util.logger.logger.die(*license_errors.error_messages())
+        logger.die(*license_errors.error_messages())
     else:
-        ramble.util.logger.logger.msg('No license issues found.')
+        logger.msg('No license issues found.')
 
 
 def setup_parser(subparser):
@@ -205,7 +205,7 @@ def setup_parser(subparser):
 
 def license(parser, args):
     if not git:
-        ramble.util.logger.logger.die('ramble license requires git in your environment')
+        logger.die('ramble license requires git in your environment')
 
     licensed_files[:] = [re.compile(regex) for regex in licensed_files]
 

--- a/lib/ramble/ramble/cmd/license.py
+++ b/lib/ramble/ramble/cmd/license.py
@@ -11,9 +11,8 @@ import os
 import re
 from collections import defaultdict
 
-import llnl.util.tty as tty
-
 import ramble.paths
+import ramble.util.logger
 from spack.util.executable import which
 
 description = 'list and check license headers on files in ramble'
@@ -141,7 +140,7 @@ def _check_license(lines, path):
                 # out of date.
                 if i == 0:
                     if not re.search(strict_date, line):
-                        tty.debug('{0}: copyright date mismatch'.format(path))
+                        ramble.util.logger.logger.debug(f'{path}: copyright date mismatch')
                 found.append(i)
 
     if len(found) == len(license_lines) and found == list(sorted(found)):
@@ -189,9 +188,9 @@ def verify(args):
             license_errors.add_error(error)
 
     if license_errors.has_errors():
-        tty.die(*license_errors.error_messages())
+        ramble.util.logger.logger.die(*license_errors.error_messages())
     else:
-        tty.msg('No license issues found.')
+        ramble.util.logger.logger.msg('No license issues found.')
 
 
 def setup_parser(subparser):
@@ -206,7 +205,7 @@ def setup_parser(subparser):
 
 def license(parser, args):
     if not git:
-        tty.die('ramble license requires git in your environment')
+        ramble.util.logger.logger.die('ramble license requires git in your environment')
 
     licensed_files[:] = [re.compile(regex) for regex in licensed_files]
 

--- a/lib/ramble/ramble/cmd/mirror.py
+++ b/lib/ramble/ramble/cmd/mirror.py
@@ -5,14 +5,13 @@
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
-import llnl.util.tty as tty
-
 import ramble.cmd.common.arguments as arguments
 import ramble.config
 import ramble.spec
 import ramble.workspace
 import ramble.mirror
 import ramble.repository
+import ramble.util.logger
 from ramble.error import RambleError
 
 import spack.util.url as url_util
@@ -108,7 +107,7 @@ def mirror_set_url(args):
         mirrors = syaml_dict()
 
     if args.name not in mirrors:
-        tty.die("No mirror found with name %s." % args.name)
+        ramble.util.logger.logger.die(f"No mirror found with name {args.name}.")
 
     entry = mirrors[args.name]
     try:
@@ -142,11 +141,11 @@ def mirror_set_url(args):
     ramble.config.set('mirrors', mirrors, scope=args.scope)
 
     if changes_made:
-        tty.msg(
+        ramble.util.logger.logger.msg(
             "Changed%s url or connection information for mirror %s." %
             ((" (push)" if args.push else ""), args.name))
     else:
-        tty.msg("No changes made to mirror %s." % args.name)
+        ramble.util.logger.logger.msg(f"No changes made to mirror {args.name}.")
 
 
 def mirror_list(args):
@@ -154,7 +153,7 @@ def mirror_list(args):
 
     mirrors = ramble.mirror.MirrorCollection(scope=args.scope)
     if not mirrors:
-        tty.msg("No mirrors configured.")
+        ramble.util.logger.logger.msg("No mirrors configured.")
         return
 
     mirrors.display()
@@ -169,9 +168,9 @@ def _read_specs_from_file(filename):
                 s.application
                 specs.append(s)
             except RambleError as e:
-                tty.debug(e)
-                tty.die("Parse error in %s, line %d:" % (filename, i + 1),
-                        ">>> " + string, str(e))
+                ramble.util.logger.logger.debug(e)
+                ramble.util.logger.logger.die("Parse error in %s, line %d:" % (filename, i + 1),
+                                              ">>> " + string, str(e))
     return specs
 
 

--- a/lib/ramble/ramble/cmd/mirror.py
+++ b/lib/ramble/ramble/cmd/mirror.py
@@ -11,7 +11,7 @@ import ramble.spec
 import ramble.workspace
 import ramble.mirror
 import ramble.repository
-import ramble.util.logger
+from ramble.util.logger import logger
 from ramble.error import RambleError
 
 import spack.util.url as url_util
@@ -107,7 +107,7 @@ def mirror_set_url(args):
         mirrors = syaml_dict()
 
     if args.name not in mirrors:
-        ramble.util.logger.logger.die(f"No mirror found with name {args.name}.")
+        logger.die(f"No mirror found with name {args.name}.")
 
     entry = mirrors[args.name]
     try:
@@ -141,11 +141,11 @@ def mirror_set_url(args):
     ramble.config.set('mirrors', mirrors, scope=args.scope)
 
     if changes_made:
-        ramble.util.logger.logger.msg(
+        logger.msg(
             "Changed%s url or connection information for mirror %s." %
             ((" (push)" if args.push else ""), args.name))
     else:
-        ramble.util.logger.logger.msg(f"No changes made to mirror {args.name}.")
+        logger.msg(f"No changes made to mirror {args.name}.")
 
 
 def mirror_list(args):
@@ -153,7 +153,7 @@ def mirror_list(args):
 
     mirrors = ramble.mirror.MirrorCollection(scope=args.scope)
     if not mirrors:
-        ramble.util.logger.logger.msg("No mirrors configured.")
+        logger.msg("No mirrors configured.")
         return
 
     mirrors.display()
@@ -168,9 +168,9 @@ def _read_specs_from_file(filename):
                 s.application
                 specs.append(s)
             except RambleError as e:
-                ramble.util.logger.logger.debug(e)
-                ramble.util.logger.logger.die("Parse error in %s, line %d:" % (filename, i + 1),
-                                              ">>> " + string, str(e))
+                logger.debug(e)
+                logger.die("Parse error in %s, line %d:" % (filename, i + 1),
+                           ">>> " + string, str(e))
     return specs
 
 

--- a/lib/ramble/ramble/cmd/repo.py
+++ b/lib/ramble/ramble/cmd/repo.py
@@ -14,7 +14,7 @@ import sys
 import ramble.config
 import ramble.repository
 import ramble.cmd.common.arguments
-import ramble.util.logger
+from ramble.util.logger import logger
 
 description = "manage Ramble repositories"
 section = "config"
@@ -93,9 +93,9 @@ def repo_create(args):
     full_path, namespace = ramble.repository.create_repo(
         args.directory, args.namespace, subdir, object_type=obj_type
     )
-    ramble.util.logger.logger.msg(f"Created {obj_type.name} repo with namespace '{namespace}'.")
-    ramble.util.logger.logger.msg("To register it with ramble, run this command:",
-                                  f'ramble repo -t {obj_type.name} add {full_path}')
+    logger.msg(f"Created {obj_type.name} repo with namespace '{namespace}'.")
+    logger.msg("To register it with ramble, run this command:",
+               f'ramble repo -t {obj_type.name} add {full_path}')
 
 
 def repo_add(args):
@@ -109,11 +109,11 @@ def repo_add(args):
 
     # check if the path exists
     if not os.path.exists(canon_path):
-        ramble.util.logger.logger.die(f"No such file or directory: {path}")
+        logger.die(f"No such file or directory: {path}")
 
     # Make sure the path is a directory.
     if not os.path.isdir(canon_path):
-        ramble.util.logger.logger.die(f"Not a Ramble repository: {path}")
+        logger.die(f"Not a Ramble repository: {path}")
 
     # Make sure it's actually a ramble repository by constructing it.
     repo = ramble.repository.Repo(canon_path, obj_type)
@@ -124,11 +124,11 @@ def repo_add(args):
         repos = []
 
     if repo.root in repos or path in repos:
-        ramble.util.logger.logger.die(f"Repository is already registered with Ramble: {path}")
+        logger.die(f"Repository is already registered with Ramble: {path}")
 
     repos.insert(0, canon_path)
     ramble.config.set(type_def['config_section'], repos, args.scope)
-    ramble.util.logger.logger.msg(f"Added {obj_type.name} repo with namespace '{repo.namespace}'.")
+    logger.msg(f"Added {obj_type.name} repo with namespace '{repo.namespace}'.")
 
 
 def repo_remove(args):
@@ -146,7 +146,7 @@ def repo_remove(args):
         if canon_path == repo_canon_path:
             repos.remove(repo_path)
             ramble.config.set(type_def['config_section'], repos, args.scope)
-            ramble.util.logger.logger.msg(f"Removed {obj_type.name} repository {repo_path}")
+            logger.msg(f"Removed {obj_type.name} repository {repo_path}")
             return
 
     # If it is a namespace, remove corresponding repo
@@ -156,13 +156,13 @@ def repo_remove(args):
             if repo.namespace == namespace_or_path:
                 repos.remove(path)
                 ramble.config.set(type_def['config_section'], repos, args.scope)
-                ramble.util.logger.logger.msg(f"Removed {obj_type.name} repository {repo.root} "
-                                              f"with namespace '{repo.namespace}'.")
+                logger.msg(f"Removed {obj_type.name} repository {repo.root} "
+                           f"with namespace '{repo.namespace}'.")
                 return
         except ramble.repository.RepoError:
             continue
 
-    ramble.util.logger.logger.die(
+    logger.die(
         f"No {obj_type.name} repository with path or namespace: {namespace_or_path}"
     )
 
@@ -183,7 +183,7 @@ def repo_list(args):
     if sys.stdout.isatty():
         msg = f"{len(repos)} {obj_type.name} repository"
         msg += "y." if len(repos) == 1 else "ies."
-        ramble.util.logger.logger.msg(msg)
+        logger.msg(msg)
 
     if not repos:
         return
@@ -202,6 +202,6 @@ def repo(parser, args):
               'rm': repo_remove}
 
     if args.type not in ramble.repository.OBJECT_NAMES:
-        ramble.util.logger.logger.die(f"Repository type '{args.type}' is not valid.")
+        logger.die(f"Repository type '{args.type}' is not valid.")
 
     action[args.repo_command](args)

--- a/lib/ramble/ramble/cmd/repo.py
+++ b/lib/ramble/ramble/cmd/repo.py
@@ -11,11 +11,10 @@ from __future__ import print_function
 import os
 import sys
 
-import llnl.util.tty as tty
-
 import ramble.config
 import ramble.repository
 import ramble.cmd.common.arguments
+import ramble.util.logger
 
 description = "manage Ramble repositories"
 section = "config"
@@ -94,9 +93,9 @@ def repo_create(args):
     full_path, namespace = ramble.repository.create_repo(
         args.directory, args.namespace, subdir, object_type=obj_type
     )
-    tty.msg(f"Created {obj_type.name} repo with namespace '{namespace}'.")
-    tty.msg("To register it with ramble, run this command:",
-            f'ramble repo -t {obj_type.name} add {full_path}')
+    ramble.util.logger.logger.msg(f"Created {obj_type.name} repo with namespace '{namespace}'.")
+    ramble.util.logger.logger.msg("To register it with ramble, run this command:",
+                                  f'ramble repo -t {obj_type.name} add {full_path}')
 
 
 def repo_add(args):
@@ -110,11 +109,11 @@ def repo_add(args):
 
     # check if the path exists
     if not os.path.exists(canon_path):
-        tty.die("No such file or directory: %s" % path)
+        ramble.util.logger.logger.die(f"No such file or directory: {path}")
 
     # Make sure the path is a directory.
     if not os.path.isdir(canon_path):
-        tty.die("Not a Ramble repository: %s" % path)
+        ramble.util.logger.logger.die(f"Not a Ramble repository: {path}")
 
     # Make sure it's actually a ramble repository by constructing it.
     repo = ramble.repository.Repo(canon_path, obj_type)
@@ -125,11 +124,11 @@ def repo_add(args):
         repos = []
 
     if repo.root in repos or path in repos:
-        tty.die("Repository is already registered with Ramble: %s" % path)
+        ramble.util.logger.logger.die(f"Repository is already registered with Ramble: {path}")
 
     repos.insert(0, canon_path)
     ramble.config.set(type_def['config_section'], repos, args.scope)
-    tty.msg(f"Added {obj_type.name} repo with namespace '{repo.namespace}'.")
+    ramble.util.logger.logger.msg(f"Added {obj_type.name} repo with namespace '{repo.namespace}'.")
 
 
 def repo_remove(args):
@@ -147,7 +146,7 @@ def repo_remove(args):
         if canon_path == repo_canon_path:
             repos.remove(repo_path)
             ramble.config.set(type_def['config_section'], repos, args.scope)
-            tty.msg(f"Removed {obj_type.name} repository {repo_path}")
+            ramble.util.logger.logger.msg(f"Removed {obj_type.name} repository {repo_path}")
             return
 
     # If it is a namespace, remove corresponding repo
@@ -157,13 +156,15 @@ def repo_remove(args):
             if repo.namespace == namespace_or_path:
                 repos.remove(path)
                 ramble.config.set(type_def['config_section'], repos, args.scope)
-                tty.msg(f"Removed {obj_type.name} repository {repo.root} "
-                        f"with namespace '{repo.namespace}'.")
+                ramble.util.logger.logger.msg(f"Removed {obj_type.name} repository {repo.root} "
+                                              f"with namespace '{repo.namespace}'.")
                 return
         except ramble.repository.RepoError:
             continue
 
-    tty.die(f"No {obj_type.name} repository with path or namespace: {namespace_or_path}")
+    ramble.util.logger.logger.die(
+        f"No {obj_type.name} repository with path or namespace: {namespace_or_path}"
+    )
 
 
 def repo_list(args):
@@ -182,7 +183,7 @@ def repo_list(args):
     if sys.stdout.isatty():
         msg = f"{len(repos)} {obj_type.name} repository"
         msg += "y." if len(repos) == 1 else "ies."
-        tty.msg(msg)
+        ramble.util.logger.logger.msg(msg)
 
     if not repos:
         return
@@ -201,6 +202,6 @@ def repo(parser, args):
               'rm': repo_remove}
 
     if args.type not in ramble.repository.OBJECT_NAMES:
-        tty.die(f"Repository type '{args.type}' is not valid.")
+        ramble.util.logger.logger.die(f"Repository type '{args.type}' is not valid.")
 
     action[args.repo_command](args)

--- a/lib/ramble/ramble/cmd/results.py
+++ b/lib/ramble/ramble/cmd/results.py
@@ -9,7 +9,7 @@
 import json
 
 import ramble.experimental.uploader
-import ramble.util.logger
+from ramble.util.logger import logger
 
 description = "import experiment results from file"
 section = "results"
@@ -38,21 +38,21 @@ def import_results_file(filename):
     """
     Import Ramble experiment results from a JSON file.
     """
-    ramble.util.logger.logger.debug("File to import:")
-    ramble.util.logger.logger.debug(filename)
+    logger.debug("File to import:")
+    logger.debug(filename)
 
     imported_file = open(filename)
 
     try:
-        ramble.util.logger.logger.msg("Import file...")
+        logger.msg("Import file...")
         parsed_json_file = json.load(imported_file)
         # Check if data contains an experiment
         if parsed_json_file.get('experiments'):
             return parsed_json_file
         else:
-            ramble.util.logger.logger.die("Error parsing file: Does not contain valid data to upload.")
+            logger.die("Error parsing file: Does not contain valid data to upload.")
     except ValueError:
-        ramble.util.logger.logger.die("Error parsing file: Invalid JSON formatting.")
+        logger.die("Error parsing file: Invalid JSON formatting.")
 
 
 def results(parser, args):

--- a/lib/ramble/ramble/cmd/results.py
+++ b/lib/ramble/ramble/cmd/results.py
@@ -6,10 +6,10 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-import llnl.util.tty as tty
 import json
 
 import ramble.experimental.uploader
+import ramble.util.logger
 
 description = "import experiment results from file"
 section = "results"
@@ -38,21 +38,21 @@ def import_results_file(filename):
     """
     Import Ramble experiment results from a JSON file.
     """
-    tty.debug("File to import:")
-    tty.debug(filename)
+    ramble.util.logger.logger.debug("File to import:")
+    ramble.util.logger.logger.debug(filename)
 
     imported_file = open(filename)
 
     try:
-        tty.msg("Import file...")
+        ramble.util.logger.logger.msg("Import file...")
         parsed_json_file = json.load(imported_file)
         # Check if data contains an experiment
         if parsed_json_file.get('experiments'):
             return parsed_json_file
         else:
-            tty.die("Error parsing file: Does not contain valid data to upload.")
+            ramble.util.logger.logger.die("Error parsing file: Does not contain valid data to upload.")
     except ValueError:
-        tty.die("Error parsing file: Invalid JSON formatting.")
+        ramble.util.logger.logger.die("Error parsing file: Invalid JSON formatting.")
 
 
 def results(parser, args):

--- a/lib/ramble/ramble/cmd/unit_test.py
+++ b/lib/ramble/ramble/cmd/unit_test.py
@@ -15,13 +15,13 @@ import re
 import argparse
 from six import StringIO
 
-import llnl.util.tty as tty
 import llnl.util.tty.color as color
 from llnl.util.filesystem import working_dir
 from llnl.util.tty.colify import colify
 
 import ramble.paths
 import ramble.workspace
+import ramble.util.logger
 
 description = "run ramble's unit tests (wrapper around pytest)"
 section = "developer"
@@ -79,7 +79,9 @@ def do_list(args, extra_args):
             import pytest
             pytest.main(['--collect-only'] + extra_args)
         except ImportError:
-            tty.die('Pytest python module not found. Ensure requirements.txt are installed.')
+            ramble.util.logger.logger.die(
+                'Pytest python module not found. Ensure requirements.txt are installed.'
+            )
     finally:
         sys.stdout = old_output
 
@@ -164,7 +166,9 @@ def unit_test(parser, args, unknown_args):
             import pytest
             return pytest.main(['-h'])
         except ImportError:
-            tty.die('Pytest python module not found. Ensure requirements.txt are installed.')
+            ramble.util.logger.logger.die(
+                'Pytest python module not found. Ensure requirements.txt are installed.'
+            )
 
     # add back any parsed pytest args we need to pass to pytest
     pytest_args = add_back_pytest_args(args, unknown_args)
@@ -188,4 +192,6 @@ def unit_test(parser, args, unknown_args):
                 import pytest
                 return pytest.main(pytest_args)
             except ImportError:
-                tty.die('Pytest python module not found. Ensure requirements.txt are installed.')
+                ramble.util.logger.logger.die(
+                    'Pytest python module not found. Ensure requirements.txt are installed.'
+                )

--- a/lib/ramble/ramble/cmd/unit_test.py
+++ b/lib/ramble/ramble/cmd/unit_test.py
@@ -21,7 +21,7 @@ from llnl.util.tty.colify import colify
 
 import ramble.paths
 import ramble.workspace
-import ramble.util.logger
+from ramble.util.logger import logger
 
 description = "run ramble's unit tests (wrapper around pytest)"
 section = "developer"
@@ -79,7 +79,7 @@ def do_list(args, extra_args):
             import pytest
             pytest.main(['--collect-only'] + extra_args)
         except ImportError:
-            ramble.util.logger.logger.die(
+            logger.die(
                 'Pytest python module not found. Ensure requirements.txt are installed.'
             )
     finally:
@@ -166,7 +166,7 @@ def unit_test(parser, args, unknown_args):
             import pytest
             return pytest.main(['-h'])
         except ImportError:
-            ramble.util.logger.logger.die(
+            logger.die(
                 'Pytest python module not found. Ensure requirements.txt are installed.'
             )
 
@@ -192,6 +192,6 @@ def unit_test(parser, args, unknown_args):
                 import pytest
                 return pytest.main(pytest_args)
             except ImportError:
-                ramble.util.logger.logger.die(
+                logger.die(
                     'Pytest python module not found. Ensure requirements.txt are installed.'
                 )

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -32,7 +32,7 @@ import ramble.filters
 import ramble.experimental.uploader
 import ramble.software_environments
 import ramble.util.colors as rucolor
-import ramble.util.logger
+from ramble.util.logger import logger
 
 if sys.version_info >= (3, 3):
     from collections.abc import Sequence  # novm noqa: F401
@@ -103,7 +103,7 @@ def create_temp_workspace_directory():
 
 def workspace_activate(args):
     if not args.activate_workspace and not args.dir and not args.temp:
-        ramble.util.logger.logger.die(
+        logger.die(
             'ramble workspace activate requires a workspace name, directory, or --temp'
         )
 
@@ -133,7 +133,7 @@ def workspace_activate(args):
         short_name = os.path.basename(workspace_path)
 
     else:
-        ramble.util.logger.logger.die(f"No such workspace: '{workspace_name_or_dir}'")
+        logger.die(f"No such workspace: '{workspace_name_or_dir}'")
 
     workspace_prompt = '[%s]' % short_name
 
@@ -186,14 +186,14 @@ def workspace_deactivate(args):
 
     # Error out when -w, -W, -D flags are given, cause they are ambiguous.
     if args.workspace or args.no_workspace or args.workspace_dir:
-        ramble.util.logger.logger.die(
+        logger.die(
             'Calling ramble workspace deactivate with --workspace,'
             ' --workspace-dir, and --no-workspace '
             'is ambiguous'
         )
 
     if ramble.workspace.active_workspace() is None:
-        ramble.util.logger.logger.die('No workspace is currently active.')
+        logger.die('No workspace is currently active.')
 
     cmds = ramble.workspace.shell.deactivate_header(args.shell)
     env_mods = ramble.workspace.shell.deactivate()
@@ -240,15 +240,15 @@ def _workspace_create(name_or_path, dir=False,
     if dir:
         workspace = ramble.workspace.Workspace(name_or_path)
         workspace.write()
-        ramble.util.logger.logger.msg(f"Created workspace in {workspace.path}")
-        ramble.util.logger.logger.msg("You can activate this workspace with:")
-        ramble.util.logger.logger.msg(f"  ramble workspace activate {workspace.path}")
+        logger.msg(f"Created workspace in {workspace.path}")
+        logger.msg("You can activate this workspace with:")
+        logger.msg(f"  ramble workspace activate {workspace.path}")
     else:
         workspace = ramble.workspace.create(name_or_path)
         workspace.write()
-        ramble.util.logger.logger.msg(f"Created workspace in {name_or_path}")
-        ramble.util.logger.logger.msg("You can activate this workspace with:")
-        ramble.util.logger.logger.msg(f"  ramble workspace activate {name_or_path}")
+        logger.msg(f"Created workspace in {name_or_path}")
+        logger.msg("You can activate this workspace with:")
+        logger.msg(f"  ramble workspace activate {name_or_path}")
 
     if config:
         with open(config, 'r') as f:
@@ -284,7 +284,7 @@ def workspace_remove(args):
         workspace = ramble.workspace.read(workspace_name)
         read_workspaces.append(workspace)
 
-    ramble.util.logger.logger.debug(f'Removal args: {args}')
+    logger.debug(f'Removal args: {args}')
 
     if not args.yes_to_all:
         answer = tty.get_yes_or_no(
@@ -293,16 +293,16 @@ def workspace_remove(args):
                 string.comma_and(args.rm_wrkspc)),
             default=False)
         if not answer:
-            ramble.util.logger.logger.die("Will not remove any workspaces")
+            logger.die("Will not remove any workspaces")
 
     for workspace in read_workspaces:
         if workspace.active:
-            ramble.util.logger.logger.die(
+            logger.die(
                 f"Workspace {workspace.name} can't be removed while activated."
             )
 
         workspace.destroy()
-        ramble.util.logger.logger.msg(f"Successfully removed workspace '{workspace.name}'")
+        logger.msg(f"Successfully removed workspace '{workspace.name}'")
 
 
 def workspace_concretize_setup_parser(subparser):
@@ -313,7 +313,7 @@ def workspace_concretize_setup_parser(subparser):
 def workspace_concretize(args):
     ws = ramble.cmd.require_active_workspace(cmd_name='workspace concretize')
 
-    ramble.util.logger.logger.debug('Concretizing workspace')
+    logger.debug('Concretizing workspace')
     ws.concretize()
 
 
@@ -354,7 +354,7 @@ def workspace_setup(args):
 
     pipeline_cls = ramble.pipeline.pipeline_class(current_pipeline)
 
-    ramble.util.logger.logger.debug('Setting up workspace')
+    logger.debug('Setting up workspace')
     pipeline = pipeline_cls(ws, filters)
 
     with ws.write_transaction():
@@ -402,7 +402,7 @@ def workspace_analyze(args):
 
     pipeline_cls = ramble.pipeline.pipeline_class(current_pipeline)
 
-    ramble.util.logger.logger.debug('Analyzing workspace')
+    logger.debug('Analyzing workspace')
     pipeline = pipeline_cls(ws,
                             filters,
                             output_formats=args.output_formats,
@@ -563,9 +563,9 @@ def workspace_list(args):
     # say how many there are if writing to a tty
     if sys.stdout.isatty():
         if not names:
-            ramble.util.logger.logger.msg('No workspaces')
+            logger.msg('No workspaces')
         else:
-            ramble.util.logger.logger.msg(f'{len(names)} workspaces')
+            logger.msg(f'{len(names)} workspaces')
 
     colify(color_names, indent=4)
 
@@ -593,7 +593,7 @@ def workspace_edit(args):
     ramble_ws = ramble.cmd.find_workspace_path(args)
 
     if not ramble_ws:
-        ramble.util.logger.logger.die(
+        logger.die(
             'ramble workspace edit requires either a command '
             'line workspace or an active workspace'
         )

--- a/lib/ramble/ramble/config.py
+++ b/lib/ramble/ramble/config.py
@@ -45,7 +45,6 @@ from ruamel.yaml.error import MarkedYAMLError
 from six import iteritems
 
 import llnl.util.lang
-import llnl.util.tty as tty
 from llnl.util.filesystem import mkdirp, rename
 
 import spack.compilers
@@ -68,6 +67,7 @@ import ramble.schema.success_criteria
 import ramble.schema.variables
 
 from ramble.error import RambleError
+import ramble.util.logger
 
 # Hacked yaml for configuration files preserves line numbers.
 import spack.util.spack_yaml as syaml
@@ -1014,7 +1014,7 @@ def read_config_file(filename, schema=None):
         raise ConfigFileError("Config file is not readable: %s" % filename)
 
     try:
-        tty.debug("Reading config file %s" % filename)
+        ramble.util.logger.logger.debug(f"Reading config file {filename}")
         with open(filename) as f:
             data = syaml.load_config(f)
 

--- a/lib/ramble/ramble/config.py
+++ b/lib/ramble/ramble/config.py
@@ -67,7 +67,7 @@ import ramble.schema.success_criteria
 import ramble.schema.variables
 
 from ramble.error import RambleError
-import ramble.util.logger
+from ramble.util.logger import logger
 
 # Hacked yaml for configuration files preserves line numbers.
 import spack.util.spack_yaml as syaml
@@ -1015,7 +1015,7 @@ def read_config_file(filename, schema=None):
         raise ConfigFileError("Config file is not readable: %s" % filename)
 
     try:
-        ramble.util.logger.logger.debug(f"Reading config file {filename}")
+        logger.debug(f"Reading config file {filename}")
         with open(filename) as f:
             data = syaml.load_config(f)
 

--- a/lib/ramble/ramble/config.py
+++ b/lib/ramble/ramble/config.py
@@ -120,6 +120,7 @@ config_defaults = {
     'config': {
         'debug': False,
         'disable_passthrough': False,
+        'disable_progress_bar': False,
         'connect_timeout': 10,
         'verify_ssl': True,
         'checksum': True,

--- a/lib/ramble/ramble/error.py
+++ b/lib/ramble/ramble/error.py
@@ -10,7 +10,7 @@ from __future__ import print_function
 import sys
 import inspect
 
-import ramble.util.logger
+from ramble.util.logger import logger
 
 
 #: whether we should write stack traces or short error messages
@@ -54,7 +54,7 @@ class RambleError(Exception):
             return
 
         # basic debug message
-        ramble.util.logger.logger.error(self.message)
+        logger.error(self.message)
         if self.long_message:
             sys.stderr.write(self.long_message)
             sys.stderr.write('\n')

--- a/lib/ramble/ramble/error.py
+++ b/lib/ramble/ramble/error.py
@@ -10,7 +10,7 @@ from __future__ import print_function
 import sys
 import inspect
 
-import llnl.util.tty as tty
+import ramble.util.logger
 
 
 #: whether we should write stack traces or short error messages
@@ -54,7 +54,7 @@ class RambleError(Exception):
             return
 
         # basic debug message
-        tty.error(self.message)
+        ramble.util.logger.logger.error(self.message)
         if self.long_message:
             sys.stderr.write(self.long_message)
             sys.stderr.write('\n')

--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -13,7 +13,7 @@ import operator
 
 import ramble.error
 import ramble.keywords
-import ramble.util.logger
+from ramble.util.logger import logger
 
 supported_math_operators = {
     ast.Add: operator.add, ast.Sub: operator.sub,
@@ -442,7 +442,7 @@ class Expander(object):
         if ramble.config.get('config:disable_passthrough'):
             passthrough_setting = False
 
-        ramble.util.logger.logger.debug(f'BEGINNING OF EXPAND_VAR STACK ON {var}')
+        logger.debug(f'BEGINNING OF EXPAND_VAR STACK ON {var}')
         expansions = self._variables
         if extra_vars:
             expansions = self._variables.copy()
@@ -457,7 +457,7 @@ class Expander(object):
                 raise RambleSyntaxError(f'Encountered a passthrough error while expanding {var}\n'
                                         f'{e}')
 
-        ramble.util.logger.logger.debug(f'END OF EXPAND_VAR STACK {value}')
+        logger.debug(f'END OF EXPAND_VAR STACK {value}')
         return value
 
     def evaluate_predicate(self, in_str, extra_vars=None):
@@ -474,15 +474,15 @@ class Expander(object):
         evaluated = self.expand_var(in_str, extra_vars=extra_vars, allow_passthrough=False)
 
         if not isinstance(evaluated, six.string_types):
-            ramble.util.logger.logger.die('Logical compute failed to return a string')
+            logger.die('Logical compute failed to return a string')
 
         if evaluated == 'True':
             return True
         elif evaluated == 'False':
             return False
         else:
-            ramble.util.logger.logger.die(f'When evaluating {in_str}, evaluate_predicate returned '
-                                          f'a non-boolean string: "{evaluated}"')
+            logger.die(f'When evaluating {in_str}, evaluate_predicate returned '
+                       f'a non-boolean string: "{evaluated}"')
 
     @staticmethod
     def expansion_str(in_str):
@@ -529,8 +529,8 @@ class Expander(object):
             out_str = self.eval_math(math_ast.body)
             return out_str
         except MathEvaluationError as e:
-            ramble.util.logger.logger.debug(f'   Math input is: "{in_str}"')
-            ramble.util.logger.logger.debug(e)
+            logger.debug(f'   Math input is: "{in_str}"')
+            logger.debug(e)
 
         return in_str
 
@@ -717,9 +717,9 @@ class Expander(object):
 def raise_passthrough_error(in_str, out_str):
     """Raise an error when passthrough is disabled but variables are not all expanded"""
 
-    ramble.util.logger.logger.debug(f'Expansion stack errors: attempted to expand '
-                                    f'"{in_str}"')
-    ramble.util.logger.logger.debug(f'  As: {out_str}')
+    logger.debug(f'Expansion stack errors: attempted to expand '
+                 f'"{in_str}"')
+    logger.debug(f'  As: {out_str}')
     raise RamblePassthroughError('Error Stack:\n'
                                  f'Input: "{in_str}"\n'
                                  f'Output: "{out_str}"\n')

--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -11,10 +11,9 @@ import ast
 import six
 import operator
 
-import llnl.util.tty as tty
-
 import ramble.error
 import ramble.keywords
+import ramble.util.logger
 
 supported_math_operators = {
     ast.Add: operator.add, ast.Sub: operator.sub,
@@ -443,7 +442,7 @@ class Expander(object):
         if ramble.config.get('config:disable_passthrough'):
             passthrough_setting = False
 
-        tty.debug(f'BEGINNING OF EXPAND_VAR STACK ON {var}')
+        ramble.util.logger.logger.debug(f'BEGINNING OF EXPAND_VAR STACK ON {var}')
         expansions = self._variables
         if extra_vars:
             expansions = self._variables.copy()
@@ -458,7 +457,7 @@ class Expander(object):
                 raise RambleSyntaxError(f'Encountered a passthrough error while expanding {var}\n'
                                         f'{e}')
 
-        tty.debug(f'END OF EXPAND_VAR STACK {value}')
+        ramble.util.logger.logger.debug(f'END OF EXPAND_VAR STACK {value}')
         return value
 
     def evaluate_predicate(self, in_str, extra_vars=None):
@@ -475,15 +474,15 @@ class Expander(object):
         evaluated = self.expand_var(in_str, extra_vars=extra_vars, allow_passthrough=False)
 
         if not isinstance(evaluated, six.string_types):
-            tty.die('Logical compute failed to return a string')
+            ramble.util.logger.logger.die('Logical compute failed to return a string')
 
         if evaluated == 'True':
             return True
         elif evaluated == 'False':
             return False
         else:
-            tty.die(f'When evaluating {in_str}, evaluate_predicate returned a non-boolean '
-                    f'string: "{evaluated}"')
+            ramble.util.logger.logger.die(f'When evaluating {in_str}, evaluate_predicate returned '
+                                          f'a non-boolean string: "{evaluated}"')
 
     @staticmethod
     def expansion_str(in_str):
@@ -530,8 +529,8 @@ class Expander(object):
             out_str = self.eval_math(math_ast.body)
             return out_str
         except MathEvaluationError as e:
-            tty.debug(f'   Math input is: "{in_str}"')
-            tty.debug(e)
+            ramble.util.logger.logger.debug(f'   Math input is: "{in_str}"')
+            ramble.util.logger.logger.debug(e)
 
         return in_str
 
@@ -718,9 +717,9 @@ class Expander(object):
 def raise_passthrough_error(in_str, out_str):
     """Raise an error when passthrough is disabled but variables are not all expanded"""
 
-    tty.debug(f'Expansion stack errors: attempted to expand '
-              f'"{in_str}"')
-    tty.debug(f'  As: {out_str}')
+    ramble.util.logger.logger.debug(f'Expansion stack errors: attempted to expand '
+                                    f'"{in_str}"')
+    ramble.util.logger.logger.debug(f'  As: {out_str}')
     raise RamblePassthroughError('Error Stack:\n'
                                  f'Input: "{in_str}"\n'
                                  f'Output: "{out_str}"\n')

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -20,7 +20,7 @@ import ramble.keywords
 import ramble.error
 import ramble.renderer
 import ramble.util.matrices
-import ramble.util.logger
+from ramble.util.logger import logger
 import ramble.context
 
 
@@ -222,22 +222,18 @@ class ExperimentSet(object):
             test_n_nodes = math.ceil(int(n_ranks) / int(ppn))
 
             if n_nodes and n_nodes < test_n_nodes:
-                ramble.util.logger.logger.error('n_nodes in %s is %s and should be %s' %
-                                                (self.experiment_namespace, n_nodes,
-                                                 test_n_nodes))
+                logger.error(f'n_nodes in {self.experiment_namespace} is {n_nodes} '
+                             f'and should be {test_n_nodes}')
             elif not n_nodes:
-                ramble.util.logger.logger.debug('Defining n_nodes in %s' %
-                                                self.experiment_namespace)
+                logger.debug(f'Defining n_nodes in {self.experiment_namespace}')
                 variables[self.keywords.n_nodes] = test_n_nodes
         elif n_ranks and n_nodes:
             ppn = math.ceil(int(n_ranks) / int(n_nodes))
-            ramble.util.logger.logger.debug('Defining processes_per_node in %s' %
-                                            self.experiment_namespace)
+            logger.debug(f'Defining processes_per_node in {self.experiment_namespace}')
             variables[self.keywords.processes_per_node] = ppn
         elif ppn and n_nodes:
             n_ranks = ppn * n_nodes
-            ramble.util.logger.logger.debug('Defining n_ranks in %s' %
-                                            self.experiment_namespace)
+            logger.debug(f'Defining n_ranks in {self.experiment_namespace}')
             variables[self.keywords.n_ranks] = n_ranks
         elif not n_nodes:
             variables[self.keywords.n_nodes] = 1
@@ -356,10 +352,10 @@ class ExperimentSet(object):
             experiment_vars[self.keywords.log_file] = os.path.join('{experiment_run_dir}',
                                                                    '{experiment_name}.out')
 
-            ramble.util.logger.logger.debug('   Final name: %s' % final_exp_name)
+            logger.debug('   Final name: %s' % final_exp_name)
 
             if experiment_namespace in rendered_experiments:
-                ramble.util.logger.logger.die(f'Experiment {experiment_namespace} is not unique.')
+                logger.die(f'Experiment {experiment_namespace} is not unique.')
             rendered_experiments.add(experiment_namespace)
 
             try:

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -11,8 +11,6 @@ import os
 import math
 import fnmatch
 
-import llnl.util.tty as tty
-
 import ramble.expander
 from ramble.expander import Expander
 from ramble.namespace import namespace
@@ -22,6 +20,7 @@ import ramble.keywords
 import ramble.error
 import ramble.renderer
 import ramble.util.matrices
+import ramble.util.logger
 import ramble.context
 
 
@@ -223,22 +222,22 @@ class ExperimentSet(object):
             test_n_nodes = math.ceil(int(n_ranks) / int(ppn))
 
             if n_nodes and n_nodes < test_n_nodes:
-                tty.error('n_nodes in %s is %s and should be %s' %
-                          (self.experiment_namespace, n_nodes,
-                           test_n_nodes))
+                ramble.util.logger.logger.error('n_nodes in %s is %s and should be %s' %
+                                                (self.experiment_namespace, n_nodes,
+                                                 test_n_nodes))
             elif not n_nodes:
-                tty.debug('Defining n_nodes in %s' %
-                          self.experiment_namespace)
+                ramble.util.logger.logger.debug('Defining n_nodes in %s' %
+                                                self.experiment_namespace)
                 variables[self.keywords.n_nodes] = test_n_nodes
         elif n_ranks and n_nodes:
             ppn = math.ceil(int(n_ranks) / int(n_nodes))
-            tty.debug('Defining processes_per_node in %s' %
-                      self.experiment_namespace)
+            ramble.util.logger.logger.debug('Defining processes_per_node in %s' %
+                                            self.experiment_namespace)
             variables[self.keywords.processes_per_node] = ppn
         elif ppn and n_nodes:
             n_ranks = ppn * n_nodes
-            tty.debug('Defining n_ranks in %s' %
-                      self.experiment_namespace)
+            ramble.util.logger.logger.debug('Defining n_ranks in %s' %
+                                            self.experiment_namespace)
             variables[self.keywords.n_ranks] = n_ranks
         elif not n_nodes:
             variables[self.keywords.n_nodes] = 1
@@ -357,10 +356,10 @@ class ExperimentSet(object):
             experiment_vars[self.keywords.log_file] = os.path.join('{experiment_run_dir}',
                                                                    '{experiment_name}.out')
 
-            tty.debug('   Final name: %s' % final_exp_name)
+            ramble.util.logger.logger.debug('   Final name: %s' % final_exp_name)
 
             if experiment_namespace in rendered_experiments:
-                tty.die('Experiment %s is not unique.' % experiment_namespace)
+                ramble.util.logger.logger.die(f'Experiment {experiment_namespace} is not unique.')
             rendered_experiments.add(experiment_namespace)
 
             try:

--- a/lib/ramble/ramble/experimental/uploader.py
+++ b/lib/ramble/ramble/experimental/uploader.py
@@ -6,12 +6,12 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-import llnl.util.tty as tty
 import json
 import sys
 import math
 
 import ramble.config
+import ramble.util.logger
 from ramble.config import ConfigError
 
 
@@ -119,16 +119,17 @@ def upload_results(results):
             try:
                 formatted_data = ramble.experimental.uploader.format_data(results)
             except KeyError:
-                tty.die("Error parsing file: Does not contain valid data to upload.")
+                ramble.util.logger.logger.die("Error parsing file: Does not "
+                                              "contain valid data to upload.")
             # TODO: strategy object?
 
             uploader = BigQueryUploader()
 
             uri = ramble.config.get('config:upload:uri')
             if not uri:
-                tty.die('No upload URI (config:upload:uri) in config.')
+                ramble.util.logger.logger.die('No upload URI (config:upload:uri) in config.')
 
-            tty.msg('Uploading Results to ' + uri)
+            ramble.util.logger.logger.msg(f'Uploading Results to {uri}')
             uploader.perform_upload(uri, formatted_data)
         else:
             raise ConfigError("Unknown config:upload:type value")
@@ -156,8 +157,8 @@ def format_data(data_in):
     Output: The general idea is the decompose the results into a more "database"
     like format, where the runs and FOMs are in a different table.
     """
-    tty.debug("Format Data in")
-    tty.debug(data_in)
+    ramble.util.logger.logger.debug("Format Data in")
+    ramble.util.logger.logger.debug(data_in)
     results = []
 
     # TODO: what is the nice way to deal with the distinction between
@@ -212,16 +213,16 @@ class BigQueryUploader(Uploader):
         if rows_per_batch <= 1:
             rows_per_batch = 1
 
-        tty.debug("Size: {}B".format(sys.getsizeof(json.dumps(data))))
-        tty.debug("Length in rows: {}".format(data_len))
-        tty.debug("Num Batches: {}".format(approx_num_batches))
-        tty.debug("Rows per Batch: {}".format(rows_per_batch))
+        ramble.util.logger.logger.debug(f"Size: {sys.getsizeof(json.dumps(data))}B")
+        ramble.util.logger.logger.debug(f"Length in rows: {data_len}")
+        ramble.util.logger.logger.debug(f"Num Batches: {approx_num_batches}")
+        ramble.util.logger.logger.debug(f"Rows per Batch: {rows_per_batch}")
 
         for i in range(0, data_len, rows_per_batch):
             end = i + rows_per_batch
             if end > data_len:
                 end = data_len
-            tty.debug("Uploading rows {} to {}".format(i, end))
+            ramble.util.logger.logger.debug(f"Uploading rows {i} to {end}")
             error = client.insert_rows_json(table_id, data[i:end])
             if error:
                 return error
@@ -246,22 +247,22 @@ class BigQueryUploader(Uploader):
                 fom_data['experiment_name'] = experiment.name
                 foms_to_insert.append(fom_data)
 
-        tty.debug("Experiments to insert:")
-        tty.debug(exps_to_insert)
+        ramble.util.logger.logger.debug("Experiments to insert:")
+        ramble.util.logger.logger.debug(exps_to_insert)
 
-        tty.msg("Upload experiments...")
+        ramble.util.logger.logger.msg("Upload experiments...")
         errors1 = self.chunked_upload(exp_table_id, exps_to_insert)
         errors2 = None
 
         if errors1 == []:
-            tty.msg("Upload FOMs...")
+            ramble.util.logger.logger.msg("Upload FOMs...")
             errors2 = self.chunked_upload(fom_table_id, foms_to_insert)
 
         for errors, name in zip([errors1, errors2], ['exp', 'fom']):
             if errors == []:
-                tty.msg("New rows have been added in {}.".format(name))
+                ramble.util.logger.logger.msg(f"New rows have been added in {name}")
             else:
-                tty.die("Encountered errors while inserting rows: {}".format(errors))
+                ramble.util.logger.logger.die(f"Encountered errors while inserting rows: {errors}")
 
     def perform_upload(self, uri, results):
         super().perform_upload(uri, results)

--- a/lib/ramble/ramble/fetch_strategy.py
+++ b/lib/ramble/ramble/fetch_strategy.py
@@ -49,6 +49,7 @@ from spack.util.string import comma_and, quote
 from spack.version import Version, ver
 
 import ramble.config
+import ramble.util.logger
 
 #: List of all fetch strategies, created by FetchStrategy metaclass.
 all_strategies = []
@@ -61,8 +62,8 @@ CONTENT_TYPE_MISMATCH_WARNING_TEMPLATE = (
 
 
 def warn_content_type_mismatch(subject, content_type='HTML'):
-    tty.warn(CONTENT_TYPE_MISMATCH_WARNING_TEMPLATE.format(
-        subject=subject, content_type=content_type))
+    ramble.util.logger.logger.warn(CONTENT_TYPE_MISMATCH_WARNING_TEMPLATE.format(
+                                   subject=subject, content_type=content_type))
 
 
 def _needs_stage(fun):
@@ -278,7 +279,7 @@ class URLFetchStrategy(FetchStrategy):
             try:
                 self._curl = which('curl', required=True)
             except CommandNotFoundError as exc:
-                tty.error(str(exc))
+                ramble.util.logger.logger.error(str(exc))
         return self._curl
 
     def source_id(self):
@@ -310,7 +311,7 @@ class URLFetchStrategy(FetchStrategy):
     @_needs_stage
     def fetch(self):
         if self.archive_file:
-            tty.debug('Already downloaded {0}'.format(self.archive_file))
+            ramble.util.logger.logger.debug('Already downloaded {0}'.format(self.archive_file))
             return
 
         url = None
@@ -328,13 +329,13 @@ class URLFetchStrategy(FetchStrategy):
                 errors.append(str(e))
 
         for msg in errors:
-            tty.debug(msg)
+            ramble.util.logger.logger.debug(msg)
 
         if not self.archive_file:
             raise FailedDownloadError(url)
 
     def _existing_url(self, url):
-        tty.debug('Checking existence of {0}'.format(url))
+        ramble.util.logger.logger.debug('Checking existence of {0}'.format(url))
 
         if ramble.config.get('config:url_fetch_method') == 'curl':
             curl = self.curl
@@ -375,7 +376,7 @@ class URLFetchStrategy(FetchStrategy):
         save_file = None
         if self.stage.save_filename:
             save_file = self.stage.save_filename
-        tty.msg('Fetching {0}'.format(url))
+        ramble.util.logger.logger.msg('Fetching {0}'.format(url))
 
         # Check if we're about to try and open a broken simlink, and if so
         # remove that file to avoid a bad situation where a file "exists" but
@@ -408,7 +409,7 @@ class URLFetchStrategy(FetchStrategy):
         if self.stage.save_filename:
             save_file = self.stage.save_filename
             partial_file = self.stage.save_filename + '.part'
-        tty.msg('Fetching {0}'.format(url))
+        ramble.util.logger.logger.msg('Fetching {0}'.format(url))
         if partial_file:
             save_args = ['-C',
                          '-',  # continue partial downloads
@@ -508,8 +509,8 @@ class URLFetchStrategy(FetchStrategy):
     @_needs_stage
     def expand(self):
         if not self.expand_archive:
-            tty.debug('Staging unexpanded archive {0} in {1}'
-                      .format(self.archive_file, self.stage.source_path))
+            ramble.util.logger.logger.debug('Staging unexpanded archive {0} in {1}'
+                                            .format(self.archive_file, self.stage.source_path))
             if not self.stage.expanded:
                 mkdirp(self.stage.source_path)
             dest = os.path.join(self.stage.source_path,
@@ -517,7 +518,7 @@ class URLFetchStrategy(FetchStrategy):
             shutil.move(self.archive_file, dest)
             return
 
-        tty.debug('Staging archive: {0}'.format(self.archive_file))
+        ramble.util.logger.logger.debug('Staging archive: {0}'.format(self.archive_file))
 
         if not self.archive_file:
             raise NoArchiveFileError(
@@ -528,7 +529,7 @@ class URLFetchStrategy(FetchStrategy):
             self.extension = extension(self.archive_file)
 
         if self.stage.expanded:
-            tty.debug('Source already staged to %s' % self.stage.source_path)
+            ramble.util.logger.logger.debug('Source already staged to %s' % self.stage.source_path)
             return
 
         decompress = decompressor_for(self.archive_file, self.extension)
@@ -662,7 +663,7 @@ class CacheURLFetchStrategy(URLFetchStrategy):
                 raise
 
         # Notify the user how we fetched.
-        tty.msg('Using cached archive: {0}'.format(path))
+        ramble.util.logger.logger.msg('Using cached archive: {0}'.format(path))
 
 
 class VCSFetchStrategy(FetchStrategy):
@@ -692,13 +693,14 @@ class VCSFetchStrategy(FetchStrategy):
 
     @_needs_stage
     def check(self):
-        tty.debug('No checksum needed when fetching with {0}'
-                  .format(self.url_attr))
+        ramble.util.logger.logger.debug('No checksum needed when fetching with {0}'
+                                        .format(self.url_attr))
 
     @_needs_stage
     def expand(self):
-        tty.debug(
-            "Source fetched with %s is already expanded." % self.url_attr)
+        ramble.util.logger.logger.debug(
+            f"Source fetched with {self.url_attr} is already expanded."
+        )
 
     @_needs_stage
     def archive(self, destination, **kwargs):
@@ -771,7 +773,7 @@ class GoFetchStrategy(VCSFetchStrategy):
 
     @_needs_stage
     def fetch(self):
-        tty.debug('Getting go resource: {0}'.format(self.url))
+        ramble.util.logger.logger.debug(f'Getting go resource: {self.url}')
 
         with working_dir(self.stage.path):
             try:
@@ -787,8 +789,9 @@ class GoFetchStrategy(VCSFetchStrategy):
 
     @_needs_stage
     def expand(self):
-        tty.debug(
-            "Source fetched with %s is already expanded." % self.url_attr)
+        ramble.util.logger.logger.debug(
+            f"Source fetched with {self.url_attr} is already expanded."
+        )
 
         # Move the directory to the well-known stage source path
         repo_root = _ensure_one_stage_entry(self.stage.path)
@@ -903,7 +906,7 @@ class GitFetchStrategy(VCSFetchStrategy):
     @_needs_stage
     def fetch(self):
         if self.stage.expanded:
-            tty.debug('Already fetched {0}'.format(self.stage.source_path))
+            ramble.util.logger.logger.debug(f'Already fetched {self.stage.source_path}')
             return
 
         self.clone(commit=self.commit, branch=self.branch, tag=self.tag)
@@ -925,7 +928,7 @@ class GitFetchStrategy(VCSFetchStrategy):
         """
         # Default to spack source path
         dest = dest or self.stage.source_path
-        tty.debug('Cloning git repository: {0}'.format(self._repo_info()))
+        ramble.util.logger.logger.debug(f'Cloning git repository: {self._repo_info()}')
 
         git = self.git
         debug = ramble.config.get('config:debug')
@@ -1123,10 +1126,10 @@ class CvsFetchStrategy(VCSFetchStrategy):
     @_needs_stage
     def fetch(self):
         if self.stage.expanded:
-            tty.debug('Already fetched {0}'.format(self.stage.source_path))
+            ramble.util.logger.logger.debug('Already fetched {self.stage.source_path}')
             return
 
-        tty.debug('Checking out CVS repository: {0}'.format(self.url))
+        ramble.util.logger.logger.debug('Checking out CVS repository: {self.url}')
 
         with temp_cwd():
             url, module = self.url.split('%module=')
@@ -1217,10 +1220,10 @@ class SvnFetchStrategy(VCSFetchStrategy):
     @_needs_stage
     def fetch(self):
         if self.stage.expanded:
-            tty.debug('Already fetched {0}'.format(self.stage.source_path))
+            ramble.util.logger.logger.debug('Already fetched {self.stage.source_path}')
             return
 
-        tty.debug('Checking out subversion repository: {0}'.format(self.url))
+        ramble.util.logger.logger.debug('Checking out subversion repository: {self.url}')
 
         args = ['checkout', '--force', '--quiet']
         if self.revision:
@@ -1327,14 +1330,13 @@ class HgFetchStrategy(VCSFetchStrategy):
     @_needs_stage
     def fetch(self):
         if self.stage.expanded:
-            tty.debug('Already fetched {0}'.format(self.stage.source_path))
+            ramble.util.logger.logger.debug(f'Already fetched {self.stage.source_path}')
             return
 
         args = []
         if self.revision:
             args.append('at revision %s' % self.revision)
-        tty.debug('Cloning mercurial repository: {0} {1}'
-                  .format(self.url, args))
+        ramble.util.logger.logger.debug(f'Cloning mercurial repository: {self.url} {args}')
 
         args = ['clone']
 
@@ -1390,7 +1392,7 @@ class S3FetchStrategy(URLFetchStrategy):
     @_needs_stage
     def fetch(self):
         if self.archive_file:
-            tty.debug('Already downloaded {0}'.format(self.archive_file))
+            ramble.util.logger.logger.debug(f'Already downloaded {self.archive_file}')
             return
 
         parsed_url = url_util.parse(self.url)
@@ -1398,7 +1400,7 @@ class S3FetchStrategy(URLFetchStrategy):
             raise FetchError(
                 'S3FetchStrategy can only fetch from s3:// urls.')
 
-        tty.debug('Fetching {0}'.format(self.url))
+        ramble.util.logger.logger.debug(f'Fetching {self.url}')
 
         basename = os.path.basename(parsed_url.path)
 
@@ -1439,7 +1441,7 @@ class GCSFetchStrategy(URLFetchStrategy):
     def fetch(self):
         import ramble.util.web as web_util
         if self.archive_file:
-            tty.debug('Already downloaded {0}'.format(self.archive_file))
+            ramble.util.logger.logger.debug(f'Already downloaded {self.archive_file}')
             return
 
         parsed_url = url_util.parse(self.url)
@@ -1447,7 +1449,7 @@ class GCSFetchStrategy(URLFetchStrategy):
             raise FetchError(
                 'GCSFetchStrategy can only fetch from gs:// urls.')
 
-        tty.debug('Fetching {0}'.format(self.url))
+        ramble.util.logger.logger.debug(f'Fetching {self.url}')
 
         basename = os.path.basename(parsed_url.path)
 
@@ -1705,13 +1707,13 @@ def from_list_url(pkg):
                 return URLFetchStrategy(url_from_list, checksum,
                                         fetch_options=pkg.fetch_options)
             except KeyError as e:
-                tty.debug(e)
-                tty.msg("Cannot find version %s in url_list" % pkg.version)
+                ramble.util.logger.logger.debug(e)
+                ramble.util.logger.logger.msg(f"Cannot find version {pkg.version} in url_list")
 
         except BaseException as e:
             # TODO: Don't catch BaseException here! Be more specific.
-            tty.debug(e)
-            tty.msg("Could not determine url from list_url.")
+            ramble.util.logger.logger.debug(e)
+            ramble.util.logger.logger.msg("Could not determine url from list_url.")
 
 
 class FsCache(object):

--- a/lib/ramble/ramble/keywords.py
+++ b/lib/ramble/ramble/keywords.py
@@ -9,7 +9,7 @@
 from enum import Enum
 
 import ramble.error
-import ramble.util.logger
+from ramble.util.logger import logger
 
 key_type = Enum('type', ['reserved', 'optional', 'required'])
 default_keys = {
@@ -118,7 +118,7 @@ class Keywords(object):
 
         if len(required_set) > 0:
             for key in required_set:
-                ramble.util.logger.logger.warn(f'Required key "{key}" is not defined')
+                logger.warn(f'Required key "{key}" is not defined')
             raise RambleKeywordError('One or more required keys ' +
                                      'are not defined within an experiment.')
 

--- a/lib/ramble/ramble/keywords.py
+++ b/lib/ramble/ramble/keywords.py
@@ -8,9 +8,8 @@
 
 from enum import Enum
 
-import llnl.util.tty as tty
-
 import ramble.error
+import ramble.util.logger
 
 key_type = Enum('type', ['reserved', 'optional', 'required'])
 default_keys = {
@@ -119,7 +118,7 @@ class Keywords(object):
 
         if len(required_set) > 0:
             for key in required_set:
-                tty.warn(f'Required key "{key}" is not defined')
+                ramble.util.logger.logger.warn(f'Required key "{key}" is not defined')
             raise RambleKeywordError('One or more required keys ' +
                                      'are not defined within an experiment.')
 

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -9,7 +9,7 @@
 import ramble.language.language_base
 import ramble.language.language_helpers
 import ramble.success_criteria
-import ramble.util.logger
+from ramble.util.logger import logger
 
 
 """This module contains directives directives that are shared between multiple object types
@@ -207,9 +207,7 @@ def success_criteria(name, mode, match=None, file='{log_file}',
     def _execute_success_criteria(obj):
         valid_modes = ramble.success_criteria.SuccessCriteria._valid_modes
         if mode not in valid_modes:
-            ramble.util.logger.logger.die(
-                f'Mode {mode} is not valid. Valid values are {valid_modes}'
-            )
+            logger.die(f'Mode {mode} is not valid. Valid values are {valid_modes}')
 
         obj.success_criteria[name] = {
             'mode': mode,

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -6,11 +6,10 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-import llnl.util.tty as tty
-
 import ramble.language.language_base
 import ramble.language.language_helpers
 import ramble.success_criteria
+import ramble.util.logger
 
 
 """This module contains directives directives that are shared between multiple object types
@@ -208,7 +207,9 @@ def success_criteria(name, mode, match=None, file='{log_file}',
     def _execute_success_criteria(obj):
         valid_modes = ramble.success_criteria.SuccessCriteria._valid_modes
         if mode not in valid_modes:
-            tty.die(f'Mode {mode} is not valid. Valid values are {valid_modes}')
+            ramble.util.logger.logger.die(
+                f'Mode {mode} is not valid. Valid values are {valid_modes}'
+            )
 
         obj.success_criteria[name] = {
             'mode': mode,

--- a/lib/ramble/ramble/main.py
+++ b/lib/ramble/ramble/main.py
@@ -415,6 +415,13 @@ def make_argument_parser(**kwargs):
         '--disable-passthrough', action='store_true',
         help="disable passthrough of expansion variables for debugging")
     parser.add_argument(
+        '-N', '--disable-logger', action='store_true',
+        help="disable the ramble logger. All output will be printed to stdout.")
+    parser.add_argument(
+        '-P', '--disable-progress-bar', action='store_true',
+        help="disable the progress bars while setting up experiments.")
+
+    parser.add_argument(
         '--timestamp', action='store_true',
         help="Add a timestamp to tty output")
     parser.add_argument(
@@ -514,6 +521,14 @@ def setup_main_options(args):
     # override disable_passthrough configuration if passed on command line
     if args.disable_passthrough:
         ramble.config.set('config:disable_passthrough', True, scope='command_line')
+
+    if args.disable_logger:
+        ramble.config.set('config:disable_logger', True, scope='command_line')
+
+    ramble.util.logger.logger.enabled = not ramble.config.get('config:disable_logger', False)
+
+    if args.disable_progress_bar:
+        ramble.config.set('config:disable_progress_bar', True, scope='command_line')
 
     if args.mock:
         import spack.util.spack_yaml as syaml

--- a/lib/ramble/ramble/main.py
+++ b/lib/ramble/ramble/main.py
@@ -42,7 +42,7 @@ import ramble.workspace
 import ramble.workspace.shell
 import ramble.paths
 import ramble.repository
-import ramble.util.logger
+from ramble.util.logger import logger
 import spack.util.debug
 import spack.util.environment
 import spack.util.path
@@ -166,9 +166,7 @@ def index_commands():
         for p in required_command_properties:
             prop = getattr(cmd_module, p, None)
             if not prop:
-                ramble.util.logger.logger.die(
-                    f"Command doesn't define a property '{p}': {command}"
-                )
+                logger.die(f"Command doesn't define a property '{p}': {command}")
 
         # add commands to lists for their level and higher levels
         for level in reversed(levels):
@@ -487,7 +485,7 @@ def make_argument_parser(**kwargs):
 
 def send_warning_to_tty(message, *args):
     """Redirects messages to ramble.util.logger.logger.warn."""
-    ramble.util.logger.logger.warn(message)
+    logger.warn(message)
 
 
 def setup_main_options(args):
@@ -525,7 +523,7 @@ def setup_main_options(args):
     if args.disable_logger:
         ramble.config.set('config:disable_logger', True, scope='command_line')
 
-    ramble.util.logger.logger.enabled = not ramble.config.get('config:disable_logger', False)
+    logger.enabled = not ramble.config.get('config:disable_logger', False)
 
     if args.disable_progress_bar:
         ramble.config.set('config:disable_progress_bar', True, scope='command_line')
@@ -547,9 +545,7 @@ def setup_main_options(args):
 
     # If the user asked for it, don't check ssl certs.
     if args.insecure:
-        ramble.util.logger.logger.warn(
-            "You asked for --insecure. Will NOT check SSL certificates."
-        )
+        logger.warn("You asked for --insecure. Will NOT check SSL certificates.")
         ramble.config.set('config:verify_ssl', False, scope='command_line')
 
     # Use the ramble config command to handle parsing the config strings
@@ -579,9 +575,7 @@ def _invoke_command(command, parser, args, unknown_args):
         return_val = command(parser, args, unknown_args)
     else:
         if unknown_args:
-            ramble.util.logger.logger.die(
-                f'unrecognized arguments: {" ".join(unknown_args)}'
-            )
+            logger.die(f'unrecognized arguments: {" ".join(unknown_args)}')
         return_val = command(parser, args)
 
     # Allow commands to return and error code if they want
@@ -657,7 +651,7 @@ class RambleCommand(object):
             self.returncode = e.code
 
         except BaseException as e:
-            ramble.util.logger.logger.debug(e)
+            logger.debug(e)
             self.error = e
             if fail_on_error:
                 self._log_command_output(out)
@@ -677,7 +671,7 @@ class RambleCommand(object):
             fmt = self.command_name + ': {0}'
             for ln in out.getvalue().split('\n'):
                 if len(ln) > 0:
-                    ramble.util.logger.logger.verbose(fmt.format(ln.replace('==> ', '')))
+                    logger.verbose(fmt.format(ln.replace('==> ', '')))
 
 
 def _profile_wrapper(command, parser, args, unknown_args):
@@ -687,7 +681,7 @@ def _profile_wrapper(command, parser, args, unknown_args):
         nlines = int(args.lines)
     except ValueError:
         if args.lines != 'all':
-            ramble.util.logger.logger.die(f'Invalid number for --lines: {args.lines}')
+            logger.die(f'Invalid number for --lines: {args.lines}')
         nlines = -1
 
     # allow comma-separated list of fields
@@ -696,7 +690,7 @@ def _profile_wrapper(command, parser, args, unknown_args):
         sortby = args.sorted_profile.split(',')
         for stat in sortby:
             if stat not in stat_names:
-                ramble.util.logger.logger.die(f"Invalid sort field: {stat}")
+                logger.die(f"Invalid sort field: {stat}")
 
     try:
         # make a profiler and run the code.
@@ -731,7 +725,7 @@ def print_setup_info(*info):
         elif shell == 'csh':
             print("set %s = '%s'" % (var, value))
         else:
-            ramble.util.logger.logger.die('shell must be sh or csh')
+            logger.die('shell must be sh or csh')
 
 
 def _main(argv=None):
@@ -871,7 +865,7 @@ def finish_parse_and_run(parser, cmd_name, workspace_format_error):
     if workspace_format_error:
         raise_error = False
         if cmd_name.strip() in edit_cmds:
-            ramble.util.logger.logger.msg(
+            logger.msg(
                 "Error while reading workspace config. In some cases this can be " +
                 "avoided by passing `-W` to ramble"
             )
@@ -915,14 +909,14 @@ def main(argv=None):
         return _main(argv)
 
     except RambleError as e:
-        ramble.util.logger.logger.debug(e)
+        logger.debug(e)
         e.die()  # gracefully die on any RambleErrors
 
     except KeyboardInterrupt:
         if ramble.config.get('config:debug'):
             raise
         sys.stderr.write('\n')
-        ramble.util.logger.logger.error("Keyboard interrupt.")
+        logger.error("Keyboard interrupt.")
         if sys.version_info >= (3, 5):
             return signal.SIGINT.value
         else:
@@ -936,7 +930,7 @@ def main(argv=None):
     except Exception as e:
         if ramble.config.get('config:debug'):
             raise
-        ramble.util.logger.logger.error(e)
+        logger.error(e)
         return 3
 
 

--- a/lib/ramble/ramble/mirror.py
+++ b/lib/ramble/ramble/mirror.py
@@ -25,13 +25,13 @@ import traceback
 import ruamel.yaml.error as yaml_error
 import six
 
-import llnl.util.tty as tty
 from llnl.util.compat import Mapping
 from llnl.util.filesystem import mkdirp
 
 import ramble.config
 import ramble.error
 import ramble.fetch_strategy as fs
+import ramble.util.logger
 
 import spack.url
 import spack.util.spack_json
@@ -435,7 +435,7 @@ def add(name, url, scope, args={}):
         mirrors = syaml_dict()
 
     if name in mirrors:
-        tty.die("Mirror with name %s already exists." % name)
+        ramble.util.logger.logger.die(f"Mirror with name {name} already exists.")
 
     items = [(n, u) for n, u in mirrors.items()]
     mirror_data = url
@@ -451,7 +451,7 @@ def remove(name, scope):
         mirrors = syaml_dict()
 
     if name not in mirrors:
-        tty.die("No mirror with name %s" % name)
+        ramble.util.logger.logger.die(f"No mirror with name {name}")
 
     old_value = mirrors.pop(name)
     ramble.config.set('mirrors', mirrors, scope=scope)
@@ -470,8 +470,8 @@ def remove(name, scope):
         debug_msg.append(debug_msg_url)
         values.append(old_value)
 
-    tty.debug(" ".join(debug_msg) % tuple(values))
-    tty.msg("Removed mirror %s." % name)
+    ramble.util.logger.logger.debug(" ".join(debug_msg) % tuple(values))
+    ramble.util.logger.logger.msg(f"Removed mirror {name}.")
 
 
 class MirrorStats(object):
@@ -513,9 +513,9 @@ class MirrorStats(object):
 
 
 def _add_single_spec(spec, mirror_root, mirror, mirror_stats):
-    tty.msg("Adding inputs for application {app} to mirror".format(
-        app=spec.format("{name}")
-    ))
+    ramble.util.logger.logger.msg(
+        f"Adding inputs for application {spec.format('{name}')} to mirror"
+    )
     num_retries = 3
     while num_retries > 0:
         try:
@@ -533,7 +533,7 @@ def _add_single_spec(spec, mirror_root, mirror, mirror_stats):
         if ramble.config.get('config:debug'):
             traceback.print_exception(file=sys.stderr, *exc_tuple)
         else:
-            tty.warn(
+            ramble.util.logger.logger.warn(
                 "Error while fetching %s" % spec.cformat('{name}'),
                 getattr(exception, 'message', exception))
         mirror_stats.error()

--- a/lib/ramble/ramble/mirror.py
+++ b/lib/ramble/ramble/mirror.py
@@ -31,7 +31,7 @@ from llnl.util.filesystem import mkdirp
 import ramble.config
 import ramble.error
 import ramble.fetch_strategy as fs
-import ramble.util.logger
+from ramble.util.logger import logger
 
 import spack.url
 import spack.util.spack_json
@@ -435,7 +435,7 @@ def add(name, url, scope, args={}):
         mirrors = syaml_dict()
 
     if name in mirrors:
-        ramble.util.logger.logger.die(f"Mirror with name {name} already exists.")
+        logger.die(f"Mirror with name {name} already exists.")
 
     items = [(n, u) for n, u in mirrors.items()]
     mirror_data = url
@@ -451,7 +451,7 @@ def remove(name, scope):
         mirrors = syaml_dict()
 
     if name not in mirrors:
-        ramble.util.logger.logger.die(f"No mirror with name {name}")
+        logger.die(f"No mirror with name {name}")
 
     old_value = mirrors.pop(name)
     ramble.config.set('mirrors', mirrors, scope=scope)
@@ -470,8 +470,8 @@ def remove(name, scope):
         debug_msg.append(debug_msg_url)
         values.append(old_value)
 
-    ramble.util.logger.logger.debug(" ".join(debug_msg) % tuple(values))
-    ramble.util.logger.logger.msg(f"Removed mirror {name}.")
+    logger.debug(" ".join(debug_msg) % tuple(values))
+    logger.msg(f"Removed mirror {name}.")
 
 
 class MirrorStats(object):
@@ -513,9 +513,7 @@ class MirrorStats(object):
 
 
 def _add_single_spec(spec, mirror_root, mirror, mirror_stats):
-    ramble.util.logger.logger.msg(
-        f"Adding inputs for application {spec.format('{name}')} to mirror"
-    )
+    logger.msg(f"Adding inputs for application {spec.format('{name}')} to mirror")
     num_retries = 3
     while num_retries > 0:
         try:
@@ -533,7 +531,7 @@ def _add_single_spec(spec, mirror_root, mirror, mirror_stats):
         if ramble.config.get('config:debug'):
             traceback.print_exception(file=sys.stderr, *exc_tuple)
         else:
-            ramble.util.logger.logger.warn(
+            logger.warn(
                 "Error while fetching %s" % spec.cformat('{name}'),
                 getattr(exception, 'message', exception))
         mirror_stats.error()

--- a/lib/ramble/ramble/modifier.py
+++ b/lib/ramble/ramble/modifier.py
@@ -20,7 +20,7 @@ from ramble.language.shared_language import SharedMeta, register_builtin  # noqa
 from ramble.error import RambleError
 import ramble.util.colors as rucolor
 import ramble.util.directives
-import ramble.util.logger
+from ramble.util.logger import logger
 
 
 class ModifierBase(object, metaclass=ModifierMeta):
@@ -72,18 +72,14 @@ class ModifierBase(object, metaclass=ModifierMeta):
             self._usage_mode = mode
         elif hasattr(self, '_default_usage_mode'):
             self._usage_mode = self._default_usage_mode
-            ramble.util.logger.logger.msg(
-                f'    Using default usage mode {self._usage_mode} on modifier {self.name}'
-            )
+            logger.msg(f'    Using default usage mode {self._usage_mode} on modifier {self.name}')
         else:
             if len(self.modes) > 1 or len(self.modes) == 0:
                 raise InvalidModeError('Cannot auto determine usage '
                                        f'mode for modifier {self.name}')
 
             self._usage_mode = list(self.modes.keys())[0]
-            ramble.util.logger.logger.msg(
-                f'    Using default usage mode {self._usage_mode} on modifier {self.name}'
-            )
+            logger.msg(f'    Using default usage mode {self._usage_mode} on modifier {self.name}')
 
     def set_on_executables(self, on_executables):
         """Set the executables this modifier applies to.

--- a/lib/ramble/ramble/modifier.py
+++ b/lib/ramble/ramble/modifier.py
@@ -14,13 +14,13 @@ import fnmatch
 from typing import List
 
 from llnl.util.tty.colify import colified
-import llnl.util.tty as tty
 
 from ramble.language.modifier_language import ModifierMeta
 from ramble.language.shared_language import SharedMeta, register_builtin  # noqa: F401
 from ramble.error import RambleError
 import ramble.util.colors as rucolor
 import ramble.util.directives
+import ramble.util.logger
 
 
 class ModifierBase(object, metaclass=ModifierMeta):
@@ -72,14 +72,18 @@ class ModifierBase(object, metaclass=ModifierMeta):
             self._usage_mode = mode
         elif hasattr(self, '_default_usage_mode'):
             self._usage_mode = self._default_usage_mode
-            tty.msg(f'    Using default usage mode {self._usage_mode} on modifier {self.name}')
+            ramble.util.logger.logger.msg(
+                f'    Using default usage mode {self._usage_mode} on modifier {self.name}'
+            )
         else:
             if len(self.modes) > 1 or len(self.modes) == 0:
                 raise InvalidModeError('Cannot auto determine usage '
                                        f'mode for modifier {self.name}')
 
             self._usage_mode = list(self.modes.keys())[0]
-            tty.msg(f'    Using default usage mode {self._usage_mode} on modifier {self.name}')
+            ramble.util.logger.logger.msg(
+                f'    Using default usage mode {self._usage_mode} on modifier {self.name}'
+            )
 
     def set_on_executables(self, on_executables):
         """Set the executables this modifier applies to.

--- a/lib/ramble/ramble/modkit.py
+++ b/lib/ramble/ramble/modkit.py
@@ -12,7 +12,11 @@
 
 import llnl.util.filesystem
 from llnl.util.filesystem import *
-import llnl.util.tty as tty
+
+from ramble.util.logger import logger
+
+# Rename logger to tty to preserve old behavior
+from ramble.util.logger import logger as tty
 
 from ramble.modifier import ModifierBase
 from ramble.modifier_types.basic import BasicModifier

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -150,11 +150,15 @@ class Pipeline(object):
 
             disable_progress = ramble.config.get('config:disable_progress_bar', False)
             if not disable_progress:
-                progress = tqdm.tqdm(total=len(phase_list), leave=True,
-                                     ascii=' >-', bar_format='{l_bar}{bar}{elapsed_s}')
-            for phase in phase_list:
+                progress = tqdm.tqdm(total=len(phase_list),
+                                     leave=True,
+                                     ascii=' >=',
+                                     bar_format='{l_bar}{bar}| Elapsed (s): {elapsed_s}')
+            for phase_idx, phase in enumerate(phase_list):
                 if not disable_progress:
-                    progress.set_description(f'Processing phase {phase}')
+                    progress.set_description(
+                        f'Processing phase {phase} ({phase_idx}/{len(phase_list)})'
+                    )
                 app_inst.run_phase(phase, self.workspace)
                 if not disable_progress:
                     progress.update()

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -125,7 +125,7 @@ class Pipeline(object):
                             'workspace first.\n' + \
                             'Then ensure its spack configuration is ' + \
                             'properly configured.'
-            ramble.logger.logger.die(error_message)
+            ramble.util.logger.logger.die(error_message)
 
     def _prepare(self):
         """Perform preparation for pipeline execution"""

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -32,6 +32,13 @@ from ramble.namespace import namespace
 import spack.util.spack_json as sjson
 from spack.util.executable import which
 
+try:
+    import tqdm
+except ModuleNotFoundError:
+    ramble.util.logger.logger.die(
+        'Module `tqdm` is not found. Ensure requirements.txt are installed.'
+    )
+
 
 class Pipeline(object):
     """Base Class for all pipeline objects"""
@@ -140,8 +147,12 @@ class Pipeline(object):
 
             phase_list = app_inst.get_pipeline_phases(self.name, self.filters.phases)
 
+            progress = tqdm.tqdm(total=len(phase_list), leave=False)
             for phase in phase_list:
+                progress.set_description(f'Processing phase {phase}')
                 app_inst.run_phase(phase, self.workspace)
+                progress.update()
+            progress.close()
 
             ramble.util.logger.logger.remove_log()
             ramble.util.logger.logger.all_msg(

--- a/lib/ramble/ramble/renderer.py
+++ b/lib/ramble/ramble/renderer.py
@@ -13,7 +13,7 @@ import ramble.expander
 from ramble.namespace import namespace
 
 import ramble.util.matrices
-import ramble.util.logger
+from ramble.util.logger import logger
 
 
 class RenderGroup(object):
@@ -39,12 +39,12 @@ class RenderGroup(object):
             self.objects = 'environments'
             self.context = 'environment_name'
         else:
-            ramble.util.logger.logger.die(f'Object type {obj_type} is not valid to render.\n' +
-                                          f'Valid options are: {self._obj_types}')
+            logger.die(f'Object type {obj_type} is not valid to render.\n' +
+                       f'Valid options are: {self._obj_types}')
 
         if action not in self._actions:
-            ramble.util.logger.logger.die(f'Action {action} is not valid to render.\n' +
-                                          f'Valid options are: {self._actions}')
+            logger.die(f'Action {action} is not valid to render.\n' +
+                       f'Valid options are: {self._actions}')
         self.action = action
 
         self.variables = {}
@@ -162,21 +162,21 @@ class Renderer(object):
                 # Validate variable definitions
                 for var_name in group_def:
                     if var_name not in object_variables:
-                        ramble.util.logger.logger.die(f'An undefined variable {var_name} '
-                                                      f'is defined in zip {zip_group}')
+                        logger.die(f'An undefined variable {var_name} '
+                                   f'is defined in zip {zip_group}')
 
                     if var_name in zipped_vars:
-                        ramble.util.logger.logger.die(f'Variable {var_name} is used '
-                                                      'across multiple zips.\n'
-                                                      'Ensure it is only used in a single zip')
+                        logger.die(f'Variable {var_name} is used '
+                                   'across multiple zips.\n'
+                                   'Ensure it is only used in a single zip')
 
                     if not isinstance(object_variables[var_name], list):
-                        ramble.util.logger.logger.die(f'Variable {var_name} in zip {zip_group} '
-                                                      'does not refer to a vector.')
+                        logger.die(f'Variable {var_name} in zip {zip_group} '
+                                   'does not refer to a vector.')
 
                     if len(object_variables[var_name]) == 0:
-                        ramble.util.logger.logger.die(f'Variable {var_name} in zip {zip_group} '
-                                                      'has an invalid length of 0')
+                        logger.die(f'Variable {var_name} in zip {zip_group} '
+                                   'has an invalid length of 0')
 
                 # Validate variable lengths:
                 length_mismatch = False
@@ -187,10 +187,10 @@ class Renderer(object):
                         cur_zip['length'] = cur_len
                     elif cur_len != cur_zip['length']:
                         length_mismatch = True
-                        ramble.util.logger.logger.die(f'Variable {var_name} in zip {zip_group}\n'
-                                                      f'has a length of {cur_len} which differs '
-                                                      'from the current max of '
-                                                      f'{cur_zip["length"]}')
+                        logger.die(f'Variable {var_name} in zip {zip_group}\n'
+                                   f'has a length of {cur_len} which differs '
+                                   'from the current max of '
+                                   f'{cur_zip["length"]}')
 
                 # Print length information in error case
                 if length_mismatch:
@@ -200,7 +200,7 @@ class Renderer(object):
                     for var_name in group_def:
                         err_str += f'\tVariable {var_name} has length ' \
                                    f'of {len(object_variables[var_name])}\n'
-                    ramble.util.logger.logger.die(err_str)
+                    logger.die(err_str)
 
                 # Extract variables for zip
                 for var_name in group_def:
@@ -238,7 +238,7 @@ class Renderer(object):
                 variable_names = []
                 for var in matrix:
                     if var in matrix_vars:
-                        ramble.util.logger.logger.die(
+                        logger.die(
                             f'Variable {var} has been used in multiple matrices.\n'
                             + 'Ensure each variable is only used once across all matrices'
                         )
@@ -247,7 +247,7 @@ class Renderer(object):
                     if var in object_variables:
                         if not isinstance(object_variables[var], list):
                             err_context = object_variables[render_group.context]
-                            ramble.util.logger.logger.die(
+                            logger.die(
                                 f'In {render_group.object} {err_context}'
                                 + f' variable {var} does not refer to a vector.'
                             )
@@ -268,7 +268,7 @@ class Renderer(object):
                         variable_names.append(var)
                     else:
                         err_context = object_variables[render_group.context]
-                        ramble.util.logger.logger.die(
+                        logger.die(
                             f'In {render_group.object} {err_context}'
                             + f' variable or zip {var} has not been defined yet.'
                         )
@@ -278,7 +278,7 @@ class Renderer(object):
 
                 if last_size != matrix_size:
                     err_context = object_variables[render_group.context]
-                    ramble.util.logger.logger.die(
+                    logger.die(
                         f'Matrices defined in {render_group.object} {err_context}'
                         + ' do not result in the same number of elements.'
                     )
@@ -341,7 +341,7 @@ class Renderer(object):
                           f'{err_context}\n'
                 for var, val in vector_vars.items():
                     err_str += f'\tVariable {var} has length {len(val)}\n'
-                ramble.util.logger.logger.die(err_str)
+                logger.die(err_str)
 
             # Iterate over the vector length, and set the value in the
             # object dict to the index value.
@@ -368,7 +368,7 @@ class Renderer(object):
         where_expander = ramble.expander.Expander(object_variables, None)
 
         for obj in new_objects:
-            ramble.util.logger.logger.debug(f'Rendering {render_group.object}:')
+            logger.debug(f'Rendering {render_group.object}:')
             for var, val in obj.items():
                 object_variables[var] = val
 

--- a/lib/ramble/ramble/renderer.py
+++ b/lib/ramble/ramble/renderer.py
@@ -8,13 +8,12 @@
 
 import itertools
 
-import llnl.util.tty as tty
-
 import ramble.error
 import ramble.expander
 from ramble.namespace import namespace
 
 import ramble.util.matrices
+import ramble.util.logger
 
 
 class RenderGroup(object):
@@ -40,12 +39,12 @@ class RenderGroup(object):
             self.objects = 'environments'
             self.context = 'environment_name'
         else:
-            tty.die(f'Object type {obj_type} is not valid to render.\n' +
-                    f'Valid options are: {self._obj_types}')
+            ramble.util.logger.logger.die(f'Object type {obj_type} is not valid to render.\n' +
+                                          f'Valid options are: {self._obj_types}')
 
         if action not in self._actions:
-            tty.die(f'Action {action} is not valid to render.\n' +
-                    f'Valid options are: {self._actions}')
+            ramble.util.logger.logger.die(f'Action {action} is not valid to render.\n' +
+                                          f'Valid options are: {self._actions}')
         self.action = action
 
         self.variables = {}
@@ -163,19 +162,21 @@ class Renderer(object):
                 # Validate variable definitions
                 for var_name in group_def:
                     if var_name not in object_variables:
-                        tty.die(f'An undefined variable {var_name} is defined in zip {zip_group}')
+                        ramble.util.logger.logger.die(f'An undefined variable {var_name} '
+                                                      f'is defined in zip {zip_group}')
 
                     if var_name in zipped_vars:
-                        tty.die(f'Variable {var_name} is used across multiple zips.\n'
-                                'Ensure it is only used in a single zip')
+                        ramble.util.logger.logger.die(f'Variable {var_name} is used '
+                                                      'across multiple zips.\n'
+                                                      'Ensure it is only used in a single zip')
 
                     if not isinstance(object_variables[var_name], list):
-                        tty.die(f'Variable {var_name} in zip {zip_group} '
-                                'does not refer to a vector.')
+                        ramble.util.logger.logger.die(f'Variable {var_name} in zip {zip_group} '
+                                                      'does not refer to a vector.')
 
                     if len(object_variables[var_name]) == 0:
-                        tty.die(f'Variable {var_name} in zip {zip_group} '
-                                'has an invalid length of 0')
+                        ramble.util.logger.logger.die(f'Variable {var_name} in zip {zip_group} '
+                                                      'has an invalid length of 0')
 
                 # Validate variable lengths:
                 length_mismatch = False
@@ -186,9 +187,10 @@ class Renderer(object):
                         cur_zip['length'] = cur_len
                     elif cur_len != cur_zip['length']:
                         length_mismatch = True
-                        tty.die(f'Variable {var_name} in zip {zip_group}\n'
-                                f'has a length of {cur_len} which differs from\n'
-                                f'the current max of {cur_zip["length"]}')
+                        ramble.util.logger.logger.die(f'Variable {var_name} in zip {zip_group}\n'
+                                                      f'has a length of {cur_len} which differs '
+                                                      f'from\nthe current max of '
+                                                      f'{cur_zip["length"]}')
 
                 # Print length information in error case
                 if length_mismatch:
@@ -198,7 +200,7 @@ class Renderer(object):
                     for var_name in group_def:
                         err_str += f'\tVariable {var_name} has length ' \
                                    f'of {len(object_variables[var_name])}\n'
-                    tty.die(err_str)
+                    ramble.util.logger.logger.die(err_str)
 
                 # Extract variables for zip
                 for var_name in group_def:
@@ -236,15 +238,19 @@ class Renderer(object):
                 variable_names = []
                 for var in matrix:
                     if var in matrix_vars:
-                        tty.die(f'Variable {var} has been used in multiple matrices.\n'
-                                + 'Ensure each variable is only used once across all matrices')
+                        ramble.util.logger.logger.die(
+                            f'Variable {var} has been used in multiple matrices.\n'
+                            + 'Ensure each variable is only used once across all matrices'
+                        )
                     matrix_vars.add(var)
 
                     if var in object_variables:
                         if not isinstance(object_variables[var], list):
                             err_context = object_variables[render_group.context]
-                            tty.die(f'In {render_group.object} {err_context}'
-                                    + f' variable {var} does not refer to a vector.')
+                            ramble.util.logger.logger.die(
+                                f'In {render_group.object} {err_context}'
+                                + f' variable {var} does not refer to a vector.'
+                            )
 
                         matrix_size = matrix_size * len(object_variables[var])
                         vectors.append(object_variables[var])
@@ -262,16 +268,20 @@ class Renderer(object):
                         variable_names.append(var)
                     else:
                         err_context = object_variables[render_group.context]
-                        tty.die(f'In {render_group.object} {err_context}'
-                                + f' variable or zip {var} has not been defined yet.')
+                        ramble.util.logger.logger.die(
+                            f'In {render_group.object} {err_context}'
+                            + f' variable or zip {var} has not been defined yet.'
+                        )
 
                 if last_size == -1:
                     last_size = matrix_size
 
                 if last_size != matrix_size:
                     err_context = object_variables[render_group.context]
-                    tty.die(f'Matrices defined in {render_group.object} {err_context}'
-                            + ' do not result in the same number of elements.')
+                    ramble.util.logger.logger.die(
+                        f'Matrices defined in {render_group.object} {err_context}'
+                        + ' do not result in the same number of elements.'
+                    )
 
                 matrix_vectors.append(vectors)
                 matrix_variables.append(variable_names)
@@ -331,7 +341,7 @@ class Renderer(object):
                           f'{err_context}\n'
                 for var, val in vector_vars.items():
                     err_str += f'\tVariable {var} has length {len(val)}\n'
-                tty.die(err_str)
+                ramble.util.logger.logger.die(err_str)
 
             # Iterate over the vector length, and set the value in the
             # object dict to the index value.
@@ -358,7 +368,7 @@ class Renderer(object):
         where_expander = ramble.expander.Expander(object_variables, None)
 
         for obj in new_objects:
-            tty.debug(f'Rendering {render_group.object}:')
+            ramble.util.logger.logger.debug(f'Rendering {render_group.object}:')
             for var, val in obj.items():
                 object_variables[var] = val
 

--- a/lib/ramble/ramble/renderer.py
+++ b/lib/ramble/ramble/renderer.py
@@ -189,7 +189,7 @@ class Renderer(object):
                         length_mismatch = True
                         ramble.util.logger.logger.die(f'Variable {var_name} in zip {zip_group}\n'
                                                       f'has a length of {cur_len} which differs '
-                                                      f'from\nthe current max of '
+                                                      'from the current max of '
                                                       f'{cur_zip["length"]}')
 
                 # Print length information in error case

--- a/lib/ramble/ramble/repository.py
+++ b/lib/ramble/ramble/repository.py
@@ -40,9 +40,9 @@ import llnl.util.filesystem as fs
 import ramble.caches
 import ramble.config
 import ramble.spec
-import ramble.util.logger
 import ramble.util.path
 import ramble.util.naming as nm
+from ramble.util.logger import logger
 
 import spack.util.spack_json as sjson
 import ramble.util.imp
@@ -273,7 +273,7 @@ class FastObjectChecker(Mapping):
                 if not obj_name.startswith('.') and not any(
                     obj_name == obj_info['config'] for obj_info in type_definitions.values()
                 ):
-                    ramble.util.logger.logger.warn(
+                    logger.warn(
                         f'Skipping {self.object_type} '
                         f'at {obj_dir}. "{obj_name}" is not '
                         'a valid Ramble module name.'
@@ -293,7 +293,7 @@ class FastObjectChecker(Mapping):
                     # No application.py file here.
                     continue
                 elif e.errno == errno.EACCES:
-                    ramble.util.logger.logger.warn(
+                    logger.warn(
                         f"Can't read {self.object_type} file {obj_file}."
                     )
                     continue
@@ -556,7 +556,7 @@ class RepoPath(object):
                     repo = Repo(repo, object_type=object_type)
                 self.put_last(repo)
             except RepoError as e:
-                ramble.util.logger.logger.warn(
+                logger.warn(
                     "Failed to initialize repository: '%s'." % repo,
                     e.message,
                     "To remove the bad repository, run this command:",
@@ -697,7 +697,7 @@ class RepoPath(object):
         """Given a spec, get the repository for its object."""
         # We don't @_autospec this function b/c it's called very frequently
         # and we want to avoid parsing str's into Specs unnecessarily.
-        ramble.util.logger.logger.debug(f'Getting repo for obj {spec}')
+        logger.debug(f'Getting repo for obj {spec}')
         namespace = None
         if isinstance(spec, ramble.spec.Spec):
             namespace = spec.namespace
@@ -706,7 +706,7 @@ class RepoPath(object):
             # handle strings directly for speed instead of @_autospec'ing
             namespace, _, name = spec.rpartition('.')
 
-        ramble.util.logger.logger.debug(f' Name and namespace = {namespace} - {name}')
+        logger.debug(f' Name and namespace = {namespace} - {name}')
         # If the spec already has a namespace, then return the
         # corresponding repo if we know about it.
         if namespace:
@@ -718,7 +718,7 @@ class RepoPath(object):
         # If there's no namespace, search in the RepoPath.
         for repo in self.repos:
             if name in repo:
-                ramble.util.logger.logger.debug('Found repo...')
+                logger.debug('Found repo...')
                 return repo
 
         # If the object isn't in any repo, return the one with
@@ -974,14 +974,12 @@ class Repo(object):
 
                 if (not yaml_data or 'repo' not in yaml_data or
                         not isinstance(yaml_data['repo'], dict)):
-                    ramble.util.logger.logger.die(
-                        f"Invalid {self.config_name} in repository {self.root}"
-                    )
+                    logger.die(f"Invalid {self.config_name} in repository {self.root}")
 
                 return yaml_data['repo']
 
         except IOError:
-            ramble.util.logger.logger.die(
+            logger.die(
                 f"Error reading {self.config_file} when opening {self.root}"
             )
 
@@ -992,7 +990,7 @@ class Repo(object):
         # it actually exists, because we have to load it anyway, and that ends
         # up checking for existence. We avoid constructing
         # FastObjectChecker, which will stat all objects.
-        ramble.util.logger.logger.debug(f'Getting obj {spec} from repo')
+        logger.debug(f'Getting obj {spec} from repo')
         if spec.name is None:
             raise UnknownObjectError(None, self)
 
@@ -1006,7 +1004,7 @@ class Repo(object):
             # pass these through as their error messages will be fine.
             raise
         except Exception as e:
-            ramble.util.logger.logger.debug(e)
+            logger.debug(e)
 
             # Make sure other errors in constructors hit the error
             # handler by wrapping them
@@ -1137,10 +1135,10 @@ class Repo(object):
                 raise UnknownObjectError(obj_name, self)
 
             if not os.path.isfile(file_path):
-                ramble.util.logger.logger.die(f"Something's wrong. '{file_path}' is not a file!")
+                logger.die(f"Something's wrong. '{file_path}' is not a file!")
 
             if not os.access(file_path, os.R_OK):
-                ramble.util.logger.logger.die(f"Cannot read '{file_path}'!")
+                logger.die(f"Cannot read '{file_path}'!")
 
             # e.g., ramble.app.builtin.mpich
             fullname = "%s.%s" % (self.full_namespace, obj_name)
@@ -1174,12 +1172,12 @@ class Repo(object):
                                         % (self.namespace, namespace))
 
         class_name = nm.mod_to_class(obj_name)
-        ramble.util.logger.logger.debug(f' Class name = {class_name}')
+        logger.debug(f' Class name = {class_name}')
         module = self._get_obj_module(obj_name)
 
         cls = getattr(module, class_name)
         if not inspect.isclass(cls):
-            ramble.util.logger.logger.die(f"{obj_name}.{class_name} is not a class")
+            logger.die(f"{obj_name}.{class_name} is not a class")
 
         return cls
 

--- a/lib/ramble/ramble/schema/config.py
+++ b/lib/ramble/ramble/schema/config.py
@@ -152,6 +152,22 @@ properties['config']['upload'] = {
     }
 }
 
+properties['config']['disable_passthrough'] = {
+    'type': 'boolean',
+    'default': False
+}
+
+properties['config']['disable_progress_bar'] = {
+    'type': 'boolean',
+    'default': False
+}
+
+properties['config']['disable_logger'] = {
+    'type': 'boolean',
+    'default': False
+}
+
+
 #: Full schema with metadata
 schema = {
     '$schema': 'http://json-schema.org/schema#',

--- a/lib/ramble/ramble/software_environments.py
+++ b/lib/ramble/ramble/software_environments.py
@@ -16,7 +16,7 @@ import ramble.renderer
 import ramble.expander
 from ramble.namespace import namespace
 
-import ramble.util.logger
+from ramble.util.logger import logger
 import ramble.util.matrices
 import ramble.util.colors as rucolor
 
@@ -72,13 +72,13 @@ class SoftwareEnvironments(object):
                 namespace.environments in self.spack_dict:
             conf_type = 'v2'
 
-        ramble.util.logger.logger.debug(f'Detected config type of: {conf_type}')
+        logger.debug(f'Detected config type of: {conf_type}')
 
         return conf_type
 
     def _v2_setup(self):
         """Process a v2 `spack:` dictionary in the workspace configuration."""
-        ramble.util.logger.logger.debug('Performing v2 software setup.')
+        logger.debug('Performing v2 software setup.')
 
         pkg_renderer = ramble.renderer.Renderer()
         env_renderer = ramble.renderer.Renderer()
@@ -205,15 +205,15 @@ class SoftwareEnvironments(object):
                             if 'compiler' in pkg_info and pkg_info['compiler'] in env_packages:
                                 pkgs_with_compiler.append((pkg_name, pkg_info['compiler']))
                         if pkgs_with_compiler:
-                            ramble.util.logger.logger.warn(
+                            logger.warn(
                                 f'Environment {final_name} contains packages and their '
                                 'compilers in the package list. These include:'
                             )
                             for pkg_name, comp_name in pkgs_with_compiler:
-                                ramble.util.logger.logger.warn(
+                                logger.warn(
                                     f'    Package: {pkg_name}, Compiler: {comp_name}'
                                 )
-                            ramble.util.logger.logger.warn(
+                            logger.warn(
                                 'This might cause problems when installing the packages.'
                             )
 

--- a/lib/ramble/ramble/software_environments.py
+++ b/lib/ramble/ramble/software_environments.py
@@ -6,7 +6,6 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-import llnl.util.tty as tty
 import llnl.util.tty.color as color
 
 import ramble.repository
@@ -17,6 +16,7 @@ import ramble.renderer
 import ramble.expander
 from ramble.namespace import namespace
 
+import ramble.util.logger
 import ramble.util.matrices
 import ramble.util.colors as rucolor
 
@@ -72,13 +72,13 @@ class SoftwareEnvironments(object):
                 namespace.environments in self.spack_dict:
             conf_type = 'v2'
 
-        tty.debug(f'Detected config type of: {conf_type}')
+        ramble.util.logger.logger.debug(f'Detected config type of: {conf_type}')
 
         return conf_type
 
     def _v2_setup(self):
         """Process a v2 `spack:` dictionary in the workspace configuration."""
-        tty.debug('Performing v2 software setup.')
+        ramble.util.logger.logger.debug('Performing v2 software setup.')
 
         pkg_renderer = ramble.renderer.Renderer()
         env_renderer = ramble.renderer.Renderer()
@@ -205,11 +205,17 @@ class SoftwareEnvironments(object):
                             if 'compiler' in pkg_info and pkg_info['compiler'] in env_packages:
                                 pkgs_with_compiler.append((pkg_name, pkg_info['compiler']))
                         if pkgs_with_compiler:
-                            tty.warn(f'Environment {final_name} contains packages and their '
-                                     'compilers in the package list. These include:')
+                            ramble.util.logger.logger.warn(
+                                f'Environment {final_name} contains packages and their '
+                                'compilers in the package list. These include:'
+                            )
                             for pkg_name, comp_name in pkgs_with_compiler:
-                                tty.warn(f'    Package: {pkg_name}, Compiler: {comp_name}')
-                            tty.warn('This might cause problems when installing the packages.')
+                                ramble.util.logger.logger.warn(
+                                    f'    Package: {pkg_name}, Compiler: {comp_name}'
+                                )
+                            ramble.util.logger.logger.warn(
+                                'This might cause problems when installing the packages.'
+                            )
 
     def print_environments(self, verbosity=0):
         color.cprint(rucolor.section_title('Software Stack:'))

--- a/lib/ramble/ramble/spack_runner.py
+++ b/lib/ramble/ramble/spack_runner.py
@@ -25,7 +25,7 @@ import spack.util.spack_yaml as syaml
 import ramble.config
 import ramble.error
 import ramble.util.hashing
-import ramble.util.logger
+from ramble.util.logger import logger
 
 import spack.util.spack_json as sjson
 
@@ -156,7 +156,7 @@ class SpackRunner(object):
         if require_exists:
             if not os.path.isdir(env_path) or \
                     not os.path.exists(os.path.join(env_path, 'spack.yaml')):
-                ramble.util.logger.logger.die(f'Path {env_path} is not a spack environment')
+                logger.die(f'Path {env_path} is not a spack environment')
 
         self.env_path = env_path
 
@@ -221,7 +221,7 @@ class SpackRunner(object):
         if not self.dry_run:
             if not os.path.exists(os.path.join(path, 'spack.yaml')):
                 with fs.working_dir(path):
-                    active_stream = ramble.util.logger.logger.active_stream()
+                    active_stream = logger.active_stream()
                     self.spack(*self.env_create_args,
                                output=active_stream,
                                error=active_stream)
@@ -265,7 +265,7 @@ class SpackRunner(object):
         ]
 
         if not self.dry_run:
-            active_stream = ramble.util.logger.logger.active_stream()
+            active_stream = logger.active_stream()
             load_cmds = self.spack(*args, output=str, error=active_stream).split('\n')
 
             for cmd in load_cmds:
@@ -307,7 +307,7 @@ class SpackRunner(object):
             comp_info_args.extend(['-C', self.env_path])
         comp_info_args.extend(['compiler', 'info', spec])
 
-        active_stream = ramble.util.logger.logger.active_stream()
+        active_stream = logger.active_stream()
         compiler_find_flags = ramble.config.get(f'{self.compiler_find_config_name}:flags')
         compiler_find_args = self.compiler_find_args.copy()
         if compiler_find_flags:
@@ -320,7 +320,7 @@ class SpackRunner(object):
 
         try:
             self.spack(*comp_info_args, output=os.devnull, error=os.devnull)
-            ramble.util.logger.logger.msg(f'{spec} is already an available compiler')
+            logger.msg(f'{spec} is already an available compiler')
             return
         except ProcessError:
 
@@ -414,7 +414,7 @@ class SpackRunner(object):
 
         pkg_names = []
 
-        active_stream = ramble.util.logger.logger.active_stream()
+        active_stream = logger.active_stream()
         for pkg in self.spack(*args, output=str, error=active_stream).split('\n'):
             match = package_name_regex.match(pkg)
             if match:
@@ -449,7 +449,7 @@ class SpackRunner(object):
             'add'
         ]
 
-        active_stream = ramble.util.logger.logger.active_stream()
+        active_stream = logger.active_stream()
         for config in self.configs:
             args = config_args.copy()
             args.append(config)
@@ -490,7 +490,7 @@ class SpackRunner(object):
         path = env_name_or_path
         if not os.path.exists(path):
             try:
-                active_stream = ramble.util.logger.logger.active_stream()
+                active_stream = logger.active_stream()
                 path = self.spack(*named_location_args, output=str,
                                   error=active_stream).strip('\n')
             # If a named environment fails, copy directly from the path
@@ -556,15 +556,11 @@ class SpackRunner(object):
                 # If the yaml hash matches the new generated data hash...
                 if gen_env_hash == existing_env_hash:
                     self.concretized = True
-                    ramble.util.logger.logger.msg(
-                        f'Environment {self.env_path} will not be regenerated.'
-                    )
+                    logger.msg(f'Environment {self.env_path} will not be regenerated.')
                     return
 
             if not self.concretized:
-                ramble.util.logger.logger.verbose(
-                    f'Removing invalid spack lock file {spack_lock_file}'
-                )
+                logger.verbose(f'Removing invalid spack lock file {spack_lock_file}')
                 fs.force_remove(spack_lock_file)
 
         # Write spack.yaml to environment before concretizing
@@ -583,7 +579,7 @@ class SpackRunner(object):
         self._check_active()
 
         if self.concretized:
-            ramble.util.logger.logger.msg(
+            logger.msg(
                 f'Environment {self.env_path} is already concretized. Skipping concretize...'
             )
             return
@@ -595,7 +591,7 @@ class SpackRunner(object):
             args.extend(shlex.split(concretize_flags))
 
         if not self.dry_run:
-            active_stream = ramble.util.logger.logger.active_stream()
+            active_stream = logger.active_stream()
             self.concretizer(*args, output=active_stream, error=active_stream)
         else:
             self._dry_run_print(self.concretizer, args)
@@ -616,7 +612,7 @@ class SpackRunner(object):
 
         if not self.dry_run:
             if not lock_exists and require_exist:
-                ramble.util.logger.logger.die(
+                logger.die(
                     'spack.lock file does not exist in environment '
                     f'{self.env_path}\n'
                     'Make sure your workspace is fully setup with\n'
@@ -654,7 +650,7 @@ class SpackRunner(object):
             args.extend(shlex.split(install_flags))
 
         if not self.dry_run:
-            active_stream = ramble.util.logger.logger.active_stream()
+            active_stream = logger.active_stream()
             self.installer(*args, output=active_stream, error=active_stream)
         else:
             self._dry_run_print(self.installer, args)
@@ -668,7 +664,7 @@ class SpackRunner(object):
         name_args.extend(package_spec.split())
 
         if not self.dry_run:
-            active_stream = ramble.util.logger.logger.active_stream()
+            active_stream = logger.active_stream()
             name = self.spack(*name_args, output=str, error=active_stream).strip()
             location = self.spack(*loc_args, output=str, error=active_stream).strip()
             return (name, location)
@@ -694,7 +690,7 @@ class SpackRunner(object):
         ]
 
         if not self.dry_run:
-            active_stream = ramble.util.logger.logger.active_stream()
+            active_stream = logger.active_stream()
             return self.spack(*args, output=str, error=active_stream).strip()
         else:
             self._dry_run_print(self.spack, args)
@@ -710,7 +706,7 @@ class SpackRunner(object):
             '--format',
             '/{hash}'
         ]
-        active_stream = ramble.util.logger.logger.active_stream()
+        active_stream = logger.active_stream()
         output = self.spack(*args, output=str, error=active_stream).strip().replace('\n', ' ')
         return output
 
@@ -726,7 +722,7 @@ class SpackRunner(object):
         ]
         user_flags = ramble.config.get(f'{self.buildcache_config_name}:flags')
 
-        ramble.util.logger.logger.debug(f"Running with user flags: {user_flags}")
+        logger.debug(f"Running with user flags: {user_flags}")
 
         if user_flags is not None:
             args.extend(shlex.split(user_flags))
@@ -734,15 +730,15 @@ class SpackRunner(object):
         args.extend([spack_cache_path, hash_list])
 
         if not self.dry_run:
-            active_stream = ramble.util.logger.logger.active_stream()
+            active_stream = logger.active_stream()
             return self.spack(*args, output=str, error=active_stream).strip()
         else:
             self._dry_run_print(self.spack, args)
             return
 
     def _dry_run_print(self, executable, args):
-        ramble.util.logger.logger.msg(f'DRY-RUN: would run {executable}')
-        ramble.util.logger.logger.msg(f'         with args: {args}')
+        logger.msg(f'DRY-RUN: would run {executable}')
+        logger.msg(f'         with args: {args}')
 
 
 class RunnerError(ramble.error.RambleError):

--- a/lib/ramble/ramble/spec.py
+++ b/lib/ramble/ramble/spec.py
@@ -13,6 +13,7 @@ import llnl.util.tty.color as clr
 
 import ramble.repository
 import ramble.error
+from ramble.util.logger import logger
 
 import spack.parse
 
@@ -75,7 +76,7 @@ class SpecParser(spack.parse.Parser):
                 directly into. This is used to avoid construction of a
                 superfluous Spec object in the Spec constructor.
         """
-        ramble.util.logger.logger.debug('Starting parser with spec %s' % (initial_spec))
+        logger.debug(f'Starting parser with spec {initial_spec}')
         super(SpecParser, self).__init__(_lexer)
         self.previous = None
         self._initial = initial_spec

--- a/lib/ramble/ramble/spec.py
+++ b/lib/ramble/ramble/spec.py
@@ -9,7 +9,6 @@
 import os
 import six
 
-import llnl.util.tty as tty
 import llnl.util.tty.color as clr
 
 import ramble.repository
@@ -76,7 +75,7 @@ class SpecParser(spack.parse.Parser):
                 directly into. This is used to avoid construction of a
                 superfluous Spec object in the Spec constructor.
         """
-        tty.debug('Starting parser with spec %s' % (initial_spec))
+        ramble.util.logger.logger.debug('Starting parser with spec %s' % (initial_spec))
         super(SpecParser, self).__init__(_lexer)
         self.previous = None
         self._initial = initial_spec

--- a/lib/ramble/ramble/stage.py
+++ b/lib/ramble/ramble/stage.py
@@ -38,7 +38,7 @@ import ramble.fetch_strategy as fs
 import ramble.util.lock
 import ramble.error
 import ramble.mirror
-import ramble.util.logger
+from ramble.util.logger import logger
 
 
 # The well-known stage source subdirectory name.
@@ -67,12 +67,12 @@ def create_stage_root(path):
 
             p_stat = os.stat(p)
             if par_stat.st_gid != p_stat.st_gid:
-                ramble.util.logger.logger.warn(f"Expected {p} to have group "
-                                               f"{par_stat.st_gid}, but it is {p_stat.st_gid}")
+                logger.warn(f"Expected {p} to have group "
+                            f"{par_stat.st_gid}, but it is {p_stat.st_gid}")
 
             if par_stat.st_mode & p_stat.st_mode != par_stat.st_mode:
-                ramble.util.logger.logger.warn(f"Expected {p} to support mode "
-                                               f"{par_stat.st_mode}, but it is {p_stat.st_mode}")
+                logger.warn(f"Expected {p} to support mode "
+                            f"{par_stat.st_mode}, but it is {p_stat.st_mode}")
 
             if not can_access(p):
                 raise OSError(errno.EACCES, err_msg.format(path, p))
@@ -90,8 +90,8 @@ def create_stage_root(path):
 
             p_stat = os.stat(p)
             if p_stat.st_mode & stat.S_IRWXU != stat.S_IRWXU:
-                ramble.util.logger.logger.error(f"Expected {p} to support mode "
-                                                f"{stat.S_IRWXU}, but it is {p_stat.st_mode}")
+                logger.error(f"Expected {p} to support mode "
+                             f"{stat.S_IRWXU}, but it is {p_stat.st_mode}")
 
                 raise OSError(errno.EACCES, err_msg.format(path, p))
         else:
@@ -124,7 +124,7 @@ def _first_accessible_path(paths):
                 return path
 
         except OSError as e:
-            ramble.util.logger.logger.debug(f'OSError while checking stage path {path}: {e}')
+            logger.debug(f'OSError while checking stage path {path}: {e}')
 
     return None
 
@@ -290,7 +290,7 @@ class InputStage(object):
                 lock_id = prefix_bits(sha1, bit_length(sys.maxsize))
                 stage_lock_path = os.path.join(self.path, '.lock')
 
-                ramble.util.logger.logger.debug(f"Creating stage lock {self.name}")
+                logger.debug(f"Creating stage lock {self.name}")
                 InputStage.stage_locks[self.name] = ramble.util.lock.Lock(
                     stage_lock_path, lock_id, 1, desc=self.name)
 
@@ -451,7 +451,7 @@ class InputStage(object):
 
         def print_errors(errors):
             for msg in errors:
-                ramble.util.logger.logger.debug(msg)
+                logger.debug(msg)
 
         errors = []
         for fetcher in generate_fetchers():
@@ -465,11 +465,11 @@ class InputStage(object):
                 continue
             except ramble.error.RambleError as e:
                 errors.append('Fetching from {0} failed.'.format(fetcher))
-                ramble.util.logger.logger.debug(e)
+                logger.debug(e)
                 continue
             except spack.util.web.SpackWebError as e:
                 errors.append('Fetching from {0} failed.'.format(fetcher))
-                ramble.util.logger.logger.debug(e)
+                logger.debug(e)
                 continue
 
         else:
@@ -520,12 +520,12 @@ class InputStage(object):
            No-op if this stage checks code out of a repository."""
         if self.fetcher is not self.default_fetcher and \
            self.skip_checksum_for_mirror:
-            ramble.util.logger.logger.warn("Fetching from mirror without a checksum!",
-                                           "This input is normally checked out from a version "
-                                           "control system, but it has been archived on a "
-                                           "mirror.  This means we cannot know a checksum for the "
-                                           "tarball in advance. Be sure that your connection to "
-                                           "this mirror is secure!")
+            logger.warn("Fetching from mirror without a checksum!",
+                        "This input is normally checked out from a version "
+                        "control system, but it has been archived on a "
+                        "mirror.  This means we cannot know a checksum for the "
+                        "tarball in advance. Be sure that your connection to "
+                        "this mirror is secure!")
         elif ramble.config.get('config:checksum'):
             self.fetcher.check()
 
@@ -558,15 +558,15 @@ class InputStage(object):
             mirror.root, self.mirror_paths.storage_path)
 
         if os.path.exists(absolute_storage_path):
-            ramble.util.logger.logger.debug(f'Already existed: {absolute_storage_path}')
+            logger.debug(f'Already existed: {absolute_storage_path}')
             stats.already_existed(absolute_storage_path)
-            ramble.util.logger.logger.debug(f'   Stats? {stats.present}')
+            logger.debug(f'   Stats? {stats.present}')
         else:
             self.fetch()
             self.check()
             mirror.store(
                 self.fetcher, self.mirror_paths.storage_path)
-            ramble.util.logger.logger.debug(f'Added: {absolute_storage_path}')
+            logger.debug(f'Added: {absolute_storage_path}')
             stats.added(absolute_storage_path)
 
         if not os.path.exists(absolute_storage_path):
@@ -580,9 +580,9 @@ class InputStage(object):
         downloaded."""
         if not self.expanded:
             self.fetcher.expand()
-            ramble.util.logger.logger.debug(f'Created stage in {self.path}')
+            logger.debug(f'Created stage in {self.path}')
         else:
-            ramble.util.logger.logger.debug(f'Already staged {self.name} in {self.path}')
+            logger.debug(f'Already staged {self.name} in {self.path}')
 
     def restage(self):
         """Removes the expanded archive path if it exists, then re-expands
@@ -613,7 +613,7 @@ class InputStage(object):
         try:
             os.getcwd()
         except OSError as e:
-            ramble.util.logger.logger.debug(e)
+            logger.debug(e)
             os.chdir(os.path.dirname(self.path))
 
         # mark as destroyed
@@ -658,7 +658,7 @@ class ResourceStage(InputStage):
         try:
             os.makedirs(target_path)
         except OSError as err:
-            ramble.util.logger.logger.debug(err)
+            logger.debug(err)
             if err.errno == errno.EEXIST and os.path.isdir(target_path):
                 pass
             else:
@@ -669,10 +669,10 @@ class ResourceStage(InputStage):
             source_path = os.path.join(self.source_path, key)
 
             if not os.path.exists(destination_path):
-                ramble.util.logger.logger.info('Moving resource stage\n\tsource : '
-                                               '{stage}\n\tdestination : {destination}'.format(
-                                                   stage=source_path, destination=destination_path
-                                               ))
+                logger.info('Moving resource stage\n\tsource : '
+                            '{stage}\n\tdestination : {destination}'.format(
+                                stage=source_path, destination=destination_path)
+                            )
 
                 src = os.path.realpath(source_path)
 
@@ -756,13 +756,13 @@ class DIYStage(object):
         pass
 
     def fetch(self, *args, **kwargs):
-        ramble.util.logger.logger.debug('No need to fetch for DIY.')
+        logger.debug('No need to fetch for DIY.')
 
     def check(self):
-        ramble.util.logger.logger.debug('No checksum needed for DIY.')
+        logger.debug('No checksum needed for DIY.')
 
     def expand_archive(self):
-        ramble.util.logger.logger.debug(f'Using source directory: {self.source_path}')
+        logger.debug(f'Using source directory: {self.source_path}')
 
     @property
     def expanded(self):
@@ -780,13 +780,13 @@ class DIYStage(object):
         pass
 
     def cache_local(self):
-        ramble.util.logger.logger.debug('Sources for DIY stages are not cached')
+        logger.debug('Sources for DIY stages are not cached')
 
 
 def ensure_access(file):
     """Ensure we can access a directory and die with an error if we can't."""
     if not can_access(file):
-        ramble.util.logger.logger.die(f"Insufficient permissions for {file}")
+        logger.die(f"Insufficient permissions for {file}")
 
 
 # TODO (dwj): Need to add checksums for inputs.
@@ -821,12 +821,12 @@ def get_checksums_for_versions(
     max_len = max(len(str(v)) for v in sorted_versions)
     num_ver = len(sorted_versions)
 
-    ramble.util.logger.logger.msg('Found {0} version{1} of {2}:'.format(
-                                  num_ver, '' if num_ver == 1 else 's', name),
-                                  '',
-                                  *llnl.util.lang.elide_list(
-                                      ['{0:{1}}  {2}'.format(str(v), max_len, url_dict[v])
-                                       for v in sorted_versions]))
+    logger.msg('Found {0} version{1} of {2}:'.format(
+               num_ver, '' if num_ver == 1 else 's', name),
+               '',
+               *llnl.util.lang.elide_list(
+                   ['{0:{1}}  {2}'.format(str(v), max_len, url_dict[v])
+                    for v in sorted_versions]))
     print()
 
     if batch:
@@ -836,12 +836,12 @@ def get_checksums_for_versions(
             "How many would you like to checksum?", default=1, abort='q')
 
     if not archives_to_fetch:
-        ramble.util.logger.logger.die("Aborted.")
+        logger.die("Aborted.")
 
     versions = sorted_versions[:archives_to_fetch]
     urls = [url_dict[v] for v in versions]
 
-    ramble.util.logger.logger.debug('Downloading...')
+    logger.debug('Downloading...')
     version_hashes = []
     i = 0
     errors = []
@@ -867,13 +867,13 @@ def get_checksums_for_versions(
         except FailedDownloadError:
             errors.append('Failed to fetch {0}'.format(url))
         except Exception as e:
-            ramble.util.logger.logger.msg(f'Something failed on {url}, skipping.  ({e})')
+            logger.msg(f'Something failed on {url}, skipping.  ({e})')
 
     for msg in errors:
-        ramble.util.logger.logger.debug(msg)
+        logger.debug(msg)
 
     if not version_hashes:
-        ramble.util.logger.logger.die(f"Could not fetch any versions for {name}")
+        logger.die(f"Could not fetch any versions for {name}")
 
     # Find length of longest string in the list for padding
     max_len = max(len(str(v)) for v, h in version_hashes)
@@ -885,8 +885,8 @@ def get_checksums_for_versions(
     ])
 
     num_hash = len(version_hashes)
-    ramble.util.logger.logger.debug('Checksummed {0} version{1} of {2}:'.format(
-                                    num_hash, '' if num_hash == 1 else 's', name))
+    logger.debug('Checksummed {0} version{1} of {2}:'.format(
+                 num_hash, '' if num_hash == 1 else 's', name))
 
     return version_lines
 

--- a/lib/ramble/ramble/stage.py
+++ b/lib/ramble/ramble/stage.py
@@ -38,6 +38,7 @@ import ramble.fetch_strategy as fs
 import ramble.util.lock
 import ramble.error
 import ramble.mirror
+import ramble.util.logger
 
 
 # The well-known stage source subdirectory name.
@@ -66,12 +67,12 @@ def create_stage_root(path):
 
             p_stat = os.stat(p)
             if par_stat.st_gid != p_stat.st_gid:
-                tty.warn("Expected {0} to have group {1}, but it is {2}"
-                         .format(p, par_stat.st_gid, p_stat.st_gid))
+                ramble.util.logger.logger.warn(f"Expected {p} to have group "
+                                               f"{par_stat.st_gid}, but it is {p_stat.st_gid}")
 
             if par_stat.st_mode & p_stat.st_mode != par_stat.st_mode:
-                tty.warn("Expected {0} to support mode {1}, but it is {2}"
-                         .format(p, par_stat.st_mode, p_stat.st_mode))
+                ramble.util.logger.logger.warn(f"Expected {p} to support mode "
+                                               f"{par_stat.st_mode}, but it is {p_stat.st_mode}")
 
             if not can_access(p):
                 raise OSError(errno.EACCES, err_msg.format(path, p))
@@ -89,8 +90,8 @@ def create_stage_root(path):
 
             p_stat = os.stat(p)
             if p_stat.st_mode & stat.S_IRWXU != stat.S_IRWXU:
-                tty.error("Expected {0} to support mode {1}, but it is {2}"
-                          .format(p, stat.S_IRWXU, p_stat.st_mode))
+                ramble.util.logger.logger.error(f"Expected {p} to support mode "
+                                                f"{stat.S_IRWXU}, but it is {p_stat.st_mode}")
 
                 raise OSError(errno.EACCES, err_msg.format(path, p))
         else:
@@ -123,8 +124,7 @@ def _first_accessible_path(paths):
                 return path
 
         except OSError as e:
-            tty.debug('OSError while checking stage path %s: %s' % (
-                      path, str(e)))
+            ramble.util.logger.logger.debug(f'OSError while checking stage path {path}: {e}')
 
     return None
 
@@ -290,7 +290,7 @@ class InputStage(object):
                 lock_id = prefix_bits(sha1, bit_length(sys.maxsize))
                 stage_lock_path = os.path.join(self.path, '.lock')
 
-                tty.debug("Creating stage lock {0}".format(self.name))
+                ramble.util.logger.logger.debug(f"Creating stage lock {self.name}")
                 InputStage.stage_locks[self.name] = ramble.util.lock.Lock(
                     stage_lock_path, lock_id, 1, desc=self.name)
 
@@ -451,7 +451,7 @@ class InputStage(object):
 
         def print_errors(errors):
             for msg in errors:
-                tty.debug(msg)
+                ramble.util.logger.logger.debug(msg)
 
         errors = []
         for fetcher in generate_fetchers():
@@ -465,11 +465,11 @@ class InputStage(object):
                 continue
             except ramble.error.RambleError as e:
                 errors.append('Fetching from {0} failed.'.format(fetcher))
-                tty.debug(e)
+                ramble.util.logger.logger.debug(e)
                 continue
             except spack.util.web.SpackWebError as e:
                 errors.append('Fetching from {0} failed.'.format(fetcher))
-                tty.debug(e)
+                ramble.util.logger.logger.debug(e)
                 continue
 
         else:
@@ -520,12 +520,12 @@ class InputStage(object):
            No-op if this stage checks code out of a repository."""
         if self.fetcher is not self.default_fetcher and \
            self.skip_checksum_for_mirror:
-            tty.warn("Fetching from mirror without a checksum!",
-                     "This input is normally checked out from a version "
-                     "control system, but it has been archived on a "
-                     "mirror.  This means we cannot know a checksum for the "
-                     "tarball in advance. Be sure that your connection to "
-                     "this mirror is secure!")
+            ramble.util.logger.logger.warn("Fetching from mirror without a checksum!",
+                                           "This input is normally checked out from a version "
+                                           "control system, but it has been archived on a "
+                                           "mirror.  This means we cannot know a checksum for the "
+                                           "tarball in advance. Be sure that your connection to "
+                                           "this mirror is secure!")
         elif ramble.config.get('config:checksum'):
             self.fetcher.check()
 
@@ -558,15 +558,15 @@ class InputStage(object):
             mirror.root, self.mirror_paths.storage_path)
 
         if os.path.exists(absolute_storage_path):
-            tty.debug('Already existed: %s' % absolute_storage_path)
+            ramble.util.logger.logger.debug(f'Already existed: {absolute_storage_path}')
             stats.already_existed(absolute_storage_path)
-            tty.debug('   Stats? %s' % stats.present)
+            ramble.util.logger.logger.debug(f'   Stats? {stats.present}')
         else:
             self.fetch()
             self.check()
             mirror.store(
                 self.fetcher, self.mirror_paths.storage_path)
-            tty.debug('Added: %s' % absolute_storage_path)
+            ramble.util.logger.logger.debug(f'Added: {absolute_storage_path}')
             stats.added(absolute_storage_path)
 
         if not os.path.exists(absolute_storage_path):
@@ -580,9 +580,9 @@ class InputStage(object):
         downloaded."""
         if not self.expanded:
             self.fetcher.expand()
-            tty.debug('Created stage in {0}'.format(self.path))
+            ramble.util.logger.logger.debug(f'Created stage in {self.path}')
         else:
-            tty.debug('Already staged {0} in {1}'.format(self.name, self.path))
+            ramble.util.logger.logger.debug(f'Already staged {self.name} in {self.path}')
 
     def restage(self):
         """Removes the expanded archive path if it exists, then re-expands
@@ -613,7 +613,7 @@ class InputStage(object):
         try:
             os.getcwd()
         except OSError as e:
-            tty.debug(e)
+            ramble.util.logger.logger.debug(e)
             os.chdir(os.path.dirname(self.path))
 
         # mark as destroyed
@@ -658,7 +658,7 @@ class ResourceStage(InputStage):
         try:
             os.makedirs(target_path)
         except OSError as err:
-            tty.debug(err)
+            ramble.util.logger.logger.debug(err)
             if err.errno == errno.EEXIST and os.path.isdir(target_path):
                 pass
             else:
@@ -669,10 +669,10 @@ class ResourceStage(InputStage):
             source_path = os.path.join(self.source_path, key)
 
             if not os.path.exists(destination_path):
-                tty.info('Moving resource stage\n\tsource : '
-                         '{stage}\n\tdestination : {destination}'.format(
-                             stage=source_path, destination=destination_path
-                         ))
+                ramble.util.logger.logger.info('Moving resource stage\n\tsource : '
+                                               '{stage}\n\tdestination : {destination}'.format(
+                                                   stage=source_path, destination=destination_path
+                                               ))
 
                 src = os.path.realpath(source_path)
 
@@ -756,13 +756,13 @@ class DIYStage(object):
         pass
 
     def fetch(self, *args, **kwargs):
-        tty.debug('No need to fetch for DIY.')
+        ramble.util.logger.logger.debug('No need to fetch for DIY.')
 
     def check(self):
-        tty.debug('No checksum needed for DIY.')
+        ramble.util.logger.logger.debug('No checksum needed for DIY.')
 
     def expand_archive(self):
-        tty.debug('Using source directory: {0}'.format(self.source_path))
+        ramble.util.logger.logger.debug(f'Using source directory: {self.source_path}')
 
     @property
     def expanded(self):
@@ -780,13 +780,13 @@ class DIYStage(object):
         pass
 
     def cache_local(self):
-        tty.debug('Sources for DIY stages are not cached')
+        ramble.util.logger.logger.debug('Sources for DIY stages are not cached')
 
 
 def ensure_access(file):
     """Ensure we can access a directory and die with an error if we can't."""
     if not can_access(file):
-        tty.die("Insufficient permissions for %s" % file)
+        ramble.util.logger.logger.die(f"Insufficient permissions for {file}")
 
 
 # TODO (dwj): Need to add checksums for inputs.
@@ -821,12 +821,12 @@ def get_checksums_for_versions(
     max_len = max(len(str(v)) for v in sorted_versions)
     num_ver = len(sorted_versions)
 
-    tty.msg('Found {0} version{1} of {2}:'.format(
-            num_ver, '' if num_ver == 1 else 's', name),
-            '',
-            *llnl.util.lang.elide_list(
-                ['{0:{1}}  {2}'.format(str(v), max_len, url_dict[v])
-                 for v in sorted_versions]))
+    ramble.util.logger.logger.msg('Found {0} version{1} of {2}:'.format(
+                                  num_ver, '' if num_ver == 1 else 's', name),
+                                  '',
+                                  *llnl.util.lang.elide_list(
+                                      ['{0:{1}}  {2}'.format(str(v), max_len, url_dict[v])
+                                       for v in sorted_versions]))
     print()
 
     if batch:
@@ -836,12 +836,12 @@ def get_checksums_for_versions(
             "How many would you like to checksum?", default=1, abort='q')
 
     if not archives_to_fetch:
-        tty.die("Aborted.")
+        ramble.util.logger.logger.die("Aborted.")
 
     versions = sorted_versions[:archives_to_fetch]
     urls = [url_dict[v] for v in versions]
 
-    tty.debug('Downloading...')
+    ramble.util.logger.logger.debug('Downloading...')
     version_hashes = []
     i = 0
     errors = []
@@ -867,13 +867,13 @@ def get_checksums_for_versions(
         except FailedDownloadError:
             errors.append('Failed to fetch {0}'.format(url))
         except Exception as e:
-            tty.msg('Something failed on {0}, skipping.  ({1})'.format(url, e))
+            ramble.util.logger.logger.msg(f'Something failed on {url}, skipping.  ({e})')
 
     for msg in errors:
-        tty.debug(msg)
+        ramble.util.logger.logger.debug(msg)
 
     if not version_hashes:
-        tty.die("Could not fetch any versions for {0}".format(name))
+        ramble.util.logger.logger.die(f"Could not fetch any versions for {name}")
 
     # Find length of longest string in the list for padding
     max_len = max(len(str(v)) for v, h in version_hashes)
@@ -885,8 +885,8 @@ def get_checksums_for_versions(
     ])
 
     num_hash = len(version_hashes)
-    tty.debug('Checksummed {0} version{1} of {2}:'.format(
-              num_hash, '' if num_hash == 1 else 's', name))
+    ramble.util.logger.logger.debug('Checksummed {0} version{1} of {2}:'.format(
+                                    num_hash, '' if num_hash == 1 else 's', name))
 
     return version_lines
 

--- a/lib/ramble/ramble/success_criteria.py
+++ b/lib/ramble/ramble/success_criteria.py
@@ -9,7 +9,7 @@
 import re
 import fnmatch
 
-import ramble.util.logger
+from ramble.util.logger import logger
 
 
 class ScopedCriteriaList(object):
@@ -51,14 +51,14 @@ class ScopedCriteriaList(object):
 
     def validate_scope(self, scope):
         if scope not in self._valid_scopes:
-            ramble.util.logger.logger.die(f'Success scope {scope} is not valid. '
-                                          f'Possible scopes are: {self._valid_scopes}')
+            logger.die(f'Success scope {scope} is not valid. '
+                       f'Possible scopes are: {self._valid_scopes}')
 
     def add_criteria(self, scope, name, mode, *args, **kwargs):
         self.validate_scope(scope)
         exists = self.find_criteria(name)
         if exists:
-            ramble.util.logger.logger.die(f'Success criteria {name} is not unique.')
+            logger.die(f'Success criteria {name} is not unique.')
 
         self.criteria[scope].append(SuccessCriteria(name, mode, *args, **kwargs))
 
@@ -70,10 +70,10 @@ class ScopedCriteriaList(object):
         self.validate_scope(scope)
 
         for scope in self._flush_scopes[scope]:
-            ramble.util.logger.logger.debug(' Flushing scope: %s' % scope)
-            ramble.util.logger.logger.debug('    It contained:')
+            logger.debug(f' Flushing scope: {scope}')
+            logger.debug('    It contained:')
             for crit in self.criteria[scope]:
-                ramble.util.logger.logger.debug('      %s' % crit.name)
+                logger.debug(f'      {crit.name}')
             del self.criteria[scope]
             self.criteria[scope] = []
 
@@ -111,7 +111,7 @@ class SuccessCriteria(object):
                  fom_name=None, fom_context='null', formula=None):
         self.name = name
         if mode not in self._valid_modes:
-            ramble.util.logger.logger.die(
+            logger.die(
                 f'{mode} is not valid. Possible modes are: {self._valid_modes}'
             )
 
@@ -125,22 +125,22 @@ class SuccessCriteria(object):
 
         if mode == 'string':
             if match is None:
-                ramble.util.logger.logger.die(f'Success criteria with mode="{mode}" '
-                                              'require a "match" attribute.')
+                logger.die(f'Success criteria with mode="{mode}" '
+                           'require a "match" attribute.')
 
             self.match = re.compile(match)
             self.file = file
 
         elif mode == 'fom_comparison':
             if formula is None or fom_name is None:
-                ramble.util.logger.logger.die(f'Success criteria with mode="{mode}" '
-                                              'require a "fom_name" and "formula" attribute.')
+                logger.die(f'Success criteria with mode="{mode}" '
+                           'require a "fom_name" and "formula" attribute.')
             self.formula = formula
             self.fom_name = fom_name
             self.fom_context = fom_context
 
     def passed(self, test=None, app_inst=None, fom_values=None):
-        ramble.util.logger.logger.debug(f'Testing criteria {self.name} mode = {self.mode}')
+        logger.debug(f'Testing criteria {self.name} mode = {self.mode}')
         if self.mode == 'string':
             match_obj = self.match.match(test)
             if match_obj:
@@ -151,12 +151,12 @@ class SuccessCriteria(object):
                 return func()
         elif self.mode == 'fom_comparison':
             if fom_values is None:
-                ramble.util.logger.logger.die(f'Success criteria of mode="{self.mode}" requires '
-                                              'defined fom_values attribute in "passed" function.')
+                logger.die(f'Success criteria of mode="{self.mode}" requires '
+                           'defined fom_values attribute in "passed" function.')
 
             if app_inst is None:
-                ramble.util.logger.logger.die(f'Success criteria of mode="{self.mode}" requires '
-                                              'defined app_inst attribute in "passed" function.')
+                logger.die(f'Success criteria of mode="{self.mode}" requires '
+                           'defined app_inst attribute in "passed" function.')
 
             comparison_tested = False
             result = True
@@ -165,7 +165,7 @@ class SuccessCriteria(object):
                                       app_inst.expander.expand_var(self.fom_context))
             # If fom context doesn't exist, fail the comparison
             if not contexts:
-                ramble.util.logger.logger.debug(
+                logger.debug(
                     f'When checking success criteria "{self.name}" FOM '
                     f'context "{self.fom_context}" matches no contexts.'
                 )
@@ -186,7 +186,7 @@ class SuccessCriteria(object):
 
             # If fom doesn't match any fom names, fail the comparison
             if not comparison_tested:
-                ramble.util.logger.logger.debug(
+                logger.debug(
                     f'When checking success criteria "{self.name}" FOM '
                     f'"{self.fom_name}" did not match any FOMs.'
                 )
@@ -196,7 +196,7 @@ class SuccessCriteria(object):
         return False
 
     def mark_found(self):
-        ramble.util.logger.logger.debug(f'   {self.name} was matched!')
+        logger.debug(f'   {self.name} was matched!')
         self.found = True
 
     def reset_found(self):

--- a/lib/ramble/ramble/test/commands.py
+++ b/lib/ramble/ramble/test/commands.py
@@ -8,9 +8,8 @@
 
 import pytest
 
-import llnl.util.tty as tty
-
 from ramble.main import RambleCommand, RambleCommandError
+import ramble.util.logger  # noqa:  F401
 
 
 def test_missing_command():
@@ -24,6 +23,6 @@ def test_available_command():
     import ramble.cmd
 
     for command in ramble.cmd.all_commands():
-        tty.msg('Command = %s' % command)
+        ramble.util.logger.logger.msg('Command = %s' % command)
 
         RambleCommand(command)

--- a/lib/ramble/ramble/test/commands.py
+++ b/lib/ramble/ramble/test/commands.py
@@ -9,7 +9,7 @@
 import pytest
 
 from ramble.main import RambleCommand, RambleCommandError
-import ramble.util.logger  # noqa:  F401
+from ramble.util.logger import logger  # noqa:  F401
 
 
 def test_missing_command():
@@ -23,6 +23,6 @@ def test_available_command():
     import ramble.cmd
 
     for command in ramble.cmd.all_commands():
-        ramble.util.logger.logger.msg('Command = %s' % command)
+        logger.msg(f'Command = {command}')
 
         RambleCommand(command)

--- a/lib/ramble/ramble/util/editor.py
+++ b/lib/ramble/ramble/util/editor.py
@@ -19,7 +19,7 @@ import os
 import shlex
 
 import ramble.config
-import ramble.util.logger
+from ramble.util.logger import logger
 from spack.util.executable import which_string
 
 
@@ -94,7 +94,7 @@ def editor(*args, **kwargs):
             # Show variable we were trying to use, if it's from one
             if var:
                 exe = '$%s (%s)' % (var, exe)
-            ramble.util.logger.logger.warn(f'Could not execute {exe} due to error: {e}')
+            logger.warn(f'Could not execute {exe} due to error: {e}')
             return False
 
     def try_env_var(var):
@@ -108,7 +108,7 @@ def editor(*args, **kwargs):
 
         exe, editor_args = _find_exe_from_env_var(var)
         if not exe:
-            ramble.util.logger.logger.warn(f'${var} is not an executable: {os.environ[var]}')
+            logger.warn(f'${var} is not an executable: {os.environ[var]}')
             return False
 
         full_args = editor_args + list(args)

--- a/lib/ramble/ramble/util/editor.py
+++ b/lib/ramble/ramble/util/editor.py
@@ -18,9 +18,8 @@ raising an EnvironmentError if we are unable to find one.
 import os
 import shlex
 
-import llnl.util.tty as tty
-
 import ramble.config
+import ramble.util.logger
 from spack.util.executable import which_string
 
 
@@ -95,7 +94,7 @@ def editor(*args, **kwargs):
             # Show variable we were trying to use, if it's from one
             if var:
                 exe = '$%s (%s)' % (var, exe)
-            tty.warn('Could not execute %s due to error:' % exe, str(e))
+            ramble.util.logger.logger.warn(f'Could not execute {exe} due to error: {e}')
             return False
 
     def try_env_var(var):
@@ -109,7 +108,7 @@ def editor(*args, **kwargs):
 
         exe, editor_args = _find_exe_from_env_var(var)
         if not exe:
-            tty.warn('$%s is not an executable:' % var, os.environ[var])
+            ramble.util.logger.logger.warn(f'${var} is not an executable: {os.environ[var]}')
             return False
 
         full_args = editor_args + list(args)

--- a/lib/ramble/ramble/util/executable.py
+++ b/lib/ramble/ramble/util/executable.py
@@ -9,8 +9,6 @@
 import six
 import shlex
 
-import llnl.util.tty as tty  # noqa: F401
-
 import ramble.error
 
 from ramble.schema.types import OUTPUT_CAPTURE

--- a/lib/ramble/ramble/util/logger.py
+++ b/lib/ramble/ramble/util/logger.py
@@ -17,7 +17,16 @@ class Logger(object):
     printed to all log files instead of only one.
     """
     def __init__(self):
+        """Construct a a logger instance
+
+        A logger instance consists of a stack of logs (self.log_stack) and an
+        enabled flag.
+
+        If the enabled flag is set to False, the logger will only print to
+        screen instead of to underlying files.
+        """
         self.log_stack = []
+        self.enabled = True
 
     def add_log(self, path):
         """Add a log to the current log stack
@@ -29,9 +38,9 @@ class Logger(object):
         Args:
             path: File path for the new log file
         """
-        if isinstance(path, str):
+        if isinstance(path, str) and self.enabled:
             stream = None
-            stream = open(path, 'w+')
+            stream = open(path, 'a+')
             self.log_stack.append((path, stream))
 
     def remove_log(self):
@@ -39,8 +48,9 @@ class Logger(object):
 
         Pop the active log from the log stack, and close the log stream.
         """
-        last_log = self.log_stack.pop()
-        last_log[1].close()
+        if self.enabled:
+            last_log = self.log_stack.pop()
+            last_log[1].close()
 
     def active_log(self):
         """Return the path for the active log

--- a/lib/ramble/ramble/util/logger.py
+++ b/lib/ramble/ramble/util/logger.py
@@ -162,6 +162,8 @@ class Logger(object):
         st_kwargs = self._stream_kwargs(default_kwargs=kwargs)
         tty.warn(*args, **st_kwargs)
 
+        tty.warn(*args, **kwargs)
+
     def debug(self, *args, **kwargs):
         """Print a debug message to the active log
 

--- a/lib/ramble/ramble/util/logger.py
+++ b/lib/ramble/ramble/util/logger.py
@@ -1,0 +1,191 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import llnl.util.tty as tty
+
+
+class Logger(object):
+    """Logger class
+
+    This class providers additional functionality on top of LLNL's tty utility.
+    Namely, this class provides a stack of log files, and allows errors to be
+    printed to all log files instead of only one.
+    """
+    def __init__(self):
+        self.log_stack = []
+
+    def add_log(self, path):
+        """Add a log to the current log stack
+
+        Opens (with 'w+' permissions) the file provided by the 'path' argument,
+        and stores both the path, and the opened stream object in the current stack
+        in the active position.
+
+        Args:
+            path: File path for the new log file
+        """
+        if isinstance(path, str):
+            stream = None
+            stream = open(path, 'w+')
+            self.log_stack.append((path, stream))
+
+    def remove_log(self):
+        """Remove the active stack
+
+        Pop the active log from the log stack, and close the log stream.
+        """
+        last_log = self.log_stack.pop()
+        last_log[1].close()
+
+    def active_log(self):
+        """Return the path for the active log
+
+        If any logs are in the log stack, return the filepath of the active log.
+        Otherwise, return the string 'stdout'
+        """
+        if len(self.log_stack) > 0:
+            return self.log_stack[-1][0]
+        return "stdout"
+
+    def active_stream(self):
+        """Return the stream for the active log
+
+        If any logs are in the log stack, return the stream object of the active log.
+        Otherwise, return None to indicate the system is handling printing.
+        """
+        if len(self.log_stack) > 0:
+            return self.log_stack[-1][1]
+        return None
+
+    def _stream_kwargs(self, default_kwargs={}, index=None):
+        """Construct keyword arguments for a stream
+
+        Build keyword arguments of the form: {'stream': <log_stream>} to allow
+        LLNL's tty utility to print to a specific stream.
+
+        When default_kwargs are passed in, these are applied on top of the
+        constructed kwargs.
+
+        When index is passed in, the stream added into kwargs is the log in
+        position index within the stack (where -1 is considered active).
+
+        Args:
+            default_kwargs: Default keyword arguments to use
+            index: Index of log (in stack) to build kwargs for
+
+        Returns:
+            kwargs: Constructed kwargs with defaults applied
+        """
+        kwargs = {}
+        stream_index = None
+        if index is not None:
+            if index >= 0 and index <= len(self.log_stack):
+                stream_index = index
+            else:
+                tty.die(
+                    f'Error: Requested stream index of {index} is outside of '
+                    f'the stream range of 0 - {len(self.log_stack)}'
+                )
+
+        else:
+            if len(self.log_stack) > 0:
+                stream_index = len(self.log_stack) - 1
+
+        if stream_index is not None:
+            kwargs['stream'] = self.log_stack[stream_index][1]
+
+        kwargs.update(default_kwargs)
+
+        return kwargs
+
+    def all_msg(self, *args, **kwargs):
+        """Print a message to all logs
+
+        Pass all args and kwargs to tty.info (which will concatenate and
+        print). Perform this action for all logs and the default log (to
+        screen).
+        """
+        for idx, log in enumerate(self.log_stack):
+            st_kwargs = self._stream_kwargs(default_kwargs=kwargs, index=idx)
+            tty.info(*args, **st_kwargs)
+
+        tty.info(*args, **kwargs)
+
+    def msg(self, *args, **kwargs):
+        """Print a message to the active log
+
+        Pass all args and kwargs to tty.info (which will concatenate and
+        print). Perform this action for the active log only.
+        """
+        st_kwargs = self._stream_kwargs(default_kwargs=kwargs)
+        tty.info(*args, **st_kwargs)
+
+    def info(self, *args, **kwargs):
+        """Print a message to the active log
+
+        Pass all args and kwargs to tty.info (which will concatenate and
+        print). Perform this action for the active log only.
+        """
+        st_kwargs = self._stream_kwargs(default_kwargs=kwargs)
+        tty.info(*args, **st_kwargs)
+
+    def verbose(self, *args, **kwargs):
+        """Print a verbose message to the active log
+
+        Pass all args and kwargs to tty.verbose (which will concatenate and
+        print). Perform this action for the active log only.
+        """
+        st_kwargs = self._stream_kwargs(default_kwargs=kwargs)
+        tty.verbose(*args, **st_kwargs)
+
+    def warn(self, *args, **kwargs):
+        """Print a warning message to the active log
+
+        Pass all args and kwargs to tty.warn (which will concatenate and
+        print). Perform this action for the active log only.
+        """
+        st_kwargs = self._stream_kwargs(default_kwargs=kwargs)
+        tty.warn(*args, **st_kwargs)
+
+    def debug(self, *args, **kwargs):
+        """Print a debug message to the active log
+
+        Pass all args and kwargs to tty.debug (which will concatenate and
+        print). Perform this action for the active log only.
+        """
+        st_kwargs = self._stream_kwargs(default_kwargs=kwargs)
+        tty.debug(*args, **st_kwargs)
+
+    def error(self, *args, **kwargs):
+        """Print an error message
+
+        Pass all args and kwargs to tty.error (which will concatenate and
+        print). Perform this action all logs, and the default stream (print to
+        screen).
+        """
+        for idx, log in enumerate(self.log_stack):
+            st_kwargs = self._stream_kwargs(index=idx, default_kwargs=kwargs)
+            tty.error(*args, **st_kwargs)
+
+        tty.error(*args, **kwargs)
+
+    def die(self, *args, **kwargs):
+        """Print an error message and terminate execution
+
+        Pass all args and kwargs to tty.error (which will concatenate and
+        print). Perform this action all logs. After all logs are printed to,
+        terminate execution (and error) using tty.die.
+        """
+        for idx, log in enumerate(self.log_stack):
+            st_kwargs = self._stream_kwargs(index=idx, default_kwargs=kwargs)
+            tty.error(*args, **st_kwargs)
+
+        tty.die(*args, **kwargs)
+
+
+logger = Logger()

--- a/lib/ramble/ramble/util/matrices.py
+++ b/lib/ramble/ramble/util/matrices.py
@@ -5,10 +5,8 @@
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
-
-import llnl.util.tty as tty
-
 from ramble.namespace import namespace
+import ramble.util.logger
 
 
 def extract_matrices(action, name, in_dict):
@@ -33,9 +31,9 @@ def extract_matrices(action, name, in_dict):
             # Extract named matrices
             if isinstance(matrix, dict):
                 if len(matrix.keys()) != 1:
-                    tty.die(f'While performing {action} with {name} '
-                            ' each list element may only contain '
-                            '1 matrix in a matrices definition.')
+                    ramble.util.logger.logger.die(f'While performing {action} with {name} '
+                                                  ' each list element may only contain '
+                                                  '1 matrix in a matrices definition.')
 
                 for name, val in matrix.items():
                     matrices.append(val)

--- a/lib/ramble/ramble/util/matrices.py
+++ b/lib/ramble/ramble/util/matrices.py
@@ -6,7 +6,7 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 from ramble.namespace import namespace
-import ramble.util.logger
+from ramble.util.logger import logger
 
 
 def extract_matrices(action, name, in_dict):
@@ -31,9 +31,9 @@ def extract_matrices(action, name, in_dict):
             # Extract named matrices
             if isinstance(matrix, dict):
                 if len(matrix.keys()) != 1:
-                    ramble.util.logger.logger.die(f'While performing {action} with {name} '
-                                                  ' each list element may only contain '
-                                                  '1 matrix in a matrices definition.')
+                    logger.die(f'While performing {action} with {name} '
+                               ' each list element may only contain '
+                               '1 matrix in a matrices definition.')
 
                 for name, val in matrix.items():
                     matrices.append(val)

--- a/lib/ramble/ramble/util/path.py
+++ b/lib/ramble/ramble/util/path.py
@@ -16,10 +16,10 @@ import getpass
 import subprocess
 import tempfile
 
-import llnl.util.tty as tty
 from llnl.util.lang import memoized
 
 import ramble.paths
+import ramble.util.logger
 
 
 __all__ = [
@@ -59,8 +59,8 @@ def get_system_path_max():
         proc_output = str(path_max_proc.communicate()[0].decode())
         sys_max_path_length = int(proc_output)
     except (ValueError, subprocess.CalledProcessError, OSError):
-        tty.msg('Unable to find system max path length, using: {0}'.format(
-            sys_max_path_length))
+        ramble.util.logger.logger.msg('Unable to find system max path length, using: {0}'.format(
+                                      sys_max_path_length))
 
     return sys_max_path_length
 

--- a/lib/ramble/ramble/util/path.py
+++ b/lib/ramble/ramble/util/path.py
@@ -19,7 +19,7 @@ import tempfile
 from llnl.util.lang import memoized
 
 import ramble.paths
-import ramble.util.logger
+from ramble.util.logger import logger
 
 
 __all__ = [
@@ -59,8 +59,7 @@ def get_system_path_max():
         proc_output = str(path_max_proc.communicate()[0].decode())
         sys_max_path_length = int(proc_output)
     except (ValueError, subprocess.CalledProcessError, OSError):
-        ramble.util.logger.logger.msg('Unable to find system max path length, using: {0}'.format(
-                                      sys_max_path_length))
+        logger.msg(f'Unable to find system max path length, using: {sys_max_path_length}')
 
     return sys_max_path_length
 

--- a/lib/ramble/ramble/util/web.py
+++ b/lib/ramble/ramble/util/web.py
@@ -28,13 +28,13 @@ from llnl.util.filesystem import mkdirp, rename
 
 import spack
 import ramble.config
-import ramble.util.logger
 import spack.error
 import spack.url
 import spack.util.crypto
 import spack.util.gcs as gcs_util
 import spack.util.s3 as s3_util
 import spack.util.url as url_util
+from ramble.util.logger import logger
 from spack.util.compression import ALLOWED_ARCHIVE_TYPES
 from spack.util.path import convert_to_posix_path
 
@@ -81,7 +81,7 @@ def uses_ssl(parsed_url):
             return True
 
     elif parsed_url.scheme == 'gs':
-        ramble.util.logger.logger.debug("(uses_ssl) GCS Blob is https")
+        logger.debug("(uses_ssl) GCS Blob is https")
         return True
 
     return False
@@ -156,7 +156,7 @@ def read_from_url(url, accept_content_type=None):
             not content_type.startswith(accept_content_type)))
 
     if reject_content_type:
-        ramble.util.logger.logger.debug("ignoring page {0}{1}{2}".format(
+        logger.debug("ignoring page {0}{1}{2}".format(
             url,
             " with content type " if content_type is not None else "",
             content_type or ""))
@@ -167,8 +167,8 @@ def read_from_url(url, accept_content_type=None):
 
 
 def warn_no_ssl_cert_checking():
-    ramble.util.logger.logger.warn("Ramble will not check SSL certificates. You need to update "
-                                   "your Python to enable certificate verification.")
+    logger.warn("Ramble will not check SSL certificates. You need to update "
+                "your Python to enable certificate verification.")
 
 
 def push_to_url(
@@ -183,7 +183,7 @@ def push_to_url(
         warn_no_ssl_cert_checking()
 
     remote_file_path = url_util.local_file_path(remote_url)
-    ramble.util.logger.logger.debug(f'Trying to backup file to: {remote_file_path}')
+    logger.debug(f'Trying to backup file to: {remote_file_path}')
     if remote_file_path is not None:
         mkdirp(os.path.dirname(remote_file_path))
         if keep_original:
@@ -264,10 +264,10 @@ def url_exists(url):
 def _debug_print_delete_results(result):
     if 'Deleted' in result:
         for d in result['Deleted']:
-            ramble.util.logger.logger.debug(f'Deleted {d["Key"]}')
+            logger.debug(f'Deleted {d["Key"]}')
     if 'Errors' in result:
         for e in result['Errors']:
-            ramble.util.logger.logger.debug(f'Failed to delete {e["Key"]} ({e["Message"]})')
+            logger.debug(f'Failed to delete {e["Key"]} ({e["Message"]})')
 
 
 def remove_url(url, recursive=False):
@@ -481,13 +481,13 @@ def spider(root_urls, depth=0, concurrency=32):
                     _visited.add(abs_link)
 
         except URLError as e:
-            ramble.util.logger.logger.debug(str(e))
+            logger.debug(str(e))
 
             if hasattr(e, 'reason') and isinstance(e.reason, ssl.SSLError):
-                ramble.util.logger.logger.warn("Ramble was unable to fetch url list due to a "
-                                               "certificate verification problem. You can try "
-                                               "running ramble -k, which will not check SSL "
-                                               "certificates. Use this at your own risk.")
+                logger.warn("Ramble was unable to fetch url list due to a "
+                            "certificate verification problem. You can try "
+                            "running ramble -k, which will not check SSL "
+                            "certificates. Use this at your own risk.")
 
         except HTMLParseError as e:
             # This error indicates that Python's HTML parser sucks.
@@ -497,16 +497,16 @@ def spider(root_urls, depth=0, concurrency=32):
             if sys.version_info[:3] < (2, 7, 3):
                 msg += " Use Python 2.7.3 or newer for better HTML parsing."
 
-            ramble.util.logger.logger.warn(msg, url, "HTMLParseError: " + str(e))
+            logger.warn(msg, url, "HTMLParseError: " + str(e))
 
         except Exception as e:
             # Other types of errors are completely ignored,
             # except in debug mode
-            ramble.util.logger.logger.debug(f"Error in _spider: {type(e)}:{str(e)}",
-                                            traceback.format_exc())
+            logger.debug(f"Error in _spider: {type(e)}:{str(e)}",
+                         traceback.format_exc())
 
         finally:
-            ramble.util.logger.logger.debug("SPIDER: [url={0}]".format(url))
+            logger.debug("SPIDER: [url={0}]".format(url))
 
         return pages, links, subcalls
 
@@ -527,7 +527,7 @@ def spider(root_urls, depth=0, concurrency=32):
     tp = multiprocessing.pool.ThreadPool(processes=concurrency)
     try:
         while current_depth <= depth:
-            ramble.util.logger.logger.debug(
+            logger.debug(
                 "SPIDER: [depth={0}, max_depth={1}, urls={2}]".format(
                     current_depth, depth, len(spider_args)
                 )

--- a/lib/ramble/ramble/util/web.py
+++ b/lib/ramble/ramble/util/web.py
@@ -267,7 +267,7 @@ def _debug_print_delete_results(result):
             ramble.util.logger.logger.debug(f'Deleted {d["Key"]}')
     if 'Errors' in result:
         for e in result['Errors']:
-            ramble.util.logger.logger.debug('Failed to delete {e["Key"]} ({e["Message"]})')
+            ramble.util.logger.logger.debug(f'Failed to delete {e["Key"]} ({e["Message"]})')
 
 
 def remove_url(url, recursive=False):

--- a/lib/ramble/ramble/util/web.py
+++ b/lib/ramble/ramble/util/web.py
@@ -24,11 +24,11 @@ from six.moves.urllib.error import URLError
 from six.moves.urllib.request import Request, urlopen
 
 import llnl.util.lang
-import llnl.util.tty as tty
 from llnl.util.filesystem import mkdirp, rename
 
 import spack
 import ramble.config
+import ramble.util.logger
 import spack.error
 import spack.url
 import spack.util.crypto
@@ -81,7 +81,7 @@ def uses_ssl(parsed_url):
             return True
 
     elif parsed_url.scheme == 'gs':
-        tty.debug("(uses_ssl) GCS Blob is https")
+        ramble.util.logger.logger.debug("(uses_ssl) GCS Blob is https")
         return True
 
     return False
@@ -156,7 +156,7 @@ def read_from_url(url, accept_content_type=None):
             not content_type.startswith(accept_content_type)))
 
     if reject_content_type:
-        tty.debug("ignoring page {0}{1}{2}".format(
+        ramble.util.logger.logger.debug("ignoring page {0}{1}{2}".format(
             url,
             " with content type " if content_type is not None else "",
             content_type or ""))
@@ -167,8 +167,8 @@ def read_from_url(url, accept_content_type=None):
 
 
 def warn_no_ssl_cert_checking():
-    tty.warn("Spack will not check SSL certificates. You need to update "
-             "your Python to enable certificate verification.")
+    ramble.util.logger.logger.warn("Ramble will not check SSL certificates. You need to update "
+                                   "your Python to enable certificate verification.")
 
 
 def push_to_url(
@@ -183,7 +183,7 @@ def push_to_url(
         warn_no_ssl_cert_checking()
 
     remote_file_path = url_util.local_file_path(remote_url)
-    tty.debug('Trying to backup file to: %s' % remote_file_path)
+    ramble.util.logger.logger.debug(f'Trying to backup file to: {remote_file_path}')
     if remote_file_path is not None:
         mkdirp(os.path.dirname(remote_file_path))
         if keep_original:
@@ -264,11 +264,10 @@ def url_exists(url):
 def _debug_print_delete_results(result):
     if 'Deleted' in result:
         for d in result['Deleted']:
-            tty.debug('Deleted {0}'.format(d['Key']))
+            ramble.util.logger.logger.debug(f'Deleted {d["Key"]}')
     if 'Errors' in result:
         for e in result['Errors']:
-            tty.debug('Failed to delete {0} ({1})'.format(
-                e['Key'], e['Message']))
+            ramble.util.logger.logger.debug('Failed to delete {e["Key"]} ({e["Message"]})')
 
 
 def remove_url(url, recursive=False):
@@ -482,13 +481,13 @@ def spider(root_urls, depth=0, concurrency=32):
                     _visited.add(abs_link)
 
         except URLError as e:
-            tty.debug(str(e))
+            ramble.util.logger.logger.debug(str(e))
 
             if hasattr(e, 'reason') and isinstance(e.reason, ssl.SSLError):
-                tty.warn("Spack was unable to fetch url list due to a "
-                         "certificate verification problem. You can try "
-                         "running spack -k, which will not check SSL "
-                         "certificates. Use this at your own risk.")
+                ramble.util.logger.logger.warn("Ramble was unable to fetch url list due to a "
+                                               "certificate verification problem. You can try "
+                                               "running ramble -k, which will not check SSL "
+                                               "certificates. Use this at your own risk.")
 
         except HTMLParseError as e:
             # This error indicates that Python's HTML parser sucks.
@@ -498,16 +497,16 @@ def spider(root_urls, depth=0, concurrency=32):
             if sys.version_info[:3] < (2, 7, 3):
                 msg += " Use Python 2.7.3 or newer for better HTML parsing."
 
-            tty.warn(msg, url, "HTMLParseError: " + str(e))
+            ramble.util.logger.logger.warn(msg, url, "HTMLParseError: " + str(e))
 
         except Exception as e:
             # Other types of errors are completely ignored,
             # except in debug mode
-            tty.debug("Error in _spider: %s:%s" % (type(e), str(e)),
-                      traceback.format_exc())
+            ramble.util.logger.logger.debug(f"Error in _spider: {type(e)}:{str(e)}",
+                                            traceback.format_exc())
 
         finally:
-            tty.debug("SPIDER: [url={0}]".format(url))
+            ramble.util.logger.logger.debug("SPIDER: [url={0}]".format(url))
 
         return pages, links, subcalls
 
@@ -528,8 +527,10 @@ def spider(root_urls, depth=0, concurrency=32):
     tp = multiprocessing.pool.ThreadPool(processes=concurrency)
     try:
         while current_depth <= depth:
-            tty.debug("SPIDER: [depth={0}, max_depth={1}, urls={2}]".format(
-                current_depth, depth, len(spider_args))
+            ramble.util.logger.logger.debug(
+                "SPIDER: [depth={0}, max_depth={1}, urls={2}]".format(
+                    current_depth, depth, len(spider_args)
+                )
             )
             results = tp.map(llnl.util.lang.star(_spider), spider_args)
             spider_args = []

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -52,6 +52,7 @@ import ramble.util.hashing
 from ramble.namespace import namespace
 import ramble.util.matrices
 import ramble.util.env
+import ramble.util.logger
 
 #: Environment variable used to indicate the active workspace
 ramble_workspace_var = 'RAMBLE_WORKSPACE'
@@ -179,7 +180,7 @@ def valid_workspace_name(name):
 
 def validate_workspace_name(name):
     if not valid_workspace_name(name):
-        tty.debug('Validation failed for %s' % name)
+        ramble.util.logger.logger.debug(f'Validation failed for {name}')
         raise ValueError((
             "'%s': names must start with a letter, and only contain "
             "letters, numbers, _, and -.") % name)
@@ -206,7 +207,7 @@ def activate(ws):
     # below.
     prepare_config_scope(ws)
 
-    tty.debug("Using workspace '%s'" % ws.root)
+    ramble.util.logger.logger.debug(f"Using workspace '{ws.root}'")
 
     # Do this last, because setting up the config must succeed first.
     _active_workspace = ws
@@ -219,7 +220,7 @@ def deactivate():
     if not _active_workspace:
         return
 
-    tty.debug("Deactivated workspace '%s'" % _active_workspace.root)
+    ramble.util.logger.logger.debug(f"Deactivated workspace '{_active_workspace.root}'")
 
     deactivate_config_scope(_active_workspace)
 
@@ -276,7 +277,7 @@ def get_workspace_path():
     path_in_config = ramble.config.get('config:workspace_dirs')
     if not path_in_config:
         # command above should have worked, so if it doesn't, error out:
-        tty.die('No config:workspace_dirs setting found in configuration!')
+        ramble.util.logger.logger.die('No config:workspace_dirs setting found in configuration!')
 
     wspath = ramble.util.path.canonicalize_path(str(path_in_config))
     return wspath
@@ -390,7 +391,7 @@ def get_workspace(args, cmd_name, required=False):
         (Workspace): if there is an arg or active workspace
     """
 
-    tty.debug('In get_workspace()')
+    ramble.util.logger.logger.debug('In get_workspace()')
 
     workspace = getattr(args, 'workspace', None)
     if workspace:
@@ -406,12 +407,12 @@ def get_workspace(args, cmd_name, required=False):
         return _active_workspace
     # elif not required:
     else:
-        tty.die(
-            '`ramble %s` requires a workspace' % cmd_name,
+        ramble.util.logger.logger.die(
+            f'`ramble {cmd_name}` requires a workspace',
             'activate a workspace first:',
             '    ramble workspace activate WRKSPC',
             'or use:',
-            '    ramble -w WRKSPC %s ...' % cmd_name)
+            f'    ramble -w WRKSPC {cmd_name} ...')
 
 
 class Workspace(object):
@@ -447,7 +448,7 @@ class Workspace(object):
     hash_file_name = 'workspace_hash.sha256'
 
     def __init__(self, root, dry_run=False):
-        tty.debug('In workspace init. Root = {}'.format(root))
+        ramble.util.logger.logger.debug(f'In workspace init. Root = {root}')
         self.root = ramble.util.path.canonicalize_path(root)
         self.txlock = lk.Lock(self._transaction_lock_path)
         self.dry_run = dry_run
@@ -635,17 +636,25 @@ class Workspace(object):
         deprecated_sections = []
 
         if len(deprecated_sections) > 0:
-            tty.warn('Your workspace configuration contains deprecated sections:')
+            ramble.util.logger.logger.warn(
+                'Your workspace configuration contains deprecated sections:'
+            )
             for section in deprecated_sections:
-                tty.warn(f'     {section}')
-            tty.warn('Please see the current workspace documentation and update')
-            tty.warn('to ensure your workspace continues to function properly')
+                ramble.util.logger.logger.warn(f'     {section}')
+            ramble.util.logger.logger.warn(
+                'Please see the current workspace documentation and update'
+            )
+            ramble.util.logger.logger.warn(
+                'to ensure your workspace continues to function properly'
+            )
 
         if len(error_sections) > 0:
-            tty.warn('Your workspace configuration contains invalid sections:')
+            ramble.util.logger.logger.warn(
+                'Your workspace configuration contains invalid sections:'
+            )
             for section in deprecated_sections:
-                tty.warn(f'     {section}')
-            tty.die('Please update to the latest format.')
+                ramble.util.logger.logger.warn(f'     {section}')
+            ramble.util.logger.logger.die('Please update to the latest format.')
 
     def _read_yaml(self, config, f, raw_yaml=None):
         if raw_yaml:
@@ -719,9 +728,9 @@ class Workspace(object):
         self.success_list.flush_scope(scope)
 
         if namespace.success in contents:
-            tty.debug(' ---- Found success in %s' % scope)
+            ramble.util.logger.logger.debug(' ---- Found success in %s' % scope)
             for conf in contents[namespace.success]:
-                tty.debug(' ---- Adding criteria %s' % conf['name'])
+                ramble.util.logger.logger.debug(' ---- Adding criteria %s' % conf['name'])
                 self.success_list.add_criteria(scope, **conf)
 
     def all_specs(self):
@@ -769,7 +778,7 @@ class Workspace(object):
         """
 
         ws_dict = self._get_workspace_dict()
-        tty.debug(' With ws dict: %s' % (ws_dict))
+        ramble.util.logger.logger.debug(f' With ws dict: {ws_dict}')
 
         # Iterate over applications in ramble.yaml first
         app_dict = ramble.config.config.get_config('applications')
@@ -781,14 +790,13 @@ class Workspace(object):
 
             yield contents, application_context
 
-        tty.debug('  Iterating over configs in directories...')
+        ramble.util.logger.logger.debug('  Iterating over configs in directories...')
         # Iterate over applications defined in application directories
         # files after the ramble.yaml file is complete
         for app_conf in self.application_configs:
             config = self._get_application_dict_config(app_conf)
             if namespace.application not in config:
-                tty.msg('No applications in config file %s'
-                        % app_conf)
+                ramble.util.logger.logger.msg(f'No applications in config file {app_conf}')
             app_dict = config[namespace.application]
             for application, contents in app_dict.items():
                 application_context = \
@@ -806,7 +814,7 @@ class Workspace(object):
         """
 
         if namespace.workload not in application:
-            tty.msg('No workloads in application')
+            ramble.util.logger.logger.msg('No workloads in application')
             return
 
         workloads = application[namespace.workload]
@@ -827,7 +835,7 @@ class Workspace(object):
         """
 
         if namespace.experiment not in workload:
-            tty.msg('No experiments in workload')
+            ramble.util.logger.logger.msg('No experiments in workload')
             return
 
         experiments = workload[namespace.experiment]
@@ -898,8 +906,8 @@ class Workspace(object):
                                 f'compiler:{info["compiler"]}'
                             ramble.config.add(config_path, scope=self.ws_file_config_scope_name())
                     elif not specs_equiv(info, packages_dict[comp]):
-                        tty.debug(f'  Spec 1: {str(info)}')
-                        tty.debug(f'  Spec 2: {str(packages_dict[comp])}')
+                        ramble.util.logger.logger.debug(f'  Spec 1: {str(info)}')
+                        ramble.util.logger.logger.debug(f'  Spec 2: {str(packages_dict[comp])}')
                         raise RambleConflictingDefinitionError(
                             f'Compiler {comp} defined in multiple conflicting ways'
                         )
@@ -908,7 +916,7 @@ class Workspace(object):
                 environments_dict[env_name] = syaml.syaml_dict()
                 environments_dict[env_name][namespace.packages] = []
 
-            tty.debug(f'Trying to define packages for {env_name}')
+            ramble.util.logger.logger.debug(f'Trying to define packages for {env_name}')
             app_packages = environments_dict[env_name][namespace.packages]
 
             software_dicts = [app_inst.software_specs]
@@ -917,7 +925,7 @@ class Workspace(object):
 
             for software_dict in software_dicts:
                 for spec_name, info in software_dict.items():
-                    tty.debug(f'    Found spec: {spec_name}')
+                    ramble.util.logger.logger.debug(f'    Found spec: {spec_name}')
                     if spec_name not in packages_dict:
                         packages_dict[spec_name] = syaml.syaml_dict()
                         packages_dict[spec_name]['spack_spec'] = info['spack_spec']
@@ -927,8 +935,10 @@ class Workspace(object):
                             packages_dict[spec_name]['compiler'] = info['compiler']
 
                     elif not specs_equiv(info, packages_dict[spec_name]):
-                        tty.debug(f'  Spec 1: {str(info)}')
-                        tty.debug(f'  Spec 2: {str(packages_dict[spec_name])}')
+                        ramble.util.logger.logger.debug(f'  Spec 1: {str(info)}')
+                        ramble.util.logger.logger.debug(
+                            f'  Spec 2: {str(packages_dict[spec_name])}'
+                        )
                         raise RambleConflictingDefinitionError(
                             f'Package {spec_name} defined in multiple conflicting ways'
                         )
@@ -1033,7 +1043,7 @@ class Workspace(object):
                                                              fom['units'])
                                     f.write('    %s\n' % (output.strip()))
                 else:
-                    tty.msg('No results to write')
+                    ramble.util.logger.logger.msg('No results to write')
 
             self.simlink_result(filename_base, latest_base, file_extension)
 
@@ -1054,11 +1064,11 @@ class Workspace(object):
             self.simlink_result(filename_base, latest_base, file_extension)
 
         if not results_written:
-            tty.die('Results were not written.')
+            ramble.util.logger.logger.die('Results were not written.')
 
-        tty.msg('Results are written to:')
+        ramble.util.logger.logger.msg('Results are written to:')
         for out_file in results_written:
-            tty.msg('  %s' % out_file)
+            ramble.util.logger.logger.msg('  %s' % out_file)
 
         return filename_base
 
@@ -1260,7 +1270,7 @@ class Workspace(object):
         if missing:
             msg = 'Detected {0} missing include path(s):'.format(len(missing))
             msg += '\n   {0}'.format('\n   '.join(missing))
-            tty.die('{0}\nPlease correct and try again.'.format(msg))
+            ramble.util.logger.logger.die('{0}\nPlease correct and try again.'.format(msg))
 
         return scopes
 
@@ -1335,8 +1345,8 @@ class Workspace(object):
 
     def get_applications(self):
         """Get the dictionary of applications"""
-        tty.debug('Getting app dict.')
-        tty.debug(' %s ' % self._get_workspace_dict())
+        ramble.util.logger.logger.debug('Getting app dict.')
+        ramble.util.logger.logger.debug(f' {self._get_workspace_dict()}')
         workspace_dict = self._get_workspace_dict()
         if namespace.application not in workspace_dict[namespace.ramble]:
             workspace_dict[namespace.ramble][namespace.application] = \

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ google-api-core # for gcs fetch error .execptions
 coverage
 pre-commit
 google-cloud-bigquery
+tqdm

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -265,7 +265,7 @@ complete -o bashdefault -o default -F _bash_completion_ramble ramble
 _ramble() {
     if $list_options
     then
-        RAMBLE_COMPREPLY="-h --help -H --all-help --color -c --config -C --config-scope -d --debug --disable-passthrough --timestamp --pdb -w --workspace -D --workspace-dir -W --no-workspace --use-workspace-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -p --profile --sorted-profile --lines -v --verbose --stacktrace -V --version --print-shell-vars"
+        RAMBLE_COMPREPLY="-h --help -H --all-help --color -c --config -C --config-scope -d --debug --disable-passthrough -N --disable-logger -P --disable-progress-bar --timestamp --pdb -w --workspace -D --workspace-dir -W --no-workspace --use-workspace-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -p --profile --sorted-profile --lines -v --verbose --stacktrace -V --version --print-shell-vars"
     else
         RAMBLE_COMPREPLY="attributes clean commands config debug edit flake8 help info license list mirror mods on repo results software-definitions unit-test workspace"
     fi


### PR DESCRIPTION
This merge adds a custom logger to Ramble to handle the redirection of output to various log files.

It enables a hierarchy of log files, and messages can be printed to multiple of these in a single call. Additionally, it adds progress bars back into Ramble, and adds arguments to disable both the logger, and the progress bars.