### PR TITLE
Add description to all subparser helps

### DIFF
--- a/lib/ramble/ramble/cmd/license.py
+++ b/lib/ramble/ramble/cmd/license.py
@@ -195,9 +195,11 @@ def verify(args):
 
 def setup_parser(subparser):
     sp = subparser.add_subparsers(metavar='SUBCOMMAND', dest='license_command')
-    sp.add_parser('list-files', help=list_files.__doc__)
+    sp.add_parser('list-files', help=list_files.__doc__,
+                  description=list_files.__doc__)
 
-    verify_parser = sp.add_parser('verify', help=verify.__doc__)
+    verify_parser = sp.add_parser('verify', help=verify.__doc__,
+                                  description=verify.__doc__)
     verify_parser.add_argument(
         '--root', action='store', default=ramble.paths.prefix,
         help='scan a different prefix for license issues')

--- a/lib/ramble/ramble/cmd/mirror.py
+++ b/lib/ramble/ramble/cmd/mirror.py
@@ -30,7 +30,8 @@ def setup_parser(subparser):
         metavar='SUBCOMMAND', dest='mirror_command')
 
     # Destroy
-    destroy_parser = sp.add_parser('destroy', help=mirror_destroy.__doc__)
+    destroy_parser = sp.add_parser('destroy', help=mirror_destroy.__doc__,
+                                   description=mirror_destroy.__doc__)
 
     destroy_target = destroy_parser.add_mutually_exclusive_group(required=True)
     destroy_target.add_argument('-m', '--mirror-name',
@@ -47,7 +48,8 @@ def setup_parser(subparser):
     scopes_metavar = ramble.config.scopes_metavar
 
     # Add
-    add_parser = sp.add_parser('add', help=mirror_add.__doc__)
+    add_parser = sp.add_parser('add', help=mirror_add.__doc__,
+                               description=mirror_add.__doc__)
     add_parser.add_argument(
         'name', help="mnemonic name for mirror", metavar="mirror")
     add_parser.add_argument(
@@ -58,7 +60,8 @@ def setup_parser(subparser):
         help="configuration scope to modify")
     # Remove
     remove_parser = sp.add_parser('remove', aliases=['rm'],
-                                  help=mirror_remove.__doc__)
+                                  help=mirror_remove.__doc__,
+                                  description=mirror_remove.__doc__)
     remove_parser.add_argument(
         'name', help="mnemonic name for mirror", metavar="mirror")
     remove_parser.add_argument(
@@ -67,7 +70,8 @@ def setup_parser(subparser):
         help="configuration scope to modify")
 
     # Set-Url
-    set_url_parser = sp.add_parser('set-url', help=mirror_set_url.__doc__)
+    set_url_parser = sp.add_parser('set-url', help=mirror_set_url.__doc__,
+                                   description=mirror_set_url.__doc__)
     set_url_parser.add_argument(
         'name', help="mnemonic name for mirror", metavar="mirror")
     set_url_parser.add_argument(
@@ -81,7 +85,8 @@ def setup_parser(subparser):
         help="configuration scope to modify")
 
     # List
-    list_parser = sp.add_parser('list', help=mirror_list.__doc__)
+    list_parser = sp.add_parser('list', help=mirror_list.__doc__,
+                                description=mirror_list.__doc__)
     list_parser.add_argument(
         '--scope', choices=scopes, metavar=scopes_metavar,
         default=ramble.config.default_list_scope(),

--- a/lib/ramble/ramble/cmd/mods.py
+++ b/lib/ramble/ramble/cmd/mods.py
@@ -69,7 +69,8 @@ def setup_parser(subparser):
         setup_parser_cmd = globals()[setup_parser_cmd_name]
 
         subsubparser = sp.add_parser(
-            name, aliases=aliases, help=setup_parser_cmd.__doc__)
+            name, aliases=aliases, help=setup_parser_cmd.__doc__,
+            description=setup_parser_cmd.__doc__)
         setup_parser_cmd(subsubparser)
 
 

--- a/lib/ramble/ramble/cmd/repo.py
+++ b/lib/ramble/ramble/cmd/repo.py
@@ -35,7 +35,8 @@ def setup_parser(subparser):
     scopes_metavar = ramble.config.scopes_metavar
 
     # Create
-    create_parser = sp.add_parser('create', help=repo_create.__doc__)
+    create_parser = sp.add_parser('create', help=repo_create.__doc__,
+                                  description=repo_create.__doc__)
     create_parser.add_argument(
         'directory', help="directory to create the repo in")
     create_parser.add_argument(
@@ -53,7 +54,8 @@ def setup_parser(subparser):
     ramble.cmd.common.arguments.add_common_arguments(create_parser, ['repo_type'])
 
     # List
-    list_parser = sp.add_parser('list', help=repo_list.__doc__)
+    list_parser = sp.add_parser('list', help=repo_list.__doc__,
+                                description=repo_list.__doc__)
     list_parser.add_argument(
         '--scope', choices=scopes, metavar=scopes_metavar,
         default=ramble.config.default_list_scope(),
@@ -61,7 +63,8 @@ def setup_parser(subparser):
     ramble.cmd.common.arguments.add_common_arguments(list_parser, ['repo_type'])
 
     # Add
-    add_parser = sp.add_parser('add', help=repo_add.__doc__)
+    add_parser = sp.add_parser('add', help=repo_add.__doc__,
+                               description=repo_add.__doc__)
     add_parser.add_argument(
         'path', help="path to a Ramble repository directory")
     add_parser.add_argument(
@@ -72,7 +75,8 @@ def setup_parser(subparser):
 
     # Remove
     remove_parser = sp.add_parser(
-        'remove', help=repo_remove.__doc__, aliases=['rm'])
+        'remove', help=repo_remove.__doc__,
+        description=repo_remove.__doc__, aliases=['rm'])
     remove_parser.add_argument(
         'namespace_or_path',
         help="namespace or path of a Ramble repository")

--- a/lib/ramble/ramble/cmd/results.py
+++ b/lib/ramble/ramble/cmd/results.py
@@ -21,7 +21,8 @@ def setup_parser(subparser):
                                   dest='results_command')
 
     # Upload
-    upload_parser = sp.add_parser('upload', help=results_upload.__doc__)
+    upload_parser = sp.add_parser('upload', help=results_upload.__doc__,
+                                  description=results_upload.__doc__)
     upload_parser.add_argument(
         'filename', help='path of file to upload')
 

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -725,7 +725,8 @@ def setup_parser(subparser):
         setup_parser_cmd = globals()[setup_parser_cmd_name]
 
         subsubparser = sp.add_parser(
-            name, aliases=aliases, help=setup_parser_cmd.__doc__)
+            name, aliases=aliases, help=setup_parser_cmd.__doc__,
+            description=setup_parser_cmd.__doc__)
         setup_parser_cmd(subsubparser)
 
 


### PR DESCRIPTION
Add the subcommand description to all command subparsers so that any command of the form

   ramble <command> <subcommand> --help

will display the subcommand's doc string just below the usage line.

For example, 'ramble workspace mirror --help' will show "mirror current workspace state" below
usage.

The subcommand doc string is already available via 'ramble <command> --help' under the
positional argument section, but  that usage is not obvious to users unfamiliar with argparse 
subcommands, and adding the description increases help output by (usually) only one line 
while making the commandline interface more user friendly.