### PR TITLE
Add support for chained experiment variable inheritance

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -596,6 +596,11 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                     new_inst.variables[self.keywords.experiment_index] = \
                         self.expander.expand_var_name(self.keywords.experiment_index)
 
+                    # Extract inherited variables
+                    if namespace.inherit_variables in cur_exp_def:
+                        for inherit_var in cur_exp_def[namespace.inherit_variables]:
+                            new_inst.variables[inherit_var] = self.variables[inherit_var]
+
                     # Expand the chained experiment vars, so we can build the execution command
                     new_inst.add_expand_vars(workspace)
                     chain_cmd = new_inst.expander.expand_var(cur_exp_def[self.keywords.command])

--- a/lib/ramble/ramble/namespace.py
+++ b/lib/ramble/ramble/namespace.py
@@ -25,6 +25,7 @@ class namespace:
     environments = 'environments'
     template = 'template'
     chained_experiments = 'chained_experiments'
+    inherit_variables = 'inherit_variables'
     modifiers = 'modifiers'
 
     # For rendering objects

--- a/lib/ramble/ramble/schema/applications.py
+++ b/lib/ramble/ramble/schema/applications.py
@@ -47,6 +47,14 @@ matrices_def = {
     }
 }
 
+variable_list = {
+    'type': 'array',
+    'default': [],
+    'items': {
+        'type': 'string',
+    }
+}
+
 chained_experiment_def = {
     'type': 'array',
     'default': [],
@@ -58,6 +66,7 @@ chained_experiment_def = {
                 'name': {'type': 'string'},
                 'command': {'type': 'string'},
                 'order': {'type': 'string'},
+                'inherit_variables': variable_list,
             },
             ramble.schema.variables.properties
         ),

--- a/lib/ramble/ramble/test/end_to_end/chained_experiment_var_inheritance.py
+++ b/lib/ramble/ramble/test/end_to_end/chained_experiment_var_inheritance.py
@@ -1,0 +1,159 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.filters
+import ramble.pipeline
+import ramble.workspace
+import ramble.config
+import ramble.software_environments
+from ramble.main import RambleCommand
+
+
+# everything here uses the mock_workspace_path
+pytestmark = pytest.mark.usefixtures('mutable_config',
+                                     'mutable_mock_workspace_path')
+
+workspace = RambleCommand('workspace')
+
+
+@pytest.mark.filterwarnings("ignore:invalid decimal literal:DeprecationWarning")
+def test_chained_experiment_variable_inheritance(mutable_config,
+                                                 mutable_mock_workspace_path):
+    test_config = r"""
+ramble:
+  variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
+    processes_per_node: '10'
+    n_ranks: '{processes_per_node}*{n_nodes}'
+    n_threads: '1'
+  applications:
+    intel-mpi-benchmarks:
+      template: true
+      workloads:
+        pingpong:
+          template: true
+          experiments:
+            pingpong_chain:
+              template: true
+              variables:
+                n_ranks: '1'
+                n_nodes: '1'
+        collective:
+          template: true
+          experiments:
+            collective_chain:
+              template: true
+              variables:
+                n_ranks: '1'
+                n_nodes: '1'
+              chained_experiments:
+              - name: 'intel-mpi-benchmarks.pingpong.pingpong_chain'
+                command: '{execute_experiment}'
+                inherit_variables:
+                - n_nodes
+                - n_ranks
+    gromacs:
+      chained_experiments:
+      - name: intel-mpi-benchmarks.collective.*
+        command: '{execute_experiment}'
+        order: 'after_root'
+        inherit_variables:
+        - n_ranks
+        - n_nodes
+      workloads:
+        water_bare:
+          chained_experiments:
+          - name: intel-mpi-benchmarks.*.collective_chain
+            command: '{execute_experiment}'
+            order: 'before_root'
+            inherit_variables:
+            - n_ranks
+            - n_nodes
+          experiments:
+            parent_test:
+              chained_experiments:
+              - name: intel-mpi-benchmarks.collective.collective_chain
+                command: '{execute_experiment}'
+                order: 'before_root'
+                inherit_variables:
+                - n_nodes
+                - n_ranks
+              variables:
+                n_nodes: '2'
+  spack:
+    concretized: true
+    packages:
+      gcc:
+        spack_spec: gcc@9.3.0 target=x86_64
+      impi2018:
+        spack_spec: intel-mpi@2018.4.274
+        compiler: gcc
+      imb:
+        spack_spec: intel-mpi-benchmarks
+        compiler: gcc
+      gromacs:
+        spack_spec: gromacs
+        compiler: gcc
+    environments:
+      intel-mpi-benchmarks:
+        packages:
+        - imb
+        - impi2018
+      gromacs:
+        packages:
+        - gromacs
+        - impi2018
+"""
+
+    setup_type = ramble.pipeline.pipelines.setup
+    setup_cls = ramble.pipeline.pipeline_class(setup_type)
+
+    filters = ramble.filters.Filters()
+
+    workspace_name = 'test_chained_experiment_variable_inheritance'
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+
+        config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+
+        with open(config_path, 'w+') as f:
+            f.write(test_config)
+
+        ws.dry_run = True
+        ws._re_read()
+
+        setup_pipeline = setup_cls(ws, filters)
+        setup_pipeline.run()
+
+        template_dir = os.path.join(ws.experiment_dir, 'intel-mpi-benchmarks')
+        assert not os.path.exists(template_dir)
+
+        parent_dir = os.path.join(ws.experiment_dir, 'gromacs', 'water_bare',
+                                  'parent_test')
+        script = os.path.join(parent_dir, 'execute_experiment')
+        assert os.path.exists(script)
+
+        # Check all chained experiments have the correct arguments
+        with open(script, 'r') as f:
+            parent_script_data = f.read()
+
+        for chain_idx in [1, 3, 5]:
+            chained_script = os.path.join(parent_dir, 'chained_experiments',
+                                          f'{chain_idx}' +
+                                          r'.intel-mpi-benchmarks.collective.collective_chain',
+                                          'execute_experiment')
+            assert os.path.exists(chained_script)
+            assert chained_script in parent_script_data
+
+            with open(chained_script, 'r') as f:
+                assert 'mpirun -n 20 -ppn 10' in f.read()


### PR DESCRIPTION
This merge adds a new `inherit_variables` attribute under chained experiments. This can be used to explicitly define that a chained experiment should take the value of a variable from the root experiment in its chain.

Documentation and tests are added for this feature as well.