### PR TITLE
Allow modifiers to specify required variables

### DIFF
--- a/lib/ramble/ramble/application_types/spack.py
+++ b/lib/ramble/ramble/application_types/spack.py
@@ -15,7 +15,7 @@ from ramble.language.application_language import register_phase
 from ramble.language.shared_language import register_builtin
 from ramble.application import ApplicationBase, ApplicationError
 import ramble.spack_runner
-from ramble.keywords import Keywords
+import ramble.keywords
 
 header_color = '@*b'
 level1_color = '@*g'
@@ -50,6 +50,8 @@ class SpackApplication(ApplicationBase):
 
     def __init__(self, file_path):
         super().__init__(file_path)
+
+        self.keywords = ramble.keywords.keywords
 
         self.spack_runner = ramble.spack_runner.SpackRunner()
         self.application_class = 'SpackApplication'
@@ -98,7 +100,7 @@ class SpackApplication(ApplicationBase):
             self.spack_runner.set_compiler_config_dir(workspace.auxiliary_software_dir)
             self.spack_runner.set_dry_run(workspace.dry_run)
 
-            app_context = self.expander.expand_var_name(Keywords.env_name)
+            app_context = self.expander.expand_var_name(self.keywords.env_name)
 
             for pkg_name in workspace.software_environments.get_env_packages(app_context):
                 pkg_spec = workspace.software_environments.get_spec(pkg_name)
@@ -146,14 +148,14 @@ class SpackApplication(ApplicationBase):
 
         try:
             self.spack_runner.set_dry_run(workspace.dry_run)
-            self.spack_runner.create_env(self.expander.expand_var_name(Keywords.env_path))
+            self.spack_runner.create_env(self.expander.expand_var_name(self.keywords.env_path))
             self.spack_runner.activate()
 
             # Write auxiliary software files into created spack env.
             for name, contents in workspace.all_auxiliary_software_files():
                 aux_file_path = self.expander.expand_var(
                     os.path.join(
-                        self.expander.expansion_str(Keywords.env_path),
+                        self.expander.expansion_str(self.keywords.env_path),
                         f'{name}'
                     )
                 )
@@ -161,7 +163,7 @@ class SpackApplication(ApplicationBase):
                 with open(aux_file_path, 'w+') as f:
                     f.write(self.expander.expand_var(contents))
 
-            env_context = self.expander.expand_var_name(Keywords.env_name)
+            env_context = self.expander.expand_var_name(self.keywords.env_name)
             external_spack_env = workspace.external_spack_env(env_context)
             if external_spack_env:
                 self.spack_runner.copy_from_external_env(external_spack_env)
@@ -290,7 +292,7 @@ class SpackApplication(ApplicationBase):
 
             self.spack_runner.activate()
 
-            app_context = self.expander.expand_var_name(Keywords.env_name)
+            app_context = self.expander.expand_var_name(self.keywords.env_name)
 
             for pkg_name in \
                     workspace.software_environments.get_env_packages(app_context):
@@ -409,7 +411,7 @@ class SpackApplication(ApplicationBase):
     def _clean_hash_variables(self, workspace, variables):
         """Perform spack specific cleanup of variables before hashing"""
 
-        self.spack_runner.configure_env(self.expander.expand_var_name(Keywords.env_path))
+        self.spack_runner.configure_env(self.expander.expand_var_name(self.keywords.env_path))
         self.spack_runner.activate()
 
         for var in variables:
@@ -435,7 +437,7 @@ class SpackApplication(ApplicationBase):
         return self.spack_runner.generate_source_command()
 
     def spack_activate(self):
-        self.spack_runner.configure_env(self.expander.expand_var_name(Keywords.env_path))
+        self.spack_runner.configure_env(self.expander.expand_var_name(self.keywords.env_path))
         self.spack_runner.activate()
         cmds = self.spack_runner.generate_activate_command()
         self.spack_runner.deactivate()

--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -247,10 +247,10 @@ class Expander(object):
 
     Additionally, math will be evaluated as part of expansion.
     """
-
-    _keywords = ramble.keywords.keywords
-
     def __init__(self, variables, experiment_set):
+
+        self._keywords = ramble.keywords.keywords
+
         self._variables = variables
 
         self._experiment_set = experiment_set

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -41,9 +41,8 @@ class ExperimentSet(object):
                                   'application', 'workload', 'experiment',
                                   'required'])
 
-    keywords = ramble.keywords.keywords
-
     def __init__(self, workspace):
+        self.keywords = ramble.keywords.keywords
         """Create experiment set class"""
         self.experiments = {}
         self.experiment_order = []

--- a/lib/ramble/ramble/language/modifier_language.py
+++ b/lib/ramble/ramble/language/modifier_language.py
@@ -221,3 +221,17 @@ def env_var_modification(name, modification=None, method='set', mode=None, modes
             mod.env_var_modifications[mode_name][method].append(append_dict.copy())
 
     return _env_var_modification
+
+
+@modifier_directive('required_vars')
+def required_variable(var: str):
+    """Mark a var as being required
+
+    Args:
+        var: Value to mark as required
+    """
+
+    def _mark_required_var(mod):
+        mod.required_vars[var] = ramble.keywords.key_type.required
+
+    return _mark_required_var

--- a/lib/ramble/ramble/software_environments.py
+++ b/lib/ramble/ramble/software_environments.py
@@ -28,11 +28,10 @@ class SoftwareEnvironments(object):
     software environments, and unify their format.
     """
 
-    keywords = ramble.keywords.keywords
-
     supported_confs = ['v2']
 
     def __init__(self, workspace):
+        self.keywords = ramble.keywords.keywords
 
         self._raw_packages = {}
         self._packages = {}

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -873,7 +873,7 @@ class Workspace(object):
 
         for exp, app_inst, _ in experiment_set.all_experiments():
             app_inst.build_modifier_instances()
-            env_name_str = app_inst.expander.expansion_str(ramble.keywords.Keywords.env_name)
+            env_name_str = app_inst.expander.expansion_str(ramble.keywords.keywords.env_name)
             env_name = app_inst.expander.expand_var(env_name_str)
 
             compiler_dicts = [app_inst.default_compilers]


### PR DESCRIPTION
This PR adds a modifier directive called `required_variable(` which makes a workspace invalid if a var the modifier requires is not present 

It also turns the keywords class from a static to a global 