### PR TITLE
Fix issue when compiler is already installed

### DIFF
--- a/lib/ramble/ramble/test/spack_runner.py
+++ b/lib/ramble/ramble/test/spack_runner.py
@@ -280,7 +280,7 @@ def test_new_compiler_installs(tmpdir, capsys):
     import os
 
     compilers_config = """
-compilers:
+compilers::
 - compiler:
     spec: gcc@12.1.0
     paths:
@@ -468,7 +468,7 @@ def test_config_compiler_find_attribute(tmpdir, capsys, attr, value, expected_st
     import os
 
     compilers_config = """
-compilers:
+compilers::
 - compiler:
     spec: gcc@12.1.0
     paths:


### PR DESCRIPTION
Previously we didn't fully overwrite the env so `test_config_compiler_find_attribute` could fail if a system has gcc@12.2.0 already installed. This PR fixes that 