### PR TITLE
Add modifier_variable directive

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -726,6 +726,9 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         # (note: the base ramble variables are checked earlier too)
         self.keywords.check_required_keys(self.variables)
 
+    def define_modifier_variables(self):
+        """Extract default variable definitions from modifier instances"""
+
     def _get_executables(self):
         """Return executables for add_expand_vars"""
 
@@ -833,10 +836,15 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         """Set default experiment variables (for add_expand_vars),
         if they haven't been set already"""
         # Set default experiment variables, if they haven't been set already
+        var_sets = []
         if self.expander.workload_name in self.workload_variables:
-            wl_vars = self.workload_variables[self.expander.workload_name]
+            var_sets.append(self.workload_variables[self.expander.workload_name])
 
-            for var, conf in wl_vars.items():
+        for mod_inst in self._modifier_instances:
+            var_sets.append(mod_inst.mode_variables())
+
+        for var_set in var_sets:
+            for var, conf in var_set.items():
                 if var not in self.variables.keys():
                     self.variables[var] = conf['default']
 

--- a/lib/ramble/ramble/language/modifier_language.py
+++ b/lib/ramble/ramble/language/modifier_language.py
@@ -6,6 +6,8 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+from typing import Optional
+
 import ramble.language.language_helpers
 import ramble.language.language_base
 import ramble.language.shared_language
@@ -238,6 +240,45 @@ def required_variable(var: str, results_level='variable'):
                                   'level': ramble.keywords.output_level.variable}
 
     return _mark_required_var
+
+
+@modifier_directive('modifier_variables')
+def modifier_variable(name: str, default, description: str, values: Optional[list] = None,
+                      mode: Optional[str] = None, modes: Optional[list] = None,
+                      expandable: bool = True, **kwargs):
+    """Define a variable for this modifier
+
+    Args:
+        name (str): Name of variable to define
+        default: Default value of variable definition
+        description (str): Description of variable's purpose
+        values (list): Optional list of suggested values for this variable
+        mode (str): Single mode this variable is used in
+        modes (list): List of modes this variable is used in
+        expandable (bool): True if the variable should be expanded, False if not.
+    """
+
+    def _define_modifier_variable(mod):
+        all_modes = ramble.language.language_helpers.require_definition(mode,
+                                                                        modes,
+                                                                        'mode',
+                                                                        'modes',
+                                                                        'modifier_variable')
+
+        for mode_name in all_modes:
+            if mode_name not in mod.modifier_variables:
+                mod.modifier_variables[mode_name] = {}
+
+            mod.modifier_variables[mode_name][name] = {
+                'default': default,
+                'description': description,
+                'expandable': expandable
+            }
+
+            if values:
+                mod.modifier_variables[mode_name][name]['values'] = values
+
+    return _define_modifier_variable
 
 
 @modifier_directive('package_manager_requirements')

--- a/lib/ramble/ramble/modifier.py
+++ b/lib/ramble/ramble/modifier.py
@@ -124,11 +124,20 @@ class ModifierBase(object, metaclass=ModifierMeta):
             for mode_name, wl_conf in self.modes.items():
                 out_str.append(rucolor.section_title('Mode:') + f' {mode_name}\n')
 
+                if mode_name in self.modifier_variables:
+                    out_str.append(rucolor.nested_1('\tVariables:\n'))
+                    indent = '\t\t'
+                    for var, conf in self.modifier_variables[mode_name].items():
+                        out_str.append(rucolor.nested_2(f'{indent}{var}:\n'))
+                        out_str.append(f'{indent}\tDescription: {conf["description"]}\n')
+                        out_str.append(f'{indent}\tDefault: {conf["default"]}\n')
+                        if 'values' in conf:
+                            out_str.append(f'{indent}\tSuggested Values: {conf["values"]}\n')
+
                 if mode_name in self.variable_modifications:
                     out_str.append(rucolor.nested_1('\tVariable Modifications:\n'))
+                    indent = '\t\t'
                     for var, conf in self.variable_modifications[mode_name].items():
-                        indent = '\t\t'
-
                         out_str.append(rucolor.nested_2(f'{indent}{var}:\n'))
                         out_str.append(f'{indent}\tMethod: {conf["method"]}\n')
                         out_str.append(f'{indent}\tModification: {conf["modification"]}\n')
@@ -265,6 +274,13 @@ class ModifierBase(object, metaclass=ModifierMeta):
         if self._usage_mode in self.package_manager_requirements:
             for req in self.package_manager_requirements[self._usage_mode]:
                 yield req
+
+    def mode_variables(self):
+        """Return a dict of variables that should be defined for the current mode"""
+
+        if self._usage_mode in self.modifier_variables:
+            return self.modifier_variables[self._usage_mode]
+        return {}
 
     def run_phase_hook(self, workspace, hook_name):
         """Run a modifier hook.

--- a/lib/ramble/ramble/test/modifier_language.py
+++ b/lib/ramble/ramble/test/modifier_language.py
@@ -49,6 +49,7 @@ def test_modifier_type_features(mod_class):
     assert hasattr(test_mod, 'required_packages')
     assert hasattr(test_mod, 'success_criteria')
     assert hasattr(test_mod, 'builtins')
+    assert hasattr(test_mod, 'modifier_variables')
     assert hasattr(test_mod, 'executable_modifiers')
     assert hasattr(test_mod, 'env_var_modifications')
     assert hasattr(test_mod, 'maintainers')
@@ -503,3 +504,48 @@ def test_env_var_modification_directive(mod_class, func_type):
             assert test_def['name'] in mod_inst.env_var_modifications[mode][method]
             assert test_def['modification'] == \
                 mod_inst.env_var_modifications[mode][method][test_def['name']]
+
+
+def add_modifier_variable(mod_inst, mod_var_num=1, func_type=func_types.directive):
+    var_name = f'mod_var_{mod_var_num}'
+    var_default = f'default_{mod_var_num}'
+    var_desc = f'Test variable {mod_var_num}'
+    var_mode = 'mod_var_mode'
+
+    test_defs = {
+        'name': var_name,
+        'default': var_default,
+        'description': var_desc,
+        'mode': var_mode
+    }
+
+    if func_type == func_types.directive:
+        modifier_variable(var_name, default=var_default, description=var_desc,
+                          mode=var_mode)(mod_inst)
+    elif func_type == func_types.method:
+        mod_inst.modifier_variable(var_name, default=var_default, description=var_desc,
+                                   mode=var_mode)
+    else:
+        assert False
+
+    return test_defs
+
+
+@pytest.mark.parametrize('func_type', func_types)
+@pytest.mark.parametrize('mod_class', mod_types)
+def test_modifier_variable_directive(mod_class, func_type):
+    test_class = generate_mod_class(mod_class)
+    mod_inst = test_class('/not/a/path')
+    test_defs = []
+    test_defs.append(add_modifier_variable(mod_inst, func_type))
+
+    assert hasattr(mod_inst, 'modifier_variables')
+
+    for test_def in test_defs:
+        mode = test_def['mode']
+        var_name = test_def['name']
+
+        assert mode in mod_inst.modifier_variables
+        assert test_def['name'] in mod_inst.modifier_variables[mode]
+        for attr in ['description', 'default']:
+            assert test_def[attr] == mod_inst.modifier_variables[mode][var_name][attr]


### PR DESCRIPTION
This merge adds support for modifiers to define variables in experiments when they are used.

Tests are also added for this.