### PR TITLE
Change spack hash semantics to hash yaml contents

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -595,6 +595,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                     new_inst.variables[self.keywords.experiment_name] = new_name
                     new_inst.variables[self.keywords.experiment_index] = \
                         self.expander.expand_var_name(self.keywords.experiment_index)
+                    new_inst.read_status()
 
                     # Expand the chained experiment vars, so we can build the execution command
                     new_inst.add_expand_vars(workspace)

--- a/lib/ramble/ramble/application_types/spack.py
+++ b/lib/ramble/ramble/application_types/spack.py
@@ -408,7 +408,7 @@ class SpackApplication(ApplicationBase):
         self.hash_inventory['software'].append(
             {
                 'name': self.spack_runner.env_path.replace(workspace.root + os.path.sep, ''),
-                'digest': self.spack_runner.inventory_hash(require_exist)
+                'digest': self.spack_runner.inventory_hash()
             }
         )
         self.spack_runner.deactivate()

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -76,15 +76,6 @@ class Pipeline(object):
     def _construct_hash(self):
         """Hash all of the experiments, construct workspace inventory"""
         for exp, app_inst, _ in self._experiment_set.all_experiments():
-            if self.require_inventory:
-                if app_inst.get_status() == ramble.application.experiment_status.UNKNOWN.name:
-                    if not self.workspace.dry_run:
-                        logger.die(
-                            f'Workspace status is {app_inst.get_status()}\n'
-                            'Make sure your workspace is fully setup with\n'
-                            '    ramble workspace setup'
-                        )
-
             app_inst.populate_inventory(self.workspace,
                                         force_compute=self.force_inventory,
                                         require_exist=self.require_inventory)
@@ -234,6 +225,14 @@ class AnalyzePipeline(Pipeline):
         self.upload_results = upload
 
     def _prepare(self):
+        for _, app_inst, _ in self._experiment_set.filtered_experiments(self.filters):
+            if not app_inst.is_template:
+                if app_inst.get_status() == ramble.application.experiment_status.UNKNOWN.name:
+                    logger.die(
+                        f'Workspace status is {app_inst.get_status()}\n'
+                        'Make sure your workspace is fully setup with\n'
+                        '    ramble workspace setup'
+                    )
         super()._construct_hash()
         super()._prepare()
 

--- a/lib/ramble/ramble/test/workspace_hashing/unsetup_workspace_cannot_analyze.py
+++ b/lib/ramble/ramble/test/workspace_hashing/unsetup_workspace_cannot_analyze.py
@@ -66,6 +66,9 @@ ramble:
         with open(config_path, 'w+') as f:
             f.write(test_config)
         ws._re_read()
+
+        assert not os.path.exists(os.path.join(ws.experiment_dir, 'zlib'))
+
         with pytest.raises(RambleCommandError):
             output = workspace('analyze', global_args=['-w', workspace_name])
             assert 'Make sure your workspace is fully setup' in output


### PR DESCRIPTION
This merge changes the semantics of how hashes of spack environments work. Previously, spack.lock files were hashed when an experiment was setup, however this gets in the way of many things (like partially setting up a workspace).

This changes the hashing to only hash the contents of the YAML file (not actually the YAML file, as we don't always write it) instead to avoid these issues.