### PR TITLE
Fix expander removing leading zeros

### DIFF
--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -526,6 +526,10 @@ class Expander(object):
         """
         try:
             math_ast = ast.parse(in_str, mode='eval')
+            # If the only node in the AST is a constant, return an unmodified
+            # in_str.
+            if isinstance(math_ast.body, ast.Constant) and hasattr(math_ast.body, 'value'):
+                return in_str
             out_str = self.eval_math(math_ast.body)
             return out_str
         except MathEvaluationError as e:


### PR DESCRIPTION
This merge fixes an issue where the expander would remove leading zeros when passed a floating point number (as a string).

These can be forced to remove leading zeros still by using curly braces and a format string, however there was no way to force leading zeros to not be removed previously.