### PR TITLE
Allow the setup pipeline to skip/fail workspace inventory generation

### DIFF
--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -319,7 +319,7 @@ class SetupPipeline(Pipeline):
     def __init__(self, workspace, filters):
         super().__init__(workspace, filters)
         self.force_inventory = True
-        self.require_inventory = True
+        self.require_inventory = False
         self.action_string = 'Setting up'
 
     def _prepare(self):
@@ -329,7 +329,12 @@ class SetupPipeline(Pipeline):
         self.workspace.experiments_script = experiment_file
 
     def _complete(self):
-        super()._construct_hash()
+        try:
+            super()._construct_hash()
+        except FileNotFoundError as e:
+            tty.warn("Unable to construct workspace hash due to missing file")
+            tty.warn(e)
+
         self.workspace.experiments_script.close()
         experiment_file_path = os.path.join(self.workspace.root,
                                             self.workspace.all_experiments_path)

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -329,6 +329,11 @@ class SetupPipeline(Pipeline):
         self.workspace.experiments_script = experiment_file
 
     def _complete(self):
+        # Check if the selected phases require the inventory is successful
+        if "write_inventory" in self.filters.phases or \
+           "*" in self.filters.phases:
+            self.require_inventory = True
+
         try:
             super()._construct_hash()
         except FileNotFoundError as e:


### PR DESCRIPTION
Currently any call into setup hard requires an inventory, regardless of the phases selected. This causes issues as not all phases are able to safely generate the inventory as it depends on the software being installed

This PR allows the inventory to be optional and for the execution to proceed when non-software phases are selected (eg get_inputs)

@douglasjacobsen let me know what you think of this. It would be nice if we were more able to discriminately set `require_inventory = True` again when it makes sense to