### PR TITLE
Prevent expander from searching across new lines

### DIFF
--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -200,6 +200,8 @@ class ExpansionGraph(object):
                     children[-1].append(cur_match)
                 else:
                     self.root.add_children(cur_match)
+            elif c == '\n':  # Don't expand across new lines
+                opened = []
 
         if len(opened) > 0:
             self.root.add_children(children.pop())


### PR DESCRIPTION
This merge forces the expander to not allow expanding across new lines to help with expanding formatted json and yaml template files.