### PR TITLE
Add a `sleep` application definition

### DIFF
--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -11,6 +11,7 @@ import ast
 import six
 import operator
 import math
+import random
 
 import ramble.error
 import ramble.keywords
@@ -22,7 +23,7 @@ supported_math_operators = {
     operator.pow, ast.BitXor: operator.xor, ast.USub: operator.neg,
     ast.Eq: operator.eq, ast.NotEq: operator.ne, ast.Gt: operator.gt,
     ast.GtE: operator.ge, ast.Lt: operator.lt, ast.LtE: operator.le,
-    ast.And: operator.and_, ast.Or: operator.or_
+    ast.And: operator.and_, ast.Or: operator.or_, ast.Mod: operator.mod
 }
 
 supported_scalar_function_pointers = {
@@ -32,7 +33,9 @@ supported_scalar_function_pointers = {
     'max': max,
     'min': min,
     'ceil': math.ceil,
-    'floor': math.floor
+    'floor': math.floor,
+    'randrange': random.randrange,
+    'randint': random.randint
 }
 
 supported_list_function_pointers = {

--- a/var/ramble/repos/builtin/applications/sleep/application.py
+++ b/var/ramble/repos/builtin/applications/sleep/application.py
@@ -1,0 +1,68 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+from ramble.appkit import *
+from ramble.expander import Expander
+
+
+class Sleep(ExecutableApplication):
+    """This is an example application that will simply run sleep for a
+    controlled random amount of time"""
+    name = "sleep"
+
+    tags("test-app")
+
+    maintainers('douglasjacobsen')
+
+    time_file = os.path.join(Expander.expansion_str('experiment_run_dir'),
+                             'time_output')
+    executable('define_sleep_time', 'export SLEEP_TIME={sleep_seconds}', output_capture='', redirect='')
+    executable('sleep', '/usr/bin/time sleep $SLEEP_TIME', output_capture='&>>')
+    executable('echo', 'echo "Sleep for $SLEEP_TIME seconds"')
+
+    workload('sleep', executables=['define_sleep_time', 'echo', 'sleep'])
+    workload('rand_sleep', executables=['define_sleep_time', 'echo', 'sleep'])
+
+    workload_variable('sleep_seconds', default='3',
+                      description='Number of seconds to sleep for',
+                      workloads=['sleep'])
+
+    workload_variable('rand_min', default='1',
+                      description='Minimum of the random range',
+                      workloads=['rand_sleep'])
+
+    workload_variable('rand_max', default='5',
+                      description='Maximum of the random range',
+                      workloads=['rand_sleep'])
+
+    workload_variable('sleep_seconds', default='{randint({rand_min}, {rand_max})}',
+                      description='Number of seconds to sleep for',
+                      workloads=['rand_sleep'])
+
+    echo_regex = r'.*Sleep for (?P<time>[0-9]+) seconds.*'
+    figure_of_merit('Sleep time', fom_regex=echo_regex,
+                    group_name='time', units='s')
+
+    figure_of_merit('User time',
+                    fom_regex=r'(?P<user_time>[0-9]+\.[0-9]+)user.*',
+                    group_name='user_time', units='s')
+
+    figure_of_merit('Elapsed minutes',
+                    fom_regex=r'.*(?P<mins>[0-9]+):(?P<secs>[0-9]+)\.(?P<millisecs>[0-9]+)elapsed.*',
+                    group_name='mins', units='minutes')
+
+    figure_of_merit('Elapsed seconds',
+                    fom_regex=r'.*(?P<mins>[0-9]+):(?P<secs>[0-9]+)\.(?P<millisecs>[0-9]+)elapsed.*',
+                    group_name='secs', units='s')
+
+    figure_of_merit('Elapsed milliseconds',
+                    fom_regex=r'.*(?P<mins>[0-9]+):(?P<secs>[0-9]+)\.(?P<millisecs>[0-9]+)elapsed.*',
+                    group_name='millisecs', units='ms')
+
+    success_criteria('printed_sleep_time', mode='string', match=echo_regex)


### PR DESCRIPTION
This merge adds a `sleep` application definition, to help randomly generate figures of merit.

Additionally, it adds support to the expander for `randint`, `randrange`, and `%`.