### PR TITLE
Add hashes for objects to workspace inventories

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -97,6 +97,8 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         self._input_fetchers = None
 
         self.hash_inventory = {
+            'application_definition': None,
+            'modifier_definitions': [],
             'attributes': [],
             'inputs': [],
             'software': [],
@@ -1163,6 +1165,20 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                 ('internals', self.internals),
                 ('env_vars', self._env_variable_sets),
             ]
+
+            self.hash_inventory['application_definition'] = \
+                ramble.util.hashing.hash_file(self._file_path)
+
+            added_mods = set()
+            for mod_inst in self._modifier_instances:
+                if mod_inst.name not in added_mods:
+                    self.hash_inventory['modifier_definitions'].append(
+                        {
+                            'name': mod_inst.name,
+                            'digest': ramble.util.hashing.hash_file(mod_inst._file_path)
+                        }
+                    )
+                    added_mods.add(mod_inst.name)
 
             for attr, attr_dict in attributes_to_hash:
                 self.hash_inventory['attributes'].append(

--- a/lib/ramble/ramble/repository.py
+++ b/lib/ramble/ramble/repository.py
@@ -999,7 +999,7 @@ class Repo(object):
 
         object_class = self.get_obj_class(spec.name)
         try:
-            return object_class(spec)
+            return object_class(self.object_path(spec))
         except ramble.error.RambleError:
             # pass these through as their error messages will be fine.
             raise
@@ -1060,6 +1060,12 @@ class Repo(object):
         """
         obj_dir = self.dirname_for_object_name(obj_name)
         return os.path.join(obj_dir, self.object_file_name)
+
+    @autospec
+    def object_path(self, spec):
+        return os.path.join(self.objects_path,
+                            self.dirname_for_object_name(spec.name),
+                            self.filename_for_object_name(spec.name))
 
     @property
     def _obj_checker(self):


### PR DESCRIPTION
This merge adds the ability for workspace inventory files to track hashes of the python definition files (application.py and modifier.py).