### PR TITLE
Extend accepted functions in expander AST

### DIFF
--- a/lib/ramble/docs/workspace_config.rst
+++ b/lib/ramble/docs/workspace_config.rst
@@ -105,8 +105,6 @@ variables apply to all experiments within their scope.
 
 These variables can be referred to within the YAML file, or template files
 using python keyword ( ``{var_name}`` ) syntax to perform variable expansion.
-This syntax allows basic math operations ( ``+``, ``-``, ``/``, ``*``, and
-``**`` ) to evaluate math expressions using variable definitions.
 
 If a variable is defined within multiple dictionaries, values defined closer to
 individual experiments take precedence.
@@ -135,6 +133,35 @@ individual experiments take precedence.
 In this example, ``n_ranks`` will take a value of ``1`` within the ``test_exp``
 experiment. This experiment will also include definitions for
 ``processes_per_node``, ``n_nodes``, and ``n_threads``.
+
+
+.. _ramble-supported-functions:
+
+~~~~~~~~~~~~~~~~~~~~
+Supported Functions:
+~~~~~~~~~~~~~~~~~~~~
+
+Ramble's variable expansion logic supports several mathematical operators and
+functions to help construct useful variable definitions.
+
+Supported math operators are:
+
+* ``+`` (addition)
+* ``-`` (subtraction)
+* ``*`` (multiplication)
+* ``/`` (division)
+* ``**`` (exponent)
+
+Support functions are:
+
+* ``str()`` (explicit string cast)
+* ``int()`` (explicit integer cast)
+* ``float()`` (explicit float cast)
+* ``min()`` (minimum)
+* ``max()`` (maximum)
+* ``ceil()`` (ceiling of input)
+* ``floor()`` (floor of input)
+* ``range()`` (construct range, see :ref:`ramble vector logic<ramble-vector-logic>` for more information)
 
 .. _ramble-vector-logic:
 
@@ -173,7 +200,7 @@ All lists defined within any experiment namespace are required to be the same
 length. They are zipped together, and iterated over to generate unique experiments.
 
 In addition to accepting explicit lists, Ramble supports using
-`python's range function<https://docs.python.org/3/library/functions.html#func-range>`
+`Python's range() function <https://docs.python.org/3/library/functions.html#func-range>`_
 to create a list. With this functionality, the example above could be re-written as:
 
 .. code-block:: yaml

--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -10,6 +10,7 @@ import string
 import ast
 import six
 import operator
+import math
 
 import ramble.error
 import ramble.keywords
@@ -22,6 +23,20 @@ supported_math_operators = {
     ast.Eq: operator.eq, ast.NotEq: operator.ne, ast.Gt: operator.gt,
     ast.GtE: operator.ge, ast.Lt: operator.lt, ast.LtE: operator.le,
     ast.And: operator.and_, ast.Or: operator.or_
+}
+
+supported_scalar_function_pointers = {
+    'str': str,
+    'int': int,
+    'float': float,
+    'max': max,
+    'min': min,
+    'ceil': math.ceil,
+    'floor': math.floor
+}
+
+supported_list_function_pointers = {
+    'range': range,
 }
 
 
@@ -623,8 +638,12 @@ class Expander(object):
         for kw in node.keywords:
             kwargs[self.eval_math(kw.arg)] = self.eval_math(kw.value)
 
-        if node.func.id == 'range':
-            return list(range(*args, **kwargs))
+        if node.func.id in supported_scalar_function_pointers.keys():
+            func = supported_scalar_function_pointers[node.func.id]
+            return func(*args, **kwargs)
+        elif node.func.id in supported_list_function_pointers.keys():
+            func = supported_list_function_pointers[node.func.id]
+            return list(func(*args, **kwargs))
         else:
             raise MathEvaluationError(f'Undefined function {node.func.id} used.\n'
                                       'returning unexapanded string')

--- a/lib/ramble/ramble/test/expander.py
+++ b/lib/ramble/ramble/test/expander.py
@@ -54,7 +54,14 @@ def exp_dict():
         ('{{n_ranks}-1}', '3', set()),
         ('{{{n_ranks}/2}:0.0f}', '2', set()),
         ('{size}', '0000.96', set(['size'])),
-        ('CPU(s)', 'CPU(s)', set())
+        ('CPU(s)', 'CPU(s)', set()),
+        ('str(1.5)', '1.5', set()),
+        ('int(1.5)', '1', set()),
+        ('float(1.5)', '1.5', set()),
+        ('ceil(0.6)', '1', set()),
+        ('floor(0.6)', '0', set()),
+        ('max(1, 5)', '5', set()),
+        ('min(1, 5)', '1', set()),
     ]
 )
 def test_expansions(input, output, no_expand_vars):


### PR DESCRIPTION
This merge adds support for several more functions within the expansion logic. This includes:
- min
- max
- ceil
- floor
- str
- int
- float