### PR TITLE
Add support for formatted executable variables

### DIFF
--- a/etc/ramble/defaults/formatted_executables.yaml
+++ b/etc/ramble/defaults/formatted_executables.yaml
@@ -1,0 +1,3 @@
+formatted_executables:
+  command:
+    join_separator: '\n'

--- a/lib/ramble/docs/configuration_files.rst
+++ b/lib/ramble/docs/configuration_files.rst
@@ -29,6 +29,7 @@ Currently, Ramble supports the following configuration sections:
 * :ref:`applications <application-config>`
 * :ref:`config <config-yaml>`
 * :ref:`env_vars <env-vars-config>`
+* :ref:`formatted_executables <formatted-execs-config>`
 * :ref:`internals <internals-config>`
 * :ref:`licenses <licenses-config>`
 * :ref:`mirrors <mirrors-config>`
@@ -262,6 +263,38 @@ actions is available. These actions are:
 * ``append`` - Append the given value to the end of a previous variable definition. Delimited for vars is defined by ``var_separator``, ``paths`` uses ``:``
 * ``prepend`` - Prepent the given value to the beginning of a previous variable definition. Only supports paths, delimiter is ``:``
 * ``unset`` - Remove a variable definition, if it is set.
+
+.. _formatted-execs-config:
+
+------------------------------
+Formatted Executables Section:
+------------------------------
+
+The formatted executables config section is named ``formatted_executables`` and
+controls the creation of variables that represent the complete list of
+executables an experiment needs to execute.
+
+The format of this config section is as follows:
+
+.. code-block:: yaml
+
+  formatted_executables:
+    new_command:
+      indentation: 8
+      prefix: '- '
+      join_separator: '\n'
+
+
+The above example defines a new variable named ``new_command`` which will be a
+new-line (``\n``) demlimited list of executables, where each executable is
+prefixed with ``- `` and is indented 8 space characters.
+
+The default configuration files define one formatted executable named
+``command``. Its definition can be seen with:
+
+.. code-block:: console
+
+  $ ramble config get formatted_executables
 
 .. _internals-config:
 

--- a/lib/ramble/docs/workspace_config.rst
+++ b/lib/ramble/docs/workspace_config.rst
@@ -771,7 +771,7 @@ executables (or custom executables) are pieced together to build an experiment.
            - lscpu
 
 The above example builds off of the custom executable example, and shows how
-one can control the order of the executables in the ``{command}`` expansion.
+one can control the order of the executables in the formatted executable expansions.
 
 The default for the hostname application is ``[builtin::env_vars,
 serial/parallel]`` but this changes the order and injects ``lscpu`` into the
@@ -902,7 +902,6 @@ Ramble automatically generates definitions for the following variables:
   ``$workspace_root/configs`` have a variable generated that resolves to the
   absolute path to: ``{experiment_run_dir}/<template_name>`` where
   ``<template_name>`` is the filename of the template, without the extension.
-* ``command`` - Set to all of the commands needed to perform an experiment.
 
 """"""""""""""""""""""""""""""""""
 Spack Specific Generated Variables

--- a/lib/ramble/ramble/config.py
+++ b/lib/ramble/ramble/config.py
@@ -54,6 +54,7 @@ import spack.platforms
 import ramble.schema
 import ramble.schema.config
 import ramble.schema.env_vars
+import ramble.schema.formatted_executables
 import ramble.schema.repos
 import ramble.schema.modifier_repos
 import ramble.schema.workspace
@@ -75,6 +76,7 @@ from spack.util.cpus import cpus_available
 
 #: Dict from section names -> schema for that section
 section_schemas = {
+    'formatted_executables': ramble.schema.formatted_executables.schema,
     'config': ramble.schema.config.schema,
     'env_vars': ramble.schema.env_vars.schema,
     'repos': ramble.schema.repos.schema,

--- a/lib/ramble/ramble/context.py
+++ b/lib/ramble/ramble/context.py
@@ -28,6 +28,7 @@ class Context(object):
         self.variables = syaml.syaml_dict()
         self.internals = {}
         self.templates = None
+        self.formatted_executables = {}
         self.chained_experiments = []
         self.modifiers = []
         self.context_name = None
@@ -84,6 +85,8 @@ class Context(object):
             self.tags.extend(in_context.tags)
         if in_context.n_repeats != 0:
             self.n_repeats = int(in_context.n_repeats)
+        if in_context.formatted_executables:
+            self.formatted_executables.update(in_context.formatted_executables)
 
 
 def create_context_from_dict(context_name, in_dict):
@@ -152,5 +155,8 @@ def create_context_from_dict(context_name, in_dict):
 
     if namespace.n_repeats in in_dict:
         new_context.n_repeats = int(in_dict[namespace.n_repeats])
+
+    if namespace.formatted_executables in in_dict:
+        new_context.formatted_executables = in_dict[namespace.formatted_executables].copy()
 
     return new_context

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -62,6 +62,7 @@ class ExperimentSet(object):
         workspace_context.context_name = workspace.name
         workspace_context.variables = workspace.get_workspace_vars()
         workspace_context.env_variables = workspace.get_workspace_env_vars()
+        workspace_context.formatted_executables = workspace.get_workspace_formatted_executables()
         workspace_context.internals = workspace.get_workspace_internals()
         workspace_context.modifiers = workspace.get_workspace_modifiers()
         workspace_context.zips = workspace.get_workspace_zips()
@@ -410,6 +411,7 @@ class ExperimentSet(object):
             app_inst.set_chained_experiments(final_context.chained_experiments)
             app_inst.set_modifiers(final_context.modifiers)
             app_inst.set_tags(final_context.tags)
+            app_inst.set_formatted_executables(final_context.formatted_executables)
             app_inst.read_status()
             self.experiments[experiment_namespace] = app_inst
             self.experiment_order.append(experiment_namespace)

--- a/lib/ramble/ramble/keywords.py
+++ b/lib/ramble/ramble/keywords.py
@@ -35,7 +35,6 @@ default_keys = {
     'log_dir': {'type': key_type.reserved, 'level': output_level.variable},
     'log_file': {'type': key_type.reserved, 'level': output_level.variable},
     'err_file': {'type': key_type.reserved, 'level': output_level.variable},
-    'command': {'type': key_type.reserved, 'level': output_level.variable},
     'env_path': {'type': key_type.reserved, 'level': output_level.variable},
     'input_name': {'type': key_type.reserved, 'level': output_level.variable},
 

--- a/lib/ramble/ramble/namespace.py
+++ b/lib/ramble/ramble/namespace.py
@@ -25,10 +25,14 @@ class namespace:
     environments = 'environments'
     template = 'template'
     chained_experiments = 'chained_experiments'
-    inherit_variables = 'inherit_variables'
     modifiers = 'modifiers'
     tags = 'tags'
     n_repeats = 'n_repeats'
+    formatted_executables = 'formatted_executables'
+
+    # For chained experiments
+    command = 'command'
+    inherit_variables = 'inherit_variables'
 
     # For rendering objects
     variables = 'variables'
@@ -48,3 +52,8 @@ class namespace:
     spack_spec = 'spack_spec'
     compiler_spec = 'compiler_spec'
     compiler = 'compiler'
+
+    # For formatted executables
+    indentation = 'indentation'
+    prefix = 'prefix'
+    join_separator = 'join_separator'

--- a/lib/ramble/ramble/schema/applications.py
+++ b/lib/ramble/ramble/schema/applications.py
@@ -15,6 +15,7 @@
 from llnl.util.lang import union_dicts
 from ramble.schema.success_criteria import success_list_def
 
+import ramble.schema.formatted_executables
 import ramble.schema.env_vars
 import ramble.schema.internals
 import ramble.schema.types
@@ -117,6 +118,7 @@ sub_props = union_dicts(
     ramble.schema.internals.properties,
     ramble.schema.modifiers.properties,
     ramble.schema.zips.properties,
+    ramble.schema.formatted_executables.properties,
     {
         'chained_experiments': chained_experiment_def,
         'template': {'type': 'boolean'},

--- a/lib/ramble/ramble/schema/formatted_executables.py
+++ b/lib/ramble/ramble/schema/formatted_executables.py
@@ -1,0 +1,50 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+"""Schema for defining variables representing the formatted merging of executables
+
+.. literalinclude:: _ramble_root/lib/ramble/ramble/schema/formatted_executables.py
+   :lines: 12-
+"""  # noqa E501
+
+#: Properties for inclusion in other schemas
+properties = {
+    'formatted_executables': {
+        'type': 'object',
+        'default': {},
+        'properties': {},
+        'additionalProperties': {
+            'type': 'object',
+            'default': {},
+            'additionalProperties': False,
+            'properties':  {
+                'prefix': {
+                    'type': 'string',
+                    'default': ''
+                },
+                'indentation': {
+                    'type': 'number',
+                    'default': 0
+                },
+                'join_separator': {
+                    'type': 'string',
+                    'default': '\n'
+                }
+            }
+        }
+    }
+}
+
+#: Full schema with metadata
+schema = {
+    '$schema': 'http://json-schema.org/schema#',
+    'title': 'Ramble formatted executables configuration file schema',
+    'type': 'object',
+    'additionalProperties': False,
+    'properties': properties
+}

--- a/lib/ramble/ramble/schema/merged.py
+++ b/lib/ramble/ramble/schema/merged.py
@@ -15,6 +15,7 @@ from llnl.util.lang import union_dicts
 
 import ramble.schema.applications
 import ramble.schema.config
+import ramble.schema.formatted_executables
 import ramble.schema.repos
 import ramble.schema.spack
 import ramble.schema.success_criteria
@@ -28,6 +29,7 @@ import ramble.schema.zips
 properties = union_dicts(
     ramble.schema.applications.properties,
     ramble.schema.config.properties,
+    ramble.schema.formatted_executables.properties,
     ramble.schema.repos.properties,
     ramble.schema.spack.properties,
     ramble.schema.success_criteria.properties,

--- a/lib/ramble/ramble/test/application_tests.py
+++ b/lib/ramble/ramble/test/application_tests.py
@@ -410,8 +410,8 @@ def test_set_default_experiment_variables(mutable_mock_apps_repo):
     assert executable_application_instance.variables['n_ranks'] == '1'
 
 
-def test_inject_commands(mutable_mock_apps_repo):
-    """ test _inject_commands """
+def test_define_commands(mutable_mock_apps_repo):
+    """ test _define_commands """
 
     executable_application_instance = mutable_mock_apps_repo.get('basic')
 
@@ -435,10 +435,14 @@ def test_inject_commands(mutable_mock_apps_repo):
     executable_application_instance.workload_variables = {'test_wl2': {'n_ranks':
                                                                        {'default': '1'}}}
 
+    executable_application_instance.set_formatted_executables(
+        {'command': {'join_separator': '\n'}}
+    )
     executable_application_instance._set_default_experiment_variables()
 
     executable_application_instance.chain_prepend = []
-    executable_application_instance._inject_commands(executables)
+    executable_application_instance._define_commands(executables)
+    executable_application_instance._define_formatted_executables()
     assert 'mpirun' in executable_application_instance.variables['command']
 
 
@@ -511,7 +515,8 @@ ramble:
     executable_application_instance._set_default_experiment_variables()
 
     executable_application_instance.chain_prepend = []
-    executable_application_instance._inject_commands(executables)
+    executable_application_instance._define_commands(executables)
+    executable_application_instance._define_formatted_executables()
 
     test_answer = "/workspace/experiments/bar/test_wl2/baz/execute_experiment"
     executable_application_instance._derive_variables_for_template_path(ws1)

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -1519,7 +1519,7 @@ ramble:
 
 
 @pytest.mark.parametrize('tpl_name', [
-    'command'
+    'env_path'
 ])
 def test_invalid_template_name_errors(tpl_name, capsys):
     test_config = """

--- a/lib/ramble/ramble/test/data/config/formatted_executables.yaml
+++ b/lib/ramble/ramble/test/data/config/formatted_executables.yaml
@@ -1,0 +1,3 @@
+formatted_executables:
+  command:
+    join_separator: '\n'

--- a/lib/ramble/ramble/test/end_to_end/chained_experiment_var_inheritance.py
+++ b/lib/ramble/ramble/test/end_to_end/chained_experiment_var_inheritance.py
@@ -30,6 +30,9 @@ def test_chained_experiment_variable_inheritance(mutable_config,
                                                  mutable_mock_workspace_path):
     test_config = r"""
 ramble:
+  formatted_executables:
+    command:
+      join_separator: '\n'
   variables:
     mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
     batch_submit: 'batch_submit {execute_experiment}'

--- a/lib/ramble/ramble/test/end_to_end/formatted_executables.py
+++ b/lib/ramble/ramble/test/end_to_end/formatted_executables.py
@@ -1,0 +1,135 @@
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+from ramble.application import FormattedExecutableError
+import ramble.workspace
+import ramble.config
+import ramble.software_environments
+from ramble.main import RambleCommand
+
+
+# everything here uses the mock_workspace_path
+pytestmark = pytest.mark.usefixtures('mutable_config',
+                                     'mutable_mock_workspace_path')
+
+workspace = RambleCommand('workspace')
+
+
+def test_formatted_executables(mutable_config, mutable_mock_workspace_path, mock_applications):
+    test_config = r"""
+ramble:
+  variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: '{execute_experiment}'
+    processes_per_node: '16'
+    n_threads: '1'
+  formatted_executables:
+    ws_exec_def:
+      prefix: 'from_ws '
+      indentation: 9
+      join_separator: ';'
+  applications:
+    basic:
+      formatted_executables:
+        app_exec_def:
+          prefix: 'from_app '
+      workloads:
+        working_wl:
+          formatted_executables:
+            wl_exec_def:
+              prefix: 'from_wl '
+              indentation: 11
+          experiments:
+            simple_test:
+              formatted_executables:
+                exp_exec_def:
+                  prefix: 'from_exp '
+                  indentation: 10
+                  join_separator: '\n'
+              variables:
+                n_nodes: 1
+  spack:
+    concretized: true
+    packages: {}
+    environments: {}
+"""
+    workspace_name = 'test_formatted_executables'
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+
+        config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+
+        with open(config_path, 'w+') as f:
+            f.write(test_config)
+
+        with open(os.path.join(ws.config_dir, 'execute_experiment.tpl'), 'w+') as f:
+            f.write('{ws_exec_def}\n')
+            f.write('{app_exec_def}\n')
+            f.write('{wl_exec_def}\n')
+            f.write('{exp_exec_def}\n')
+        ws._re_read()
+
+        workspace('setup', '--dry-run', global_args=['-w', workspace_name])
+
+        experiment_root = ws.experiment_dir
+        exp_dir = os.path.join(experiment_root, 'basic', 'working_wl', 'simple_test')
+        exp_script = os.path.join(exp_dir, 'execute_experiment')
+
+        with open(exp_script, 'r') as f:
+            data = f.read()
+            assert ';           from_ws echo' in data
+            assert 'from_app echo' in data
+            assert '           from_wl echo' in data
+            assert '          from_exp echo' in data
+
+
+def test_redefined_executable_errors(mutable_config, mutable_mock_workspace_path,
+                                     mock_applications):
+    test_config = r"""
+ramble:
+  variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: '{execute_experiment}'
+    processes_per_node: '16'
+    n_threads: '1'
+  applications:
+    basic:
+      workloads:
+        working_wl:
+          experiments:
+            simple_test:
+              formatted_executables:
+                var_exec_name:
+                  indentation: 3
+                  join_separator: '\n'
+              variables:
+                var_exec_name: 'nothing'
+                n_nodes: 1
+  spack:
+    concretized: true
+    packages: {}
+    environments: {}
+"""
+    workspace_name = 'test_redefined_executable_errors'
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+
+        config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+
+        with open(config_path, 'w+') as f:
+            f.write(test_config)
+
+        ws._re_read()
+
+        with pytest.raises(FormattedExecutableError):
+            output = workspace('setup', '--dry-run', global_args=['-w', workspace_name])
+            assert 'Formatted executable var_exec_name defined' in output

--- a/lib/ramble/ramble/test/experiment_set.py
+++ b/lib/ramble/ramble/test/experiment_set.py
@@ -828,7 +828,7 @@ def test_processes_per_node_correct_defaults(mutable_mock_workspace_path):
 
 
 @pytest.mark.parametrize('var', [
-    'command', 'env_path'
+    'env_path'
 ])
 def test_reserved_keywords_error_in_application(mutable_mock_workspace_path, var, capsys):
     workspace('create', 'test')
@@ -858,7 +858,7 @@ def test_reserved_keywords_error_in_application(mutable_mock_workspace_path, var
 
 
 @pytest.mark.parametrize('var', [
-    'command', 'env_path'
+    'env_path'
 ])
 def test_reserved_keywords_error_in_workload(mutable_mock_workspace_path, var, capsys):
     workspace('create', 'test')
@@ -896,7 +896,7 @@ def test_reserved_keywords_error_in_workload(mutable_mock_workspace_path, var, c
 
 
 @pytest.mark.parametrize('var', [
-    'command', 'env_path'
+    'env_path'
 ])
 def test_reserved_keywords_error_in_experiment(mutable_mock_workspace_path, var, capsys):
     workspace('create', 'test')

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1371,6 +1371,10 @@ class Workspace(object):
         """Return a dict of workspace environment variables"""
         return ramble.config.config.get_config('env_vars')
 
+    def get_workspace_formatted_executables(self):
+        """Return a dict of workspace formatted executables"""
+        return ramble.config.config.get_config('formatted_executables')
+
     def get_workspace_internals(self):
         """Return a dict of workspace internals"""
         return ramble.config.config.get_config(namespace.internals)


### PR DESCRIPTION
This merge adds a new config section `formatted_executables` which allows users to define new formatting for merging executable commands into variables.

Previously, only one variable was defined (`{command}`) which was a new-line delimited list with no indentation, and no prefix. This allows additional definitions to be created, supporting additional workflows.