### PR TITLE
Prevent undefined functions from erroring string expansion

### DIFF
--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -625,6 +625,9 @@ class Expander(object):
 
         if node.func.id == 'range':
             return list(range(*args, **kwargs))
+        else:
+            raise MathEvaluationError(f'Undefined function {node.func.id} used.\n'
+                                      'returning unexapanded string')
 
     def _eval_bool_op(self, node):
         """Handle a boolean operator node in the ast"""

--- a/lib/ramble/ramble/test/expander.py
+++ b/lib/ramble/ramble/test/expander.py
@@ -29,7 +29,7 @@ def exp_dict():
         'var2': '{var3}',
         'var3': '3',
         'decimal.06.var': 'foo',
-        'size': '"0000.96"'  # Escaped as a string
+        'size': '"0000.96"',  # Escaped as a string
     }
 
 
@@ -54,6 +54,7 @@ def exp_dict():
         ('{{n_ranks}-1}', '3', set()),
         ('{{{n_ranks}/2}:0.0f}', '2', set()),
         ('{size}', '0000.96', set(['size'])),
+        ('CPU(s)', 'CPU(s)', set())
     ]
 )
 def test_expansions(input, output, no_expand_vars):


### PR DESCRIPTION
This merge catches undefined function calls in the AST, and prevents them from being converted to `None`.