### PR TITLE
Add `expandable` attribute to variable definitions

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -76,6 +76,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         self._vars_are_expanded = False
         self.expander = None
         self.variables = None
+        self.no_expand_vars = None
         self.experiment_set = None
         self.internals = None
         self.is_template = False
@@ -335,6 +336,14 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         self.variables = variables
         self.experiment_set = experiment_set
         self.expander = ramble.expander.Expander(self.variables, self.experiment_set)
+
+        self.no_expand_vars = set()
+        workload_name = self.expander.workload_name
+        if workload_name in self.workload_variables:
+            for var, conf in self.workload_variables[workload_name].items():
+                if 'expandable' in conf and not conf['expandable']:
+                    self.no_expand_vars.add(var)
+        self.expander.set_no_expand_vars(self.no_expand_vars)
 
     def set_internals(self, internals):
         """Set internal reference to application internals

--- a/lib/ramble/ramble/language/application_language.py
+++ b/lib/ramble/ramble/language/application_language.py
@@ -155,7 +155,7 @@ def input_file(name, url, description, target_dir='{input_name}', sha256=None, e
 
 @application_directive('workload_variables')
 def workload_variable(name, default, description, values=None, workload=None,
-                      workloads=None, **kwargs):
+                      workloads=None, expandable=True, **kwargs):
     """Define a new variable to be used in experiments
 
     Defines a new variable that can be defined within the
@@ -178,7 +178,8 @@ def workload_variable(name, default, description, values=None, workload=None,
 
             app.workload_variables[wl_name][name] = {
                 'default': default,
-                'description': description
+                'description': description,
+                'expandable': expandable
             }
             if values:
                 app.workload_variables[wl_name][name]['values'] = values

--- a/lib/ramble/ramble/test/end_to_end/gromacs_size_expansion.py
+++ b/lib/ramble/ramble/test/end_to_end/gromacs_size_expansion.py
@@ -1,0 +1,79 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.workspace
+import ramble.config
+import ramble.software_environments
+from ramble.main import RambleCommand
+
+
+# everything here uses the mock_workspace_path
+pytestmark = pytest.mark.usefixtures('mutable_config',
+                                     'mutable_mock_workspace_path')
+
+workspace = RambleCommand('workspace')
+
+
+def test_gromacs_size_expansion(mutable_config, mutable_mock_workspace_path):
+    test_config = """
+ramble:
+  variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
+    processes_per_node: '1'
+    n_ranks: '{processes_per_node}*{n_nodes}'
+    n_threads: '1'
+  applications:
+    gromacs:
+      workloads:
+        water_bare:
+          experiments:
+            expansion_test:
+              variables:
+                n_nodes: '1'
+                size: '0000.96'
+  spack:
+    concretized: true
+    packages:
+      gcc:
+        spack_spec: gcc@8.5.0
+      intel-mpi:
+        spack_spec: intel-mpi@2018.4.274
+        compiler: gcc
+      gromacs:
+        spack_spec: gromacs
+        compiler: gcc
+    environments:
+      gromacs:
+        packages:
+        - gromacs
+        - intel-mpi
+"""
+
+    workspace_name = 'test_gromacs_size_expansion'
+    with ramble.workspace.create(workspace_name) as ws1:
+        ws1.write()
+
+        config_path = os.path.join(ws1.config_dir, ramble.workspace.config_file_name)
+
+        with open(config_path, 'w+') as f:
+            f.write(test_config)
+
+        ws1._re_read()
+
+        workspace('setup', '--dry-run', global_args=['-w', workspace_name])
+
+        exec_script_path = os.path.join(ws1.experiment_dir, 'gromacs', 'water_bare',
+                                        'expansion_test', 'execute_experiment')
+
+        with open(exec_script_path, 'r') as f:
+            assert '0000.96' in f.read()

--- a/lib/ramble/ramble/test/expander.py
+++ b/lib/ramble/ramble/test/expander.py
@@ -29,36 +29,37 @@ def exp_dict():
         'var2': '{var3}',
         'var3': '3',
         'decimal.06.var': 'foo',
-        'size': '0000.96'
+        'size': '"0000.96"'  # Escaped as a string
     }
 
 
 @pytest.mark.parametrize(
-    'input,output',
+    'input,output,no_expand_vars',
     [
-        ('{var1}', '3'),
-        ('{var2}', '3'),
-        ('{var3}', '3'),
-        ('{application_name}', 'foo'),
-        ('{n_nodes}', '2'),
-        ('{processes_per_node}', '2'),
-        ('{n_nodes}*{processes_per_node}', '4'),
-        ('2**4', '16'),
-        ('{((((16-10+2)/4)**2)*4)}', '16.0'),
-        ('gromacs +blas', 'gromacs +blas'),
-        ('range(0, 5)', '[0, 1, 2, 3, 4]'),
-        ('{decimal.06.var}', 'foo'),
-        ('{}', '{}'),
-        ('{{n_ranks}+2}', '6'),
-        ('{{n_ranks}*{var{processes_per_node}}:05d}', '00012'),
-        ('{{n_ranks}-1}', '3'),
-        ('{{{n_ranks}/2}:0.0f}', '2')
+        ('{var1}', '3', set()),
+        ('{var2}', '3', set()),
+        ('{var3}', '3', set()),
+        ('{application_name}', 'foo', set()),
+        ('{n_nodes}', '2', set()),
+        ('{processes_per_node}', '2', set()),
+        ('{n_nodes}*{processes_per_node}', '4', set()),
+        ('2**4', '16', set()),
+        ('{((((16-10+2)/4)**2)*4)}', '16.0', set()),
+        ('gromacs +blas', 'gromacs +blas', set()),
+        ('range(0, 5)', '[0, 1, 2, 3, 4]', set()),
+        ('{decimal.06.var}', 'foo', set()),
+        ('{}', '{}', set()),
+        ('{{n_ranks}+2}', '6', set()),
+        ('{{n_ranks}*{var{processes_per_node}}:05d}', '00012', set()),
+        ('{{n_ranks}-1}', '3', set()),
+        ('{{{n_ranks}/2}:0.0f}', '2', set()),
+        ('{size}', '0000.96', set(['size'])),
     ]
 )
-def test_expansions(input, output):
+def test_expansions(input, output, no_expand_vars):
     expansion_vars = exp_dict()
 
-    expander = ramble.expander.Expander(expansion_vars, None)
+    expander = ramble.expander.Expander(expansion_vars, None, no_expand_vars=no_expand_vars)
 
     assert expander.expand_var(input) == output
 

--- a/lib/ramble/ramble/test/mirror_tests.py
+++ b/lib/ramble/ramble/test/mirror_tests.py
@@ -142,7 +142,7 @@ ramble:
     with archive_dir.as_cwd():
         app_type = ramble.repository.ObjectTypes.applications
         app_class = ramble.repository.paths[app_type].get_obj_class(app_name)('test')
-        app_class.set_variables(None, None)
+        app_class.set_variables({}, None)
         create_archive(archive_dir, app_class)
 
         # Create workspace

--- a/var/ramble/repos/builtin/applications/gromacs/application.py
+++ b/var/ramble/repos/builtin/applications/gromacs/application.py
@@ -148,15 +148,16 @@ class Gromacs(SpackApplication):
                               '0048', '0096', '0192', '0384',
                               '0768', '1536', '3072'],
                       description='Workload size',
-                      workloads=['water_gmx50', 'water_bare'])
+                      workloads=['water_gmx50', 'water_bare'],
+                      expandable=False)
     workload_variable('type', default='pme',
                       description='Workload type.',
                       values=['pme', 'rf'],
                       workloads=['water_gmx50', 'water_bare'])
-    workload_variable('input_path', default='{water_gmx50_bare}/*{size}',
+    workload_variable('input_path', default='{water_gmx50_bare}/{size}',
                       description='Input path for water GMX50',
                       workload='water_gmx50')
-    workload_variable('input_path', default='{water_bare_hbonds}/*{size}',
+    workload_variable('input_path', default='{water_bare_hbonds}/{size}',
                       description='Input path for water bare hbonds',
                       workload='water_bare')
     workload_variable('input_path', default='{lignocellulose}/lignocellulose-rf.tpr',


### PR DESCRIPTION
This merge adds the ability for variables to say they cannot be expanded. When variables are defined as `expandable=False` the expander replaces references to the variable with their exact value.

This is also used in the Gromacs application definition on the `size` variable.