### PR TITLE
Allow flags on `spack env create`

### DIFF
--- a/etc/ramble/defaults/config.yaml
+++ b/etc/ramble/defaults/config.yaml
@@ -28,3 +28,7 @@ config:
       flags: --reuse
     concretize:
       flags: --reuse
+    buildcache:
+      flags: ''
+    env_create:
+      flags: ''

--- a/lib/ramble/docs/configuration_files.rst
+++ b/lib/ramble/docs/configuration_files.rst
@@ -158,15 +158,18 @@ The current default configuration is as follows:
         install:
           flags: '--reuse'
         concretize:
-            flags: '--reuse'
+          flags: '--reuse'
+        buildcache:
+          flags: ''
+        env_create:
+          flags: ''
         global
-            flags: ''
+          flags: ''
       input_cache: '$ramble/var/ramble/cache'
       workspace_dirs: '$ramble/var/ramble/workspaces'
       upload:
         type: 'BigQuery'
         uri: ''
-
 
 .. _upload-config-option:
 

--- a/lib/ramble/ramble/schema/config.py
+++ b/lib/ramble/ramble/schema/config.py
@@ -121,6 +121,19 @@ properties['config']['spack'] = {
             },
             'additionalProperties': False
         },
+        'env_create': {
+            'type': 'object',
+            'default': {
+                'flags': '',
+            },
+            'properties': {
+                'flags': {
+                    'type': 'string',
+                    'default': '',
+                },
+            },
+            'additionalProperties': False
+        },
     },
     'additionalProperties': False,
 }

--- a/lib/ramble/ramble/spack_runner.py
+++ b/lib/ramble/ramble/spack_runner.py
@@ -50,6 +50,7 @@ class SpackRunner(object):
     compiler_find_config_name = 'config:spack:compiler_find'
     buildcache_config_name = 'config:spack:buildcache'
     concretize_config_name = 'config:spack:concretize'
+    env_create_config_name = 'config:spack:env_create'
 
     env_create_args = [
         'env',
@@ -218,8 +219,13 @@ class SpackRunner(object):
         # Create a spack env
         if not self.dry_run:
             if not os.path.exists(os.path.join(path, 'spack.yaml')):
+                env_create_flags = ramble.config.get(f'{self.env_create_config_name}:flags')
+                env_create_args = self.env_create_args.copy()
+                if env_create_flags:
+                    for flag in shlex.split(env_create_flags):
+                        env_create_args.append(flag)
                 with fs.working_dir(path):
-                    self._run_command(self.spack, self.env_create_args)
+                    self._run_command(self.spack, env_create_args)
 
         # Ensure subsequent commands use the created env now.
         self.env_path = path

--- a/lib/ramble/ramble/test/spack_runner.py
+++ b/lib/ramble/ramble/test/spack_runner.py
@@ -506,3 +506,25 @@ compilers::
                     assert expected_str in captured.out
                 except ramble.spack_runner.RunnerError as e:
                     pytest.skip('%s' % e)
+
+
+def test_env_create_no_view(tmpdir):
+
+    import os
+
+    with tmpdir.as_cwd():
+        with ramble.config.override('config:spack',
+                                    {'env_create': {'flags': '--without-view'}}):
+            try:
+                sr = ramble.spack_runner.SpackRunner()
+                sr.create_env(os.getcwd())
+
+                assert not os.path.exists(
+                    os.path.join(
+                        os.getcwd(),
+                        '.spack-env',
+                        'view'
+                    )
+                )
+            except ramble.spack_runner.RunnerError as e:
+                pytest.skip('%s' % e)


### PR DESCRIPTION
This merge adds support for config to pass flags to the `spack env create` command.