### PR TITLE
Fix error introduced where workspace_name is not passed to context

### DIFF
--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -57,6 +57,7 @@ class ExperimentSet(object):
 
         # Set all workspace variables as base variables.
         workspace_context = ramble.context.Context()
+        workspace_context.context_name = workspace.name
         workspace_context.variables = workspace.get_workspace_vars()
         workspace_context.env_variables = workspace.get_workspace_env_vars()
         workspace_context.internals = workspace.get_workspace_internals()

--- a/lib/ramble/ramble/test/experiment_set.py
+++ b/lib/ramble/ramble/test/experiment_set.py
@@ -488,6 +488,8 @@ def test_full_experiments_from_dict(mutable_mock_workspace_path):
         assert 'basic.test_wl.test_8_4_3' in exp_set.experiments.keys()
         assert 'basic.test_wl.test_12_4_4' in exp_set.experiments.keys()
 
+        assert exp_set._context[exp_set._contexts.workspace].context_name is not None
+
 
 def test_matrix_undefined_var_errors(mutable_mock_workspace_path, capsys):
     workspace('create', 'test')


### PR DESCRIPTION
A previous change (82b46ea) restructured how context names as passed during context creation, and accidentally dropped the setting of the name of the workspace context. This had down stream affects on the json, and this PR fixes that