### PR TITLE
Allow python style list comparisons in expansion strings

### DIFF
--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -719,8 +719,9 @@ class Expander(object):
         """Handle in nodes in the ast
 
         Perform extraction of `<variable> in <experiment>` syntax.
-
         Raises an exception if the experiment does not exist.
+
+        Also, evaluated `<value> in [list, of, values]` syntax.
         """
         if isinstance(node.left, ast.Name):
             var_name = self._ast_name(node.left)
@@ -733,6 +734,18 @@ class Expander(object):
                                             f'"{var_name} in {namespace}"')
                     self.__raise_syntax_error(node)
                 return val
+        elif isinstance(node.left, ast.Constant):
+            lhs_value = self.eval_math(node.left)
+
+            found = False
+            for comp in node.comparators:
+                if isinstance(comp, ast.List):
+                    for elt in comp.elts:
+                        rhs_value = self.eval_math(elt)
+                        if lhs_value == rhs_value:
+                            found = True
+            return found
+
         self.__raise_syntax_error(node)
 
     def _eval_binary_ops(self, node):

--- a/lib/ramble/ramble/test/expander.py
+++ b/lib/ramble/ramble/test/expander.py
@@ -69,6 +69,8 @@ def exp_dict():
         (r'\\{experiment_name\\}', r'\{experiment_name\}', set(), 1),
         (r'\\{experiment_name\\}', '{experiment_name}', set(), 2),
         (r'\\{experiment_name\\}', 'baz', set(), 3),
+        ('"2.1.1" in ["2.1.1", "3.1.1", "4.2.1"]', 'True', set(), 1),
+        ('"2.1.2" in ["2.1.1", "3.1.1", "4.2.1"]', 'False', set(), 1),
     ]
 )
 def test_expansions(input, output, no_expand_vars, passes):


### PR DESCRIPTION
This merge adds support for expansion strings of the format:

`'{value} in ["list", "of", "values"]'`

Which will return True or False instead of erroring.