### PR TITLE
Add package_manager_requirements directive

### DIFF
--- a/lib/ramble/ramble/language/modifier_language.py
+++ b/lib/ramble/ramble/language/modifier_language.py
@@ -235,3 +235,44 @@ def required_variable(var: str):
         mod.required_vars[var] = ramble.keywords.key_type.required
 
     return _mark_required_var
+
+
+@modifier_directive('package_manager_requirements')
+def package_manager_requirement(command: str, validation_type: str, modes: list,
+                                regex=None, **kwargs):
+    """Define a requirement for the modifier's package manager
+
+    Args:
+        command: Package manager command to execute, when evaluating the requirement
+        validation_type: Type of validation to perform on output of command.
+                         Valid types are: 'empty', 'not_empty', 'contains_regex',
+                         'does_not_contain_regex'
+        modes: List of usage modes this requirement should apply to
+        regex: Regular expression to use when validation_type is either 'contains_regex'
+               or 'does_no_contain_regex'
+    """
+    def _new_package_manager_requirement(mod):
+
+        regex_validations = ['contains_regex', 'does_not_contain_regex']
+        validation_types = ['empty', 'not_empty'] + regex_validations
+
+        if validation_type not in validation_types:
+            raise DirectiveError(f'package_manager_requirement directive given an invalid '
+                                 f'validation_type of {validation_type}\n'
+                                 f'Valid values are {validation_types}')
+
+        if validation_type in regex_validations and not regex:
+            raise DirectiveError(f'package_manager_requirement validation type is '
+                                 f'{validation_type} but no regex is given')
+
+        for mode in modes:
+            if mode not in mod.package_manager_requirements:
+                mod.package_manager_requirements[mode] = []
+
+            mod.package_manager_requirements[mode].append({
+                'command': command,
+                'validation_type': validation_type,
+                'regex': regex,
+            })
+
+    return _new_package_manager_requirement

--- a/lib/ramble/ramble/modifier.py
+++ b/lib/ramble/ramble/modifier.py
@@ -261,6 +261,11 @@ class ModifierBase(object, metaclass=ModifierMeta):
         for action, conf in self.env_var_modifications[self._usage_mode].items():
             yield action, conf
 
+    def all_package_manager_requirements(self):
+        if self._usage_mode in self.package_manager_requirements:
+            for req in self.package_manager_requirements[self._usage_mode]:
+                yield req
+
     def run_phase_hook(self, workspace, hook_name):
         """Run a modifier hook.
 

--- a/lib/ramble/ramble/test/end_to_end/package_manager_requirements.py
+++ b/lib/ramble/ramble/test/end_to_end/package_manager_requirements.py
@@ -1,0 +1,122 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.workspace
+import ramble.config
+import ramble.software_environments
+from ramble.main import RambleCommand
+import ramble.spack_runner
+
+
+pytestmark = pytest.mark.usefixtures('mutable_config',
+                                     'mutable_mock_workspace_path')
+
+workspace = RambleCommand('workspace')
+
+
+def test_package_manager_requirements_zlib(mock_applications, mock_modifiers):
+    test_config = """
+ramble:
+  variables:
+    mpi_command: ''
+    batch_submit: 'batch_submit {execute_experiment}'
+    processes_per_node: '1'
+    n_ranks: '1'
+  modifiers:
+  - name: spack-mod
+  applications:
+    zlib-configs:
+      workloads:
+        ensure_installed:
+          experiments:
+            test:
+              variables: {}
+  spack:
+    concretized: true
+    packages: {}
+    environments:
+      zlib-configs:
+        packages: []
+"""
+
+    try:
+        ramble.spack_runner.SpackRunner()
+    except ramble.spack_runner.RunnerError as e:
+        pytest.skip(e)
+
+    workspace_name = 'test_package_manager_requirements_zlib'
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+
+        config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+
+        with open(config_path, 'w+') as f:
+            f.write(test_config)
+        ws._re_read()
+
+        workspace('setup', global_args=['-w', workspace_name])
+
+        spack_yaml = os.path.join(ws.software_dir, 'zlib-configs.ensure_installed',
+                                  'spack.yaml')
+
+        assert os.path.isfile(spack_yaml)
+
+        with open(spack_yaml, 'r') as f:
+            data = f.read()
+            assert 'config:' in data
+            assert 'debug: true' in data
+
+
+def test_package_manager_requirements_error(mock_applications, mock_modifiers):
+    test_config = """
+ramble:
+  variables:
+    mpi_command: ''
+    batch_submit: 'batch_submit {execute_experiment}'
+    processes_per_node: '1'
+    n_ranks: '1'
+  modifiers:
+  - name: spack-failed-reqs
+  applications:
+    zlib-configs:
+      workloads:
+        ensure_installed:
+          experiments:
+            test:
+              variables: {}
+  spack:
+    concretized: true
+    packages: {}
+    environments:
+      zlib-configs:
+        packages: []
+"""
+
+    try:
+        ramble.spack_runner.SpackRunner()
+    except ramble.spack_runner.RunnerError as e:
+        pytest.skip(e)
+
+    workspace_name = 'test_package_manager_requirements_error'
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+
+        config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+
+        with open(config_path, 'w+') as f:
+            f.write(test_config)
+        ws._re_read()
+
+        with pytest.raises(ramble.spack_runner.ValidationFailedError) as e:
+            workspace('setup', global_args=['-w', workspace_name])
+
+            assert 'Validation of: "spack list not-a-package" failed' in e

--- a/lib/ramble/ramble/test/modifier_functionality/mock_spack_modifier.py
+++ b/lib/ramble/ramble/test/modifier_functionality/mock_spack_modifier.py
@@ -62,6 +62,14 @@ def test_gromacs_dry_run_mock_spack_mod(mutable_mock_workspace_path,
 
         assert search_files_for_string(out_files, expected_str)
 
+        expected_str = "with args: ['list', 'not-a-package']"
+
+        assert search_files_for_string(out_files, expected_str)
+
+        expected_str = "with args: ['info', 'zlib']"
+
+        assert search_files_for_string(out_files, expected_str)
+
         # Test software directories
         software_base_dir = ws1.software_dir
 

--- a/var/ramble/repos/builtin.mock/modifiers/spack-failed-reqs/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/spack-failed-reqs/modifier.py
@@ -9,15 +9,13 @@
 from ramble.modkit import *  # noqa: F403
 
 
-class SpackMod(SpackModifier):
-    """Define spack modifier with various software aspects"""
+class SpackFailedReqs(SpackModifier):
+    """Define spack modifier requirements that will fail"""
     name = "spack-mod"
 
     tags('test')
 
-    mode('default', description='This is the default mode for the spack-mod')
-
-    package_manager_config('enable_debug', 'config:debug:true')
+    mode('default', description='This is the default mode for the spack-failed-reqs modifier')
 
     default_compiler('mod_compiler',
                      spack_spec='mod_compiler@1.1 target=x86_64',
@@ -31,9 +29,4 @@ class SpackMod(SpackModifier):
                   spack_spec='mod_package2@1.1',
                   compiler='mod_compiler')
 
-    package_manager_requirement('list not-a-package', validation_type='empty', modes=['default'])
-    package_manager_requirement('list zlib', validation_type='not_empty', modes=['default'])
-    package_manager_requirement('info zlib', validation_type='contains_regex', modes=['default'],
-                                regex=r'\s*Safe versions:\s*')
-    package_manager_requirement('info zlib', validation_type='does_not_contain_regex',
-                                modes=['default'], regex=r'\s*Broken versions:\s*')
+    package_manager_requirement('list not-a-package', validation_type='not_empty', modes=['default'])


### PR DESCRIPTION
This merge adds a new language feature called
package_manager_requirements which can be used to define requirements for underlying package managers.

Tests are added to ensure this is functional.