### PR TITLE
Add execution-date modifier

### DIFF
--- a/var/ramble/repos/builtin/modifiers/execution-date/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/execution-date/modifier.py
@@ -1,0 +1,54 @@
+
+# Copyright 2022-2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.modkit import *  # noqa: F403
+
+
+class ExecutionDate(BasicModifier):
+    """Define a modifier to print the date
+    """
+    name = "execution-date"
+
+    maintainers('rfbgo')
+
+    mode('standard', description='Standard execution mode')
+
+    executable_modifier('get_startend_date')
+
+    modifier_variable('date_format', default="", description="Date args to format output", mode='standard')
+
+    def get_startend_date(self, executable_name, executable, app_inst=None):
+        from ramble.util.executable import CommandExecutable
+        if hasattr(self, '_already_applied'):
+            return [], []
+
+        self._already_applied = True
+
+        pre_cmds = []
+        post_cmds = []
+
+        pre_cmds.append(
+            CommandExecutable('start-date',
+                              template=[self.expander.expand_var('date {date_format}')],
+                              redirect='{experiment_run_dir}/start_date'
+                              )
+        )
+        post_cmds.append(
+            CommandExecutable('end-date',
+                              template=[self.expander.expand_var('date {date_format}')],
+                              redirect='{experiment_run_dir}/end_date'
+                              )
+        )
+        return pre_cmds, post_cmds
+
+    figure_of_merit('Start Date', fom_regex=r'(?P<date>.*)', log_file='{experiment_run_dir}/start_date',
+                    group_name='date', units='')
+
+    figure_of_merit('End Date', fom_regex=r'(?P<date>.*)', log_file='{experiment_run_dir}/end_date',
+                    group_name='date', units='')


### PR DESCRIPTION
This uses the new `modifier_variable` to allow users to specify the date format args to support functionality such as `date -Ins` or `date +'%s'`