### PR TITLE
Fix typos

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,20 +1,24 @@
+[files]
+extend-exclude = [
+    ".git/",
+    # Copy of https://github.com/spack/spack/tree/develop/lib/spack
+    "lib/ramble/external/",
+    "lib/ramble/llnl/",
+    "lib/ramble/spack/",
+    "var/",
+]
+ignore-hidden = false
+
 [default]
-extend-ignore-identifiers-re = [
-    # *sigh* this just isn't worth the cost of fixing
-    "AttributeID.*Supress.*",
+extend-ignore-re = [
+    "\\bFOMs",
 ]
 
-[default.extend-identifiers]
-# *sigh* this just isn't worth the cost of fixing
-AttributeIDSupressMenu = "AttributeIDSupressMenu"
-
-
 [default.extend-words]
-fom = "fom"
-foms = "foms"
-FO = "FO"
-FOM = "FOM"
-FOMs = "FOMs"
-namd = "namd"
-cachable = "cachable"
-clen = "clen"
+"fom" = "fom"
+"namd" = "namd"
+
+[default.extend-identifiers]
+"ATPase" = "ATPase"
+"cachable" = "cachable"
+"clen" = "clen"

--- a/lib/ramble/docs/tutorials/11_using_internals.rst
+++ b/lib/ramble/docs/tutorials/11_using_internals.rst
@@ -200,7 +200,7 @@ And define the order of the executables for your experiments to include
 want them to be executed.
 
 For the purposes of this tutorial, add ``start_time`` directly before
-``execute`` and ``end_time`` directly after ``exectute``. The resulting
+``execute`` and ``end_time`` directly after ``execute``. The resulting
 configuration file should look like the following:
 
 .. code-block:: YAML

--- a/lib/ramble/docs/tutorials/5_changing_your_software_stack.rst
+++ b/lib/ramble/docs/tutorials/5_changing_your_software_stack.rst
@@ -124,7 +124,7 @@ compilation could result in build-time errors that need to be resolved before
 Ramble can generate experiments. Oftentimes it is both easier and faster to
 work through these issues (if you encounter them) outside of Ramble, using the
 package manager directly. Because Ramble uses the package manager, if the
-package is already intalled it will not cause the package manager to re-install
+package is already installed it will not cause the package manager to re-install
 it.
 
 In order to get information about what changes you can make to the GROMACS

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -1353,7 +1353,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                     success = True
         success = success and criteria_list.passed()
 
-        logger.debug('fom_vals = %s' % fom_values)
+        logger.debug('fom_values = %s' % fom_values)
         results['EXPERIMENT_CHAIN'] = self.chain_order.copy()
         if success:
             self.set_status(status='SUCCESS')

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -698,7 +698,7 @@ subcommand_functions = {}
 
 
 def sanitize_arg_name(base_name):
-    """Allow function names to be remaped (eg `-` to `_`) """
+    """Allow function names to be remapped (eg `-` to `_`) """
     formatted_name = base_name.replace('-', '_')
     return formatted_name
 

--- a/lib/ramble/ramble/fetch_strategy.py
+++ b/lib/ramble/ramble/fetch_strategy.py
@@ -1738,7 +1738,7 @@ class FsCache(object):
 
 
 class FetchError(ramble.error.RambleError):
-    """Superclass fo fetcher errors."""
+    """Superclass for fetcher errors."""
 
 
 class NoCacheError(FetchError):


### PR DESCRIPTION
Properly configure `typos` and fix misspellings.
That is all.
