### PR TITLE
Remove pmi as an openmpi dep as it is not needed (and sometimes invalid)

### DIFF
--- a/var/ramble/repos/builtin/applications/cloverleaf/application.py
+++ b/var/ramble/repos/builtin/applications/cloverleaf/application.py
@@ -22,7 +22,7 @@ class Cloverleaf(SpackApplication):
 
     default_compiler('gcc12', spack_spec='gcc@12.2.0')
 
-    software_spec('ompi414', spack_spec='openmpi@4.1.4 +legacylaunchers +pmi +cxx',
+    software_spec('ompi414', spack_spec='openmpi@4.1.4 +legacylaunchers +cxx',
                   compiler='gcc12')
     software_spec('cloverleaf',
                   spack_spec='cloverleaf@1.1 build=ref',

--- a/var/ramble/repos/builtin/applications/minixyce/application.py
+++ b/var/ramble/repos/builtin/applications/minixyce/application.py
@@ -21,7 +21,7 @@ class Minixyce(SpackApplication):
 
     default_compiler('gcc12', spack_spec="gcc@12.2.0")
 
-    software_spec('ompi415cxx', spack_spec='openmpi@4.1.5 +legacylaunchers +pmi +cxx',
+    software_spec('ompi415cxx', spack_spec='openmpi@4.1.5 +legacylaunchers +cxx',
                   compiler='gcc12')
 
     software_spec('minixyce', spack_spec='minixyce@1.0 +mpi',

--- a/var/ramble/repos/builtin/applications/openfoam/application.py
+++ b/var/ramble/repos/builtin/applications/openfoam/application.py
@@ -22,7 +22,7 @@ class Openfoam(SpackApplication):
     default_compiler('gcc9', spack_spec='gcc@9.3.0')
 
     software_spec('ompi412',
-                  spack_spec='openmpi@4.1.2 +legacylaunchers +pmi +thread_multiple +cxx',
+                  spack_spec='openmpi@4.1.2 +legacylaunchers +cxx',
                   compiler='gcc9')
 
     software_spec('flex',


### PR DESCRIPTION
Overall this makes the openmpi deps more consistent too