### PR TITLE
Allow for empty spack env

### DIFF
--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -385,6 +385,11 @@ def workspace_analyze_setup_parser(subparser):
         help='Control if figures of merit are printed even if an experiment fails',
         required=False)
 
+    subparser.add_argument(
+        '--dry-run', dest='dry_run',
+        action='store_true',
+        help='perform a dry run. Allows progress on workspaces which are not fully setup')
+
     arguments.add_common_arguments(subparser, ['phases', 'include_phase_dependencies',
                                                'where', 'exclude_where'])
 
@@ -393,6 +398,9 @@ def workspace_analyze(args):
     current_pipeline = ramble.pipeline.pipelines.analyze
     ws = ramble.cmd.require_active_workspace(cmd_name='workspace analyze')
     ws.always_print_foms = args.always_print_foms
+
+    if args.dry_run:
+        ws.dry_run = True
 
     filters = ramble.filters.Filters(
         phase_filters=args.phases,

--- a/lib/ramble/ramble/experimental/uploader.py
+++ b/lib/ramble/ramble/experimental/uploader.py
@@ -129,11 +129,7 @@ def upload_results(results):
                 logger.die('No upload URI (config:upload:uri) in config.')
 
             logger.msg(f'Uploading Results to {uri}')
-
-            if len(formatted_data) == 0:
-                logger.warn('No data to upload')
-            else:
-                uploader.perform_upload(uri, formatted_data)
+            uploader.perform_upload(uri, formatted_data)
         else:
             raise ConfigError("Unknown config:upload:type value")
 

--- a/lib/ramble/ramble/experimental/uploader.py
+++ b/lib/ramble/ramble/experimental/uploader.py
@@ -129,7 +129,11 @@ def upload_results(results):
                 logger.die('No upload URI (config:upload:uri) in config.')
 
             logger.msg(f'Uploading Results to {uri}')
-            uploader.perform_upload(uri, formatted_data)
+
+            if len(formatted_data) == 0:
+                logger.warn('No data to upload')
+            else:
+                uploader.perform_upload(uri, formatted_data)
         else:
             raise ConfigError("Unknown config:upload:type value")
 

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -76,12 +76,13 @@ class Pipeline(object):
         """Hash all of the experiments, construct workspace inventory"""
         for exp, app_inst, _ in self._experiment_set.all_experiments():
             if self.require_inventory:
-                if app_inst.get_status() == ramble.application.experiment_status.UNKNOWN.name and not self.workspace.dry_run:
-                    logger.die(
-                        f'Workspace status is {app_inst.get_status()}\n'
-                        'Make sure your workspace is fully setup with\n'
-                        '    ramble workspace setup'
-                    )
+                if app_inst.get_status() == ramble.application.experiment_status.UNKNOWN.name:
+                    if not self.workspace.dry_run:
+                        logger.die(
+                            f'Workspace status is {app_inst.get_status()}\n'
+                            'Make sure your workspace is fully setup with\n'
+                            '    ramble workspace setup'
+                        )
 
             app_inst.populate_inventory(self.workspace,
                                         force_compute=self.force_inventory,

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -75,6 +75,14 @@ class Pipeline(object):
     def _construct_hash(self):
         """Hash all of the experiments, construct workspace inventory"""
         for exp, app_inst, _ in self._experiment_set.all_experiments():
+            if self.require_inventory:
+                if app_inst.get_status() == ramble.application.experiment_status.UNKNOWN.name and not self.workspace.dry_run:
+                    logger.die(
+                        f'Workspace status is {app_inst.get_status()}\n'
+                        'Make sure your workspace is fully setup with\n'
+                        '    ramble workspace setup'
+                    )
+
             app_inst.populate_inventory(self.workspace,
                                         force_compute=self.force_inventory,
                                         require_exist=self.require_inventory)

--- a/lib/ramble/ramble/spack_runner.py
+++ b/lib/ramble/ramble/spack_runner.py
@@ -602,20 +602,17 @@ class SpackRunner(object):
         contents_to_hash = None
 
         if not self.dry_run:
-            if not lock_exists and require_exist and len(self.env_contents) > 0:
-                logger.die(
-                    'spack.lock file does not exist in environment '
-                    f'{self.env_path}\n'
-                    'Make sure your workspace is fully setup with\n'
-                    '    ramble workspace setup'
-                )
-            elif len(self.env_contents) == 0:
-                contents_to_hash = {}
-            elif lock_exists:
+            if not lock_exists:
+                if require_exist and len(self.env_contents) > 0:
+                    logger.die(
+                        'spack.lock file does not exist in environment '
+                        f'{self.env_path}\n'
+                        'Make sure your workspace is fully setup with\n'
+                        '    ramble workspace setup'
+                    )
+            else:  # lock_exists
                 with open(spack_file, 'r') as f:
                     contents_to_hash = sjson.load(f)
-            else:
-                logger.die('Issue with spack.lock file')
 
         if self.dry_run or not lock_exists:
             contents_to_hash = self._env_file_dict()

--- a/lib/ramble/ramble/spack_runner.py
+++ b/lib/ramble/ramble/spack_runner.py
@@ -602,16 +602,20 @@ class SpackRunner(object):
         contents_to_hash = None
 
         if not self.dry_run:
-            if not lock_exists and (require_exist or len(self.env_contents) == 0):
+            if not lock_exists and require_exist and len(self.env_contents) > 0:
                 logger.die(
                     'spack.lock file does not exist in environment '
                     f'{self.env_path}\n'
                     'Make sure your workspace is fully setup with\n'
                     '    ramble workspace setup'
                 )
+            elif len(self.env_contents) == 0:
+                contents_to_hash = {}
             elif lock_exists:
                 with open(spack_file, 'r') as f:
                     contents_to_hash = sjson.load(f)
+            else:
+                logger.die('Issue with spack.lock file')
 
         if self.dry_run or not lock_exists:
             contents_to_hash = self._env_file_dict()

--- a/lib/ramble/ramble/test/end_to_end/exclusive_filtered_vector_workloads.py
+++ b/lib/ramble/ramble/test/end_to_end/exclusive_filtered_vector_workloads.py
@@ -54,11 +54,12 @@ ramble:
 
         with open(config_path, 'w+') as f:
             f.write(test_config)
+
         ws._re_read()
 
         workspace('setup', '--dry-run', '--exclude-where', '"{workload_name}" == "serial"',
                   global_args=['-w', workspace_name])
-        workspace('analyze', '--exclude-where', '"{workload_name}" == "serial"',
+        workspace('analyze', '--dry-run', '--exclude-where', '"{workload_name}" == "serial"',
                   global_args=['-w', workspace_name])
         workspace('archive', '--exclude-where', '"{workload_name}" == "serial"',
                   global_args=['-w', workspace_name])

--- a/lib/ramble/ramble/test/end_to_end/inclusive_filtered_vector_workloads.py
+++ b/lib/ramble/ramble/test/end_to_end/inclusive_filtered_vector_workloads.py
@@ -58,7 +58,7 @@ ramble:
 
         workspace('setup', '--dry-run', '--where', '"{workload_name}" == "serial"',
                   global_args=['-w', workspace_name])
-        workspace('analyze', '--where', '"{workload_name}" == "serial"',
+        workspace('analyze', '--dry-run', '--where', '"{workload_name}" == "serial"',
                   global_args=['-w', workspace_name])
         workspace('archive', '--where', '"{workload_name}" == "serial"',
                   global_args=['-w', workspace_name])

--- a/lib/ramble/ramble/test/workspace_hashing/unsetup_workspace_cannot_analyze.py
+++ b/lib/ramble/ramble/test/workspace_hashing/unsetup_workspace_cannot_analyze.py
@@ -68,4 +68,4 @@ ramble:
         ws._re_read()
         with pytest.raises(RambleCommandError):
             output = workspace('analyze', global_args=['-w', workspace_name])
-            assert 'spack.lock file does not exist' in output
+            assert 'Make sure your workspace is fully setup' in output

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -670,7 +670,7 @@ _ramble_workspace_setup() {
 }
 
 _ramble_workspace_analyze() {
-    RAMBLE_COMPREPLY="-h --help -f --formats -u --upload --always-print-foms --phases --include-phase-dependencies --where --exclude-where"
+    RAMBLE_COMPREPLY="-h --help -f --formats -u --upload --always-print-foms --dry-run --phases --include-phase-dependencies --where --exclude-where"
 }
 
 _ramble_workspace_push_to_cache() {


### PR DESCRIPTION
Follow on from https://github.com/GoogleCloudPlatform/ramble/pull/336 which I think did not do what was intended 

I want to be able to support something like:
```
 42     environments:
 43       app_name: {}
```

This gives a `len(self.env_contents) == 0` so is currently considered invalid.

This PR instead lets it continue and hash an empty dict 