### PR TITLE
Allow ramble to read from the config to specify shell inside scripts

### DIFF
--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -430,7 +430,9 @@ class SetupPipeline(Pipeline):
     def _prepare(self):
         super()._prepare()
         experiment_file = open(self.workspace.all_experiments_path, 'w+')
-        experiment_file.write('#!/bin/sh\n')
+        shell = ramble.config.get('config:shell')
+        shell_path = os.path.join('/bin/', shell)
+        experiment_file.write(f'#!{shell_path}\n')
         self.workspace.experiments_script = experiment_file
 
     def _complete(self):

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -148,8 +148,9 @@ workspace_all_experiments_file = 'all_experiments'
 workspace_execution_template = 'execute_experiment' + \
     workspace_template_extension
 
-template_execute_script = """\
-#!/bin/sh
+shell = ramble.config.get('config:shell')
+shell_path = os.path.join('/bin/', shell)
+template_execute_script = f'#!{shell_path}\n' + """\
 # This is a template execution script for
 # running the execute pipeline.
 #


### PR DESCRIPTION
This PR avoid ramble hard writing `/bin/sh` and instead uses the value of `config:shell`. This can either be `sh/csh/fish/bat/pwsh` as defined by our inherited code from `spack:util:environment`

In the future we might want to help a user directly emit calls to `bash` or `zsh`, which would be an easy alias in the env class. 