### PR TITLE
Convert ramble root to existing variable

### DIFF
--- a/lib/ramble/docs/tutorials/1_hello_world.rst
+++ b/lib/ramble/docs/tutorials/1_hello_world.rst
@@ -112,7 +112,7 @@ This will create a named workspace for you in:
 
 .. code-block:: console
 
-    $ $ramble_root/var/ramble/workspaces/hello_world
+    $ $RAMBLE_ROOT/var/ramble/workspaces/hello_world
 
 Now you can activate the workspace and view its default configuration.
 
@@ -212,7 +212,7 @@ For each setup run, a set of logs will be created at:
 
 .. code-block:: console
 
-    $ $ramble_root/var/ramble/workspaces/$workspace_root/logs
+    $ $RAMBLE_ROOT/var/ramble/workspaces/$workspace_root/logs
 
 Each run will have its own primary log, along with a folder containing a log for each
 experiment that is being configured.

--- a/lib/ramble/docs/tutorials/2_running_a_simple_gromacs_experiment.rst
+++ b/lib/ramble/docs/tutorials/2_running_a_simple_gromacs_experiment.rst
@@ -124,7 +124,7 @@ For each setup run, a set of logs will be created at:
 
 .. code-block:: console
 
-    $ $ramble_root/var/ramble/workspaces/$workspace_root/logs
+    $ $RAMBLE_ROOT/var/ramble/workspaces/$workspace_root/logs
 
 Each run will have its own primary log, along with a folder containing a log
 for each experiment that is being configured. While setup is running, you can
@@ -132,7 +132,7 @@ monitor the process by looking at the contents of:
 
 .. code-block:: console
 
-    $ $ramble_root/var/ramble/workspaces/basic_gromacs/logs/setup.latest/gromacs.water_gmx50.pme_single_rank.out
+    $ $RAMBLE_ROOT/var/ramble/workspaces/basic_gromacs/logs/setup.latest/gromacs.water_gmx50.pme_single_rank.out
 
 Executing Experiments
 ---------------------
@@ -174,7 +174,7 @@ After analyzing the workspace, you can exmine the structure of the workspace at:
 
 .. code-block:: console
 
-    $ $ramble_root/var/ramble/workspaces/basic_gromacs
+    $ $RAMBLE_ROOT/var/ramble/workspaces/basic_gromacs
 
 Within this directory, you should see the following directories:
 

--- a/lib/ramble/docs/tutorials/shared/gromacs_vector_workspace.rst
+++ b/lib/ramble/docs/tutorials/shared/gromacs_vector_workspace.rst
@@ -30,7 +30,7 @@ This will create a workspace for you in:
 
 .. code-block:: console
 
-    $ $ramble_root/var/ramble/workspaces/basic_gromacs
+    $ $RAMBLE_ROOT/var/ramble/workspaces/basic_gromacs
 
 Now you can activate the workspace and view its default configuration.
 
@@ -59,7 +59,7 @@ You can edit these files directly or with the command ``ramble workspace edit``.
 
 To begin, you should edit the ``ramble.yaml`` file to set up the configuration
 for your experiments. For this tutorial, replace the default yaml text with the
-contents of ``$ramble_root/examples/vector_matrix_gromacs_config.yaml``:
+contents of ``$RAMBLE_ROOT/examples/vector_matrix_gromacs_config.yaml``:
 
 
 .. literalinclude:: ../../../../examples/vector_matrix_gromacs_config.yaml

--- a/lib/ramble/docs/tutorials/shared/gromacs_workspace.rst
+++ b/lib/ramble/docs/tutorials/shared/gromacs_workspace.rst
@@ -30,7 +30,7 @@ This will create a workspace for you in:
 
 .. code-block:: console
 
-    $ $ramble_root/var/ramble/workspaces/basic_gromacs
+    $ $RAMBLE_ROOT/var/ramble/workspaces/basic_gromacs
 
 Now you can activate the workspace and view its default configuration.
 
@@ -59,7 +59,7 @@ You can edit these files directly or with the command ``ramble workspace edit``.
 
 To begin, you should edit the ``ramble.yaml`` file to set up the configuration
 for your experiments. For this tutorial, replace the default yaml text with the
-contents of ``$ramble_root/examples/basic_gromacs_config.yaml``:
+contents of ``$RAMBLE_ROOT/examples/basic_gromacs_config.yaml``:
 
 
 .. literalinclude:: ../../../../examples/basic_gromacs_config.yaml


### PR DESCRIPTION
This merge changes the tutorials from `$ramble_root` to `$RAMBLE_ROOT` which is a variable that exists.