### PR TITLE
Stop using "shm:tcp" as it is no longer supported

### DIFF
--- a/var/ramble/repos/builtin/applications/intel-mpi-benchmarks/application.py
+++ b/var/ramble/repos/builtin/applications/intel-mpi-benchmarks/application.py
@@ -38,16 +38,11 @@ class IntelMpiBenchmarks(SpackApplication):
     required_package('intel-mpi-benchmarks')
 
     executable('pingpong',
-               '-genv FI_PROVIDER=tcp '
-               '-genv I_MPI_FABRICS=shm:ofi '
-               '-genv I_MPI_PIN_PROCESSOR_LIST=0 '
                '{install_path}/IMB-MPI1 {pingpong_type} -msglog {msglog_min}:{msglog_max} '
                '-iter {num_iterations} {additional_args}',
                use_mpi=True)
 
     executable('multi-pingpong',
-               '-genv FI_PROVIDER=tcp '
-               '-genv I_MPI_FABRICS=shm:ofi '
                '{install_path}/IMB-MPI1 Pingpong -msglog {msglog_min}:{msglog_max} '
                '-iter {num_iterations} -multi {multi_val} -map {map_args} {additional_args}',
                use_mpi=True)
@@ -68,8 +63,6 @@ class IntelMpiBenchmarks(SpackApplication):
                       workloads=['multi-pingpong'])
 
     executable('collective',
-               '-genv FI_PROVIDER=tcp '
-               '-genv I_MPI_FABRICS=shm:ofi '
                '{install_path}/IMB-MPI1 {collective_type} -msglog {msglog_min}:{msglog_max} '
                '-iter {num_iterations} -npmin {min_collective_ranks} {additional_args}',
                use_mpi=True)

--- a/var/ramble/repos/builtin/applications/intel-mpi-benchmarks/application.py
+++ b/var/ramble/repos/builtin/applications/intel-mpi-benchmarks/application.py
@@ -38,14 +38,16 @@ class IntelMpiBenchmarks(SpackApplication):
     required_package('intel-mpi-benchmarks')
 
     executable('pingpong',
-               '-genv I_MPI_FABRICS=shm:tcp '
+               '-genv FI_PROVIDER=tcp '
+               '-genv I_MPI_FABRICS=shm:ofi '
                '-genv I_MPI_PIN_PROCESSOR_LIST=0 '
                '{install_path}/IMB-MPI1 {pingpong_type} -msglog {msglog_min}:{msglog_max} '
                '-iter {num_iterations} {additional_args}',
                use_mpi=True)
 
     executable('multi-pingpong',
-               '-genv I_MPI_FABRICS=shm:tcp '
+               '-genv FI_PROVIDER=tcp '
+               '-genv I_MPI_FABRICS=shm:ofi '
                '{install_path}/IMB-MPI1 Pingpong -msglog {msglog_min}:{msglog_max} '
                '-iter {num_iterations} -multi {multi_val} -map {map_args} {additional_args}',
                use_mpi=True)
@@ -66,7 +68,8 @@ class IntelMpiBenchmarks(SpackApplication):
                       workloads=['multi-pingpong'])
 
     executable('collective',
-               '-genv I_MPI_FABRICS=shm:tcp '
+               '-genv FI_PROVIDER=tcp '
+               '-genv I_MPI_FABRICS=shm:ofi '
                '{install_path}/IMB-MPI1 {collective_type} -msglog {msglog_min}:{msglog_max} '
                '-iter {num_iterations} -npmin {min_collective_ranks} {additional_args}',
                use_mpi=True)


### PR DESCRIPTION
When running the Intel MPI microbenchmarks, this is the first line of the output:

```
MPI startup(): shm:tcp fabric is unknown or has been removed from the product, please use ofi or shm:ofi instead.
```

This PR updates the variable `I_MPI_FABRICS` to be `shm:ofi` (previously `shm:tcp`) and adds `FI_PROVIDER=tcp`.