### PR TITLE
Allow executable scoped variable definitions

### DIFF
--- a/lib/ramble/docs/workspace_config.rst
+++ b/lib/ramble/docs/workspace_config.rst
@@ -707,6 +707,41 @@ This is a generic way to add the ``lscpu`` custom executable to the end of the
 list of executables for the experiment. For more information on this see the
 :ref:`internals config section<internals-config>` documentation.
 
+"""""""""""""""""""""""""""""""
+Overriding Variable Definitions
+"""""""""""""""""""""""""""""""
+
+When defining custom executables, sometimes it's useful to be able to override
+specific variable definitions for only this executable definition. As an
+example, consider running a command to get information from every node in a job
+allocation. While the actual experiment might be utilizing many processes on
+each compute node, the custom executable only wants to run a single process on
+each compute node. Ramble provides the ability for users to define variables
+that are scoped to only the custom executable instead of the entire experiment.
+Consider the following example:
+
+.. code-block:: yaml
+
+   ramble:
+     applications:
+       gromacs:
+         internals:
+           custom_executables:
+             all_hosts:
+               template:
+               - 'hostname'
+               use_mpi: true
+               variables:
+                 n_ranks: '{n_nodes}'
+                 processes_per_node: '1'
+               redirect: '{log_file}'
+
+In this example, a custom executable named ``all_hosts`` is defined. Within
+this executable, the value of ``n_ranks`` is defined to be the value of
+``n_nodes``, and ``processes_per_node`` is defined to be ``1``, causing only
+one rank per compute node. This would print the hostname of each node in the
+experiment once.
+
 ^^^^^^^^^^^^^^^^^^^
 Reserved Variables:
 ^^^^^^^^^^^^^^^^^^^

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -831,6 +831,8 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
             builtin_match = builtin_regex.match(executable)
 
             exec_vars = {'executable_name': executable}
+            if executable in self.executables:
+                exec_vars.update(self.executables[executable].variables)
 
             for mod in self._modifier_instances:
                 if mod.applies_to_executable(executable):

--- a/lib/ramble/ramble/language/application_language.py
+++ b/lib/ramble/ramble/language/application_language.py
@@ -91,7 +91,7 @@ def workload(name, executables=None, executable=None, input=None,
 
 
 @application_directive('executables')
-def executable(name, template, use_mpi=False, redirect='{log_file}',
+def executable(name, template, use_mpi=False, variables={}, redirect='{log_file}',
                output_capture=OUTPUT_CAPTURE.DEFAULT, **kwargs):
     """Adds an executable to this application
 
@@ -104,6 +104,8 @@ def executable(name, template, use_mpi=False, redirect='{log_file}',
         template: The template command this executable should generate from
         use_mpi: (Boolean) determines if this executable should be
                  wrapped with an `mpirun` like command or not.
+
+        variables (dict): dictionary of variable definitions to use for this executable only
         redirect (Optional): Sets the path for outputs to be written to.
                              defaults to {log_file}
         output_capture (Optional): Declare which ouptu (stdout, stderr, both) to

--- a/lib/ramble/ramble/schema/internals.py
+++ b/lib/ramble/ramble/schema/internals.py
@@ -12,7 +12,10 @@
    :lines: 12-
 """  # noqa E501
 
+from llnl.util.lang import union_dicts
+
 import ramble.schema.types
+import ramble.schema.variables
 
 
 custom_executables_def = {
@@ -24,13 +27,17 @@ custom_executables_def = {
             'template': [],
             'use_mpi': False,
             'redirect': '{log_file}',
+            'variables': {},
             'output_capture': ramble.schema.types.OUTPUT_CAPTURE.DEFAULT
         },
-        'properties': {
-            'template': ramble.schema.types.array_or_scalar_of_strings_or_nums,
-            'use_mpi': {'type': 'boolean'},
-            'redirect': ramble.schema.types.string_or_num,
-        }
+        'properties': union_dicts(
+            {
+                'template': ramble.schema.types.array_or_scalar_of_strings_or_nums,
+                'use_mpi': {'type': 'boolean'},
+                'redirect': ramble.schema.types.string_or_num,
+            },
+            ramble.schema.variables.properties,
+        ),
     },
     'default': {},
 }

--- a/lib/ramble/ramble/test/end_to_end/custom_executables.py
+++ b/lib/ramble/ramble/test/end_to_end/custom_executables.py
@@ -54,10 +54,12 @@ ramble:
                     - 'echo "after all"'
                   before_env_vars:
                     template:
-                    - 'echo "before env_vars"'
+                    - 'echo "before env_vars {env_var_name}"'
+                    variables:
+                      env_var_name: 'OTHER_ENV_VAR'
                   after_env_vars:
                     template:
-                    - 'echo "after env_vars"'
+                    - 'echo "after env_vars {env_var_name}"'
                 executables:
                 - lscpu
                 - builtin::env_vars
@@ -74,9 +76,11 @@ ramble:
                   relative_to: builtin::env_vars
               variables:
                 n_nodes: 1
+                env_var_name: 'MY_VAR'
               env_vars:
                 set:
                   MY_VAR: 'TEST'
+                  OTHER_ENV_VAR: 'ANOTHER_TEST'
   spack:
     concretized: true
     packages: {}
@@ -105,8 +109,8 @@ ramble:
 
         inject_order_regex = [
             re.compile('echo "before all"'),
-            re.compile('echo "before env_vars"'),
-            re.compile('echo "after env_vars"'),
+            re.compile('echo "before env_vars OTHER_ENV_VAR"'),
+            re.compile('echo "after env_vars MY_VAR"'),
             re.compile('echo "after all"'),
         ]
 

--- a/lib/ramble/ramble/util/executable.py
+++ b/lib/ramble/ramble/util/executable.py
@@ -62,8 +62,8 @@ class CommandExecutable(object):
     generally used to group one or more commands together into an executable
     name.
     """
-    def __init__(self, name, template, use_mpi=False, mpi=False, redirect='{log_file}',
-                 output_capture=OUTPUT_CAPTURE.DEFAULT, **kwargs):
+    def __init__(self, name, template, use_mpi=False, mpi=False, variables={},
+                 redirect='{log_file}', output_capture=OUTPUT_CAPTURE.DEFAULT, **kwargs):
         """Create a CommandExecutable instance
 
         Args:
@@ -72,6 +72,7 @@ class CommandExecutable(object):
         - use_mpi: Boolean value for if MPI should be applied to each
                    portion of this executable's template
         - mpi: Same as use_mpi
+        - variables (dict): dictionary of variable definitions to use for this executable only
         - redirect: File to redirect output of template into
         - output_capture: Operator to use when capturing output
         """
@@ -88,11 +89,13 @@ class CommandExecutable(object):
         self.mpi = use_mpi or mpi
         self.redirect = redirect
         self.output_capture = output_capture
+        self.variables = variables.copy()
 
     def copy(self):
         """Replicate a CommandExecutable instance"""
         new_inst = type(self)(self.name, self.template, mpi=self.mpi,
                               redirect=self.redirect,
+                              variables=self.variables,
                               output_capture=self.output_capture)
         return new_inst
 
@@ -101,6 +104,7 @@ class CommandExecutable(object):
         self_str = f'exec: {self.name}:\n' + \
                    f'    template: {str(self.template)}\n' + \
                    f'    mpi: {self.mpi}\n' +\
+                   f'    variables: {self.variables}\n' +\
                    f'    redirect: {self.redirect}\n' +\
                    f'    output_capture: {self.output_capture}\n'
 


### PR DESCRIPTION
This merge adds support for variables to be scoped within an executable definition (both in the directive, and in the custom executables section of the internals config section).

Tests and documentation are added as well.