### PR TITLE
Allow empty spack environments when constructing hash

### DIFF
--- a/lib/ramble/ramble/spack_runner.py
+++ b/lib/ramble/ramble/spack_runner.py
@@ -602,7 +602,7 @@ class SpackRunner(object):
         contents_to_hash = None
 
         if not self.dry_run:
-            if not lock_exists and require_exist:
+            if not lock_exists and (require_exist or len(self.env_contents) == 0):
                 logger.die(
                     'spack.lock file does not exist in environment '
                     f'{self.env_path}\n'

--- a/lib/ramble/ramble/test/workspace_hashing/unsetup_workspace_cannot_analyze.py
+++ b/lib/ramble/ramble/test/workspace_hashing/unsetup_workspace_cannot_analyze.py
@@ -49,8 +49,13 @@ ramble:
                   MY_VAR: 'TEST'
   spack:
     concretized: true
-    packages: {}
-    environments: {}
+    packages:
+      zlib:
+        spack_spec: zlib
+    environments:
+      zlib:
+        packages:
+        - zlib
 """
     workspace_name = 'test_unsetup_workspace_cannot_analyze'
     with ramble.workspace.create(workspace_name) as ws:


### PR DESCRIPTION
When building an experiment / workspace inventory, previously it was required that if an environment had a spack.yaml, it also created a spack.lock (or Ramble would error).

This merge allows spack.yaml files that have no packages (And thus, won't concretized into a spack.lock) without throwing an error.