### PR TITLE
Add support for workload and experiment tagging

### DIFF
--- a/lib/ramble/docs/workspace.rst
+++ b/lib/ramble/docs/workspace.rst
@@ -217,10 +217,11 @@ Filtering Experiments
 
 Several of the workspace commands support filtering the experiments they should
 act on. This can be performed using the ``--where`` argument for inclusive
-filtering, or the ``--exclude-where`` argument for exclusive filtering. These
-arguments take a string representing a logical expression, which can use
-variables the experiment would define. If the logical expression evaluates to
-true, the experiment will be included or excluded for action (respectively).
+filtering, the ``--exclude-where`` argument for exclusive filtering, or the
+``--filter-tags`` argument to filter based on experiment tags.. These arguments
+take a string representing a logical expression, which can use variables the
+experiment would define. If the logical expression evaluates to true, the
+experiment will be included or excluded for action (respectively).
 
 As an example:
 
@@ -236,6 +237,14 @@ Will only setup experiments that have less than 500 ranks, and:
 
 Will exclude all experiments from the ``hostname`` application.
 
+To filter by tags, see the following example:
+
+.. code-block:: console
+
+  $ ramble workspace setup --filter-tags my-tag
+
+Will only setup experiments that have the ``my-tag`` on them.
+
 The commands that accept these filters are:
 
 .. code-block:: console
@@ -247,6 +256,7 @@ The commands that accept these filters are:
     $ ramble on
 
 **NOTE:** The exclusive filter takes precedence over the inclusive filter.
+
 
 ^^^^^^^^^^^^^^^^^^^^^
 Software Environments

--- a/lib/ramble/docs/workspace_config.rst
+++ b/lib/ramble/docs/workspace_config.rst
@@ -609,6 +609,55 @@ If the ``on_executable`` attribute is not set, it will default to ``'*'`` which
 will match all executables. Modifier classes can (and should) be implemented to
 only act on the correct executable types (i.e. executables with ``use_mpi=true``).
 
+.. _experiment_tags:
+
+^^^^^^^^^^^^^^^
+Experiment Tags
+^^^^^^^^^^^^^^^
+
+While applications and workloads can be tagged within an application definition
+file (using the ``tags()`` or ``workload()`` directives), workloads and
+experiments can also be tagged within a workspace configuration file. This
+allows users to define their own tags to communicate what an experiment and
+workload might be used for beyond the information captured in the application
+definition file.
+
+The below example shows how tags can be defined within a workspace:
+
+.. code-block:: yaml
+
+  ramble:
+    variables:
+      mpi_command: 'mpirun -n {n_ranks}'
+        batch_submit: '{execute_experiment}'
+        processes_per_node: '16'
+      applications:
+        gromacs:
+          workloads:
+            water_bare:
+              tags:
+              - wltag
+              experiments:
+                test_exp1:
+                  tags:
+                  - tag1
+                  variables:
+                    n_ranks: '1' 
+                test_exp2:
+                  tags:
+                  - tag2
+                  variables:
+                    n_ranks: '1' 
+
+
+In the above example, all experiments are tagged with the ``wltag`` tag. Only
+the ``test_exp1`` experiment is tagged with the ``tag1`` tag, while the
+``test_exp2`` experiment is tagged with the ``tag2`` tag.
+
+These tags are propagated into a workspace's results file, and can be used to
+filter pipeline commands, as show in the
+:ref:`filtering experiments documentation <filter-experiments>`.
+
 .. _workspace_internals:
 
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/lib/ramble/ramble/cmd/common/arguments.py
+++ b/lib/ramble/ramble/cmd/common/arguments.py
@@ -132,7 +132,7 @@ def exclude_where():
 
 
 @arg
-def tag_filter():
+def filter_tags():
     return Args(
         '--filter-tags', action='append',
         nargs='+',

--- a/lib/ramble/ramble/cmd/common/arguments.py
+++ b/lib/ramble/ramble/cmd/common/arguments.py
@@ -132,6 +132,16 @@ def exclude_where():
 
 
 @arg
+def tag_filter():
+    return Args(
+        '--filter-tags', action='append',
+        nargs='+',
+        help='filter experiments to only those that include the provided tags',
+        required=False
+    )
+
+
+@arg
 def no_checksum():
     return Args(
         '-n', '--no-checksum', action='store_true', default=False,

--- a/lib/ramble/ramble/cmd/on.py
+++ b/lib/ramble/ramble/cmd/on.py
@@ -32,7 +32,7 @@ def setup_parser(subparser):
         help='execution template for each experiment',
              required=False)
 
-    arguments.add_common_arguments(subparser, ['where', 'exclude_where'])
+    arguments.add_common_arguments(subparser, ['where', 'exclude_where', 'filter_tags'])
 
 
 def ramble_on(args):
@@ -44,7 +44,8 @@ def ramble_on(args):
     filters = ramble.filters.Filters(
         phase_filters=[],
         include_where_filters=args.where,
-        exclude_where_filters=args.exclude_where
+        exclude_where_filters=args.exclude_where,
+        tags=args.filter_tags
     )
 
     pipeline_cls = ramble.pipeline.pipeline_class(current_pipeline)

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -356,7 +356,7 @@ def workspace_setup_setup_parser(subparser):
              'for installation, and files that would be downloaded.')
 
     arguments.add_common_arguments(subparser, ['phases', 'include_phase_dependencies',
-                                               'where', 'exclude_where'])
+                                               'where', 'exclude_where', 'filter_tags'])
 
 
 def workspace_setup(args):
@@ -369,7 +369,8 @@ def workspace_setup(args):
     filters = ramble.filters.Filters(
         phase_filters=args.phases,
         include_where_filters=args.where,
-        exclude_where_filters=args.exclude_where
+        exclude_where_filters=args.exclude_where,
+        tags=args.filter_tags
     )
 
     pipeline_cls = ramble.pipeline.pipeline_class(current_pipeline)
@@ -411,7 +412,7 @@ def workspace_analyze_setup_parser(subparser):
         help='perform a dry run. Allows progress on workspaces which are not fully setup')
 
     arguments.add_common_arguments(subparser, ['phases', 'include_phase_dependencies',
-                                               'where', 'exclude_where'])
+                                               'where', 'exclude_where', 'filter_tags'])
 
 
 def workspace_analyze(args):
@@ -425,7 +426,8 @@ def workspace_analyze(args):
     filters = ramble.filters.Filters(
         phase_filters=args.phases,
         include_where_filters=args.where,
-        exclude_where_filters=args.exclude_where
+        exclude_where_filters=args.exclude_where,
+        tags=args.filter_tags
     )
 
     pipeline_cls = ramble.pipeline.pipeline_class(current_pipeline)
@@ -447,7 +449,8 @@ def workspace_push_to_cache(args):
     filters = ramble.filters.Filters(
         phase_filters='*',
         include_where_filters=args.where,
-        exclude_where_filters=args.exclude_where
+        exclude_where_filters=args.exclude_where,
+        tags=args.filter_tags
     )
     pipeline_cls = ramble.pipeline.pipeline_class(current_pipeline)
 
@@ -466,7 +469,7 @@ def workspace_push_to_cache_setup_parser(subparser):
         required=True,
         help='Path to spack cache.')
 
-    arguments.add_common_arguments(subparser, ['where', 'exclude_where'])
+    arguments.add_common_arguments(subparser, ['where', 'exclude_where', 'filter_tags'])
 
 
 def workspace_info_setup_parser(subparser):
@@ -486,15 +489,27 @@ def workspace_info_setup_parser(subparser):
     subparser.add_argument('--phases', action='store_true',
                            help='If set, phase information will be printed')
 
-    arguments.add_common_arguments(subparser, ['where', 'exclude_where', 'tag_filter'])
+    arguments.add_common_arguments(subparser, ['where', 'exclude_where', 'filter_tags'])
 
     subparser.add_argument('-v', '--verbose', action='count', default=0,
                            help='level of verbosity. Add flags to ' +
-                                'increase description of workspace')
+                                'increase description of workspace\n' +
+                                'level 1 enables software, tags, and templates\n' +
+                                'level 2 enables expansions and phases\n')
 
 
 def workspace_info(args):
     ws = ramble.cmd.require_active_workspace(cmd_name='workspace info')
+
+    # Enable verbose mode
+    if args.verbose >= 1:
+        args.software = True
+        args.tags = True
+        args.templates = True
+
+    if args.verbose >= 2:
+        args.expansions = True
+        args.phases = True
 
     color.cprint(rucolor.section_title('Workspace: ') + ws.name)
     color.cprint('')

--- a/lib/ramble/ramble/context.py
+++ b/lib/ramble/ramble/context.py
@@ -34,6 +34,7 @@ class Context(object):
         self.exclude = {}
         self.zips = {}
         self.matrices = []
+        self.tags = []
         self.is_template = False
 
     def merge_context(self, in_context):
@@ -78,6 +79,8 @@ class Context(object):
             self.zips.update(in_context.zips)
         if in_context.matrices:
             self.matrices = in_context.matrices
+        if in_context.tags:
+            self.tags.extend(in_context.tags)
 
 
 def create_context_from_dict(context_name, in_dict):
@@ -96,6 +99,7 @@ def create_context_from_dict(context_name, in_dict):
         'exclude': {},
         'zips': {},
         'matrices': {} or [],
+        'tags': []
 
     Args:
         context_name: The name of the context (e.g., application name)
@@ -132,6 +136,9 @@ def create_context_from_dict(context_name, in_dict):
 
     if namespace.zips in in_dict:
         new_context.zips = in_dict[namespace.zips]
+
+    if namespace.tags in in_dict:
+        new_context.tags = in_dict[namespace.tags].copy()
 
     new_context.matrices = ramble.util.matrices.extract_matrices(
         'experiment creation',

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -375,6 +375,7 @@ class ExperimentSet(object):
             app_inst.set_template(final_context.is_template)
             app_inst.set_chained_experiments(final_context.chained_experiments)
             app_inst.set_modifiers(final_context.modifiers)
+            app_inst.set_tags(final_context.tags)
             app_inst.read_status()
             self.experiments[experiment_namespace] = app_inst
             self.experiment_order.append(experiment_namespace)
@@ -385,6 +386,19 @@ class ExperimentSet(object):
         for experiment in base_experiments:
             instance = self.experiments[experiment]
             instance.create_experiment_chain(self._workspace)
+
+    def all_experiment_tags(self):
+        """Aggregate all tags from experiments in this experiment set
+
+        Returns:
+            (set): A set of all tags from the experiment set.
+        """
+        all_tags = set()
+        for _, inst, _ in self.all_experiments():
+            if inst.experiment_tags:
+                for tag in inst.experiment_tags:
+                    all_tags.add(tag)
+        return all_tags
 
     def all_experiments(self):
         """Iterator over all experiments in this set"""
@@ -433,6 +447,10 @@ class ExperimentSet(object):
                 for expression in filters.exclude_where:
                     if inst.expander.evaluate_predicate(expression):
                         active = False
+
+            if filters.tags:
+                if not inst.has_tags(filters.tags):
+                    active = False
 
             if active:
                 yield exp, inst, idx

--- a/lib/ramble/ramble/filters.py
+++ b/lib/ramble/ramble/filters.py
@@ -14,13 +14,17 @@ class Filters(object):
 
     def __init__(self, phase_filters=['*'],
                  include_where_filters=None,
-                 exclude_where_filters=None):
+                 exclude_where_filters=None,
+                 tags=None):
         """Create a new filter instance"""
 
         self.phases = phase_filters
         self.include_where = None
         self.exclude_where = None
+        self.tags = set()
         if include_where_filters:
             self.include_where = list(itertools.chain.from_iterable(include_where_filters))
         if exclude_where_filters:
             self.exclude_where = list(itertools.chain.from_iterable(exclude_where_filters))
+        if tags:
+            self.tags = set(itertools.chain.from_iterable(tags))

--- a/lib/ramble/ramble/language/application_language.py
+++ b/lib/ramble/ramble/language/application_language.py
@@ -54,7 +54,7 @@ application_directive = ApplicationMeta.directive
 
 @application_directive('workloads')
 def workload(name, executables=None, executable=None, input=None,
-             inputs=None, **kwargs):
+             inputs=None, tags=None, **kwargs):
     """Adds a workload to this application
 
     Defines a new workload that can be used within the context of
@@ -72,7 +72,8 @@ def workload(name, executables=None, executable=None, input=None,
     def _execute_workload(app):
         app.workloads[name] = {
             'executables': [],
-            'inputs': []
+            'inputs': [],
+            'tags': [],
         }
 
         all_execs = ramble.language.language_helpers.require_definition(executable,
@@ -86,6 +87,9 @@ def workload(name, executables=None, executable=None, input=None,
         all_inputs = ramble.language.language_helpers.merge_definitions(input, inputs)
 
         app.workloads[name]['inputs'] = all_inputs.copy()
+
+        if tags:
+            app.workloads[name]['tags'] = tags.copy()
 
     return _execute_workload
 

--- a/lib/ramble/ramble/namespace.py
+++ b/lib/ramble/ramble/namespace.py
@@ -27,6 +27,7 @@ class namespace:
     chained_experiments = 'chained_experiments'
     inherit_variables = 'inherit_variables'
     modifiers = 'modifiers'
+    tags = 'tags'
 
     # For rendering objects
     variables = 'variables'

--- a/lib/ramble/ramble/schema/applications.py
+++ b/lib/ramble/ramble/schema/applications.py
@@ -95,6 +95,14 @@ exclude_def = {
     'additionalProperties': False
 }
 
+tags_def = {
+    'type': 'array',
+    'default': [],
+    'items': {
+        'type': 'string'
+    }
+}
+
 sub_props = union_dicts(
     ramble.schema.variables.properties,
     ramble.schema.success_criteria.properties,
@@ -105,6 +113,7 @@ sub_props = union_dicts(
     {
         'chained_experiments': chained_experiment_def,
         'template': {'type': 'boolean'},
+        'tags': tags_def,
     }
 )
 

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -181,7 +181,7 @@ ramble:
 
     ws1._re_read()
 
-    output = workspace('info', global_args=['-w', workspace_name])
+    output = workspace('info', '--software', global_args=['-w', workspace_name])
 
     check_info_basic(output)
 
@@ -233,7 +233,7 @@ config:
 
     ws1._re_read()
 
-    output = workspace('info', '-v', global_args=['-w', workspace_name])
+    output = workspace('info', '--expansions', global_args=['-w', workspace_name])
     assert 'Variables from Config:' in output
     assert 'Variables from Workspace:' in output
     assert 'Variables from Application:' in output
@@ -283,7 +283,7 @@ ramble:
 
     output = workspace('info', global_args=['-w', workspace_name])
 
-    assert "Template Experiment: basic.test_wl.test_experiment" in output
+    assert "Template Experiment 1: basic.test_wl.test_experiment" in output
 
 
 def test_workspace_info_with_experiment_chain():
@@ -330,9 +330,9 @@ ramble:
 
     ws1._re_read()
 
-    output = workspace('info', '-v', global_args=['-w', workspace_name])
+    output = workspace('info', '-vv', global_args=['-w', workspace_name])
 
-    assert "Template Experiment: basic.test_wl.test_experiment" in output
+    assert "Template Experiment 1: basic.test_wl.test_experiment" in output
     assert "Experiment Chain:" in output
     assert "- basic.test_wl2.test_experiment.chain.0.basic.test_wl.test_experiment" in output
 
@@ -1544,7 +1544,7 @@ ramble:
 
     ws1._re_read()
 
-    output = workspace('info', global_args=['-w', workspace_name])
+    output = workspace('info', '--software', global_args=['-w', workspace_name])
 
     check_info_basic(output)
 
@@ -1646,7 +1646,7 @@ ramble:
 
     ws1._re_read()
 
-    output = workspace('info', '-v', global_args=['-w', workspace_name])
+    output = workspace('info', '-vv', global_args=['-w', workspace_name])
 
     assert 'app_level_cmd' in output
     assert 'wl_level_cmd' in output
@@ -1709,7 +1709,7 @@ ramble:
 
     ws1._re_read()
 
-    output = workspace('info', '-v', global_args=['-w', workspace_name])
+    output = workspace('info', '-vv', global_args=['-w', workspace_name])
 
     assert "['exp_level_cmd', 'wl_level_cmd', 'app_level_cmd']" in output
 

--- a/lib/ramble/ramble/test/end_to_end/phase_selection.py
+++ b/lib/ramble/ramble/test/end_to_end/phase_selection.py
@@ -138,7 +138,7 @@ licenses:
 
         ws1._re_read()
 
-        output = workspace('info', global_args=['-w', workspace_name])
+        output = workspace('info', '-vv', global_args=['-w', workspace_name])
         assert "Phases for setup pipeline:" in output
         assert "get_inputs" in output
         assert "make_experiments" in output

--- a/lib/ramble/ramble/test/end_to_end/phase_selection_with_dependencies.py
+++ b/lib/ramble/ramble/test/end_to_end/phase_selection_with_dependencies.py
@@ -139,7 +139,7 @@ licenses:
 
         ws1._re_read()
 
-        output = workspace('info', global_args=['-w', workspace_name])
+        output = workspace('info', '-vv', global_args=['-w', workspace_name])
         assert "Phases for setup pipeline:" in output
         assert "get_inputs" in output
         assert "make_experiments" in output

--- a/lib/ramble/ramble/test/end_to_end/tag_filtering.py
+++ b/lib/ramble/ramble/test/end_to_end/tag_filtering.py
@@ -1,0 +1,111 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.workspace
+import ramble.config
+import ramble.software_environments
+from ramble.main import RambleCommand
+
+
+# everything here uses the mock_workspace_path
+pytestmark = pytest.mark.usefixtures('mutable_config',
+                                     'mutable_mock_workspace_path')
+
+workspace = RambleCommand('workspace')
+on = RambleCommand('on')
+
+
+def check_output(output, compared_list, contains=False):
+    for item in compared_list:
+        if contains:
+            assert item in output
+        else:
+            assert item not in output
+
+
+@pytest.mark.parametrize(
+    'tag,expected_experiments,unexpected_experiments',
+    [
+        (
+            'first',
+            [
+                'workload-tags.test_wl.first_experiment'
+            ],
+            [
+                'workload-tags.test_wl2.second_experiment'
+            ]
+        )
+    ]
+)
+def test_workspace_tag_filtering(mutable_config, mutable_mock_workspace_path,
+                                 mock_applications, tag, expected_experiments,
+                                 unexpected_experiments):
+    test_config = """
+ramble:
+  variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: '{execute_experiment}'
+    processes_per_node: 1
+    n_threads: '1'
+  applications:
+    workload-tags:
+      workloads:
+        test_wl:
+          experiments:
+            first_experiment:
+              tags:
+              - first
+              variables:
+                n_nodes: 1
+        test_wl2:
+          experiments:
+            second_experiment:
+              tags:
+              - second
+              variables:
+                n_nodes: 1
+  spack:
+    concretized: true
+    packages: {}
+    environments: {}
+"""
+
+    workspace_name = f'test_tag_filtering_{tag}'
+    with ramble.workspace.create(workspace_name) as ws1:
+        ws1.write()
+
+        config_path = os.path.join(ws1.config_dir, ramble.workspace.config_file_name)
+
+        with open(config_path, 'w+') as f:
+            f.write(test_config)
+
+        ws1._re_read()
+
+        output = workspace('info', '--filter-tags', tag, global_args=['-w', workspace_name])
+
+        check_output(output, expected_experiments, contains=True)
+        check_output(output, unexpected_experiments, contains=False)
+
+        output = workspace('setup', '--filter-tags', tag,
+                           global_args=['-v', '-w', workspace_name])
+
+        check_output(output, expected_experiments, contains=True)
+        check_output(output, unexpected_experiments, contains=False)
+
+        output = on('--filter-tags', tag,
+                    global_args=['-v', '-w', workspace_name])
+
+        output = workspace('analyze', '--filter-tags', tag,
+                           global_args=['-v', '-w', workspace_name])
+
+        check_output(output, expected_experiments, contains=True)
+        check_output(output, unexpected_experiments, contains=False)

--- a/lib/ramble/ramble/test/end_to_end/wrfv4_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/wrfv4_dry_run.py
@@ -267,6 +267,7 @@ licenses:
         for text_result in text_results_files:
             with open(text_result, 'r') as f:
                 data = f.read()
+                assert 'Tags =' in data
                 assert 'Average Timestep Time = 33.3 s' in data
                 assert 'Cumulative Timestep Time = 166.5 s' in data
                 assert 'Minimum Timestep Time = 11.1 s' in data

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1018,6 +1018,9 @@ class Workspace(object):
                                 exp['name'])
                         f.write('  Status = %s\n' %
                                 exp['RAMBLE_STATUS'])
+                        if 'TAGS' in exp:
+                            f.write(f'  Tags = {exp["TAGS"]}\n')
+
                         if exp['RAMBLE_STATUS'] == 'SUCCESS' or self.always_print_foms:
                             for context in exp['CONTEXTS']:
                                 f.write('  %s figures of merit:\n' %

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -543,7 +543,7 @@ _ramble_mods_info() {
 }
 
 _ramble_on() {
-    RAMBLE_COMPREPLY="-h --help --executor --where --exclude-where"
+    RAMBLE_COMPREPLY="-h --help --executor --where --exclude-where --filter-tags"
 }
 
 _ramble_python() {
@@ -675,19 +675,19 @@ _ramble_workspace_concretize() {
 }
 
 _ramble_workspace_setup() {
-    RAMBLE_COMPREPLY="-h --help --dry-run --phases --include-phase-dependencies --where --exclude-where"
+    RAMBLE_COMPREPLY="-h --help --dry-run --phases --include-phase-dependencies --where --exclude-where --filter-tags"
 }
 
 _ramble_workspace_analyze() {
-    RAMBLE_COMPREPLY="-h --help -f --formats -u --upload --always-print-foms --dry-run --phases --include-phase-dependencies --where --exclude-where"
+    RAMBLE_COMPREPLY="-h --help -f --formats -u --upload --always-print-foms --dry-run --phases --include-phase-dependencies --where --exclude-where --filter-tags"
 }
 
 _ramble_workspace_push_to_cache() {
-    RAMBLE_COMPREPLY="-h --help -d --where --exclude-where"
+    RAMBLE_COMPREPLY="-h --help -d --where --exclude-where --filter-tags"
 }
 
 _ramble_workspace_info() {
-    RAMBLE_COMPREPLY="-h --help -v --verbose"
+    RAMBLE_COMPREPLY="-h --help --software --templates --expansions --tags --phases --where --exclude-where --filter-tags -v --verbose"
 }
 
 _ramble_workspace_edit() {

--- a/var/ramble/repos/builtin.mock/applications/workload-tags/application.py
+++ b/var/ramble/repos/builtin.mock/applications/workload-tags/application.py
@@ -1,0 +1,19 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.appkit import *
+
+
+class WorkloadTags(ExecutableApplication):
+    name = "workload-tags"
+
+    executable('foo', 'echo "bar"', use_mpi=False)
+    executable('bar', 'echo "baz"', use_mpi=False)
+
+    workload('test_wl', executable='foo', tags=['wl-tag1', 'wl-shared-tag'])
+    workload('test_wl2', executable='bar', tags=['wl-tag2', 'wl-shared-tag'])


### PR DESCRIPTION
This merge adds the ability for workloads (defined in either an `application.py` or in workspace configuration files) and experiments (via only workspace configuration files) to define their own tags.

Tags are used for two things:
1) Several workspace and pipeline commands can be filtered on tags (such as `workspace info` and `on`).
2) Tags are pushed into the results file

Testing and documentation is added for this feature as well.