### PR TITLE
Suppress printing non-actionable experiments in pipeline output

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -140,6 +140,18 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
 
         return new_copy
 
+    def is_actionable(self):
+        """Determine if an experiment should be actioned in pipelines
+
+        Returns True if the experiment should be actioned in a pipeline, False
+        if not.
+        """
+
+        if self.is_template:
+            return False
+
+        return True
+
     def build_phase_order(self):
         for pipeline in self._pipelines:
             pipeline_phases = []

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -439,16 +439,21 @@ class ExperimentSet(object):
         count = 1
 
         for exp, inst in self.experiments.items():
-            yield exp, inst, count
-            count += 1
+            if inst.is_actionable():
+                yield exp, inst, count
+                count += 1
 
         for exp, inst in self.chained_experiments.items():
-            yield exp, inst, count
-            count += 1
+            if inst.is_actionable():
+                yield exp, inst, count
+                count += 1
 
     def num_experiments(self):
         """Return the number of total experiments in this set"""
-        return len(self.experiments.items()) + len(self.chained_experiments.items())
+        count = 0
+        for _, _, _ in self.all_experiments():
+            count += 1
+        return count
 
     def num_filtered_experiments(self, filters):
         """Return the number of filtered experiments in this set"""
@@ -486,7 +491,7 @@ class ExperimentSet(object):
                 if not inst.has_tags(filters.tags):
                     active = False
 
-            if active:
+            if active and inst.is_actionable():
                 yield exp, inst, idx
 
     def add_chained_experiment(self, name, instance):

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -256,51 +256,6 @@ config:
     assert 'Variables from Experiment:' in output
 
 
-def test_workspace_info_with_templates():
-    test_config = """
-ramble:
-  variables:
-    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
-    batch_submit: 'batch_submit {execute_experiment}'
-    processes_per_node: '5'
-    n_ranks: '{processes_per_node}*{n_nodes}'
-  applications:
-    basic:
-      workloads:
-        test_wl:
-          experiments:
-            test_experiment:
-              template: true
-              variables:
-                n_nodes: '2'
-        test_wl2:
-          experiments:
-            test_experiment:
-              variables:
-                n_nodes: '2'
-
-  spack:
-    concretized: true
-    packages: {}
-    environments: {}
-"""
-
-    workspace_name = 'test_workspace_info_with_templates'
-    ws1 = ramble.workspace.create(workspace_name)
-    ws1.write()
-
-    config_path = os.path.join(ws1.config_dir, ramble.workspace.config_file_name)
-
-    with open(config_path, 'w+') as f:
-        f.write(test_config)
-
-    ws1._re_read()
-
-    output = workspace('info', global_args=['-w', workspace_name])
-
-    assert "Template Experiment 1: basic.test_wl.test_experiment" in output
-
-
 def test_workspace_info_with_experiment_chain():
     test_config = """
 ramble:
@@ -347,7 +302,6 @@ ramble:
 
     output = workspace('info', '-vv', global_args=['-w', workspace_name])
 
-    assert "Template Experiment 1: basic.test_wl.test_experiment" in output
     assert "Experiment Chain:" in output
     assert "- basic.test_wl2.test_experiment.chain.0.basic.test_wl.test_experiment" in output
 


### PR DESCRIPTION
This merge prevents experiments like tempaltes and repeat bases from being printed in the output of pipeline actions.