### PR TITLE
Add `experiment_index` as a defined variable

### DIFF
--- a/lib/ramble/docs/workspace_config.rst
+++ b/lib/ramble/docs/workspace_config.rst
@@ -719,6 +719,8 @@ Ramble automatically generates definitions for the following variables:
   ``$workspace_root/inputs/{application_name}``
 * ``workload_input_dir`` - Absolute path to
   ``$workspace_root/inputs/{application_name}/{workload_name}``
+* ``experiment_index`` - Index, in set, of experiment. If part of a chain,
+  shares a value with its root.
 * ``env_path`` - Absolute path to
   ``$workspace_root/software/{env_name}.{workload_name}``
 * ``log_dir`` - Absolute path to ``$workspace_root/logs``
@@ -1015,6 +1017,10 @@ definition of variables from the chained experiment if needed.
 
 Once the experiments are defined, the final order of the chain can be viewed using
 ``ramble workspace info -v``.
+
+**NOTE** When using the ``experiment_index`` variable, all experiments in a
+chain share the same value. This ensures the resulting experiment will be
+complete when executed.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^
 Suppressing Experiments:

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -560,6 +560,8 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                     new_inst.expander._experiment_namespace = new_name
                     new_inst.variables[self.keywords.experiment_run_dir] = new_run_dir
                     new_inst.variables[self.keywords.experiment_name] = new_name
+                    new_inst.variables[self.keywords.experiment_index] = \
+                        self.expander.expand_var_name(self.keywords.experiment_index)
 
                     # Expand the chained experiment vars, so we can build the execution command
                     new_inst.add_expand_vars(workspace)

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -514,6 +514,10 @@ def workspace_info(args):
                     else:
                         color.cprint(rucolor.nested_3('      Experiment: ') + exp_name)
 
+                    experiment_index = \
+                        app_inst.expander.expand_var_name(app_inst.keywords.experiment_index)
+                    color.cprint('        Experiment Index: ' + experiment_index)
+
                     if args.verbose >= 1:
                         var_groups = [config_vars, workspace_vars,
                                       application_context.variables,

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -348,6 +348,7 @@ class ExperimentSet(object):
             experiment_vars[self.keywords.application_name] = final_app_name
             experiment_vars[self.keywords.workload_name] = final_wl_name
             experiment_vars[self.keywords.experiment_name] = final_exp_name
+            experiment_vars[self.keywords.experiment_index] = len(self.experiments) + 1
 
             experiment_namespace = expander.experiment_namespace
 

--- a/lib/ramble/ramble/keywords.py
+++ b/lib/ramble/ramble/keywords.py
@@ -23,6 +23,7 @@ default_keys = {
     'experiment_name': key_type.reserved,
     'experiment_run_dir': key_type.reserved,
     'experiment_status': key_type.reserved,
+    'experiment_index': key_type.reserved,
     'log_dir': key_type.reserved,
     'log_file': key_type.reserved,
     'err_file': key_type.reserved,

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -136,8 +136,12 @@ class Pipeline(object):
         for exp, app_inst, idx in self._experiment_set.filtered_experiments(self.filters):
             exp_log_path = app_inst.experiment_log_file(self.log_dir)
 
-            logger.all_msg(f'Experiment {idx} ({count}/{num_exps}):')
+            experiment_index_value = \
+                app_inst.expander.expand_var_name(app_inst.keywords.experiment_index)
+
+            logger.all_msg(f'Experiment #{idx} ({count}/{num_exps}):')
             logger.all_msg(f'    name: {exp}')
+            logger.all_msg(f'    root experiment_index: {experiment_index_value}')
             logger.all_msg(f'    log file: {exp_log_path}')
 
             logger.add_log(exp_log_path)


### PR DESCRIPTION
This merge adds `experiment_index` to every rendered experiment. This can then be used within `--where` clauses to control which experiments will be actioned within pipelines.