### PR TITLE
Fix object usage from modifier builtins

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -735,12 +735,15 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         if namespace.executables in self.internals:
             exec_order = self.internals[namespace.executables]
 
+        builtin_objects = [self]
         all_builtins = [self.builtins]
         for mod_inst in self._modifier_instances:
+            builtin_objects.append(mod_inst)
             all_builtins.append(mod_inst.builtins)
 
         executable_graph = ramble.graphs.ExecutableGraph(exec_order, self.executables,
-                                                         all_builtins, self)
+                                                         builtin_objects, all_builtins,
+                                                         self)
 
         # Perform executable injection
         if namespace.executable_injection in self.internals:
@@ -872,7 +875,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
 
             else:  # All Builtins
                 func = exec_node.attribute
-                func_cmds = func(self)
+                func_cmds = func()
                 for cmd in func_cmds:
                     self._command_list.append(self.expander.expand_var(cmd, exec_vars))
 

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -278,8 +278,7 @@ def register_builtin(name, required=True, injection_method='prepend', depends_on
         obj.builtins[builtin_name] = {'name': name,
                                       'required': required,
                                       'injection_method': injection_method,
-                                      'depends_on': depends_on.copy(),
-                                      'function': getattr(obj, name)}
+                                      'depends_on': depends_on.copy()}
     return _store_builtin
 
 

--- a/var/ramble/repos/builtin.mock/modifiers/test-mod/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/test-mod/modifier.py
@@ -40,5 +40,8 @@ class TestMod(BasicModifier):
 
     register_builtin('test_builtin', required=True, injection_method='append')
 
+    test_attr = 'test_value'
+
     def test_builtin(self):
-        return ['echo "fom_contextFOM_GOES_HERE" >> {analysis_log}']
+        return ['echo "fom_contextFOM_GOES_HERE" >> {analysis_log}',
+                f'echo "{self.test_attr}"' + ' >> {analysis_log}']


### PR DESCRIPTION
Previously, modifier builtins that referenced self would cause an issue (because the application instance was passed as self instead of the modifier instance). This merge fixes this issue by forcing the object (application / modifier) extraction to happen later than it happened previously.

A test is also added to capture this in the future (and if tested before the last commit it fails).