### PR TITLE
Allow custom executables to be injected relative to other executables

### DIFF
--- a/lib/ramble/docs/configuration_files.rst
+++ b/lib/ramble/docs/configuration_files.rst
@@ -231,6 +231,10 @@ The format of the internals config section is as follows:
       - executables
       - to use in
       - experiments
+      executable_injection:
+      - name: <executable_name>
+        order: 'before' / 'after' # Default: 'after'
+        [relative_to: <relative_executable_name>]
 
 Currently this section has two sub-sections.
 
@@ -241,6 +245,22 @@ of an internally defined executable within an experiment.
 The ``executables`` sub-section can be used to control the order executables
 will be used in the experiment. This is also the mechanism to inject custom
 executables into an experiment.
+
+The ``executable_injection`` sub-section can be used to inject custom
+executables into the list of executables an experiment would use without having
+to define the entire list. The ``name`` attribute should be set to the name of
+an executable. This can be either a custom executable (defined in
+``custom_executables``) or an existing executable (including a ``builtin``).
+The ``order`` attrbite can be set to either ``before`` or ``after`` with
+``after`` being the default value if it is not specified. The ``relative_to``
+attribute can be set to the name of an executable already in the list of
+experiment executables (including custom executables that are already injected).
+
+Processing the ``executable_injection`` sub-section occurs after processing the
+``executables`` sub-section. Executables are injected in the order they are
+listed in the YAML file, with lower precedence scopes being processed first.
+(e.g. ``workspace`` executables are injected before ``experiment`` executables
+are).
 
 .. _licenses-config:
 

--- a/lib/ramble/docs/workspace_config.rst
+++ b/lib/ramble/docs/workspace_config.rst
@@ -647,6 +647,34 @@ The default for the hostname application is ``[builtin::env_vars,
 serial/parallel]`` but this changes the order and injects ``lscpu`` into the
 expansion.
 
+
+"""""""""""""""""""""""""""
+Using Executable Injection:
+"""""""""""""""""""""""""""
+
+Executable order can also be controlled via the ``executable_injection`` block
+within the ``internals`` block. Injecting the ``lscpu`` executable to the end of
+the list of executables can be performed with the following:
+
+.. code-block:: yaml
+
+   ramble:
+     applications:
+       hostname:
+         internals:
+           custom_executables:
+             lscpu:
+               template:
+               - 'lscpu'
+               use_mpi: false
+               redirect: '{log_file}'
+           executable_injection:
+           - name: lscpu
+
+This is a generic way to add the ``lscpu`` custom executable to the end of the
+list of executables for the experiment. For more information on this see the
+:ref:`internals config section<internals-config>` documentation.
+
 ^^^^^^^^^^^^^^^^^^^
 Reserved Variables:
 ^^^^^^^^^^^^^^^^^^^

--- a/lib/ramble/ramble/context.py
+++ b/lib/ramble/ramble/context.py
@@ -40,7 +40,8 @@ class Context(object):
         """Merges another Context into this Context."""
 
         internal_sections = [namespace.custom_executables,
-                             namespace.executables]
+                             namespace.executables,
+                             namespace.executable_injection]
 
         if in_context.variables:
             self.variables.update(in_context.variables)

--- a/lib/ramble/ramble/namespace.py
+++ b/lib/ramble/ramble/namespace.py
@@ -19,6 +19,7 @@ class namespace:
     internals = 'internals'
     custom_executables = 'custom_executables'
     executables = 'executables'
+    executable_injection = 'executable_injection'
     env_var = 'env_vars'
     packages = 'packages'
     environments = 'environments'

--- a/lib/ramble/ramble/schema/internals.py
+++ b/lib/ramble/ramble/schema/internals.py
@@ -37,12 +37,36 @@ custom_executables_def = {
 
 executables_def = ramble.schema.types.array_of_strings_or_nums
 
+executable_injection_def = {
+    'type': 'array',
+    'default': [],
+    'items': {
+        'type': 'object',
+        'default': {},
+        'properties': {
+            'name': {
+                'type': 'string'
+            },
+            'order': {
+                'type': 'string',
+                'default': 'after',
+            }
+        },
+        'additionalProperties': {
+            'relative_to': {
+                'type': 'string'
+            }
+        }
+    }
+}
+
 internals_def = {
     'type': 'object',
     'default': {},
     'properties': {
         'custom_executables': custom_executables_def,
         'executables': executables_def,
+        'executable_injection': executable_injection_def,
     },
     'additionalProperties': False
 }


### PR DESCRIPTION
This merge adds functionality, tests, and documentation for controlling executable order through injection rather than only the explicit order list that was previously supported.

This defines a new block in the `internals` section, named `exectuable_injection`. This block is a list of executables to inject into an experiment. The format of an executable in this list is:

```
- name: <executable_name>
  order: <before / after>
  [realtive_to: <relative_executable_name>
```

The default `order` is `after`. `relative_to` is an optional attribute which controls where the new executable will be injected in the list. If it is omitted, the `before` and `after` orders apply to the entire list.