### PR TITLE
Add two new tutorials

### DIFF
--- a/examples/vector_gromacs_software_config.yaml
+++ b/examples/vector_gromacs_software_config.yaml
@@ -1,0 +1,41 @@
+ramble:
+  variables:
+    processes_per_node: 16
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: '{execute_experiment}'
+    gromacs_version: [2021.6, 2021.7]
+  applications:
+    gromacs: # Application name
+      workloads:
+        '{app_workloads}': # Workload name from application
+          experiments:
+            '{type}_{n_ranks}ranks-{gromacs_version}': # Arbitrary experiment name
+              variables:
+                app_workloads: ['water_gmx50', 'water_bare']
+                n_ranks: [1, 2, 4]
+                n_threads: '1'
+                size: '0003'
+                type: ['pme', 'rf']
+                env_name: 'gromacs-{gromacs_version}'
+              matrix:
+              - app_workloads
+              - type
+              - n_ranks
+              - gromacs_version
+  spack:
+    concretized: true
+    packages:
+      gcc9:
+        spack_spec: gcc@9.3.0 target=x86_64
+        compiler_spec: gcc@9.3.0
+      impi2018:
+        spack_spec: intel-mpi@2018.4.274 target=x86_64
+        compiler: gcc9
+      gromacs-{gromacs_version}:
+        spack_spec: gromacs@{gromacs_version}
+        compiler: gcc9
+    environments:
+      gromacs-{gromacs_version}:
+        packages:
+        - gromacs-{gromacs_version}
+        - impi2018

--- a/examples/vector_matrix_gromacs_config.yaml
+++ b/examples/vector_matrix_gromacs_config.yaml
@@ -1,0 +1,38 @@
+ramble:
+  variables:
+    processes_per_node: 16
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: '{execute_experiment}'
+  applications:
+    gromacs: # Application name
+      workloads:
+        '{app_workloads}': # Workload name from application
+          experiments:
+            '{type}_{n_ranks}ranks': # Arbitrary experiment name
+              variables:
+                app_workloads: ['water_gmx50', 'water_bare']
+                n_ranks: [1, 2, 4]
+                n_threads: '1'
+                size: '0003'
+                type: ['pme', 'rf']
+              matrix:
+              - app_workloads
+              - type
+              - n_ranks
+  spack:
+    concretized: true
+    packages:
+      gcc9:
+        spack_spec: gcc@9.3.0 target=x86_64
+        compiler_spec: gcc@9.3.0
+      impi2018:
+        spack_spec: intel-mpi@2018.4.274 target=x86_64
+        compiler: gcc9
+      gromacs:
+        spack_spec: gromacs@2021.6
+        compiler: gcc9
+    environments:
+      gromacs:
+        packages:
+        - gromacs
+        - impi2018

--- a/lib/ramble/docs/tutorials.rst
+++ b/lib/ramble/docs/tutorials.rst
@@ -21,4 +21,5 @@ various features.
 
     tutorials/hello_world
     tutorials/running_a_simple_gromacs_experiment
+    tutorials/modifying_a_gromacs_experiment
     tutorials/mirrors

--- a/lib/ramble/docs/tutorials.rst
+++ b/lib/ramble/docs/tutorials.rst
@@ -22,4 +22,6 @@ various features.
     tutorials/hello_world
     tutorials/running_a_simple_gromacs_experiment
     tutorials/modifying_a_gromacs_experiment
+    tutorials/using_vectors_and_matrices
+    tutorials/changing_your_software_stack
     tutorials/mirrors

--- a/lib/ramble/docs/tutorials/changing_your_software_stack.rst
+++ b/lib/ramble/docs/tutorials/changing_your_software_stack.rst
@@ -1,0 +1,198 @@
+.. Copyright 2022-2023 Google LLC
+
+   Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+   https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+   <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+   option. This file may not be copied, modified, or distributed
+   except according to those terms.
+
+.. _modifying_an_experiment_tutorial:
+
+============================
+5) Changing A Software Stack
+============================
+
+In this tutorial, you will learn how to modify an existing workspace
+configuration that contains experiments using
+`GROMACS <https://www.gromacs.org/>`_, a free and open-source application
+for molecular dynamics.
+
+This tutorial builds off of concepts introduced in previous tutorials. Please
+make sure you review those before starting with this tutorial's content.
+
+.. include:: shared/gromacs_workspace.rst
+
+Activate the Workspace
+----------------------
+
+As you are using a pre-existing workspace, ensure it is activated (NOTE: you
+only need to run this if you do not currently have the workspace active).
+
+.. code-block:: console
+
+    $ ramble workspace activate basic_gromacs
+
+
+Software Description
+--------------------
+
+Now that your workspace has been created, and configured with the default
+workspace configuration file you can examine the workspace contents. You can
+execute the following command to see what software environments and packages
+the workspace currently contains:
+
+.. code-block:: console
+
+    $ ramble workspace info
+
+This command provides a summary view of the workspace. It includes the
+experiment names, and the software environments. As an example, its output
+might contain the following information regarding software packages and
+environments:
+
+.. code-block:: console
+
+    Software Stack:
+      Packages:
+        gcc9:
+          Rendered Packages:
+            gcc9:
+              Spack spec: gcc@9.3.0 target=x86_64
+              Compiler spec: gcc@9.3.0
+        impi2018:
+          Rendered Packages:
+            impi2018:
+              Spack spec: intel-mpi@2018.4.274 target=x86_64
+              Compiler: gcc9
+        gromacs:
+          Rendered Packages:
+            gromacs:
+              Spack spec: gromacs@2021.6
+              Compiler: gcc9
+      Environments:
+        gromacs:
+          Rendered Environments:
+            gromacs Packages:
+              - gromacs
+              - impi2018
+
+
+Currently, this command outputs every package and software environment
+definition, even if they are not used directly by an experiment. By default,
+each experiment expects a software environment that is named the same as the
+application. For example, an experiment for the application ``gromacs`` expects
+a software environment named ``gromacs``. This can be overridden using the
+variable ``env_name``, which can be the name of any environment defined in the
+workspace configuration file.
+
+The above output relates to lines 37-53 in the above configuration file, where
+we define packages for Intel MPI, GROMACS, and GCC 9.3.0. The GROMACS and Intel
+MPI packages are then combined into the ``gromacs`` software environment. Lines
+40, 43, and 46 are the names of packages within this workspace, while line 50
+is the name of a software environment.
+
+Changing Software Definitions
+-----------------------------
+
+As the GROMACS application definition inherits from the ``SpackApplication``
+base class, it is expected to use Spack as its package manager. When changing
+the software definitions in a workspace, many options are available to you. For
+example, you could modify the compiler used for building GROMACS (as defined on
+line 45), or you could modify the MPI used for these experiments (as seen on
+line 53). However, we will explore changing aspects of GROMACS itself (such as
+its version or variants). 
+
+**NOTE:** It is important to note that changing aspects of
+compilation could result in build-time errors that need to be resolved before
+Ramble can generate experiments. Oftentimes it is both easier and faster to
+work through these issues (if you encounter them) outside of Ramble, using the
+package manager directly. Because Ramble uses the package manager, if the
+package is already intalled it will not cause the package manager to re-install
+it.
+
+In order to get information about what changes you can make to the GROMACS
+package, you can use:
+
+.. code-block:: console
+
+    $ spack info gromacs
+
+
+This command will output all of the supported versions of GROMACS, along with
+the variants for GROMACS which can modify its behavior. While you can change
+any of these, we'll begin by only modifying the version of GROMACS from
+``2021.6`` to ``2021.7``.
+
+To make editing the workspace easier, use the following command (assuming you
+have an ``EDITOR`` environment variable set):
+
+.. code-block:: console
+
+    $ ramble workspace edit
+
+This command opens the ``ramble.yaml`` file, along with any ``*.tpl`` files in
+the workspace's ``configs`` directory.
+
+Once the ``ramble.yaml`` file is opened, change the version ``2021.6`` to
+``2021.7`` on line 47. Then save and exit the files. These changes should now
+be reflected in the output of:
+
+.. code-block:: console
+
+    $ ramble workspace info
+
+
+Execute Experiments
+-------------------
+
+Now that you have made the appropriate modifications, set up, execute, and
+analyze the new experiments using:
+
+.. code-block:: console
+
+    $ ramble workspace setup
+    $ ramble on
+    $ ramble workspace analyze
+
+**NOTE**: Since you changed the package definition for GROMACS, it will be
+recompiled (unless you compiled it outside of Ramble) during the ``ramble
+workspace setup`` command. This will likely take longer than changing
+experiments and performing setup again.
+
+This creates a ``results`` file in the root of the workspace that contains
+extracted figures of merit. If the experiments were successful, this file will
+show the following results:
+
+* Core Time: CPU time (in seconds) spent on the benchmark calculations
+* Wall Time: Elapsed real time (in seconds) spent on the benchmark calculations
+* Percent Core Time: Core Time / Wall Time
+* Nanosecs per day: Nanoseconds of simulation per day at the speed achieved
+* Hours per nanosec: Hours required to calculate 1 nanosecond of simulation at
+  the speed achieved
+
+Adding Package Variants
+-----------------------
+
+So far, we have only explored changing the version a package used. More
+complicated changes to the Spack specs can be made by adding variant
+definitions. This can be directly added to the ``spack_spec`` lines within the
+package definitions in a workspace's ``ramble.yaml``.
+
+The ``spack_spec`` attribute can be parameterized with variable definitions
+also, to allow a wide range of variants to be explored with a single
+configuration.
+
+Vector and Matrix Software Definitions
+--------------------------------------
+
+Package and environment definitions support the same vector and matrix logic as
+introduced in :ref:`vector_and_matrix_tutorial`. Package and environment names
+should similarly be unique, and can use placeholder values for variable
+definitions.
+
+As an example, to explore both of the versions of GROMACS described in this
+tutorial, your ``ramble.yaml`` coudld look like the following:
+
+.. literalinclude:: ../../../../examples/vector_gromacs_software_config.yaml
+   :linenos:
+   :language: YAML

--- a/lib/ramble/docs/tutorials/modifying_a_gromacs_experiment.rst
+++ b/lib/ramble/docs/tutorials/modifying_a_gromacs_experiment.rst
@@ -1,0 +1,248 @@
+.. Copyright 2022-2023 Google LLC
+
+   Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+   https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+   <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+   option. This file may not be copied, modified, or distributed
+   except according to those terms.
+
+.. _modifying_an_experiment_tutorial:
+
+=======================================
+3) Modifying A GROMACS Experiment
+=======================================
+
+In this tutorial, you will learn how to modify an existing workspace
+configuration that contains experiments using
+`GROMACS <https://www.gromacs.org/>`_, a free and open-source application
+for molecular dynamics.
+
+This tutorial builds off of concepts introduced in previous tutorials. Please
+make sure you review those before starting with this tutorial's content.
+
+.. include:: shared/gromacs_workspace.rst
+
+Activate the Workspace
+----------------------
+
+As you are using a pre-existing workspace, ensure it is activated (NOTE: you
+only need to run this if you do not currently have the workspace active).
+
+.. code-block:: console
+
+    $ ramble workspace activate basic_gromacs
+
+
+Experiment Descriptions
+-----------------------
+
+Now that your workspace has been configured, and activated, You can execute the
+following command to see what experiments the workspace currently contains:
+
+.. code-block:: console
+
+    $ ramble workspace info
+
+This command provides a summary view of the workspace. It includes the
+experiment names, and the software environments. As an example, its output
+might contain the following information:
+
+.. code-block:: console
+
+    Experiments:
+      Application: gromacs
+        Workload: water_gmx50
+          Experiment: gromacs.water_gmx50.pme_single_rank
+      Application: gromacs
+        Workload: water_gmx50
+          Experiment: gromacs.water_gmx50.rf_single_rank
+      Application: gromacs
+        Workload: water_bare
+          Experiment: gromacs.water_bare.pme_single_rank
+      Application: gromacs
+        Workload: water_bare
+          Experiment: gromacs.water_bare.rf_single_rank
+
+To get detailed information about where variable definitions come from, you can use:
+
+.. code-block:: console
+
+    $ ramble workspace info -v
+
+The experiments section of this command's output might contain the following:
+
+.. code-block:: console
+
+    Experiments:
+      Application: gromacs
+        Workload: water_gmx50
+          Experiment: gromacs.water_gmx50.pme_single_rank
+            Variables from Workspace:
+              processes_per_node = 16 ==> 16
+              mpi_command = mpirun -n {n_ranks} -ppn {processes_per_node} ==> mpirun -n 1 -ppn 16
+              batch_submit = {execute_experiment} ==> {execute_experiment}
+            Variables from Experiment:
+              n_ranks = 1 ==> 1
+              n_threads = 1 ==> 1
+              size = 0003 ==> 0003
+              type = pme ==> pme
+      Application: gromacs
+        Workload: water_gmx50
+          Experiment: gromacs.water_gmx50.rf_single_rank
+            Variables from Workspace:
+              processes_per_node = 16 ==> 16
+              mpi_command = mpirun -n {n_ranks} -ppn {processes_per_node} ==> mpirun -n 1 -ppn 16
+              batch_submit = {execute_experiment} ==> {execute_experiment}
+            Variables from Experiment:
+              n_ranks = 1 ==> 1
+              n_threads = 1 ==> 1
+              size = 0003 ==> 0003
+              type = rf ==> rf
+      Application: gromacs
+        Workload: water_bare
+          Experiment: gromacs.water_bare.pme_single_rank
+            Variables from Workspace:
+              processes_per_node = 16 ==> 16
+              mpi_command = mpirun -n {n_ranks} -ppn {processes_per_node} ==> mpirun -n 1 -ppn 16
+              batch_submit = {execute_experiment} ==> {execute_experiment}
+            Variables from Experiment:
+              n_ranks = 1 ==> 1
+              n_threads = 1 ==> 1
+              size = 0003 ==> 0003
+              type = pme ==> pme
+      Application: gromacs
+        Workload: water_bare
+          Experiment: gromacs.water_bare.rf_single_rank
+            Variables from Workspace:
+              processes_per_node = 16 ==> 16
+              mpi_command = mpirun -n {n_ranks} -ppn {processes_per_node} ==> mpirun -n 1 -ppn 16
+              batch_submit = {execute_experiment} ==> {execute_experiment}
+            Variables from Experiment:
+              n_ranks = 1 ==> 1
+              n_threads = 1 ==> 1
+              size = 0003 ==> 0003
+              type = rf ==> rf
+
+The variables ``mpi_command``, ``processes_per_node``, and ``batch_submit``
+come from the workspace scope on lines 3, 4, and 5 of the YAML file in
+:ref:`gromacs_workspace_config`. Each experiment has its own definition for
+``n_ranks``, ``n_threads``, ``size``, and ``type``.
+
+The experiments in this configuration use both the ``water_bare`` and
+``water_gmx50`` workloads.
+
+Using Workload Variables
+------------------------
+
+Application definitions are allowed to expose variables that can be used within
+experiments. These are called **workload variables**. User can view the
+available variables with the following command:
+
+.. code-block:: console
+
+    $ ramble info gromacs
+
+
+Focusing on the relevant workloads, you see the following information:
+
+.. code-block:: console
+
+    Workload: water_gmx50
+        Executables: ['builtin::env_vars', 'builtin::spack_source', 'builtin::spack_activate', 'pre-process', 'execute-gen']
+        Inputs: ['water_gmx50_bare']
+        Variables:
+            size:
+                Description: Workload size
+                Default: 1536
+                Suggested Values: ['0000.65', '0000.96', '0001.5', '0003', '0006', '0012', '0024', '0048', '0096', '0192', '0384', '0768', '1536', '3072']
+            type:
+                Description: Workload type.
+                Default: pme
+                Suggested Values: ['pme', 'rf']
+            input_path:
+                Description: Input path for water GMX50
+                Default: {water_gmx50_bare}/{size}
+    Workload: water_bare
+        Executables: ['builtin::env_vars', 'builtin::spack_source', 'builtin::spack_activate', 'pre-process', 'execute-gen']
+        Inputs: ['water_bare_hbonds']
+        Variables:
+            size:
+                Description: Workload size
+                Default: 1536
+                Suggested Values: ['0000.65', '0000.96', '0001.5', '0003', '0006', '0012', '0024', '0048', '0096', '0192', '0384', '0768', '1536', '3072']
+            type:
+                Description: Workload type.
+                Default: pme
+                Suggested Values: ['pme', 'rf']
+            input_path:
+                Description: Input path for water bare hbonds
+                Default: {water_bare_hbonds}/{size}
+
+
+Within each of the workloads your workspace has experiments for, you can see
+definitions for both ``size`` and ``type``. The ``Suggested Values`` attribute
+defines possible values for each of the variables, which can be defined within
+your workspace's ``ramble.yaml`` file.
+
+While these variables contain ``Suggested Values`` some other variable
+definitions can take any value you want. As a result, they might not provide
+anything other than a default value. While the default value is expected to
+function properly, you as the user can override their definition within the
+``ramble.yaml`` if your experiments would benefit from it. However, be aware
+that this also has the potential to change the behavior of your experiments and
+is considered an advanced action.
+
+Editing Experiments
+-------------------
+
+Now that you know how to determine which values are possible, select one or
+more of the possible values for the ``size`` variable. You will modify the
+experiments in your workspace to use this (remember, you have 4 experiments
+defined currently). **NOTE** The larger the value, the more expensive the
+experiment will be. However you can give each experiment a unique value.
+
+To make editing the workspace easier, use the following command (assuming you
+have an ``EDITOR`` environment variable set):
+
+.. code-block:: console
+
+    $ ramble workspace edit
+
+This command opens the ``ramble.yaml`` file, along with any ``*.tpl`` files in
+the workspace's ``configs`` directory.
+
+When the ``ramble.yaml`` is open, modify any of the experiment's ``size``
+variable definitions that you want to. Finally, save and exit the file.
+
+These changes should now be reflected in the output of:
+
+.. code-block:: console
+
+    $ ramble workspace info -v
+
+Execute Experiments
+-------------------
+
+Now that you have made the appropriate modifications, set up, execute, and
+analyze the new experiments using:
+
+.. code-block:: console
+
+    $ ramble workspace setup
+    $ ramble on
+    $ ramble workspace analyze
+
+This creates a ``results`` file in the root of the workspace that contains
+extracted figures of merit. If the experiments were successful, this file will
+show the following results:
+
+* Core Time: CPU time (in seconds) spent on the benchmark calculations
+* Wall Time: Elapsed real time (in seconds) spent on the benchmark calculations
+* Percent Core Time: Core Time / Wall Time
+* Nanosecs per day: Nanoseconds of simulation per day at the speed achieved
+* Hours per nanosec: Hours required to calculate 1 nanosecond of simulation at
+  the speed achieved
+
+If you have a ``results`` file from the :ref:`running_an_experiment_tutorial`,
+you can compare it with the newly created results file to see what impact
+changing the ``size`` variable had on your figures of merit.

--- a/lib/ramble/docs/tutorials/running_a_simple_gromacs_experiment.rst
+++ b/lib/ramble/docs/tutorials/running_a_simple_gromacs_experiment.rst
@@ -16,7 +16,9 @@ In this tutorial, you will set up and run a benchmark simulation using
 `GROMACS <https://www.gromacs.org/>`_, a free and open-source application
 for molecular dynamics.
 
-This tutorial builds off of concepts introduced in the :ref:`hello_world_tutorial` tutorial.
+This tutorial builds off of concepts introduced in previous tutorials. Please
+make sure you review those before starting with this tutorial's content,
+however this tutorial is fully stand-alone as far as steps you need to perform.
 
 Application Information
 -----------------------
@@ -93,131 +95,10 @@ This output does not represent the only possible configuration that works for
 this application, it only presents a good starting point. When using Ramble,
 these can be modified freely and will be explored in a later tutorial.
 
-------------------------
-Configuring experiments
-------------------------
+.. include:: shared/gromacs_workspace.rst
 
-As mentioned before, you are going to focus on creating experiments from the
-``water_bare`` and ``water_gmx50`` workloads. We will explore the two available
-values for the ``type`` variable, and a single value for the ``size`` variable.
-
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Create and Activate a Workspace
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Before you can configure your GROMACS experiments, you'll need to set up a
-workspace. You can call this workspace ``basic_gromacs``.
-
-.. code-block:: console
-
-    $ ramble workspace create basic_gromacs
-
-This will create a workspace for you in:
-
-.. code-block:: console
-
-    $ $ramble_root/var/ramble/workspaces/basic_gromacs
-
-Now you can activate the workspace and view its default configuration.
-
-.. code-block:: console
-
-    $ ramble workspace activate basic_gromacs
-    $ ramble workspace info
-
-You can use the ``ramble workspace info`` command after editing configuration
-files to see how ramble would use the changes you made.
-
-^^^^^^^^^^^^^^^^^^^^^^^^
-Configure the Workspace
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-Within the workspace directory, ramble creates a directory named ``configs``.
-This directory contains generated configuration and template files. Each of
-these files can be edited to configure the workspace, and examples will be
-provided below.
-
-The available files are:
-* ``ramble.yaml`` This file describes all aspects of the workspace. This
-includes the software stack, the experiments, and all variables.
-* ``execute_experiment.tpl`` This file is a template shell script that will be
-rendered to execute each of the experiments that ramble generates.
-
-You can edit these files directly or with the command ``ramble workspace edit``.
-
-To begin, you should edit the ``ramble.yaml`` file to set up the configuration
-for your experiments. For this tutorial, replace the default yaml text with the
-contents of ``$ramble_root/examples/basic_gromacs_config.yaml``:
-
-.. code-block:: yaml
-
-    ramble:
-      variables:
-        processes_per_node: 1
-        mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
-        batch_submit: '{execute_experiment}'
-      applications:
-        gromacs: # Application name, from `ramble list`
-          workloads:
-            water_gmx50: # Workload name from application, in `ramble info <app>`
-              experiments:
-                pme_single_rank: # Arbitrary experiment name
-                  variables:
-                    n_ranks: '1'
-                    n_threads: '1'
-                    size: '0003'
-                    type: 'pme'
-                rf_single_rank: # Arbitrary experiment name
-                  variables:
-                    n_ranks: '1'
-                    n_threads: '1'
-                    size: '0003'
-                    type: 'rf'
-            water_bare: # Workload name from application, in `ramble info <app>`
-              experiments:
-                pme_single_rank: # Arbitrary experiment name
-                  variables:
-                    n_ranks: '1'
-                    n_threads: '1'
-                    size: '0003'
-                    type: 'pme'
-                rf_single_rank: # Arbitrary experiment name
-                  variables:
-                    n_ranks: '1'
-                    n_threads: '1'
-                    size: '0003'
-                    type: 'rf'
-      spack:
-        concretized: true
-        packages:
-          gcc9:
-            spack_spec: gcc@9.3.0 target=x86_64
-            compiler_spec: gcc@9.3.0
-          impi2018:
-            spack_spec: intel-mpi@2018.4.274 target=x86_64
-            compiler: gcc9
-          gromacs:
-            spack_spec: gromacs@2021.6
-            compiler: gcc9
-        environments:
-          gromacs:
-            packages:
-            - gromacs
-            - impi2018
-
-Note that specifying compilers that Spack doesn't have installed may take a while.
-To see available compilers, use ``spack compilers`` or see `Spack documentation
-<https://spack.readthedocs.io/en/latest/getting_started.html#spack-compilers>`_
-for more information.
-
-The second file you should edit is the ``execute_experiment.tpl`` template file.
-This file contains a template script that will be rendered into an execution
-script for each generated experiment. You can feel free to edit it as you need
-to for your given system, but for this tutorial the default value will work.
-
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Setting Up the Experiments
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+---------------------------
 
 Now that the workspace is configured correctly, you can set up the experiments
 in the active workspace using:
@@ -247,9 +128,8 @@ For each setup run, a set of logs will be created at:
 Each run will have its own primary log, along with a folder containing a log for each
 experiment that is being configured.
 
-^^^^^^^^^^^^^^^^^^^^^^
 Executing Experiments
-^^^^^^^^^^^^^^^^^^^^^^
+---------------------
 
 After the workspace is set up, its experiments can be executed. The two methods
 to run the experiments are:
@@ -260,9 +140,8 @@ to run the experiments are:
    or;
     $ ./all_experiments
 
-^^^^^^^^^^^^^^^^^^^^^^
 Analyzing Experiments
-^^^^^^^^^^^^^^^^^^^^^^
+---------------------
 
 Once the experiments within a workspace are complete, the experiments can be
 analyzed. This is done through:

--- a/lib/ramble/docs/tutorials/shared/gromacs_workspace.rst
+++ b/lib/ramble/docs/tutorials/shared/gromacs_workspace.rst
@@ -1,0 +1,78 @@
+.. Copyright 2022-2023 Google LLC
+
+   Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+   https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+   <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+   option. This file may not be copied, modified, or distributed
+   except according to those terms.
+
+Configuring experiments
+------------------------
+
+For this tutorial, you are going to focus on creating experiments from the
+``water_bare`` and ``water_gmx50`` workloads. The default configuration will
+contain experiments for each value of the ``type`` variable, and a single value
+for the ``size`` variable.
+
+You will use a Ramble workspace to manage these experiments.
+
+Create and Activate a Workspace
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Before you can configure your GROMACS experiments, you'll need to set up a
+workspace. You can call this workspace ``basic_gromacs``.
+
+.. code-block:: console
+
+    $ ramble workspace create basic_gromacs
+
+This will create a workspace for you in:
+
+.. code-block:: console
+
+    $ $ramble_root/var/ramble/workspaces/basic_gromacs
+
+Now you can activate the workspace and view its default configuration.
+
+.. code-block:: console
+
+    $ ramble workspace activate basic_gromacs
+    $ ramble workspace info
+
+You can use the ``ramble workspace info`` command after editing configuration
+files to see how ramble would use the changes you made.
+
+Configure the Workspace
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Within the workspace directory, ramble creates a directory named ``configs``.
+This directory contains generated configuration and template files. Each of
+these files can be edited to configure the workspace, and examples will be
+provided below.
+
+The available files are:
+* ``ramble.yaml`` This file describes all aspects of the workspace. This
+includes the software stack, the experiments, and all variables.
+* ``execute_experiment.tpl`` This file is a template shell script that will be
+rendered to execute each of the experiments that ramble generates.
+
+You can edit these files directly or with the command ``ramble workspace edit``.
+
+To begin, you should edit the ``ramble.yaml`` file to set up the configuration
+for your experiments. For this tutorial, replace the default yaml text with the
+contents of ``$ramble_root/examples/basic_gromacs_config.yaml``:
+
+
+.. literalinclude:: ../../../../examples/basic_gromacs_config.yaml
+   :linenos:
+   :language: YAML
+
+Note that specifying compilers that Spack doesn't have installed may take a while.
+To see available compilers, use ``spack compilers`` or see `Spack documentation
+<https://spack.readthedocs.io/en/latest/getting_started.html#spack-compilers>`_
+for more information.
+
+The second file you should edit is the ``execute_experiment.tpl`` template file.
+This file contains a template script that will be rendered into an execution
+script for each generated experiment. You can feel free to edit it as you need
+to for your given system, but for this tutorial the default value will work.

--- a/lib/ramble/docs/tutorials/using_vectors_and_matrices.rst
+++ b/lib/ramble/docs/tutorials/using_vectors_and_matrices.rst
@@ -1,0 +1,460 @@
+.. Copyright 2022-2023 Google LLC
+
+   Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+   https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+   <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+   option. This file may not be copied, modified, or distributed
+   except according to those terms.
+
+.. _vector_and_matrix_tutorial:
+
+=======================================
+4) Using Vectors and Matrices
+=======================================
+
+In this tutorial, you will learn how to utilized vectors and matrices in Ramble
+workspaces. Ramble's vector and matrix variable logic is defined in more detail in
+:ref:`ramble-vector-logic` and :ref:`ramble-matrix-logic`
+
+This tutorial builds off of concepts introduced in previous tutorials. Please
+make sure you review those before starting with this tutorial's content.
+
+.. include:: shared/gromacs_workspace.rst
+
+Activate the Workspace
+----------------------
+
+As you are using a pre-existing workspace, ensure it is activated (NOTE: you
+only need to run this if you do not currently have the workspace active).
+
+.. code-block:: console
+
+    $ ramble workspace activate basic_gromacs
+
+
+Experiment Descriptions
+-----------------------
+
+Now that your workspace has been configured, and activated, You can execute the
+following command to see what experiments the workspace currently contains:
+
+.. code-block:: console
+
+    $ ramble workspace info
+
+This command provides a summary view of the workspace. It includes the
+experiment names, and the software environments. As an example, its output
+might contain the following information:
+
+.. code-block:: console
+
+    Experiments:
+      Application: gromacs
+        Workload: water_gmx50
+          Experiment: gromacs.water_gmx50.pme_single_rank
+      Application: gromacs
+        Workload: water_gmx50
+          Experiment: gromacs.water_gmx50.rf_single_rank
+      Application: gromacs
+        Workload: water_bare
+          Experiment: gromacs.water_bare.pme_single_rank
+      Application: gromacs
+        Workload: water_bare
+          Experiment: gromacs.water_bare.rf_single_rank
+
+To get detailed information about where variable definitions come from, you can use:
+
+.. code-block:: console
+
+    $ ramble workspace info -v
+
+The experiments section of this command's output might contain the following:
+
+.. code-block:: console
+
+    Experiments:
+      Application: gromacs
+        Workload: water_gmx50
+          Experiment: gromacs.water_gmx50.pme_single_rank
+            Variables from Workspace:
+              processes_per_node = 16 ==> 16
+              mpi_command = mpirun -n {n_ranks} -ppn {processes_per_node} ==> mpirun -n 1 -ppn 16
+              batch_submit = {execute_experiment} ==> {execute_experiment}
+            Variables from Experiment:
+              n_ranks = 1 ==> 1
+              n_threads = 1 ==> 1
+              size = 0003 ==> 0003
+              type = pme ==> pme
+      Application: gromacs
+        Workload: water_gmx50
+          Experiment: gromacs.water_gmx50.rf_single_rank
+            Variables from Workspace:
+              processes_per_node = 16 ==> 16
+              mpi_command = mpirun -n {n_ranks} -ppn {processes_per_node} ==> mpirun -n 1 -ppn 16
+              batch_submit = {execute_experiment} ==> {execute_experiment}
+            Variables from Experiment:
+              n_ranks = 1 ==> 1
+              n_threads = 1 ==> 1
+              size = 0003 ==> 0003
+              type = rf ==> rf
+      Application: gromacs
+        Workload: water_bare
+          Experiment: gromacs.water_bare.pme_single_rank
+            Variables from Workspace:
+              processes_per_node = 16 ==> 16
+              mpi_command = mpirun -n {n_ranks} -ppn {processes_per_node} ==> mpirun -n 1 -ppn 16
+              batch_submit = {execute_experiment} ==> {execute_experiment}
+            Variables from Experiment:
+              n_ranks = 1 ==> 1
+              n_threads = 1 ==> 1
+              size = 0003 ==> 0003
+              type = pme ==> pme
+      Application: gromacs
+        Workload: water_bare
+          Experiment: gromacs.water_bare.rf_single_rank
+            Variables from Workspace:
+              processes_per_node = 16 ==> 16
+              mpi_command = mpirun -n {n_ranks} -ppn {processes_per_node} ==> mpirun -n 1 -ppn 16
+              batch_submit = {execute_experiment} ==> {execute_experiment}
+            Variables from Experiment:
+              n_ranks = 1 ==> 1
+              n_threads = 1 ==> 1
+              size = 0003 ==> 0003
+              type = rf ==> rf
+
+When comparing the ``ramble.yaml`` file to this output, you should notice that
+the ``ramble.yaml`` file is very repetitive. Its current content shows how to
+define many explicit experiments, but when trying to generate many experiments
+that are similar it is unncessarily verbose. In the next step, we are going to
+collapase the experiments into a single definition, and extend them to do a
+basic rank based scaling study.
+
+Editing Experiments
+-------------------
+
+In the next few sections, you will edit the workspace configuration file. To
+make editing the workspace easier, use the following command (assuming you have
+an ``EDITOR`` environment variable set):
+
+.. code-block:: console
+
+    $ ramble workspace edit
+
+This command opens the ``ramble.yaml`` file, along with any ``*.tpl`` files in
+the workspace's ``configs`` directory.
+
+When the ``ramble.yaml`` is open, modify any of the content you want to, and
+save and exit the file.
+
+These changes should now be reflected in the output of:
+
+.. code-block:: console
+
+    $ ramble workspace info -v
+
+Using Vector Variables
+----------------------
+
+Vector (or list) variables in Ramble are variables who's value is a list of
+other values in the ``ramble.yaml`` workspace configuration file. There are
+many reasons you might want to use list variables, such as defining a scaling
+study, or exploring a range of a given parameter within a single experiment
+definition.
+
+Currently, your ``basic_gromacs`` workspace has 4 experiments defined. There
+are two different workloads ( ``water_bare`` and ``water_gmx50`` ), and each
+workload explores the two different values for the ``type`` variable ( ``pme``
+and ``rf`` ).
+
+Edit your workspace configuration, and collapse the experiment definitions
+using vectors. To begin with, collapse the ``type`` values into a list within
+each individual workload. You should end up with only a single experiment
+definition within each of the workloads, which looks something like the
+following:
+
+.. code-block:: YAML
+
+    pme_single_rank:
+      variables:
+        n_ranks: '1'
+        n_threads: '1'
+        size: '0003'
+        type: ['pme', 'rf']
+
+After writing this configuration, save and exit your ``ramble.yaml`` file, and execute:
+
+.. code-block:: console
+
+    $ ramble workspace info
+
+To see the experiments within your workspace. If you use the configuration from
+above, you should see the following error printed to the screen:
+
+.. code-block:: console
+
+    ==> Error: Experiment gromacs.water_bare.pme_single_rank is not unique.
+
+Within Ramble, each experiment is required to have a unique namespace. The
+namespace of an experiment is defined as:
+
+.. code-block:: console
+
+    <application name>.<workload name>.<rendered experiment name>
+
+So, changing things like the application or workload automatically create a
+unique namespace, but changing vector variables within an experiment do not
+automatically generate a unique namespace. In this case, your experiments that
+have a different ``type`` both result in the same experiment name.
+
+Templatized Experiment Names
+----------------------------
+
+In order to generate unique experiment namespaces while using vector variable
+definitions, Ramble allows the experiment name to be templatized using variable
+names as expansion placeholders.
+
+To fix the error from the previous section, you need to modify the experiment
+name that contains the vector ``type`` definition. The result should look
+something like the following:
+
+.. code-block:: YAML
+
+    '{type}_single_rank':
+      variables:
+        n_ranks: '1'
+        n_threads: '1'
+        size: '0003'
+        type: ['pme', 'rf']
+
+Notice how the name of the experiment changed from ``pme_single_rank`` to
+``'{type}_single_rank'``. This allows Ramble to populate the experiment name by
+expanding the ``{type}`` variable reference.
+
+**NOTE** Because we are editing YAML, the experiment name needs to be
+explicitly delimited as a string. Notice how in the above example we wrap the
+experiment name in single quotes to explicitly make it a string.
+
+Now, save and exit the file. The resulting experiments can be seen using:
+
+.. code-block:: console
+
+    $ ramble workspace info
+
+And the result should be something like the following (if you have changed the
+experiment definition under both workloads):
+
+.. code-block:: console
+
+    Experiments:
+      Application: gromacs
+        Workload: water_gmx50
+          Experiment: gromacs.water_gmx50.pme_single_rank
+          Experiment: gromacs.water_gmx50.rf_single_rank
+      Application: gromacs
+        Workload: water_bare
+          Experiment: gromacs.water_bare.pme_single_rank
+          Experiment: gromacs.water_bare.rf_single_rank
+
+Vectorizing Workload Names
+--------------------------
+
+The next step in the process of simplifying your workspace configuration file
+is to vectorize the workload names used. Here, we'll use a similar technique to
+templates the experiment names.
+
+Edit your workspace configuration file, and define a new variable named
+``app_workload`` within one of the two experiments. Set the value of this
+variable to ``['water_bare', 'water_gmx50']`` and delete the other experiment
+definition entirely.
+
+Finally, to allow ramble to generate experiments for each workload, change the
+workload name to ``'{app_workload}'``. The resulting portion of the
+``ramble.yaml`` file should look like the following:
+
+.. code-block:: YAML
+
+    workloads:
+      '{app_workload}': # Workload name from application
+        experiments:
+          '{type}_single_rank': # Arbitrary experiment name
+            variables:
+              app_workload: ['water_bare', 'water_gmx50']
+              n_ranks: '1'
+              n_threads: '1'
+              size: '0003'
+              type: ['pme', 'rf']
+
+At this point, you can save and exit. Executing:
+
+.. code-block:: console
+
+    $ ramble workspace info
+
+Should show the following output:
+
+.. code-block:: console
+
+    Experiments:
+      Application: gromacs
+        Workload: {app_workload}
+          Experiment: gromacs.water_bare.pme_single_rank
+          Experiment: gromacs.water_gmx50.rf_single_rank
+
+However, at this point you should only see two experiments while we expect to
+see four. This is because of the way multiple vector variables are handled in
+Ramble. After consuming vector variables (which we'll describe in the next
+section) the resulting vectors are required to be the same length (in this case
+they are both of length 2) and are zipped together and iterated over to
+generate experiments. In this case, the resulting zip looks something like the
+following:
+
+.. code-block:: console
+
+    [ (water_bare, pme), (water_gmx50, rf) ]
+
+While we want something more like:
+
+.. code-block:: console
+
+    [ (water_bare, pme), (water_bare, rf), (water_gmx50, pme), (water_gmx50, rf) ]
+
+To remedy this issue, we will use Ramble's matrix definitions.
+
+Variable Matrices
+-----------------
+
+As you've seen so far, you can define vector variables in Ramble. These
+definitions can be implicitly zipped together to generate multiple experiments.
+However, sometimes you would actually prefer to have an explicit cross product
+of the variable definitions to explore a wider range of parameter combinations.
+To perform this task, Ramble allows you to use variable ``matrix`` or
+``matrices`` definitions. These definitions can only happen at the lowest level
+(i.e. within the individual experiment scope) of a ``ramble.yaml`` file.
+
+Any variable listed within any matrix definition is considered **consumed** by
+the matrix. This removes the variable definition from the implicit zip logic
+defined in the previous section. Multiple matrices can be defined (though we
+will not illustrate this in this tutorial). When multiple matrices are defined
+within the same experiment, they are required to have the same resulting number
+of elements. After they are individually built, they are zipped together to
+create one large set of variable values to generate experiments from. If there
+are unconsumed vector variables, they follow the zip logic described in the
+previous section, and which is then crossed with the result of the matrix
+construction.
+
+To remedy your currently configuration issue (seeing two experiments instead of
+the desired four experiments), we will employ a variable matrix to define the
+additional experiments.
+
+Edit your ``ramble.yaml`` and update your experiment definition to the following:
+
+.. code-block:: YAML
+
+    workloads:
+      '{app_workload}': # Workload name from application
+        experiments:
+          '{type}_single_rank': # Arbitrary experiment name
+            variables:
+              app_workload: ['water_bare', 'water_gmx50']
+              n_ranks: '1'
+              n_threads: '1'
+              size: '0003'
+              type: ['pme', 'rf']
+            matrix:
+            - app_workload
+            - type
+
+
+You should notice the addition of the ``matrix`` section at the bottom of this.
+Here we are constructing a new variable matrix which will be created using the
+cross product of the ``app_workload`` and ``type`` variable definitions. Since
+each has a length of two, the result would be a matrix with four elements in
+it.
+
+After saving an exiting this file, the resulting experiments can be seen using the:
+
+.. code-block:: console
+
+    $ ramble workspace info
+
+command. Which should present the following output:
+
+.. code-block:: console
+
+    Experiments:
+      Application: gromacs
+        Workload: {app_workload}
+          Experiment: gromacs.water_bare.pme_single_rank
+          Experiment: gromacs.water_bare.rf_single_rank
+          Experiment: gromacs.water_gmx50.pme_single_rank
+          Experiment: gromacs.water_gmx50.rf_single_rank
+
+
+Defining a Scaling Study
+------------------------
+
+The final modification you'll make to this workspace is to update the
+experiment definition to perform a basic rank based scaling study.
+
+Edit the ``ramble.yaml`` file, and update the value for ``n_ranks`` to be
+``[1, 2, 4]``. After doing this, add the ``n_ranks`` variable to the matrix
+definition, and ensure your experiment name uses the ``{n_ranks}`` placeholder.
+At this point, your complete ``ramble.yaml`` file should look like the
+following:
+
+.. literalinclude:: ../../../../examples/vector_matrix_gromacs_config.yaml
+   :linenos:
+   :language: YAML
+
+However, your experiment name template may look different from the above, as
+long as it contains the ``{type}`` and ``{n_ranks}`` placeholders, you should
+consider it correct.
+
+To see the final set of experiments, execute:
+
+.. code-block:: console
+
+    $ ramble workspace info
+
+Which should contain the following output:
+
+.. code-block:: console
+
+    Experiments:
+      Application: gromacs
+        Workload: {app_workload}
+          Experiment: gromacs.water_bare.pme_1ranks
+          Experiment: gromacs.water_bare.pme_2ranks
+          Experiment: gromacs.water_bare.pme_4ranks
+          Experiment: gromacs.water_bare.rf_1ranks
+          Experiment: gromacs.water_bare.rf_2ranks
+          Experiment: gromacs.water_bare.rf_4ranks
+          Experiment: gromacs.water_gmx50.pme_1ranks
+          Experiment: gromacs.water_gmx50.pme_2ranks
+          Experiment: gromacs.water_gmx50.pme_4ranks
+          Experiment: gromacs.water_gmx50.rf_1ranks
+          Experiment: gromacs.water_gmx50.rf_2ranks
+          Experiment: gromacs.water_gmx50.rf_4ranks
+
+Execute Experiments
+-------------------
+
+Now that you have made the appropriate modifications, set up, execute, and
+analyze the new experiments using:
+
+.. code-block:: console
+
+    $ ramble workspace setup
+    $ ramble on
+    $ ramble workspace analyze
+
+This creates a ``results`` file in the root of the workspace that contains
+extracted figures of merit. If the experiments were successful, this file will
+show the following results:
+
+* Core Time: CPU time (in seconds) spent on the benchmark calculations
+* Wall Time: Elapsed real time (in seconds) spent on the benchmark calculations
+* Percent Core Time: Core Time / Wall Time
+* Nanosecs per day: Nanoseconds of simulation per day at the speed achieved
+* Hours per nanosec: Hours required to calculate 1 nanosecond of simulation at
+  the speed achieved

--- a/lib/ramble/docs/workspace_config.rst
+++ b/lib/ramble/docs/workspace_config.rst
@@ -138,9 +138,9 @@ experiment. This experiment will also include definitions for
 
 .. _ramble-vector-logic:
 
-^^^^^^^^^^^^^^^
-List Variables:
-^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+List (or Vector) Variables:
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Variables can be defined as a list of values as well (again, following the same
 math and variable expansion syntax as defined above).
 


### PR DESCRIPTION
This merge adds tutorials for using vectors and matrices, and for modifying the underlying software stack within ramble configuration files.