### PR TITLE
Define zips as a config section

### DIFF
--- a/lib/ramble/ramble/config.py
+++ b/lib/ramble/ramble/config.py
@@ -87,6 +87,7 @@ section_schemas = {
     'success_criteria': ramble.schema.success_criteria.schema,
     'applications': ramble.schema.applications.schema,
     'variables': ramble.schema.variables.schema,
+    'zips': ramble.schema.zips.schema,
 }
 
 # Same as above, but including keys for workspaces

--- a/lib/ramble/ramble/context.py
+++ b/lib/ramble/ramble/context.py
@@ -74,7 +74,7 @@ class Context(object):
         if in_context.exclude:
             self.exclude = in_context.exclude
         if in_context.zips:
-            self.zips = in_context.zips
+            self.zips.update(in_context.zips)
         if in_context.matrices:
             self.matrices = in_context.matrices
 

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -61,6 +61,7 @@ class ExperimentSet(object):
         workspace_context.env_variables = workspace.get_workspace_env_vars()
         workspace_context.internals = workspace.get_workspace_internals()
         workspace_context.modifiers = workspace.get_workspace_modifiers()
+        workspace_context.zips = workspace.get_workspace_zips()
 
         try:
             self.keywords.check_reserved_keys(workspace_context.variables)

--- a/lib/ramble/ramble/schema/applications.py
+++ b/lib/ramble/ramble/schema/applications.py
@@ -22,20 +22,8 @@ import ramble.schema.variables
 import ramble.schema.success_criteria
 import ramble.schema.licenses
 import ramble.schema.modifiers
+import ramble.schema.zips
 
-
-zip_def = {
-    'type': 'array',
-    'default': [],
-    'items': {'type': 'string'}
-}
-
-zips_def = {
-    'type': 'object',
-    'default': {},
-    'properties': {},
-    'additionalProperties': zip_def
-}
 
 matrix_def = {
     'type': 'array',
@@ -88,10 +76,10 @@ exclude_def = {
     'default': {},
     'properties': union_dicts(
         ramble.schema.variables.properties,
+        ramble.schema.zips.properties,
         {
             'matrix': matrix_def,
             'matrices': matrices_def,
-            'zips': zips_def,
             'where': where_def,
         }
     ),
@@ -104,6 +92,7 @@ sub_props = union_dicts(
     ramble.schema.env_vars.properties,
     ramble.schema.internals.properties,
     ramble.schema.modifiers.properties,
+    ramble.schema.zips.properties,
     {
         'chained_experiments': chained_experiment_def,
         'template': {'type': 'boolean'},
@@ -145,7 +134,6 @@ properties = {
                                             'properties': union_dicts(
                                                 sub_props,
                                                 {
-                                                    'zips': zips_def,
                                                     'matrix': matrix_def,
                                                     'matrices': matrices_def,
                                                     'success_criteria': success_list_def,

--- a/lib/ramble/ramble/schema/merged.py
+++ b/lib/ramble/ramble/schema/merged.py
@@ -22,6 +22,7 @@ import ramble.schema.variables
 import ramble.schema.env_vars
 import ramble.schema.internals
 import ramble.schema.modifiers
+import ramble.schema.zips
 
 #: Properties for inclusion in other schemas
 properties = union_dicts(
@@ -34,6 +35,7 @@ properties = union_dicts(
     ramble.schema.env_vars.properties,
     ramble.schema.internals.properties,
     ramble.schema.modifiers.properties,
+    ramble.schema.zips.properties
 )
 
 #: Full schema with metadata

--- a/lib/ramble/ramble/schema/spack.py
+++ b/lib/ramble/ramble/schema/spack.py
@@ -14,6 +14,7 @@
 
 import ramble.schema.variables
 import ramble.schema.applications
+import ramble.schema.zips
 
 #: Properties for inclusion in other schemas
 properties = {
@@ -25,6 +26,7 @@ properties = {
                 'default': False
             },
             'variables': ramble.schema.variables.variables_def,
+            'zips': ramble.schema.zips.zips_def,
             'packages': {
                 'type': 'object',
                 'additionalProperties': {
@@ -40,7 +42,7 @@ properties = {
                             'default': None,
                         },
                         'variables': ramble.schema.variables.variables_def,
-                        'zips': ramble.schema.applications.zips_def,
+                        'zips': ramble.schema.zips.zips_def,
                         'matrix': ramble.schema.applications.matrix_def,
                         'matrices': ramble.schema.applications.matrices_def,
                         'exclude': ramble.schema.applications.exclude_def,
@@ -66,7 +68,7 @@ properties = {
                             'default': []
                         },
                         'variables': ramble.schema.variables.variables_def,
-                        'zips': ramble.schema.applications.zips_def,
+                        'zips': ramble.schema.zips.zips_def,
                         'matrix': ramble.schema.applications.matrix_def,
                         'matrices': ramble.schema.applications.matrices_def,
                         'exclude': ramble.schema.applications.exclude_def,

--- a/lib/ramble/ramble/schema/workspace.py
+++ b/lib/ramble/ramble/schema/workspace.py
@@ -35,31 +35,6 @@ properties = {
         'properties': union_dicts(
             ramble.schema.merged.properties,
             {
-                'mpi': {
-                    'type': 'object',
-                    'properties': {
-                        'command': {
-                            'type': 'string'
-                        },
-                        'args': {
-                            'type': 'array',
-                            'items': {'type': 'string'},
-                            'default': []
-                        }
-                    },
-                    'additionalProperties': False,
-                    'default': {},
-                },
-                'batch': {
-                    'type': 'object',
-                    'properties': {
-                        'submit': {
-                            'type': 'string'
-                        },
-                    },
-                    'additionalProperties': False,
-                    'default': {}
-                },
                 'include': {
                     'type': 'array',
                     'default': [],
@@ -76,9 +51,6 @@ properties = {
         ),
         'additionalProperties': False,
     },
-    # TODO (dwj): Remove when non-config spack is removed
-    # DEPRECATED
-    'spack': ramble.schema.spack.properties['spack']  # To support non-config spack
 }
 
 

--- a/lib/ramble/ramble/schema/zips.py
+++ b/lib/ramble/ramble/schema/zips.py
@@ -1,0 +1,41 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+"""Schema for variable zips configuration file.
+
+.. literalinclude:: _ramble_root/lib/ramble/ramble/schema/zips.py
+   :lines: 12-
+"""  # noqa E501
+
+
+zip_def = {
+    'type': 'array',
+    'default': [],
+    'items': {'type': 'string'}
+}
+
+zips_def = {
+    'type': 'object',
+    'default': {},
+    'properties': {},
+    'additionalProperties': zip_def
+}
+
+#: Properties for inclusion in other schemas
+properties = {
+    'zips': zips_def,
+}
+
+#: Full schema with metadata
+schema = {
+    '$schema': 'http://json-schema.org/schema#',
+    'title': 'Ramble zips configuration file schema',
+    'type': 'object',
+    'additionalProperties': False,
+    'properties': properties
+}

--- a/lib/ramble/ramble/software_environments.py
+++ b/lib/ramble/ramble/software_environments.py
@@ -86,10 +86,15 @@ class SoftwareEnvironments(object):
         expander = ramble.expander.Expander({}, None)
 
         workspace_vars = self._workspace.get_workspace_vars().copy()
+        workspace_zips = self._workspace.get_workspace_zips().copy()
 
         if namespace.variables in self.spack_dict and \
                 self.spack_dict[namespace.variables] is not None:
             workspace_vars.update(self.spack_dict[namespace.variables])
+
+        if namespace.zips in self.spack_dict and \
+                self.spack_dict[namespace.zips] is not None:
+            workspace_zips.update(self.spack_dict[namespace.zips])
 
         if namespace.packages in self.spack_dict:
             for pkg_template, pkg_info in self.spack_dict[namespace.packages].items():
@@ -97,6 +102,7 @@ class SoftwareEnvironments(object):
                 self._package_map[pkg_template] = {}
                 pkg_group = ramble.renderer.RenderGroup('package', 'create')
                 pkg_group.variables.update(workspace_vars)
+                pkg_group.zips.update(workspace_zips)
                 pkg_group.from_dict(pkg_template, pkg_info)
 
                 pkg_group.variables['package_name'] = pkg_template
@@ -147,6 +153,7 @@ class SoftwareEnvironments(object):
             for env_template, env_info in self.spack_dict[namespace.environments].items():
                 env_group = ramble.renderer.RenderGroup('environment', 'create')
                 env_group.variables.update(workspace_vars)
+                env_group.zips.update(workspace_zips)
                 env_group.from_dict(env_template, env_info)
                 self._raw_environments[env_template] = env_info
                 self._environment_map[env_template] = {}

--- a/lib/ramble/ramble/test/end_to_end/explicit_zips.py
+++ b/lib/ramble/ramble/test/end_to_end/explicit_zips.py
@@ -35,10 +35,17 @@ ramble:
     processes_per_node: ['16', '36']
     n_ranks: '{processes_per_node}*{n_nodes}'
     n_threads: '1'
+  zips:
+    partitions:
+    - partition
+    - processes_per_node
   applications:
     wrfv4:
       variables:
         env_name: ['wrfv4', 'wrfv4-portable']
+      zips:
+        environments:
+        - env_name
       workloads:
         CONUS_12km:
           experiments:
@@ -66,12 +73,11 @@ ramble:
               variables:
                 n_nodes: ['1', '2', '4', '8', '16']
               zips:
-                partitions:
-                - partition
-                - processes_per_node
+                nodes:
+                - n_nodes
               matrix:
-              - n_nodes
-              - env_name
+              - nodes
+              - environments
               - partitions
   spack:
     concretized: true

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1329,6 +1329,10 @@ class Workspace(object):
         """Return a dict of workspace modifiers"""
         return ramble.config.config.get_config('modifiers')
 
+    def get_workspace_zips(self):
+        """Return a dict of workspace zips"""
+        return ramble.config.config.get_config('zips')
+
     def get_spack_dict(self):
         """Return the spack dictionary for this workspace"""
         return ramble.config.config.get_config('spack')


### PR DESCRIPTION
This merge allows zips to be defined anywhere variables can be defined, including in the scopes supported by any config section.

It also performs some removal of deprecated definitions in the workspace schema.