### PR TITLE
Add support for including and excluding secrets (licenses) from workspace archives

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -71,6 +71,8 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
     maintainers: List[str] = []
     tags: List[str] = []
 
+    license_inc_name = 'license.inc'
+
     def __init__(self, file_path):
         super().__init__()
 
@@ -111,7 +113,6 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
 
         self.license_path = ''
         self.license_file = ''
-        self.license_inc_name = 'license.inc'
 
         self.build_phase_order()
 

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -664,6 +664,10 @@ def workspace_archive_setup_parser(subparser):
         default=None,
         help='URL to upload tar archive into. Does nothing if `-t` is not specified.')
 
+    subparser.add_argument(
+        '--include-secrets', action='store_true',
+        help='If set, secrets are included in the archive. Default is false')
+
     arguments.add_common_arguments(subparser, ['phases', 'include_phase_dependencies',
                                                'where', 'exclude_where'])
 
@@ -683,7 +687,8 @@ def workspace_archive(args):
                             filters,
                             create_tar=args.tar_archive,
                             archive_prefix=args.archive_prefix,
-                            upload_url=args.upload_url)
+                            upload_url=args.upload_url,
+                            include_secrets=args.include_secrets)
 
     workspace_run_pipeline(args, pipeline)
 

--- a/lib/ramble/ramble/workspace/__init__.py
+++ b/lib/ramble/ramble/workspace/__init__.py
@@ -42,7 +42,8 @@ from .workspace import (
     ramble_workspace_var,
     namespace,
     workspace_config_path,
-    workspace_log_path
+    workspace_log_path,
+    workspace_shared_path
 )
 
 __all__ = [
@@ -79,4 +80,5 @@ __all__ = [
     'namespace',
     'workspace_config_path',
     'workspace_log_path',
+    'workspace_shared_path',
 ]

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -654,7 +654,7 @@ _ramble_workspace_activate() {
 }
 
 _ramble_workspace_archive() {
-    RAMBLE_COMPREPLY="-h --help --tar-archive -t --prefix -p --upload-url -u --phases --include-phase-dependencies --where --exclude-where"
+    RAMBLE_COMPREPLY="-h --help --tar-archive -t --prefix -p --upload-url -u --include-secrets --phases --include-phase-dependencies --where --exclude-where"
 }
 
 _ramble_workspace_deactivate() {


### PR DESCRIPTION
This merge allows `workspace archive` to optionally include secrets (such as licenses) from the created archive.