### PR TITLE
Allow repeated experiments with summary statistics

### DIFF
--- a/lib/ramble/docs/configuration_files.rst
+++ b/lib/ramble/docs/configuration_files.rst
@@ -185,6 +185,25 @@ through and not cause an error. This is useful for things like `${ENV_VAR}`
 that are recognized as a variable. When passthrough is disabled, any variables
 that fail to expand will raise a syntax error, which can aid in debugging.
 
+.. _experiment-repeats-config-option:
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Config Options: Experiment Repeats
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The repeats config options within the ``config`` section are used to define a number
+of times each experiment will be repeated. Summary statistics will be calculated for
+the set of repeats. Its format is as follows:
+
+.. code-block:: yaml
+
+    config:
+      n_repeats: 'int'
+      repeats_success_strict: [True/False]
+
+More information on using repeats within a workspace can be found in the
+:ref:`workspace configuration file<workspace-config>`.
+
 .. _env-vars-config:
 
 ------------------------------
@@ -539,7 +558,6 @@ old files, changing the configuration of the environment that Ramble will use
 for the experiments it generates.
 
 
-
 .. _success-criteria-config:
 
 -------------------------
@@ -560,6 +578,7 @@ use when determining if they were successful or not. Its format is as follows:
 
 For more information about using success criteria, see the
 :ref:`success criteria documentation<success-criteria>`.
+
 
 .. _variables-config:
 

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -41,6 +41,7 @@ import ramble.util.colors as rucolor
 import ramble.util.hashing
 import ramble.util.env
 import ramble.util.directives
+import ramble.util.stats
 from ramble.util.logger import logger
 
 from ramble.workspace import namespace
@@ -85,6 +86,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         self.experiment_set = None
         self.internals = None
         self.is_template = False
+        self.repeats = (False, 0)
         self.chained_experiments = None
         self.chain_order = []
         self.chain_prepend = []
@@ -95,6 +97,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         self._modifier_instances = []
         self._modifier_builtins = {}
         self._input_fetchers = None
+        self.results = {}
 
         self.hash_inventory = {
             'attributes': [],
@@ -126,6 +129,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         new_copy.set_variables(self.variables.copy(), self.experiment_set)
         new_copy.set_internals(self.internals.copy())
         new_copy.set_template(False)
+        new_copy.set_repeats((False, 0))
         new_copy.set_chained_experiments(None)
 
         return new_copy
@@ -359,6 +363,18 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         """Set if this instance is a template or not"""
         self.is_template = is_template
 
+    def set_repeats(self, repeats):
+        """Set if this instance will use repeats
+
+        Args:
+            repeats (tuple): consists of:
+            is_repeat_base (Bool): True if this is the base experiment of a repeat set,
+                                   False for singletons and for repeats
+            num_repeats (Int): 0 for singletons, positive integer (n_repeats) for base
+                               experiment, index for each repeat of the base experiment
+        """
+        self.repeats = repeats
+
     def set_chained_experiments(self, chained_experiments):
         """Set chained experiments for this instance"""
         self.chained_experiments = None
@@ -478,6 +494,9 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         if self.is_template:
             logger.debug(f'{self.name} is a template. Skipping phases')
             return
+        if self.repeats[0]:
+            logger.debug(f'{self.name} is a repeat base. Skipping phases')
+            return
 
         if hasattr(self, f'_{phase}'):
             logger.msg(f'  Executing phase {phase}')
@@ -596,6 +615,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                     new_inst.variables[self.keywords.experiment_name] = new_name
                     new_inst.variables[self.keywords.experiment_index] = \
                         self.expander.expand_var_name(self.keywords.experiment_index)
+                    new_inst.repeats = self.repeats
 
                     # Extract inherited variables
                     if namespace.inherit_variables in cur_exp_def:
@@ -1390,7 +1410,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                     criteria_obj.mark_found()
 
         exp_ns = self.expander.experiment_namespace
-        results = {'name': exp_ns}
+        self.results = {'name': exp_ns}
 
         success = False
         for fom in fom_values.values():
@@ -1399,23 +1419,26 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                     success = True
         success = success and criteria_list.passed()
 
-        logger.debug('fom_values = %s' % fom_values)
-        results['EXPERIMENT_CHAIN'] = self.chain_order.copy()
+        if self.repeats[0]:
+            self.results['N_REPEATS'] = self.repeats[1]
+        else:
+            self.results['N_REPEATS'] = 0
+        self.results['EXPERIMENT_CHAIN'] = self.chain_order.copy()
 
         if success:
             self.set_status(status=experiment_status.SUCCESS)
         else:
             self.set_status(status=experiment_status.FAILED)
 
-        results['RAMBLE_STATUS'] = self.get_status()
+        self.results['RAMBLE_STATUS'] = self.get_status()
 
         if success or workspace.always_print_foms:
-            results['RAMBLE_VARIABLES'] = {}
-            results['RAMBLE_RAW_VARIABLES'] = {}
+            self.results['RAMBLE_VARIABLES'] = {}
+            self.results['RAMBLE_RAW_VARIABLES'] = {}
             for var, val in self.variables.items():
-                results['RAMBLE_RAW_VARIABLES'][var] = val
-                results['RAMBLE_VARIABLES'][var] = self.expander.expand_var(val)
-            results['CONTEXTS'] = []
+                self.results['RAMBLE_RAW_VARIABLES'][var] = val
+                self.results['RAMBLE_VARIABLES'][var] = self.expander.expand_var(val)
+            self.results['CONTEXTS'] = []
 
             for context, fom_map in fom_values.items():
                 context_map = {'name': context, 'foms': []}
@@ -1425,9 +1448,170 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                     fom_copy['name'] = fom_name
                     context_map['foms'].append(fom_copy)
 
-                results['CONTEXTS'].append(context_map)
+                self.results['CONTEXTS'].append(context_map)
 
-        workspace.append_result(results)
+        workspace.append_result(self.results)
+
+    def calculate_statistics(self, workspace):
+        """Calculate statistics for results of repeated experiments
+
+        When repeated experiments are used, this method aggregates the results of
+        each experiment's repeats and calculates statistics for each numeric FOM.
+
+        If a FOM is non-numeric, no calculations are performed.
+
+        Statistics are injected into the results file under the base experiment
+        namespace.
+        """
+
+        def is_numeric(value):
+            """Returns true if a fom value is numeric"""
+
+            try:
+                float(value)
+                return True
+            except ValueError:
+                return False
+
+        repeat_experiments = {}
+        repeat_foms = {}
+        first_repeat_exp = ''
+
+        # repeat_experiments dict {repeat experiment namespace: {dict}}
+        # repeat_foms dict {context: {(fom name, units, origin, origin_type): [list of values]}}
+        # origin_type is generated as 'summary::stat_name'
+
+        # Check if this is the base experiment of a set of repeats
+        if not self.repeats[0]:
+            return
+        n_repeats = self.repeats[1]
+
+        base_exp_name = self.expander.experiment_name
+        base_exp_namespace = self.expander.experiment_namespace
+
+        # Create a list of all repeats by inserting repeat index
+        for n in range(1, n_repeats + 1):
+            if '.chain' in base_exp_name:
+                insert_idx = base_exp_name.find('.chain')
+                repeat_exp_namespace = base_exp_name[:insert_idx] + f'.{n}' \
+                    + base_exp_name[insert_idx:]
+            else:
+                base_exp_namespace = self.expander.experiment_namespace
+                repeat_exp_namespace = f'{base_exp_namespace}.{n}'
+            repeat_experiments[repeat_exp_namespace] = {}
+            repeat_experiments[repeat_exp_namespace]['base_exp'] = base_exp_namespace
+            if n == 1:
+                first_repeat_exp = repeat_exp_namespace
+
+        # Create initial results dict since analysis pipeline was skipped for base exp
+        self.results = {'name': base_exp_namespace}
+        self.results['N_REPEATS'] = n_repeats
+        self.results['EXPERIMENT_CHAIN'] = self.chain_order.copy()
+
+        #
+        # If repeat_success_strict is true, one failed experiment will fail the whole set
+        # and statistics will not be calculated
+        # If repeat_success_strict is false, statistics will be calculated for all successful
+        # experiments
+        #
+        repeat_success = False
+        exp_success = []
+        for exp in repeat_experiments.keys():
+            if exp in self.experiment_set.experiments.keys():
+                exp_inst = self.experiment_set.experiments[exp]
+            elif exp in self.experiment_set.chained_experiments.keys():
+                exp_inst = self.experiment_set.chained_experiments[exp]
+            else:
+                continue
+
+            exp_success.append(exp_inst.get_status())
+
+        if workspace.repeat_success_strict:
+            if 'FAILED' in exp_success:
+                repeat_success = False
+            else:
+                repeat_success = True
+        else:
+            if 'SUCCESS' in exp_success:
+                repeat_success = True
+            else:
+                repeat_success = False
+
+        if repeat_success:
+            self.set_status(status=experiment_status.SUCCESS)
+        else:
+            self.set_status(status=experiment_status.FAILED)
+
+        self.results['RAMBLE_STATUS'] = self.get_status()
+
+        if repeat_success or workspace.always_print_foms:
+            logger.debug(f'Calculating statistics for {n_repeats} repeats of {base_exp_name}')
+            self.results['RAMBLE_VARIABLES'] = {}
+            self.results['RAMBLE_RAW_VARIABLES'] = {}
+            for var, val in self.variables.items():
+                self.results['RAMBLE_RAW_VARIABLES'][var] = val
+                self.results['RAMBLE_VARIABLES'][var] = self.expander.expand_var(val)
+            self.results['CONTEXTS'] = []
+
+            results = []
+
+            # Iterate through repeat experiment instances, extract foms, and aggregate them
+            for exp in repeat_experiments.keys():
+                if exp in self.experiment_set.experiments.keys():
+                    exp_inst = self.experiment_set.experiments[exp]
+                elif exp in self.experiment_set.chained_experiments.keys():
+                    exp_inst = self.experiment_set.chained_experiments[exp]
+                else:
+                    continue
+
+                # When strict success is off for repeats (loose success), skip failed exps
+                if (not workspace.repeat_success_strict
+                    and exp_inst.results['RAMBLE_STATUS'] == 'FAILED'):
+                    continue
+
+                if 'CONTEXTS' in exp_inst.results:
+                    for context in exp_inst.results['CONTEXTS']:
+                        context_name = context['name']
+
+                        if context_name not in repeat_foms.keys():
+                            repeat_foms[context_name] = {}
+
+                        for foms in context['foms']:
+                            fom_key = (foms['name'], foms['units'],
+                                       foms['origin'], foms['origin_type'])
+
+                            # Stats will not be calculated for non-numeric foms so they're skipped
+                            if is_numeric(foms['value']):
+                                if fom_key not in repeat_foms[context_name].keys():
+                                    repeat_foms[context_name][fom_key] = []
+                                repeat_foms[context_name][fom_key].append(float(foms['value']))
+
+            # Iterate through the aggregated foms, calculate stats, and insert into results
+            for context, fom_dict in repeat_foms.items():
+                context_map = {'name': context, 'foms': []}
+
+                for fom_key, fom_values in fom_dict.items():
+                    fom_name = fom_key[0]
+                    fom_units = fom_key[1]
+                    fom_origin = fom_key[2]
+
+                    calcs = []
+
+                    for statistic in ramble.util.stats.all_stats:
+                        calcs.append(statistic.report(fom_values, fom_units))
+
+                    for calc in calcs:
+                        fom_dict = {'value': calc[0], 'units': calc[1], 'origin': fom_origin,
+                                    'origin_type': calc[2], 'name': fom_name}
+
+                        context_map['foms'].append(fom_dict)
+
+                results.append(context_map)
+
+            if results:
+                self.results['CONTEXTS'] = results
+
+        workspace.insert_result(self.results, first_repeat_exp)
 
     def _new_file_dict(self):
         """Create a dictionary to represent a new log file"""

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -355,6 +355,12 @@ def workspace_setup_setup_parser(subparser):
              'all scripts. Prints commands that would be executed ' +
              'for installation, and files that would be downloaded.')
 
+    subparser.add_argument(
+        '--n_repeats', dest='n_repeats',
+        nargs='+',
+        default='0',
+        help='run each experiment n times and generate summary statistics.')
+
     arguments.add_common_arguments(subparser, ['phases', 'include_phase_dependencies',
                                                'where', 'exclude_where'])
 
@@ -418,6 +424,7 @@ def workspace_analyze(args):
     current_pipeline = ramble.pipeline.pipelines.analyze
     ws = ramble.cmd.require_active_workspace(cmd_name='workspace analyze')
     ws.always_print_foms = args.always_print_foms
+    ws.repeat_success_strict = ramble.config.get('config:repeat_success_strict')
 
     if args.dry_run:
         ws.dry_run = True
@@ -539,6 +546,8 @@ def workspace_info(args):
 
                     if app_inst.is_template:
                         color.cprint(rucolor.nested_3('      Template Experiment: ') + exp_name)
+                    elif app_inst.repeats[0]:
+                        color.cprint(rucolor.nested_3('      Repeat Base Experiment: ') + exp_name)
                     else:
                         color.cprint(rucolor.nested_3('      Experiment: ') + exp_name)
 

--- a/lib/ramble/ramble/config.py
+++ b/lib/ramble/ramble/config.py
@@ -123,6 +123,8 @@ config_defaults = {
         'disable_passthrough': False,
         'disable_progress_bar': False,
         'connect_timeout': 10,
+        'n_repeats': '0',
+        'repeat_success_strict': True,
         'verify_ssl': True,
         'checksum': True,
         'dirty': False,

--- a/lib/ramble/ramble/context.py
+++ b/lib/ramble/ramble/context.py
@@ -35,6 +35,7 @@ class Context(object):
         self.zips = {}
         self.matrices = []
         self.is_template = False
+        self.n_repeats = 0
 
     def merge_context(self, in_context):
         """Merges another Context into this Context."""
@@ -78,6 +79,8 @@ class Context(object):
             self.zips.update(in_context.zips)
         if in_context.matrices:
             self.matrices = in_context.matrices
+        if in_context.n_repeats != 0:
+            self.n_repeats = int(in_context.n_repeats)
 
 
 def create_context_from_dict(context_name, in_dict):
@@ -96,6 +99,7 @@ def create_context_from_dict(context_name, in_dict):
         'exclude': {},
         'zips': {},
         'matrices': {} or [],
+        'n_repeats': '',
 
     Args:
         context_name: The name of the context (e.g., application name)
@@ -138,5 +142,8 @@ def create_context_from_dict(context_name, in_dict):
         context_name,
         in_dict
     )
+
+    if namespace.n_repeats in in_dict:
+        new_context.n_repeats = int(in_dict[namespace.n_repeats])
 
     return new_context

--- a/lib/ramble/ramble/namespace.py
+++ b/lib/ramble/ramble/namespace.py
@@ -27,6 +27,7 @@ class namespace:
     chained_experiments = 'chained_experiments'
     inherit_variables = 'inherit_variables'
     modifiers = 'modifiers'
+    n_repeats = 'n_repeats'
 
     # For rendering objects
     variables = 'variables'

--- a/lib/ramble/ramble/renderer.py
+++ b/lib/ramble/ramble/renderer.py
@@ -50,6 +50,7 @@ class RenderGroup(object):
         self.variables = {}
         self.zips = {}
         self.matrices = []
+        self.n_repeats = 0
 
     def copy_contents(self, in_group):
         """Copy contents of in_group into self"""
@@ -131,12 +132,15 @@ class Renderer(object):
         After processing the expansion logic, this function yields a dictionary
         of variable definitions, one for each object that would be rendered.
 
-        Returns:
-            Yield a dictionary of variables for single object definition
+        Yields:
+            - a dictionary of variables for single object definition
+            - a tuple indicating whether the object is a repeat and its index
+
         """
         variables = render_group.variables
         zips = render_group.zips
         matrices = render_group.matrices
+        n_repeats = render_group.n_repeats
 
         object_variables = {}
         expander = ramble.expander.Expander(variables, None)
@@ -380,7 +384,17 @@ class Renderer(object):
                         keep_object = False
 
             if keep_object:
-                yield object_variables.copy()
+                # If n_repeats is set, yield 1 base and n duplicate copies of each object
+                # repeats = (is_repeat_base, [T:n_repeats|F:repeat index or 0 if not a repeat])
+                for n in range(0, n_repeats + 1):
+                    repeats = (False, 0)
+
+                    if n_repeats > 0 and n == 0:  # this is a repeat base
+                        repeats = (True, n_repeats)
+                    elif n_repeats > 0 and n > 0:  # this is a repeat with index n
+                        repeats = (False, n)
+                    # maybe yield a tuple of vars and repeat info
+                    yield object_variables.copy(), repeats
 
 
 class RambleRendererError(ramble.error.RambleError):

--- a/lib/ramble/ramble/schema/applications.py
+++ b/lib/ramble/ramble/schema/applications.py
@@ -95,6 +95,13 @@ exclude_def = {
     'additionalProperties': False
 }
 
+repeats_def = union_dicts(
+    ramble.schema.types.string_or_num,
+    {
+        'default': 0
+    }
+)
+
 sub_props = union_dicts(
     ramble.schema.variables.properties,
     ramble.schema.success_criteria.properties,
@@ -147,6 +154,7 @@ properties = {
                                                     'matrices': matrices_def,
                                                     'success_criteria': success_list_def,
                                                     'exclude': exclude_def,
+                                                    'n_repeats': repeats_def,
                                                 }
                                             )
                                         }

--- a/lib/ramble/ramble/schema/config.py
+++ b/lib/ramble/ramble/schema/config.py
@@ -167,6 +167,16 @@ properties['config']['disable_logger'] = {
     'default': False
 }
 
+properties['config']['n_repeats'] = {
+    'type': 'string',
+    'default': '0'
+}
+
+properties['config']['repeat_success_strict'] = {
+    'type': 'boolean',
+    'default': True
+}
+
 
 #: Full schema with metadata
 schema = {

--- a/lib/ramble/ramble/software_environments.py
+++ b/lib/ramble/ramble/software_environments.py
@@ -120,13 +120,13 @@ class SoftwareEnvironments(object):
                         exclude_where = pkg_info[namespace.exclude][namespace.where].copy()
 
                     if perform_explicit_exclude:
-                        for exclude_vars in pkg_renderer.render_objects(exclude_group):
+                        for exclude_vars, _ in pkg_renderer.render_objects(exclude_group):
                             final_name = expander.expand_var_name('package_name',
                                                                   extra_vars=exclude_vars)
                             exclude_pkgs.add(final_name)
 
-                for rendered_vars in pkg_renderer.render_objects(pkg_group,
-                                                                 exclude_where=exclude_where):
+                for rendered_vars, _ in pkg_renderer.render_objects(pkg_group,
+                                                                    exclude_where=exclude_where):
                     final_name = expander.expand_var_name('package_name',
                                                           extra_vars=rendered_vars)
                     if final_name in exclude_pkgs:
@@ -173,13 +173,13 @@ class SoftwareEnvironments(object):
                         exclude_where = env_info[namespace.exclude][namespace.where].copy()
 
                     if perform_explicit_exclude:
-                        for exclude_vars in env_renderer.render_objects(exclude_group):
+                        for exclude_vars, _ in env_renderer.render_objects(exclude_group):
                             final_name = expander.expand_var_name('environment_name',
                                                                   extra_vars=exclude_vars)
                             exclude_envs.add(final_name)
 
-                for rendered_vars in env_renderer.render_objects(env_group,
-                                                                 exclude_where=exclude_where):
+                for rendered_vars, _ in env_renderer.render_objects(env_group,
+                                                                    exclude_where=exclude_where):
                     final_name = expander.expand_var_name('environment_name',
                                                           extra_vars=rendered_vars)
 

--- a/lib/ramble/ramble/test/end_to_end/experiment_repeats.py
+++ b/lib/ramble/ramble/test/end_to_end/experiment_repeats.py
@@ -1,0 +1,180 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+import glob
+
+import pytest
+
+import ramble.workspace
+import ramble.config
+import ramble.software_environments
+from ramble.main import RambleCommand
+from ramble.test.dry_run_helpers import search_files_for_string
+
+
+# everything here uses the mock_workspace_path
+pytestmark = pytest.mark.usefixtures('mutable_config',
+                                     'mutable_mock_workspace_path')
+
+workspace = RambleCommand('workspace')
+
+
+def test_gromacs_repeats(mutable_config, mutable_mock_workspace_path):
+    test_config = """
+ramble:
+  config:
+    n_repeats: '2'
+  variables:
+    processes_per_node: 16
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: '{execute_experiment}'
+  applications:
+    gromacs:
+      workloads:
+        water_gmx50:
+          experiments:
+            pme_single_rank:
+              variables:
+                n_ranks: '1'
+                n_threads: '1'
+                size: '0003'
+                type: 'pme'
+            rf_single_rank:
+              n_repeats: '1'
+              variables:
+                n_ranks: '1'
+                n_threads: '1'
+                size: '0003'
+                type: 'rf'
+        water_bare:
+          experiments:
+            pme_single_rank:
+              variables:
+                n_ranks: '1'
+                n_threads: '1'
+                size: '0003'
+                type: 'pme'
+  spack:
+    concretized: true
+    packages:
+      gcc:
+        spack_spec: gcc@8.5.0
+      intel-mpi:
+        spack_spec: intel-mpi@2018.4.274
+        compiler: gcc
+      gromacs:
+        spack_spec: gromacs@2021.6
+        compiler: gcc
+    environments:
+      gromacs:
+        packages:
+        - gromacs
+        - intel-mpi
+"""
+
+    workspace_name = 'test_end_to_end_repeats'
+    with ramble.workspace.create(workspace_name) as ws1:
+        ws1.write()
+
+        config_path = os.path.join(ws1.config_dir, ramble.workspace.config_file_name)
+
+        aux_software_path = os.path.join(ws1.config_dir,
+                                         ramble.workspace.auxiliary_software_dir_name)
+        aux_software_files = ['packages.yaml', 'my_test.sh']
+
+        with open(config_path, 'w+') as f:
+            f.write(test_config)
+
+        for file in aux_software_files:
+            file_path = os.path.join(aux_software_path, file)
+            with open(file_path, 'w+') as f:
+                f.write('')
+
+        # Write a command template
+        with open(os.path.join(ws1.config_dir, 'full_command.tpl'), 'w+') as f:
+            f.write('{command}')
+
+        ws1._re_read()
+
+        workspace('setup', '--dry-run', global_args=['-w', workspace_name])
+
+        out_files = glob.glob(os.path.join(ws1.log_dir, '**', '*.out'), recursive=True)
+
+        assert search_files_for_string(
+            out_files, 'Would download https://ftp.gromacs.org/pub/benchmarks/water_GMX50_bare.tar.gz') # noqa
+
+        # Test software directories
+        software_dirs = ['gromacs.water_gmx50', 'gromacs.water_bare']
+        software_base_dir = os.path.join(ws1.root, ramble.workspace.workspace_software_path)
+        assert os.path.exists(software_base_dir)
+        for software_dir in software_dirs:
+            software_path = os.path.join(software_base_dir, software_dir)
+            assert os.path.exists(software_path)
+
+            spack_file = os.path.join(software_path, 'spack.yaml')
+            assert os.path.exists(spack_file)
+            for file in aux_software_files:
+                file_path = os.path.join(software_path, file)
+                assert os.path.exists(file_path)
+
+            lock_file = os.path.join(software_path, 'spack.lock')
+            with open(lock_file, 'w+') as f:
+                f.write('{\n')
+                f.write('\t"test_key": "val"\n')
+                f.write('}\n')
+
+        # Each tuple (workload, exp base, n_repeats) expands to 1 base exp plus n_repeats exps
+        expected_experiments = [
+            ('water_gmx50', 'pme_single_rank', 2),
+            ('water_gmx50', 'rf_single_rank', 1),
+            ('water_bare', 'pme_single_rank', 2)
+        ]
+
+        # Test experiment directories
+        for wl, exp, repeats in expected_experiments:
+            # Test that the base experiment directory is not created
+            base_exp_dir = os.path.join(ws1.root, 'experiments', 'gromacs', wl, exp)
+            assert not os.path.isdir(base_exp_dir)
+            assert not os.path.exists(os.path.join(base_exp_dir, 'execute_experiment'))
+
+            # Test each of the repeat directories
+            for r in range(1, repeats + 1):
+                repeat_exp_dir = f'{base_exp_dir}.{r}'
+                assert os.path.isdir(repeat_exp_dir)
+                assert os.path.exists(os.path.join(repeat_exp_dir, 'execute_experiment'))
+
+                # TODO: Create fake experiment figures of merit.
+                with open(os.path.join(repeat_exp_dir, 'md.log'), 'w+') as f:
+                    f.write('               Core t (s)   Wall t (s)        (%)\n')
+                    f.write(f'       Time:       {r}{r}.{r}{r}{r}       {r}.{r}{r}{r}    1000.1\n')
+                    f.write('                 (ns/day)    (hour/ns)\n')
+
+            # Test that the number of repeats is not exceeded
+            excess_repeat_exp_dir = f'{base_exp_dir}.{repeats + 1}'
+            assert not os.path.isdir(excess_repeat_exp_dir)
+            assert not os.path.exists(os.path.join(excess_repeat_exp_dir, 'execute_experiment'))
+
+        workspace('analyze', '-f', 'text', 'json', 'yaml', global_args=['-w', workspace_name])
+
+        text_results_files = glob.glob(os.path.join(ws1.root, 'results*.txt'))
+        json_results_files = glob.glob(os.path.join(ws1.root, 'results*.json'))
+        yaml_results_files = glob.glob(os.path.join(ws1.root, 'results*.yaml'))
+
+        # Match both the file and the simlink
+        assert len(text_results_files) == 2
+        assert len(json_results_files) == 2
+        assert len(yaml_results_files) == 2
+
+        for text_result in text_results_files:
+            with open(text_result, 'r') as f:
+                data = f.read()
+                assert 'Core Time = 11.111 s' in data
+                assert 'Core Time = 22.222 s' in data
+                assert 'summary::mean = 16.666 s' in data
+                assert 'summary::variance = 61.727 s^2' in data

--- a/lib/ramble/ramble/test/success_criteria/repeat_success_strict.py
+++ b/lib/ramble/ramble/test/success_criteria/repeat_success_strict.py
@@ -1,0 +1,100 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.workspace
+import ramble.config
+import ramble.software_environments
+from ramble.main import RambleCommand
+
+
+# everything here uses the mock_workspace_path
+pytestmark = pytest.mark.usefixtures('mutable_config',
+                                     'mutable_mock_workspace_path')
+
+workspace = RambleCommand('workspace')
+ramble_on = RambleCommand('on')
+
+
+def test_repeat_success_strict(mutable_config,
+                               mutable_mock_workspace_path,
+                               mock_applications):
+    test_config = """
+ramble:
+  config:
+    repeat_success_strict: False
+  variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: '{execute_experiment}'
+    processes_per_node: '16'
+    n_threads: '1'
+  applications:
+    basic:
+      workloads:
+        working_wl:
+          experiments:
+            test_exp:
+              n_repeats: 2
+              variables:
+                n_nodes: 1
+  spack:
+    concretized: true
+    packages: {}
+    environments: {}
+"""
+    workspace_name = 'test_repeat_success_strict'
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+
+        config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+
+        with open(config_path, 'w+') as f:
+            f.write(test_config)
+        ws._re_read()
+
+        workspace('setup', global_args=['-w', workspace_name])
+        ramble_on(global_args=['-w', workspace_name])
+        workspace('analyze', global_args=['-w', workspace_name])
+
+        with open(os.path.join(ws.root, 'results.latest.txt'), 'r') as f:
+            data = f.read()
+            print(data)
+            assert 'FAILED' not in data
+            assert 'summary::n_repeats = 2 repeats' in data
+
+        # Write mock output to fail one of the experiments
+        result_path = os.path.join(ws.experiment_dir, 'basic', 'working_wl',
+                                   'test_exp.1', 'test_exp.1.out')
+        with open(result_path, 'w+') as f:
+            f.write('')
+
+        workspace('analyze', global_args=['-w', workspace_name])
+
+        with open(os.path.join(ws.root, 'results.latest.txt'), 'r') as f:
+            data = f.read()
+            print(data)
+            assert 'SUCCESS' in data
+            assert 'FAILED' in data
+            assert 'summary::n_repeats = 1 repeats' in data
+
+        # Write mock output to fail the second experiment
+        result_path = os.path.join(ws.experiment_dir, 'basic', 'working_wl',
+                                   'test_exp.2', 'test_exp.2.out')
+        with open(result_path, 'w+') as f:
+            f.write('')
+
+        workspace('analyze', global_args=['-w', workspace_name])
+
+        with open(os.path.join(ws.root, 'results.latest.txt'), 'r') as f:
+            data = f.read()
+            print(data)
+            assert 'SUCCESS' not in data
+            assert 'summary::n_repeats' not in data

--- a/lib/ramble/ramble/test/util/stats.py
+++ b/lib/ramble/ramble/test/util/stats.py
@@ -1,0 +1,32 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import pytest
+
+import ramble.util.stats
+
+
+@pytest.mark.parametrize(
+    'statistic,input_values,input_units,output',
+    [
+        (ramble.util.stats.StatsMin(), [-2, 0, 2, 5.5], 's', (-2, 's', 'summary::min')),
+        (ramble.util.stats.StatsMax(), [-2, 0, 2, 5.5], 's', (5.5, 's', 'summary::max')),
+        (ramble.util.stats.StatsMean(), [-2, 0, 2, 5.5], 's', (1.4, 's', 'summary::mean')),
+        (ramble.util.stats.StatsMedian(), [-2, 0, 2, 5.5], 's', (1.0, 's', 'summary::median')),
+        (ramble.util.stats.StatsVar(), [-2, 0, 2, 5.5], 's', (10.2, 's^2', 'summary::variance')),
+        (ramble.util.stats.StatsVar(), [3], 's', ('variance requires at least two data points',
+                                                  '', 'summary::variance')),
+        (ramble.util.stats.StatsStdev(), [-2, 0, 2, 5.5], 's', (3.2, 's', 'summary::stdev')),
+        (ramble.util.stats.StatsStdev(), [3], 's', ('variance requires at least two data points',
+                                                    '', 'summary::stdev')),
+        (ramble.util.stats.StatsCountValues(), [-2, 0, 2, 5.5], 's', (4, 'repeats',
+                                                                      'summary::n_repeats')),
+    ]
+)
+def test_stats_for_repeat_foms(statistic, input_values, input_units, output):
+    assert statistic.report(input_values, input_units) == output

--- a/lib/ramble/ramble/util/stats.py
+++ b/lib/ramble/ramble/util/stats.py
@@ -1,0 +1,124 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import statistics
+
+
+def decimal_places(value):
+    """Returns the number of decimal places of a value"""
+
+    val_str = str(value)
+    if '.' not in val_str:
+        return 0
+    else:
+        return len(val_str.split('.')[1])
+
+
+def max_decimal_places(list):
+    """Returns the max decimal places of a list of values"""
+
+    max = 0
+    for val in list:
+        if decimal_places(val) > max:
+            max = decimal_places(val)
+    return max
+
+
+class StatsBase(object):
+    def compute(self, values):
+        pass
+
+    def report(self, values, units):
+        return (self.compute(values), units, f'summary::{self.name}')
+
+
+class StatsMin(StatsBase):
+    name = 'min'
+
+    def compute(self, values):
+        return min(values)
+
+
+class StatsMax(StatsBase):
+    name = 'max'
+
+    def compute(self, values):
+        return max(values)
+
+
+class StatsMean(StatsBase):
+    name = 'mean'
+
+    def compute(self, values):
+        return round(statistics.mean(values), max_decimal_places(values))
+
+
+class StatsMedian(StatsBase):
+    name = 'median'
+
+    def compute(self, values):
+        return round(statistics.median(values), max_decimal_places(values))
+
+
+class StatsVar(StatsBase):
+    name = 'variance'
+
+    def compute(self, values):
+        return round(statistics.variance(values), max_decimal_places(values))
+
+    def report(self, values, units):
+        var = ''
+        new_units = ''
+
+        try:
+            var = self.compute(values)
+            new_units = f'{units}^2'
+        except statistics.StatisticsError as e:
+            var = str(e)
+            new_units = ''
+
+        return (var, new_units, f'summary::{self.name}')
+
+
+class StatsStdev(StatsBase):
+    name = 'stdev'
+
+    def compute(self, values):
+        return round(statistics.stdev(values), max_decimal_places(values))
+
+    def report(self, values, units):
+        var = ''
+        new_units = ''
+
+        try:
+            var = self.compute(values)
+            new_units = units
+        except statistics.StatisticsError as e:
+            var = str(e)
+            new_units = ''
+
+        return (var, new_units, f'summary::{self.name}')
+
+
+class StatsCountValues(StatsBase):
+    name = 'n_repeats'
+
+    def compute(self, values):
+        return len(values)
+
+    def report(self, values, units):
+        return (self.compute(values), 'repeats', f'summary::{self.name}')
+
+
+all_stats = [StatsMin(),
+             StatsMax(),
+             StatsMean(),
+             StatsMedian(),
+             StatsVar(),
+             StatsStdev(),
+             StatsCountValues()]

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -453,6 +453,7 @@ class Workspace(object):
         self.txlock = lk.Lock(self._transaction_lock_path)
         self.dry_run = dry_run
         self.always_print_foms = False
+        self.repeat_success_strict = True
 
         self.read_default_template = read_default_template
         self.configs = ramble.config.ConfigScope('workspace', self.config_dir)
@@ -796,6 +797,7 @@ class Workspace(object):
                     ramble.context.create_context_from_dict(application, contents)
 
                 self.extract_success_criteria('application', contents)
+
                 yield contents, application_context
 
     def all_workloads(self, application):
@@ -971,6 +973,27 @@ class Workspace(object):
 
         self.results['experiments'].append(result)
 
+    def insert_result(self, result, insert_before_exp):
+        """Insert a result before a specified experiment"""
+
+        def search_exp_index(results_list, exp_to_search):
+            for i, exp in enumerate(results_list):
+                if exp['name'] == exp_to_search:
+                    return i
+            return None
+
+        if not self.results:
+            self.results = self.default_results()
+
+        insert_index = search_exp_index(self.results['experiments'], insert_before_exp)
+
+        tty.debug(f'Attempting to insert result before experiment {insert_before_exp}')
+        if insert_index is not None:
+            self.results['experiments'].insert(insert_index, result)
+        else:
+            tty.debug(f'Could not find {insert_before_exp}, appending result to end instead.')
+            self.results['experiments'].append(result)
+
     def simlink_result(self, filename_base, latest_base, file_extension):
         """
         Create simlink of result file so that results.latest.txt always points
@@ -993,6 +1016,7 @@ class Workspace(object):
         results.latest.<extension>
 
         """
+
         if not self.results:
             self.results = {}
 
@@ -1019,20 +1043,41 @@ class Workspace(object):
                         f.write('  Status = %s\n' %
                                 exp['RAMBLE_STATUS'])
                         if exp['RAMBLE_STATUS'] == 'SUCCESS' or self.always_print_foms:
-                            for context in exp['CONTEXTS']:
-                                f.write('  %s figures of merit:\n' %
-                                        context['name'])
-                                for fom in context['foms']:
-                                    name = fom['name']
-                                    if fom['origin_type'] == 'modifier':
-                                        delim = '::'
-                                        mod = fom['origin']
-                                        name = f"{fom['origin_type']}{delim}{mod}{delim}{name}"
+                            if exp['N_REPEATS'] > 0:  # this is a base exp with summary of repeats
+                                for context in exp['CONTEXTS']:
+                                    f.write('  %s figures of merit:\n' %
+                                            context['name'])
 
-                                    output = '%s = %s %s' % (name,
-                                                             fom['value'],
-                                                             fom['units'])
-                                    f.write('    %s\n' % (output.strip()))
+                                    fom_summary = {}
+                                    for fom in context['foms']:
+                                        name = fom['name']
+                                        if name not in fom_summary.keys():
+                                            fom_summary[name] = []
+                                        stat_name = fom['origin_type']
+                                        value = fom['value']
+                                        units = fom['units']
+
+                                        output = f'{stat_name} = {value} {units}\n'
+                                        fom_summary[name].append(output)
+
+                                    for fom_name, fom_val_list in fom_summary.items():
+                                        f.write(f'    {fom_name}:\n')
+                                        for fom_val in fom_val_list:
+                                            f.write(f'      {fom_val.strip()}\n')
+                            else:
+                                for context in exp['CONTEXTS']:
+                                    f.write(f'  {context["name"]} figures of merit:\n')
+                                    for fom in context['foms']:
+                                        name = fom['name']
+                                        if fom['origin_type'] == 'modifier':
+                                            delim = '::'
+                                            mod = fom['origin']
+                                            name = f"{fom['origin_type']}{delim}{mod}{delim}{name}"
+
+                                        output = '%s = %s %s' % (name,
+                                                                 fom['value'],
+                                                                 fom['units'])
+                                        f.write('    %s\n' % (output.strip()))
                 else:
                     logger.msg('No results to write')
 

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -675,7 +675,7 @@ _ramble_workspace_concretize() {
 }
 
 _ramble_workspace_setup() {
-    RAMBLE_COMPREPLY="-h --help --dry-run --phases --include-phase-dependencies --where --exclude-where"
+    RAMBLE_COMPREPLY="-h --help --dry-run --n_repeats --phases --include-phase-dependencies --where --exclude-where"
 }
 
 _ramble_workspace_analyze() {


### PR DESCRIPTION
Creates a new configuration setting to allow experiments to be repeated, and generates summary statistics of the set of repetitions.

Fixed version of PR 375 https://github.com/GoogleCloudPlatform/ramble/pull/375