### PR TITLE
Expand args when calling executors

### DIFF
--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -423,7 +423,7 @@ class ExecutePipeline(Pipeline):
             exec_args = exec_parts[1:]
 
             executor = Executable(exec_name)
-            executor(' '.join(exec_args))
+            executor(*exec_args)
 
 
 pipelines = Enum('pipelines',


### PR DESCRIPTION
This merge fixes an issue where arguments were passed as a string to the executor instead of correctly using `*args` syntax.