### PR TITLE
Add support for modifiers to register phases

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -54,7 +54,8 @@ from ramble.language.shared_language import SharedMeta, register_builtin, regist
 from ramble.error import RambleError
 
 from enum import Enum
-experiment_status = Enum('experiment_status', ['UNKNOWN', 'SETUP', 'SUCCESS', 'FAILED'])
+experiment_status = Enum('experiment_status', ['UNKNOWN', 'SETUP', 'RUNNING',
+                                               'COMPLETE', 'SUCCESS', 'FAILED'])
 
 
 class ApplicationBase(object, metaclass=ApplicationMeta):
@@ -658,6 +659,11 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
             exp_inst = self.experiment_set.get_experiment(exp)
             if exp_inst:
                 exp_inst.chain_order = self.chain_order.copy()
+
+    def define_variable(self, var_name, var_value):
+        self.expander._variables[var_name] = var_value
+        for mod_inst in self._modifier_instances:
+            mod_inst.expander._variables[var_name] = var_value
 
     def build_modifier_instances(self):
         """Built a map of modifier names to modifier instances needed for this

--- a/lib/ramble/ramble/application_types/spack.py
+++ b/lib/ramble/ramble/application_types/spack.py
@@ -9,8 +9,7 @@
 import os
 import six
 
-from ramble.language.application_language import register_phase
-from ramble.language.shared_language import register_builtin
+from ramble.language.shared_language import register_builtin, register_phase
 from ramble.application import ApplicationBase, ApplicationError
 import ramble.spack_runner
 import ramble.keywords
@@ -80,7 +79,7 @@ class SpackApplication(ApplicationBase):
     register_phase('software_install_requested_compilers', pipeline='setup',
                    run_after=['software_create_env'])
 
-    def _software_install_requested_compilers(self, workspace):
+    def _software_install_requested_compilers(self, workspace, app_inst=None):
         """Install compilers an application uses"""
         # See if we cached this already, and if so return
         env_path = self.expander.env_path
@@ -132,7 +131,7 @@ class SpackApplication(ApplicationBase):
     register_phase('software_create_env', pipeline='mirror')
     register_phase('software_create_env', pipeline='setup')
 
-    def _software_create_env(self, workspace):
+    def _software_create_env(self, workspace, app_inst=None):
         """Create the spack environment for this experiment
 
         Extract all specs this experiment uses, and write the spack environment
@@ -213,7 +212,7 @@ class SpackApplication(ApplicationBase):
     register_phase('software_configure', pipeline='setup',
                    run_after=['software_create_env', 'software_install_requested_compilers'])
 
-    def _software_configure(self, workspace):
+    def _software_configure(self, workspace, app_inst=None):
         """Concretize the spack environment for this experiment
 
         Perform spack's concretize step on the software environment generated
@@ -248,7 +247,7 @@ class SpackApplication(ApplicationBase):
     register_phase('software_install', pipeline='setup',
                    run_after=['software_configure'])
 
-    def _software_install(self, workspace):
+    def _software_install(self, workspace, app_inst=None):
         """Install application's software using spack"""
 
         # See if we cached this already, and if so return
@@ -275,7 +274,7 @@ class SpackApplication(ApplicationBase):
     register_phase('evaluate_requirements', pipeline='setup',
                    run_after=['software_install'])
 
-    def _evaluate_requirements(self, workspace):
+    def _evaluate_requirements(self, workspace, app_inst=None):
         """Evaluate all requirements for this experiment"""
 
         for mod_inst in self._modifier_instances:
@@ -288,7 +287,7 @@ class SpackApplication(ApplicationBase):
     register_phase('define_package_paths', pipeline='setup',
                    run_after=['software_install', 'evaluate_requirements'])
 
-    def _define_package_paths(self, workspace):
+    def _define_package_paths(self, workspace, app_inst=None):
         """Define variables containing the path to all spack packages
 
         For every spack package defined within an application context, define
@@ -328,7 +327,7 @@ class SpackApplication(ApplicationBase):
 
     register_phase('mirror_software', pipeline='mirror', run_after=['software_create_env'])
 
-    def _mirror_software(self, workspace):
+    def _mirror_software(self, workspace, app_inst=None):
         """Mirror software source for this experiment using spack"""
         import re
 
@@ -390,7 +389,7 @@ class SpackApplication(ApplicationBase):
 
     register_phase('push_to_spack_cache', pipeline='pushtocache', run_after=[])
 
-    def _push_to_spack_cache(self, workspace):
+    def _push_to_spack_cache(self, workspace, app_inst=None):
 
         env_path = self.expander.env_path
         cache_tupl = ('push-to-cache', env_path)

--- a/lib/ramble/ramble/cmd/on.py
+++ b/lib/ramble/ramble/cmd/on.py
@@ -32,6 +32,16 @@ def setup_parser(subparser):
         help='execution template for each experiment',
              required=False)
 
+    subparser.add_argument(
+        '--enable-per-experiment-prints', action='store_true',
+        dest='per_experiment_prints_on',
+        help='Enable per experiment prints (phases and log paths).')
+
+    subparser.add_argument(
+        '--suppress-run-header', action='store_true',
+        dest='run_header_off',
+        help='Disable the logger header.')
+
     arguments.add_common_arguments(subparser, ['where', 'exclude_where', 'filter_tags'])
 
 
@@ -48,8 +58,13 @@ def ramble_on(args):
         tags=args.filter_tags
     )
 
+    suppress_per_experiment_prints = not args.per_experiment_prints_on
+    suppress_run_header = args.run_header_off
+
     pipeline_cls = ramble.pipeline.pipeline_class(current_pipeline)
-    pipeline = pipeline_cls(ws, filters, executor=executor)
+    pipeline = pipeline_cls(ws, filters, executor=executor,
+                            suppress_per_experiment_prints=suppress_per_experiment_prints,
+                            suppress_run_header=suppress_run_header)
 
     with ws.write_transaction():
         pipeline.run()

--- a/lib/ramble/ramble/cmd/on.py
+++ b/lib/ramble/ramble/cmd/on.py
@@ -42,7 +42,7 @@ def ramble_on(args):
     executor = args.executor if args.executor else '{batch_submit}'
 
     filters = ramble.filters.Filters(
-        phase_filters=[],
+        phase_filters=['*'],
         include_where_filters=args.where,
         exclude_where_filters=args.exclude_where,
         tags=args.filter_tags

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -52,6 +52,8 @@ class Pipeline(object):
         self.force_inventory = False
         self.require_inventory = False
         self.action_string = 'Operating on'
+        self.suppress_per_experiment_prints = False
+        self.suppress_run_header = False
 
         dt = self.workspace.date_string()
         log_file = f'{self.name}.{dt}.out'
@@ -133,7 +135,12 @@ class Pipeline(object):
 
     def _execute(self):
         """Hook for executing the pipeline"""
+
         num_exps = self._experiment_set.num_filtered_experiments(self.filters)
+
+        if self.suppress_per_experiment_prints and not self.suppress_run_header:
+            logger.all_msg(f'  Log files for experiments are stored in: {self.log_dir}')
+
         count = 1
         for exp, app_inst, idx in self._experiment_set.filtered_experiments(self.filters):
             exp_log_path = app_inst.experiment_log_file(self.log_dir)
@@ -141,16 +148,18 @@ class Pipeline(object):
             experiment_index_value = \
                 app_inst.expander.expand_var_name(app_inst.keywords.experiment_index)
 
-            logger.all_msg(f'Experiment #{idx} ({count}/{num_exps}):')
-            logger.all_msg(f'    name: {exp}')
-            logger.all_msg(f'    root experiment_index: {experiment_index_value}')
-            logger.all_msg(f'    log file: {exp_log_path}')
+            if not self.suppress_per_experiment_prints:
+                logger.all_msg(f'Experiment #{idx} ({count}/{num_exps}):')
+                logger.all_msg(f'    name: {exp}')
+                logger.all_msg(f'    root experiment_index: {experiment_index_value}')
+                logger.all_msg(f'    log file: {exp_log_path}')
 
             logger.add_log(exp_log_path)
 
             phase_list = app_inst.get_pipeline_phases(self.name, self.filters.phases)
 
-            disable_progress = ramble.config.get('config:disable_progress_bar', False)
+            disable_progress = ramble.config.get('config:disable_progress_bar', False) \
+                or self.suppress_per_experiment_prints
             if not disable_progress:
                 progress = tqdm.tqdm(total=len(phase_list),
                                      leave=True,
@@ -170,7 +179,8 @@ class Pipeline(object):
                 progress.close()
 
             logger.remove_log()
-            logger.all_msg(f'  Returning to log file: {logger.active_log()}')
+            if not self.suppress_per_experiment_prints:
+                logger.all_msg(f'  Returning to log file: {logger.active_log()}')
             count += 1
 
     def _complete(self):
@@ -179,17 +189,18 @@ class Pipeline(object):
 
     def run(self):
         """Run the full pipeline"""
-        logger.all_msg('Streaming details to log:')
-        logger.all_msg(f'  {self.log_path}')
-        if self.workspace.dry_run:
-            cprint('@*g{      -- DRY-RUN -- DRY-RUN -- DRY-RUN -- DRY-RUN -- DRY-RUN --}')
+        if not self.suppress_run_header:
+            logger.all_msg('Streaming details to log:')
+            logger.all_msg(f'  {self.log_path}')
+            if self.workspace.dry_run:
+                cprint('@*g{      -- DRY-RUN -- DRY-RUN -- DRY-RUN -- DRY-RUN -- DRY-RUN --}')
 
-        experiment_count = self._experiment_set.num_filtered_experiments(self.filters)
-        experiment_total = self._experiment_set.num_experiments()
-        logger.all_msg(
-            f'  {self.action_string} {experiment_count} out of '
-            f'{experiment_total} experiments:'
-        )
+            experiment_count = self._experiment_set.num_filtered_experiments(self.filters)
+            experiment_total = self._experiment_set.num_experiments()
+            logger.all_msg(
+                f'  {self.action_string} {experiment_count} out of '
+                f'{experiment_total} experiments:'
+            )
 
         logger.add_log(self.log_path)
         self._validate()
@@ -477,14 +488,20 @@ class ExecutePipeline(Pipeline):
 
     name = 'execute'
 
-    def __init__(self, workspace, filters, executor='{batch_submit}'):
+    def __init__(self, workspace, filters, executor='{batch_submit}',
+                 suppress_per_experiment_prints=True, suppress_run_header=False):
         super().__init__(workspace, filters)
         self.action_string = 'Executing'
         self.require_inventory = True
         self.executor = executor
+        self.suppress_per_experiment_prints = suppress_per_experiment_prints
+        self.suppress_run_header = suppress_run_header
 
     def _execute(self):
         super()._execute()
+
+        if not self.suppress_run_header:
+            logger.all_msg('Running executors...')
 
         for exp, app_inst, idx in self._experiment_set.filtered_experiments(self.filters):
             if app_inst.is_template:

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -484,6 +484,8 @@ class ExecutePipeline(Pipeline):
         self.executor = executor
 
     def _execute(self):
+        super()._execute()
+
         for exp, app_inst, idx in self._experiment_set.filtered_experiments(self.filters):
             if app_inst.is_template:
                 logger.debug(f'{app_inst.name} is a template. Skipping execution.')

--- a/lib/ramble/ramble/test/modifier_functionality/mock_modifier_phases.py
+++ b/lib/ramble/ramble/test/modifier_functionality/mock_modifier_phases.py
@@ -1,0 +1,94 @@
+# Copyright 2022-2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import re
+import os
+import glob
+
+import pytest
+
+from ramble.test.dry_run_helpers import dry_run_config, search_files_for_string, SCOPES
+import ramble.test.modifier_functionality.modifier_helpers as modifier_helpers
+
+import ramble.workspace
+from ramble.main import RambleCommand
+
+workspace = RambleCommand('workspace')
+
+
+@pytest.mark.parametrize(
+    'scope',
+    [
+        SCOPES.workspace,
+        SCOPES.application,
+        SCOPES.workload,
+        SCOPES.experiment,
+    ]
+)
+def test_gromacs_dry_run_mock_mod_phase(mutable_mock_workspace_path,
+                                        mutable_applications,
+                                        mock_modifiers,
+                                        scope):
+    workspace_name = 'test_gromacs_dry_run_mock_mod_phase'
+
+    test_modifiers = [
+        (scope, modifier_helpers.named_modifier('mod-phase')),
+    ]
+
+    with ramble.workspace.create(workspace_name) as ws1:
+        ws1.write()
+
+        config_path = os.path.join(ws1.config_dir, ramble.workspace.config_file_name)
+
+        dry_run_config('modifiers', test_modifiers, config_path, 'gromacs', 'water_bare')
+
+        ws1._re_read()
+
+        workspace('concretize', global_args=['-D', ws1.root])
+        workspace('setup', '--dry-run', global_args=['-D', ws1.root])
+        out_files = glob.glob(os.path.join(ws1.log_dir, '**', '*.out'), recursive=True)
+
+        out_file = os.path.join(ws1.log_dir, 'setup.latest', 'gromacs.water_bare.test_exp.out')
+
+        found_phase = False
+        found_make_experiments = False
+        found_after_phase = False
+        found_first_phase = False
+        phase_regex = re.compile('Executing phase.*')
+        first_phase_regex = re.compile('Executing phase first_phase')
+        make_experiments_regex = re.compile('Executing phase make_experiments')
+        after_make_experiments_regex = re.compile('Executing phase after_make_experiments')
+
+        with open(out_file, 'r') as f:
+            for line in f.readlines():
+                if first_phase_regex.search(line):
+                    assert not found_phase
+                    found_first_phase = True
+
+                if phase_regex.search(line):
+                    found_phase = True
+
+                if make_experiments_regex.search(line):
+                    assert found_phase
+                    found_make_experiments = True
+
+                if after_make_experiments_regex.search(line):
+                    assert found_make_experiments
+                    found_after_phase = True
+
+        assert found_phase
+        assert found_first_phase
+        assert found_after_phase
+
+        expected_str = "Inside a phase: first_phase"
+
+        assert search_files_for_string(out_files, expected_str)
+
+        expected_str = "Inside a phase: after_make_experiments"
+
+        assert search_files_for_string(out_files, expected_str)

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -543,7 +543,7 @@ _ramble_mods_info() {
 }
 
 _ramble_on() {
-    RAMBLE_COMPREPLY="-h --help --executor --where --exclude-where --filter-tags"
+    RAMBLE_COMPREPLY="-h --help --executor --enable-per-experiment-prints --suppress-run-header --where --exclude-where --filter-tags"
 }
 
 _ramble_python() {

--- a/var/ramble/repos/builtin.mock/modifiers/mod-phase/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/mod-phase/modifier.py
@@ -1,0 +1,29 @@
+# Copyright 2022-2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.modkit import *  # noqa: F403
+from ramble.util.logger import logger
+
+
+class ModPhase(BasicModifier):
+    """Define a modifier that defines a new phase with register_phase"""
+    name = "mod-phase"
+
+    tags('test')
+
+    mode('test', description='This is a test mode')
+
+    register_phase('first_phase', pipeline='setup', run_before=['get_inputs'])
+
+    def _first_phase(self, workspace, app_inst=None):
+        logger.all_msg('Inside a phase: first_phase')
+
+    register_phase('after_make_experiments', pipeline='setup', run_after=['make_experiments'])
+
+    def _after_make_experiments(self, workspace, app_inst=None):
+        logger.all_msg('Inside a phase: after_make_experiments')

--- a/var/ramble/repos/builtin/applications/hpcg/application.py
+++ b/var/ramble/repos/builtin/applications/hpcg/application.py
@@ -83,7 +83,7 @@ class Hpcg(SpackApplication):
                     fom_regex=r'Final Summary::HPCG 2\.4 rating.*=(?P<rating>[0-9]+\.*[0-9]*)',
                     group_name='rating', units='')
 
-    def _make_experiments(self, workspace):
+    def _make_experiments(self, workspace, app_inst=None):
         super()._make_experiments(workspace)
 
         input_path = os.path.join(self.expander.expand_var_name('experiment_run_dir'),

--- a/var/ramble/repos/builtin/applications/hpl/application.py
+++ b/var/ramble/repos/builtin/applications/hpl/application.py
@@ -309,7 +309,7 @@ class Hpl(SpackApplication):
             # ramble.yaml configurable
             self.variables['DEPTHs'] = pad_value(depth, 'DEPTHs (>=0)')  # vs '0'
 
-    def _make_experiments(self, workspace):
+    def _make_experiments(self, workspace, app_inst=None):
         super()._make_experiments(workspace)
         self._calculate_values(workspace)
 

--- a/var/ramble/repos/builtin/applications/intel-hpl/application.py
+++ b/var/ramble/repos/builtin/applications/intel-hpl/application.py
@@ -310,7 +310,7 @@ class IntelHpl(SpackApplication):
             # ramble.yaml configurable
             self.variables['DEPTHs'] = pad_value(depth, 'DEPTHs (>=0)')  # vs '0'
 
-    def _make_experiments(self, workspace):
+    def _make_experiments(self, workspace, app_inst=None):
         super()._make_experiments(workspace)
         self._calculate_values(workspace)
 

--- a/var/ramble/repos/builtin/applications/lulesh/application.py
+++ b/var/ramble/repos/builtin/applications/lulesh/application.py
@@ -73,7 +73,7 @@ class Lulesh(SpackApplication):
                     fom_regex=r'\s*Iteration count\s+=\s+(?P<iterations>[0-9]+)',
                     group_name='iterations', units='')
 
-    def _make_experiments(self, workspace):
+    def _make_experiments(self, workspace, app_inst=None):
         """
         LULESH requires the number of ranks to be a cube root of an integer.
 

--- a/var/ramble/repos/builtin/applications/minixyce/application.py
+++ b/var/ramble/repos/builtin/applications/minixyce/application.py
@@ -136,7 +136,7 @@ class Minixyce(SpackApplication):
                                 regex=state_var_regex,
                                 output_format='{State_Variable}')
 
-    def _make_experiments(self, workspace):
+    def _make_experiments(self, workspace, app_inst=None):
         super()._make_experiments(workspace)
 
         input_path = os.path.join(self.expander.expand_var_name('experiment_run_dir'), 'params.txt')
@@ -147,7 +147,7 @@ class Minixyce(SpackApplication):
             for setting in settings:
                 f.write(setting + ' = ' + self.expander.expand_var_name(setting) + '\n')
 
-    def _analyze_experiments(self, workspace):
+    def _analyze_experiments(self, workspace, app_inst=None):
         import os
 
         output_file = os.path.join(self.expander.expand_var_name('experiment_run_dir'),

--- a/var/ramble/repos/builtin/applications/namd/application.py
+++ b/var/ramble/repos/builtin/applications/namd/application.py
@@ -320,7 +320,7 @@ class Namd(SpackApplication):
         units='ns/day'
     )
 
-    def _analyze_experiments(self, workspace):
+    def _analyze_experiments(self, workspace, app_inst=None):
         """Generate ns/day metric for the experiment"""
 
         log_path = self.expander.expand_var(self.log_file_str)

--- a/var/ramble/repos/builtin/applications/spack-stack/application.py
+++ b/var/ramble/repos/builtin/applications/spack-stack/application.py
@@ -100,11 +100,11 @@ class SpackStack(SpackApplication):
         ]
         return cmds
 
-    def _software_install(self, workspace):
+    def _software_install(self, workspace, app_inst=None):
         """This application never installs software during setup."""
         pass
 
-    def _define_package_paths(self, workspace):
+    def _define_package_paths(self, workspace, app_inst=None):
         pass
 
     def evaluate_success(self):

--- a/var/ramble/repos/builtin/applications/wrfv3/application.py
+++ b/var/ramble/repos/builtin/applications/wrfv3/application.py
@@ -90,7 +90,7 @@ class Wrfv3(SpackApplication):
     archive_pattern('{experiment_run_dir}/rsl.out.*')
     archive_pattern('{experiment_run_dir}/rsl.error.*')
 
-    def _analyze_experiments(self, workspace):
+    def _analyze_experiments(self, workspace, app_inst=None):
         import glob
         import re
         # Generate stats file

--- a/var/ramble/repos/builtin/applications/wrfv4/application.py
+++ b/var/ramble/repos/builtin/applications/wrfv4/application.py
@@ -96,7 +96,7 @@ class Wrfv4(SpackApplication):
     archive_pattern('{experiment_run_dir}/rsl.out.*')
     archive_pattern('{experiment_run_dir}/rsl.error.*')
 
-    def _analyze_experiments(self, workspace):
+    def _analyze_experiments(self, workspace, app_inst=None):
         import glob
         import re
         # Generate stats file


### PR DESCRIPTION
This merge migrates the `register_phase` directive into the shared_directives language set. This allows modifiers to also register their own phases to manipulate experiment setup / execution / etc.

Phases are allowed to specify their order based on other phase names, and will be topologically sorted to create the final phase ordering.