### PR TITLE
Add a generic include file to spack_runner

### DIFF
--- a/lib/ramble/ramble/spack_runner.py
+++ b/lib/ramble/ramble/spack_runner.py
@@ -65,7 +65,8 @@ class SpackRunner(object):
                              'mirrors.yaml', 'repos.yaml',
                              'packages.yaml', 'modules.yaml',
                              'config.yaml', 'upstreams.yaml',
-                             'bootstrap.yaml', 'spack.yaml']
+                             'bootstrap.yaml', 'spack.yaml',
+                             'spack_includes.yaml']
 
     def __init__(self, shell='bash', dry_run=False):
         """


### PR DESCRIPTION
This merge adds `spack_includes.yaml` as a supported include file for the spack runner. This file can then be used as a generic include file for spack environments.