### PR TITLE
Rename `default_compiler` to `define_compiler`

### DIFF
--- a/lib/ramble/ramble/application_types/spack.py
+++ b/lib/ramble/ramble/application_types/spack.py
@@ -39,7 +39,7 @@ class SpackApplication(ApplicationBase):
     """
 
     uses_spack = True
-    _spec_groups = [('default_compilers', 'Default Compilers'),
+    _spec_groups = [('compilers', 'Compilers'),
                     ('mpi_libraries', 'MPI Libraries'),
                     ('software_specs', 'Software Specs')]
     _spec_keys = ['spack_spec', 'compiler_spec', 'compiler']

--- a/lib/ramble/ramble/cmd/software_definitions.py
+++ b/lib/ramble/ramble/cmd/software_definitions.py
@@ -60,7 +60,7 @@ def collect_definitions():
 
     The maps are global to this module, and reused in other internal methods.
     """
-    top_level_attrs = ['default_compilers', 'software_specs']
+    top_level_attrs = ['compilers', 'software_specs']
 
     types_to_print = [
         ramble.repository.ObjectTypes.applications

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -6,6 +6,8 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+import deprecation
+
 import ramble.language.language_base
 import ramble.language.language_helpers
 import ramble.success_criteria
@@ -107,23 +109,42 @@ def figure_of_merit(name, fom_regex, group_name, log_file='{log_file}', units=''
     return _execute_figure_of_merit
 
 
-@shared_directive('default_compilers')
+@shared_directive('compilers')
+@deprecation.deprecated(deprecated_in="(0, 4, 0)", removed_in="(0, 5, 0)",
+                        current_version=str(ramble.ramble_version_info),
+                        details="Use the define_compiler directive instead")
 def default_compiler(name, spack_spec, compiler_spec=None, compiler=None):
-    """Defines the default compiler that will be used with this object
+    """Deprecated: See `define_compiler` instead"""
 
-    Adds a new compiler spec to this object. Software specs should
-    reference a compiler that has been added.
-    """
+    logger.warn('Use of deprecated directive `default_compiler`')
 
     def _execute_default_compiler(obj):
         if hasattr(obj, 'uses_spack') and getattr(obj, 'uses_spack'):
-            obj.default_compilers[name] = {
+            obj.compilers[name] = {
                 'spack_spec': spack_spec,
                 'compiler_spec': compiler_spec,
                 'compiler': compiler
             }
 
     return _execute_default_compiler
+
+@shared_directive('compilers')
+def define_compiler(name, spack_spec, compiler_spec=None, compiler=None):
+    """Defines the compiler that will be used with this object
+
+    Adds a new compiler spec to this object. Software specs should
+    reference a compiler that has been added.
+    """
+
+    def _execute_define_compiler(obj):
+        if hasattr(obj, 'uses_spack') and getattr(obj, 'uses_spack'):
+            obj.compilers[name] = {
+                'spack_spec': spack_spec,
+                'compiler_spec': compiler_spec,
+                'compiler': compiler
+            }
+
+    return _execute_define_compiler
 
 
 @shared_directive('software_specs')

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -110,15 +110,14 @@ def figure_of_merit(name, fom_regex, group_name, log_file='{log_file}', units=''
 
 
 @shared_directive('compilers')
-@deprecation.deprecated(deprecated_in="(0, 4, 0)", removed_in="(0, 5, 0)",
-                        current_version=str(ramble.ramble_version_info),
+@deprecation.deprecated(deprecated_in="0.4.0", removed_in="0.5.0",
+                        current_version=str(ramble.ramble_version),
                         details="Use the define_compiler directive instead")
 def default_compiler(name, spack_spec, compiler_spec=None, compiler=None):
     """Deprecated: See `define_compiler` instead"""
 
-    logger.warn('Use of deprecated directive `default_compiler`')
-
     def _execute_default_compiler(obj):
+        logger.warn(f'Use of deprecated directive `default_compiler` in {obj.name}')
         if hasattr(obj, 'uses_spack') and getattr(obj, 'uses_spack'):
             obj.compilers[name] = {
                 'spack_spec': spack_spec,
@@ -127,6 +126,7 @@ def default_compiler(name, spack_spec, compiler_spec=None, compiler=None):
             }
 
     return _execute_default_compiler
+
 
 @shared_directive('compilers')
 def define_compiler(name, spack_spec, compiler_spec=None, compiler=None):

--- a/lib/ramble/ramble/modifier.py
+++ b/lib/ramble/ramble/modifier.py
@@ -155,9 +155,9 @@ class ModifierBase(object, metaclass=ModifierMeta):
                 out_str.append(f'\t{name} = {config}\n')
             out_str.append('\n')
 
-        if hasattr(self, 'default_compilers'):
+        if hasattr(self, 'compilers'):
             out_str.append(rucolor.section_title('Default Compilers:\n'))
-            for comp_name, comp_def in self.default_compilers.items():
+            for comp_name, comp_def in self.compilers.items():
                 out_str.append(rucolor.nested_2(f'\t{comp_name}:\n'))
                 out_str.append(rucolor.nested_3('\t\tSpack Spec:') +
                                f'{comp_def["spack_spec"].replace("@", "@@")}\n')

--- a/lib/ramble/ramble/test/application_language.py
+++ b/lib/ramble/ramble/test/application_language.py
@@ -32,7 +32,7 @@ def test_application_type_features(app_class):
     assert hasattr(test_app, 'inputs')
     assert hasattr(test_app, 'workload_variables')
     assert hasattr(test_app, 'environment_variables')
-    assert hasattr(test_app, 'default_compilers')
+    assert hasattr(test_app, 'compilers')
     assert hasattr(test_app, 'software_specs')
     assert hasattr(test_app, 'required_packages')
     assert hasattr(test_app, 'maintainers')
@@ -211,7 +211,8 @@ def add_input_file(app_inst, input_num=1, func_type=func_types.directive):
     return input_defs
 
 
-def add_default_compiler(app_inst, spec_num=1, func_type=func_types.directive):
+# TODO: can this be dried with the modifier language add_compiler?
+def add_compiler(app_inst, spec_num=1, func_type=func_types.directive):
     spec_name = 'Compiler%spec_num'
     spec_spack_spec = f'compiler_base@{spec_num}.0 +var1 ~var2'
     spec_compiler_spec = 'compiler1_base@{spec_num}'
@@ -223,10 +224,10 @@ def add_default_compiler(app_inst, spec_num=1, func_type=func_types.directive):
     }
 
     if func_type == func_types.directive:
-        default_compiler(spec_name, spack_spec=spec_spack_spec,  # noqa: F405
+        define_compiler(spec_name, spack_spec=spec_spack_spec,  # noqa: F405
                          compiler_spec=spec_compiler_spec)(app_inst)
     elif func_type == func_types.method:
-        app_inst.default_compiler(spec_name, spack_spec=spec_spack_spec,  # noqa: F405
+        app_inst.define_compiler(spec_name, spack_spec=spec_spack_spec,  # noqa: F405
                                   compiler_spec=spec_compiler_spec)
     else:
         assert False
@@ -241,10 +242,10 @@ def add_default_compiler(app_inst, spec_num=1, func_type=func_types.directive):
     }
 
     if func_type == func_types.directive:
-        default_compiler(spec_name, spack_spec=spec_spack_spec,  # noqa: F405
+        define_compiler(spec_name, spack_spec=spec_spack_spec,  # noqa: F405
                          compiler_spec=spec_compiler_spec)(app_inst)
     elif func_type == func_types.method:
-        app_inst.default_compiler(spec_name, spack_spec=spec_spack_spec,  # noqa: F405
+        app_inst.define_compiler(spec_name, spack_spec=spec_spack_spec,  # noqa: F405
                                   compiler_spec=spec_compiler_spec)
     else:
         assert False
@@ -371,23 +372,23 @@ def test_input_file_directive(app_class, func_type):
 
 @pytest.mark.parametrize('func_type', func_types)
 @pytest.mark.parametrize('app_class', app_types)
-def test_default_compiler_directive(app_class, func_type):
+def test_define_compiler_directive(app_class, func_type):
     app_inst = app_class('/not/a/path')
     test_defs = {}
     if app_inst.uses_spack:
-        test_defs.update(add_default_compiler(app_inst, 1, func_type=func_type))
-        test_defs.update(add_default_compiler(app_inst, 2, func_type=func_type))
+        test_defs.update(add_compiler(app_inst, 1, func_type=func_type))
+        test_defs.update(add_compiler(app_inst, 2, func_type=func_type))
 
-        assert hasattr(app_inst, 'default_compilers')
+        assert hasattr(app_inst, 'compilers')
         for name, info in test_defs.items():
-            assert name in app_inst.default_compilers
+            assert name in app_inst.compilers
             for key, value in info.items():
-                assert app_inst.default_compilers[name][key] == value
+                assert app_inst.compilers[name][key] == value
     else:
-        test_defs.update(add_default_compiler(app_inst, 1, func_type=func_type))
+        test_defs.update(add_compiler(app_inst, 1, func_type=func_type))
 
-        assert hasattr(app_inst, 'default_compilers')
-        assert not app_inst.default_compilers
+        assert hasattr(app_inst, 'compilers')
+        assert not app_inst.compilers
 
 
 @pytest.mark.parametrize('func_type', func_types)

--- a/lib/ramble/ramble/test/application_language.py
+++ b/lib/ramble/ramble/test/application_language.py
@@ -9,6 +9,7 @@
 
 import pytest
 import enum
+import deprecation
 
 from ramble.appkit import *  # noqa
 
@@ -212,6 +213,7 @@ def add_input_file(app_inst, input_num=1, func_type=func_types.directive):
 
 
 # TODO: can this be dried with the modifier language add_compiler?
+@deprecation.fail_if_not_removed
 def add_compiler(app_inst, spec_num=1, func_type=func_types.directive):
     spec_name = 'Compiler%spec_num'
     spec_spack_spec = f'compiler_base@{spec_num}.0 +var1 ~var2'
@@ -224,11 +226,15 @@ def add_compiler(app_inst, spec_num=1, func_type=func_types.directive):
     }
 
     if func_type == func_types.directive:
-        define_compiler(spec_name, spack_spec=spec_spack_spec,  # noqa: F405
+        default_compiler(spec_name, spack_spec=spec_spack_spec,  # noqa: F405
                          compiler_spec=spec_compiler_spec)(app_inst)
+        define_compiler(spec_name, spack_spec=spec_spack_spec,  # noqa: F405
+                        compiler_spec=spec_compiler_spec)(app_inst)
     elif func_type == func_types.method:
-        app_inst.define_compiler(spec_name, spack_spec=spec_spack_spec,  # noqa: F405
+        app_inst.default_compiler(spec_name, spack_spec=spec_spack_spec,  # noqa: F405
                                   compiler_spec=spec_compiler_spec)
+        app_inst.define_compiler(spec_name, spack_spec=spec_spack_spec,  # noqa: F405
+                                 compiler_spec=spec_compiler_spec)
     else:
         assert False
 
@@ -242,11 +248,11 @@ def add_compiler(app_inst, spec_num=1, func_type=func_types.directive):
     }
 
     if func_type == func_types.directive:
-        define_compiler(spec_name, spack_spec=spec_spack_spec,  # noqa: F405
-                         compiler_spec=spec_compiler_spec)(app_inst)
+        define_compiler(spec_name, spack_spec=spec_spack_spec,  # noqa: f405
+                        compiler_spec=spec_compiler_spec)(app_inst)
     elif func_type == func_types.method:
         app_inst.define_compiler(spec_name, spack_spec=spec_spack_spec,  # noqa: F405
-                                  compiler_spec=spec_compiler_spec)
+                                 compiler_spec=spec_compiler_spec)
     else:
         assert False
 

--- a/lib/ramble/ramble/test/application_tests.py
+++ b/lib/ramble/ramble/test/application_tests.py
@@ -26,7 +26,7 @@ def test_app_features(mutable_mock_apps_repo, app):
     assert hasattr(app_inst, 'executables')
     assert hasattr(app_inst, 'figures_of_merit')
     assert hasattr(app_inst, 'inputs')
-    assert hasattr(app_inst, 'default_compilers')
+    assert hasattr(app_inst, 'compilers')
     assert hasattr(app_inst, 'software_specs')
     assert hasattr(app_inst, 'required_packages')
     assert hasattr(app_inst, 'workload_variables')

--- a/lib/ramble/ramble/test/modifier_language.py
+++ b/lib/ramble/ramble/test/modifier_language.py
@@ -45,7 +45,7 @@ def test_modifier_type_features(mod_class):
     assert hasattr(test_mod, 'modes')
     assert hasattr(test_mod, 'variable_modifications')
     assert hasattr(test_mod, 'software_specs')
-    assert hasattr(test_mod, 'default_compilers')
+    assert hasattr(test_mod, 'compilers')
     assert hasattr(test_mod, 'required_packages')
     assert hasattr(test_mod, 'success_criteria')
     assert hasattr(test_mod, 'builtins')
@@ -233,7 +233,7 @@ def test_software_spec_directive(mod_class, func_type):
                 assert test_def[attr] == mod_inst.software_specs[spec_name][attr]
 
 
-def add_default_compiler(mod_inst, spec_num=1, func_type=func_types.directive):
+def add_compiler(mod_inst, spec_num=1, func_type=func_types.directive):
     spec_name = f'CompilerPackage{spec_num}'
     spack_spec = 'compiler@1.1 target=x86_64'
     compiler_spec = 'compiler@1.1'
@@ -247,9 +247,9 @@ def add_default_compiler(mod_inst, spec_num=1, func_type=func_types.directive):
     }
 
     if func_type == func_types.directive:
-        default_compiler(spec_name, spack_spec, compiler_spec, compiler)(mod_inst)
+        define_compiler(spec_name, spack_spec, compiler_spec, compiler)(mod_inst)
     elif func_type == func_types.method:
-        mod_inst.default_compiler(spec_name, spack_spec, compiler_spec, compiler)
+        mod_inst.define_compiler(spec_name, spack_spec, compiler_spec, compiler)
     else:
         assert False
 
@@ -258,24 +258,24 @@ def add_default_compiler(mod_inst, spec_num=1, func_type=func_types.directive):
 
 @pytest.mark.parametrize('func_type', func_types)
 @pytest.mark.parametrize('mod_class', mod_types)
-def test_default_compiler_directive(mod_class, func_type):
+def test_define_compiler_directive(mod_class, func_type):
     test_class = generate_mod_class(mod_class)
     mod_inst = test_class('/not/a/path')
     test_defs = []
-    test_defs.append(add_default_compiler(mod_inst, func_type=func_type).copy())
+    test_defs.append(add_compiler(mod_inst, func_type=func_type).copy())
 
     expected_attrs = ['spack_spec', 'compiler_spec', 'compiler']
 
     if mod_inst.uses_spack:
-        assert hasattr(mod_inst, 'default_compilers')
+        assert hasattr(mod_inst, 'compilers')
 
         for test_def in test_defs:
             spec_name = test_def['name']
 
-            assert spec_name in mod_inst.default_compilers
+            assert spec_name in mod_inst.compilers
             for attr in expected_attrs:
-                assert attr in mod_inst.default_compilers[spec_name]
-                assert test_def[attr] == mod_inst.default_compilers[spec_name][attr]
+                assert attr in mod_inst.compilers[spec_name]
+                assert test_def[attr] == mod_inst.compilers[spec_name][attr]
 
 
 def add_required_package(mod_inst, pkg_num=1, func_type=func_types.directive):

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -887,9 +887,9 @@ class Workspace(object):
             env_name_str = app_inst.expander.expansion_str(ramble.keywords.keywords.env_name)
             env_name = app_inst.expander.expand_var(env_name_str)
 
-            compiler_dicts = [app_inst.default_compilers]
+            compiler_dicts = [app_inst.compilers]
             for mod_inst in app_inst._modifier_instances:
-                compiler_dicts.append(mod_inst.default_compilers)
+                compiler_dicts.append(mod_inst.compilers)
 
             for compiler_dict in compiler_dicts:
                 for comp, info in compiler_dict.items():

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ protobuf==3.19.4;python_version<="3.6"
 pyarrow==3.0.0;python_version<="3.6"
 google-cloud-bigquery
 tqdm
+deprecation

--- a/var/ramble/repos/builtin.mock/modifiers/spack-failed-reqs/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/spack-failed-reqs/modifier.py
@@ -17,9 +17,9 @@ class SpackFailedReqs(SpackModifier):
 
     mode('default', description='This is the default mode for the spack-failed-reqs modifier')
 
-    default_compiler('mod_compiler',
-                     spack_spec='mod_compiler@1.1 target=x86_64',
-                     compiler_spec='mod_compiler@1.1')
+    define_compiler('mod_compiler',
+                    spack_spec='mod_compiler@1.1 target=x86_64',
+                    compiler_spec='mod_compiler@1.1')
 
     software_spec('mod_package1',
                   spack_spec='mod_package1@1.1',

--- a/var/ramble/repos/builtin.mock/modifiers/spack-mod/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/spack-mod/modifier.py
@@ -19,9 +19,9 @@ class SpackMod(SpackModifier):
 
     package_manager_config('enable_debug', 'config:debug:true')
 
-    default_compiler('mod_compiler',
-                     spack_spec='mod_compiler@1.1 target=x86_64',
-                     compiler_spec='mod_compiler@1.1')
+    define_compiler('mod_compiler',
+                    spack_spec='mod_compiler@1.1 target=x86_64',
+                    compiler_spec='mod_compiler@1.1')
 
     software_spec('mod_package1',
                   spack_spec='mod_package1@1.1',

--- a/var/ramble/repos/builtin/applications/cloverleaf/application.py
+++ b/var/ramble/repos/builtin/applications/cloverleaf/application.py
@@ -20,7 +20,7 @@ class Cloverleaf(SpackApplication):
 
     tags('cfd', 'fluid', 'dynamics', 'euler', 'miniapp', 'minibenchmark', 'mini-benchmark')
 
-    default_compiler('gcc12', spack_spec='gcc@12.2.0')
+    define_compiler('gcc12', spack_spec='gcc@12.2.0')
 
     software_spec('ompi414', spack_spec='openmpi@4.1.4 +legacylaunchers +cxx',
                   compiler='gcc12')

--- a/var/ramble/repos/builtin/applications/elk/application.py
+++ b/var/ramble/repos/builtin/applications/elk/application.py
@@ -59,6 +59,6 @@ class Elk(ExecutableApplication):
     for metric in metrics:
         figure_of_merit(metric,
                         log_file=output_file,
-                        fom_regex=f'\s*(?P<metric>{metric})\s+:\s+(?P<value>[0-9]+\.[0-9]*).*',
+                        fom_regex=rf'\s*(?P<metric>{metric})\s+:\s+(?P<value>[0-9]+\.[0-9]*).*',
                         group_name='value', units='s'
                         )

--- a/var/ramble/repos/builtin/applications/gromacs/application.py
+++ b/var/ramble/repos/builtin/applications/gromacs/application.py
@@ -19,7 +19,7 @@ class Gromacs(SpackApplication):
 
     tags('molecular-dynamics')
 
-    default_compiler('gcc9', spack_spec='gcc@9.3.0')
+    define_compiler('gcc9', spack_spec='gcc@9.3.0')
     software_spec('impi2018', spack_spec='intel-mpi@2018.4.274')
     software_spec('gromacs', spack_spec='gromacs@2020.5', compiler='gcc9')
 

--- a/var/ramble/repos/builtin/applications/hmmer/application.py
+++ b/var/ramble/repos/builtin/applications/hmmer/application.py
@@ -28,7 +28,7 @@ class Hmmer(SpackApplication):
 
     tags('molecular-dynamics', 'hidden-markov-models', 'bio-molecule')
 
-    default_compiler('gcc9', spack_spec='gcc@9.3.0')
+    define_compiler('gcc9', spack_spec='gcc@9.3.0')
 
     software_spec('impi_2018', spack_spec='intel-mpi@2018.4.274')
 

--- a/var/ramble/repos/builtin/applications/hpcc/application.py
+++ b/var/ramble/repos/builtin/applications/hpcc/application.py
@@ -28,7 +28,7 @@ class Hpcc(SpackApplication):
 
     tags('benchmark-app', 'mini-app', 'benchmark', 'DGEMM')
 
-    default_compiler('gcc9', spack_spec='gcc@9.3.0')
+    define_compiler('gcc9', spack_spec='gcc@9.3.0')
 
     software_spec('impi2018',
                   spack_spec='intel-mpi@2018.4.274')

--- a/var/ramble/repos/builtin/applications/hpcg/application.py
+++ b/var/ramble/repos/builtin/applications/hpcg/application.py
@@ -19,7 +19,7 @@ class Hpcg(SpackApplication):
 
     tags('benchmark-app', 'mini-app', 'benchmark')
 
-    default_compiler('gcc9', spack_spec='gcc@9.3.0')
+    define_compiler('gcc9', spack_spec='gcc@9.3.0')
 
     software_spec('impi2018',
                   spack_spec='intel-mpi@2018.4.274')

--- a/var/ramble/repos/builtin/applications/hpl/application.py
+++ b/var/ramble/repos/builtin/applications/hpl/application.py
@@ -25,7 +25,7 @@ class Hpl(SpackApplication):
 
     tags('benchmark-app', 'benchmark', 'linpack')
 
-    default_compiler('gcc9', spack_spec='gcc@9.3.0')
+    define_compiler('gcc9', spack_spec='gcc@9.3.0')
 
     software_spec('impi_2018', spack_spec='intel-mpi@2018.4.274')
 

--- a/var/ramble/repos/builtin/applications/intel-hpl/application.py
+++ b/var/ramble/repos/builtin/applications/intel-hpl/application.py
@@ -25,7 +25,7 @@ class IntelHpl(SpackApplication):
 
     tags('benchmark-app', 'benchmark', 'linpack', 'optimized', 'intel', 'mkl')
 
-    default_compiler('gcc9', spack_spec='gcc@9.3.0')
+    define_compiler('gcc9', spack_spec='gcc@9.3.0')
     software_spec('imkl_2023p1', spack_spec='intel-oneapi-mkl@2023.1.0 threads=openmp', compiler='gcc9')
     software_spec('impi_2018', spack_spec='intel-mpi@2018.4.274')
 

--- a/var/ramble/repos/builtin/applications/intel-mpi-benchmarks/application.py
+++ b/var/ramble/repos/builtin/applications/intel-mpi-benchmarks/application.py
@@ -29,7 +29,7 @@ class IntelMpiBenchmarks(SpackApplication):
 
     tags('micro-benchmark', 'benchmark', 'mpi')
 
-    default_compiler('gcc9', spack_spec='gcc@9.3.0')
+    define_compiler('gcc9', spack_spec='gcc@9.3.0')
     software_spec('impi2018', spack_spec='intel-mpi@2018.4.274')
     software_spec('intel-mpi-benchmarks',
                   spack_spec='intel-mpi-benchmarks@2019.6',

--- a/var/ramble/repos/builtin/applications/ior/application.py
+++ b/var/ramble/repos/builtin/applications/ior/application.py
@@ -18,7 +18,7 @@ class Ior(SpackApplication):
 
     tags('synthetic-benchmarks', 'IO')
 
-    default_compiler('gcc', spack_spec='gcc')
+    define_compiler('gcc', spack_spec='gcc')
     software_spec('openmpi', spack_spec='openmpi')
     software_spec('ior', spack_spec='ior', compiler='gcc')
 

--- a/var/ramble/repos/builtin/applications/iperf2/application.py
+++ b/var/ramble/repos/builtin/applications/iperf2/application.py
@@ -17,7 +17,7 @@ class Iperf2(SpackApplication):
 
     maintainers('rfbgo')
 
-    default_compiler('gcc9', spack_spec='gcc@9.3.0')
+    define_compiler('gcc9', spack_spec='gcc@9.3.0')
 
     software_spec('iperf2',
                   spack_spec='iperf2@2.0.12',

--- a/var/ramble/repos/builtin/applications/lammps/application.py
+++ b/var/ramble/repos/builtin/applications/lammps/application.py
@@ -18,7 +18,7 @@ class Lammps(SpackApplication):
 
     tags('molecular-dynamics')
 
-    default_compiler('gcc9', spack_spec='gcc@9.3.0')
+    define_compiler('gcc9', spack_spec='gcc@9.3.0')
 
     software_spec('impi2018', spack_spec='intel-mpi@2018.4.274')
 

--- a/var/ramble/repos/builtin/applications/lulesh/application.py
+++ b/var/ramble/repos/builtin/applications/lulesh/application.py
@@ -19,7 +19,7 @@ class Lulesh(SpackApplication):
 
     tags('proxy-app', 'mini-app')
 
-    default_compiler('gcc13', spack_spec='gcc@13.1.0')
+    define_compiler('gcc13', spack_spec='gcc@13.1.0')
 
     software_spec('impi2018',
                   spack_spec='intel-mpi@2018.4.274')

--- a/var/ramble/repos/builtin/applications/md-test/application.py
+++ b/var/ramble/repos/builtin/applications/md-test/application.py
@@ -18,7 +18,7 @@ class MdTest(SpackApplication):
 
     tags('synthetic-benchmarks', 'IO')
 
-    default_compiler('gcc', spack_spec='gcc')
+    define_compiler('gcc', spack_spec='gcc')
     software_spec('openmpi', spack_spec='openmpi')
 
     # The IOR spack package also includes MDTest, but we implement it as a

--- a/var/ramble/repos/builtin/applications/minixyce/application.py
+++ b/var/ramble/repos/builtin/applications/minixyce/application.py
@@ -19,7 +19,7 @@ class Minixyce(SpackApplication):
 
     tags('circuitdesign', 'miniapp', 'mini-app', 'minibenchmark', 'mini-benchmark')
 
-    default_compiler('gcc12', spack_spec="gcc@12.2.0")
+    define_compiler('gcc12', spack_spec="gcc@12.2.0")
 
     software_spec('ompi415cxx', spack_spec='openmpi@4.1.5 +legacylaunchers +cxx',
                   compiler='gcc12')

--- a/var/ramble/repos/builtin/applications/namd/application.py
+++ b/var/ramble/repos/builtin/applications/namd/application.py
@@ -21,7 +21,7 @@ class Namd(SpackApplication):
 
     tags('molecular-dynamics', 'charm++', 'task-parallelism')
 
-    default_compiler('gcc12', spack_spec='gcc@12.2.0')
+    define_compiler('gcc12', spack_spec='gcc@12.2.0')
 
     software_spec('impi2021p8', spack_spec='intel-oneapi-mpi@2021.8.0')
 

--- a/var/ramble/repos/builtin/applications/openfoam/application.py
+++ b/var/ramble/repos/builtin/applications/openfoam/application.py
@@ -19,7 +19,7 @@ class Openfoam(SpackApplication):
 
     tags('cfd', 'fluid', 'dynamics')
 
-    default_compiler('gcc9', spack_spec='gcc@9.3.0')
+    define_compiler('gcc9', spack_spec='gcc@9.3.0')
 
     software_spec('ompi412',
                   spack_spec='openmpi@4.1.2 +legacylaunchers +cxx',

--- a/var/ramble/repos/builtin/applications/osu-micro-benchmarks/application.py
+++ b/var/ramble/repos/builtin/applications/osu-micro-benchmarks/application.py
@@ -18,7 +18,7 @@ class OsuMicroBenchmarks(SpackApplication):
 
     tags('synthetic-benchmarks')
 
-    default_compiler('gcc', spack_spec='gcc')
+    define_compiler('gcc', spack_spec='gcc')
     software_spec('openmpi', spack_spec='openmpi')
     software_spec('osu-micro-benchmarks', spack_spec='osu-micro-benchmarks',
                   compiler='gcc')

--- a/var/ramble/repos/builtin/applications/quantum-espresso/application.py
+++ b/var/ramble/repos/builtin/applications/quantum-espresso/application.py
@@ -19,7 +19,7 @@ class QuantumEspresso(SpackApplication):
 
     tags('electronic-structure', 'materials', 'dft', 'density-functional-theory', 'plane-waves', 'pseudopotentials')
 
-    default_compiler('gcc13', spack_spec='gcc@13.1.0')
+    define_compiler('gcc13', spack_spec='gcc@13.1.0')
 
     software_spec('impi2021p8', spack_spec='intel-oneapi-mpi@2021.8.0')
     software_spec('quantum-espresso', spack_spec='quantum-espresso@7.1', compiler='gcc13')

--- a/var/ramble/repos/builtin/applications/streamc/application.py
+++ b/var/ramble/repos/builtin/applications/streamc/application.py
@@ -19,7 +19,7 @@ class Streamc(SpackApplication):
 
     tags('memorybenchmark', 'microbenchmark', 'memory-benchmark', 'micro-benchmark')
 
-    default_compiler('gcc12', spack_spec='gcc@12.2.0')
+    define_compiler('gcc12', spack_spec='gcc@12.2.0')
 
     software_spec('streamc',
                   spack_spec='stream@5.10 +openmp cflags="-O3 -DSTREAM_ARRAY_SIZE=80000000 -DNTIMES=20"',

--- a/var/ramble/repos/builtin/applications/ufs-weather-model/application.py
+++ b/var/ramble/repos/builtin/applications/ufs-weather-model/application.py
@@ -19,7 +19,7 @@ class UfsWeatherModel(SpackApplication):
 
     tags('nwp', 'weather')
 
-    default_compiler('gcc9', spack_spec='gcc@9.3.0')
+    define_compiler('gcc9', spack_spec='gcc@9.3.0')
 
     software_spec('ompi415', spack_spec="openmpi@4.1.5", compiler='gcc9')
 

--- a/var/ramble/repos/builtin/applications/wrfv3/application.py
+++ b/var/ramble/repos/builtin/applications/wrfv3/application.py
@@ -19,7 +19,7 @@ class Wrfv3(SpackApplication):
 
     tags('nwp', 'weather')
 
-    default_compiler('gcc8', spack_spec='gcc@8.2.0')
+    define_compiler('gcc8', spack_spec='gcc@8.2.0')
 
     software_spec('impi2018', spack_spec='intel-mpi@2018.4.274')
 

--- a/var/ramble/repos/builtin/applications/wrfv4/application.py
+++ b/var/ramble/repos/builtin/applications/wrfv4/application.py
@@ -19,7 +19,7 @@ class Wrfv4(SpackApplication):
 
     tags('nwp', 'weather')
 
-    default_compiler('gcc9', spack_spec='gcc@9.3.0')
+    define_compiler('gcc9', spack_spec='gcc@9.3.0')
 
     software_spec('intel-mpi', spack_spec="intel-mpi@2018.4.274",
                   compiler='gcc9')


### PR DESCRIPTION
The previous semantic of this setting a "default" was somewhat misleading. This PR adds the new directive, introduces a process for deprecating a directive, and updates the applications

It also updates the internal array to be called compilers (`obj.compilers[name]`). LMK if you find that too amigious