### PR TITLE
Promote some variables to top level keys

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -960,11 +960,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
             self._set_default_experiment_variables()
             self._set_input_path()
             self._inject_commands(executables)
-            # ---------------------------------------------------------------------------------
-            # TODO (dwj): Remove this after we validate that 'spack_setup' is not in templates.
-            #             this is no longer needed, as spack was converted to builtins.
-            self.variables['spack_setup'] = ''
-            # ---------------------------------------------------------------------------------
+
             self._derive_variables_for_template_path(workspace)
             self._vars_are_expanded = True
 
@@ -1456,11 +1452,19 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
 
         if success or workspace.always_print_foms:
             results['TAGS'] = list(self.experiment_tags)
+
+            # Add defined keywords as top level keys
+            for key in self.keywords.keys:
+                if self.keywords.is_key_level(key):
+                    results[key] = self.expander.expand_var_name(key)
+
             results['RAMBLE_VARIABLES'] = {}
             results['RAMBLE_RAW_VARIABLES'] = {}
             for var, val in self.variables.items():
                 results['RAMBLE_RAW_VARIABLES'][var] = val
-                results['RAMBLE_VARIABLES'][var] = self.expander.expand_var(val)
+                if var not in self.keywords.keys or not self.keywords.is_key_level(var):
+                    results['RAMBLE_VARIABLES'][var] = self.expander.expand_var(val)
+
             results['CONTEXTS'] = []
 
             for context, fom_map in fom_values.items():

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -258,15 +258,18 @@ class ExperimentSet(object):
             None
         """
 
+        no_var_contexts = [self._contexts.global_conf,
+                           self._contexts.base, self._contexts.required]
         final_context = ramble.context.Context()
 
         for context in self._contexts:
             final_context.merge_context(self._context[context])
 
         for context in self._contexts:
-            var_name = f'{context.name}_name'
-            if self._context[context].context_name not in final_context.variables:
-                final_context.variables[var_name] = self._context[context].context_name
+            if context not in no_var_contexts:
+                var_name = f'{context.name}_name'
+                if self._context[context].context_name not in final_context.variables:
+                    final_context.variables[var_name] = self._context[context].context_name
 
         # Set namespaces
         final_context.variables[self.keywords.application_namespace] = self.application_namespace

--- a/lib/ramble/ramble/keywords.py
+++ b/lib/ramble/ramble/keywords.py
@@ -12,52 +12,55 @@ import ramble.error
 from ramble.util.logger import logger
 
 key_type = Enum('type', ['reserved', 'optional', 'required'])
+output_level = Enum('level', ['key', 'variable'])
 default_keys = {
-    'application_name': key_type.reserved,
-    'application_run_dir': key_type.reserved,
-    'application_input_dir': key_type.reserved,
-    'application_namespace': key_type.reserved,
-    'simplified_application_namespace': key_type.reserved,
-    'workload_name': key_type.reserved,
-    'workload_run_dir': key_type.reserved,
-    'workload_input_dir': key_type.reserved,
-    'workload_namespace': key_type.reserved,
-    'simplified_workload_namespace': key_type.reserved,
-    'license_input_dir': key_type.reserved,
-    'experiment_name': key_type.reserved,
-    'experiment_run_dir': key_type.reserved,
-    'experiment_status': key_type.reserved,
-    'experiment_index': key_type.reserved,
-    'experiment_namespace': key_type.reserved,
-    'simplified_experiment_namespace': key_type.reserved,
-    'log_dir': key_type.reserved,
-    'log_file': key_type.reserved,
-    'err_file': key_type.reserved,
-    'command': key_type.reserved,
-    'env_path': key_type.reserved,
-    'input_name': key_type.reserved,
+    'workspace_name': {'type': key_type.reserved, 'level': output_level.variable},
+    'application_name': {'type': key_type.reserved, 'level': output_level.key},
+    'application_run_dir': {'type': key_type.reserved, 'level': output_level.variable},
+    'application_input_dir': {'type': key_type.reserved, 'level': output_level.variable},
+    'application_namespace': {'type': key_type.reserved, 'level': output_level.key},
+    'simplified_application_namespace': {'type': key_type.reserved, 'level': output_level.key},
+    'workload_name': {'type': key_type.reserved, 'level': output_level.key},
+    'workload_run_dir': {'type': key_type.reserved, 'level': output_level.variable},
+    'workload_input_dir': {'type': key_type.reserved, 'level': output_level.variable},
+    'workload_namespace': {'type': key_type.reserved, 'level': output_level.key},
+    'simplified_workload_namespace': {'type': key_type.reserved, 'level': output_level.key},
+    'license_input_dir': {'type': key_type.reserved, 'level': output_level.variable},
+    'experiment_name': {'type': key_type.reserved, 'level': output_level.key},
+    'experiment_run_dir': {'type': key_type.reserved, 'level': output_level.variable},
+    'experiment_status': {'type': key_type.reserved, 'level': output_level.key},
+    'experiment_index': {'type': key_type.reserved, 'level': output_level.variable},
+    'experiment_namespace': {'type': key_type.reserved, 'level': output_level.key},
+    'simplified_experiment_namespace': {'type': key_type.reserved, 'level': output_level.key},
+    'log_dir': {'type': key_type.reserved, 'level': output_level.variable},
+    'log_file': {'type': key_type.reserved, 'level': output_level.variable},
+    'err_file': {'type': key_type.reserved, 'level': output_level.variable},
+    'command': {'type': key_type.reserved, 'level': output_level.variable},
+    'env_path': {'type': key_type.reserved, 'level': output_level.variable},
+    'input_name': {'type': key_type.reserved, 'level': output_level.variable},
 
-    'spec_name': key_type.optional,
-    'env_name': key_type.optional,
+    'spec_name': {'type': key_type.optional, 'level': output_level.variable},
+    'env_name': {'type': key_type.optional, 'level': output_level.variable},
 
-    'n_ranks': key_type.required,
-    'n_nodes': key_type.required,
-    'processes_per_node': key_type.required,
-    'n_threads': key_type.required,
-    'batch_submit': key_type.required,
-    'mpi_command': key_type.required,
-    'experiment_template_name': key_type.required,
+    'n_ranks': {'type': key_type.required, 'level': output_level.key},
+    'n_nodes': {'type': key_type.required, 'level': output_level.key},
+    'processes_per_node': {'type': key_type.required, 'level': output_level.key},
+    'n_threads': {'type': key_type.required, 'level': output_level.key},
+    'batch_submit': {'type': key_type.required, 'level': output_level.variable},
+    'mpi_command': {'type': key_type.required, 'level': output_level.variable},
+    'experiment_template_name': {'type': key_type.required, 'level': output_level.key},
 }
 
 
 class Keywords(object):
     """Class to represent known ramble keywords.
 
-    Each keyword can have a type. Valid types are identified by the
-    'key_type' variable as an enum.
+    Each keyword contains a dictionary of its attributes. Currently, these include:
+    - type
+    - level
 
-    A map of keys, and their types is provided in the class level 'keys'
-    variable. This enforces that each keyword can only have a single type.
+    Valid types are identified by the 'key_type' variable as an enum.
+    Valid levels are identified by the 'output_level'.
 
     Current key types are:
       - Reserved: Ramble defines these, and a user should not be allowed to define them
@@ -65,10 +68,19 @@ class Keywords(object):
       - Required: Ramble requires a definition for these. Ramble will try to set sensible defaults,
         but it might not be possible always.
 
+    Current levels are:
+      - Key: Ramble defines this as a top level variable. When results are
+             output, these are hoisted to a set of variables that are guaranteed to
+             be in the output. These are non-application specific inputs that
+             define a Ramble experiment.
+      - Variable: These are considered standard variables. They might be
+                  derived from the values of entries with the level `key`. In results, they
+                  are presented in the variables section. These may include application
+                  specific inputs to further configure the experiment.
     """
     def __init__(self, extra_keys={}):
         # Merge in additional Keys:
-        self.keys = default_keys
+        self.keys = default_keys.copy()
         self.update_keys(extra_keys)
 
     def update_keys(self, extra_keys):
@@ -85,19 +97,31 @@ class Keywords(object):
         """Check if a key is reserved"""
         if not self.is_valid(key):
             return False
-        return self.keys[key] == key_type.reserved
+        return self.keys[key]['type'] == key_type.reserved
 
     def is_optional(self, key):
         """Check if a key is optional"""
         if not self.is_valid(key):
             return False
-        return self.keys[key] == key_type.optional
+        return self.keys[key]['type'] == key_type.optional
 
     def is_required(self, key):
         """Check if a key is required"""
         if not self.is_valid(key):
             return False
-        return self.keys[key] == key_type.required
+        return self.keys[key]['type'] == key_type.required
+
+    def is_key_level(self, key):
+        """Check if key is part of the key level"""
+        if not self.is_valid(key):
+            return False
+        return self.keys[key]['level'] == output_level.key
+
+    def is_variable_level(self, key):
+        """Check if key is part of the variable level"""
+        if not self.is_valid(key):
+            return False
+        return self.keys[key]['level'] == output_level.variable
 
     def check_reserved_keys(self, definitions):
         """Check a dictionary of variable definitions for reserved keywords"""

--- a/lib/ramble/ramble/language/modifier_language.py
+++ b/lib/ramble/ramble/language/modifier_language.py
@@ -224,14 +224,17 @@ def env_var_modification(name, modification=None, method='set', mode=None, modes
 
 
 @modifier_directive('required_vars')
-def required_variable(var: str):
+def required_variable(var: str, results_level='variable'):
     """Mark a var as being required
 
     Args:
         var: Value to mark as required
+        results_level (str): 'variable' or 'key'. If 'key' variable is promoted to
+                             a key within JSON or YAML formatted results.
     """
 
     def _mark_required_var(mod):
-        mod.required_vars[var] = ramble.keywords.key_type.required
+        mod.required_vars[var] = {'type': ramble.keywords.key_type.required,
+                                  'level': ramble.keywords.output_level.variable}
 
     return _mark_required_var

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -970,6 +970,7 @@ class Workspace(object):
             except OSError:
                 res['workspace_hash'] = "Unknown.."
 
+        res['workspace_name'] = self.name
         res['experiments'] = []
 
         return res


### PR DESCRIPTION
This merge adds the ability for some variables (such as n_ranks, n_nodes, etc...) to be promoted to top level keys in results JSON and YAML formats to ease comparisons in the future.