### PR TITLE
Update intel-hpl to consume the compiler it defines

### DIFF
--- a/var/ramble/repos/builtin/applications/intel-hpl/application.py
+++ b/var/ramble/repos/builtin/applications/intel-hpl/application.py
@@ -26,7 +26,7 @@ class IntelHpl(SpackApplication):
     tags('benchmark-app', 'benchmark', 'linpack', 'optimized', 'intel', 'mkl')
 
     default_compiler('gcc9', spack_spec='gcc@9.3.0')
-    software_spec('imkl_2023p1', spack_spec='intel-oneapi-mkl@2023.1.0 threads=openmp')
+    software_spec('imkl_2023p1', spack_spec='intel-oneapi-mkl@2023.1.0 threads=openmp', compiler='gcc9')
     software_spec('impi_2018', spack_spec='intel-mpi@2018.4.274')
 
     required_package('intel-oneapi-mkl')


### PR DESCRIPTION
Also fixes an error that occurs when trying to build tbb with a higher default)