### PR TITLE
Update Variables schema to an object not an array

### DIFF
--- a/lib/ramble/ramble/schema/types.py
+++ b/lib/ramble/ramble/schema/types.py
@@ -16,12 +16,10 @@ class OUTPUT_CAPTURE:
     DEFAULT = STDOUT
 
 
-# FIXME: should this use the vector notation which type natively supports?
+string_or_num_list = [{'type': 'string'}, {'type': 'number'}]
+
 string_or_num = {
-    'anyOf': [
-        {'type': 'string'},
-        {'type': 'number'}
-    ]
+    'anyOf': string_or_num_list
 }
 
 array_of_strings_or_nums = {
@@ -31,12 +29,9 @@ array_of_strings_or_nums = {
 }
 
 array_or_scalar_of_strings_or_nums = {
-    'anyOf': [
-        {
-            'type': 'array',
-            'default': [],
-            'items': string_or_num,
-        },
-        string_or_num
-    ]
+    'anyOf':
+        [
+            *string_or_num_list,
+            {'type': 'array', 'default': [], 'items': string_or_num}
+        ]
 }


### PR DESCRIPTION
There was a small issue in how the variable schema was defined, where it was forced to be an array when not needed

The list was no causing functional issues at run time, but did manifest as when using ramble to update configs, as it was adding elemnts in a list, eg:

```
ramble -c 'variables:batch_submit:""' config blame variables
```

Was returning:

```
batch_submit:
- ''
```

This change fixes that, and instead it now returns

```
batch_submit: ''
```