### PR TITLE
Fix propagation of non expandable variables from modifiers

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -287,6 +287,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
             for var, conf in self.workload_variables[workload_name].items():
                 if 'expandable' in conf and not conf['expandable']:
                     self.no_expand_vars.add(var)
+
         self.expander.set_no_expand_vars(self.no_expand_vars)
 
     def set_internals(self, internals):
@@ -701,6 +702,12 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         # Validate the new modifiers variables exist
         # (note: the base ramble variables are checked earlier too)
         self.keywords.check_required_keys(self.variables)
+
+        # Ensure no expand vars are set correctly for modifiers
+        for mod_inst in self._modifier_instances:
+            for var in mod_inst.no_expand_vars():
+                self.expander.add_no_expand_var(var)
+                mod_inst.expander.add_no_expand_var(var)
 
     def define_modifier_variables(self):
         """Extract default variable definitions from modifier instances"""

--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -314,6 +314,14 @@ class Expander(object):
         self._workload_run_dir = None
         self._experiment_run_dir = None
 
+    def add_no_expand_var(self, var: str):
+        """Add a new variable to the no expand set
+
+        Args:
+            var (str): Variable that should not expand
+        """
+        self._no_expand_vars.add(var)
+
     def set_no_expand_vars(self, no_expand_vars):
         self._no_expand_vars = no_expand_vars.copy()
 

--- a/lib/ramble/ramble/modifier.py
+++ b/lib/ramble/ramble/modifier.py
@@ -278,6 +278,18 @@ class ModifierBase(object, metaclass=ModifierMeta):
             for phase_name, phase_node in self.phase_definitions[pipeline].items():
                 yield phase_name, phase_node
 
+    def no_expand_vars(self):
+        """Iterator over non-expandable variables in current mode
+
+        Yields:
+            (str): Variable name
+        """
+
+        if self._usage_mode in self.modifier_variables:
+            for var, var_conf in self.modifier_variables[self._usage_mode].items():
+                if not var_conf['expandable']:
+                    yield var
+
     def mode_variables(self):
         """Return a dict of variables that should be defined for the current mode"""
 

--- a/lib/ramble/ramble/test/expander.py
+++ b/lib/ramble/ramble/test/expander.py
@@ -30,6 +30,7 @@ def exp_dict():
         'var3': '3',
         'decimal.06.var': 'foo',
         'size': '"0000.96"',  # Escaped as a string
+        'test_mask': '"0x0"',
     }
 
 
@@ -71,6 +72,7 @@ def exp_dict():
         (r'\\{experiment_name\\}', 'baz', set(), 3),
         ('"2.1.1" in ["2.1.1", "3.1.1", "4.2.1"]', 'True', set(), 1),
         ('"2.1.2" in ["2.1.1", "3.1.1", "4.2.1"]', 'False', set(), 1),
+        ('{test_mask}', '0x0', set(['test_mask']), 1),
     ]
 )
 def test_expansions(input, output, no_expand_vars, passes):

--- a/lib/ramble/ramble/test/modifier_functionality/modifier_helpers.py
+++ b/lib/ramble/ramble/test/modifier_functionality/modifier_helpers.py
@@ -152,6 +152,7 @@ def env_var_set_modifier_answer():
     ]
     expected_strs = [
         'export test_var=test_val',
+        'export mask_env_var="0x0"'
     ]
     return expected_software, expected_strs
 

--- a/var/ramble/repos/builtin.mock/modifiers/set-env-var-mod/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/set-env-var-mod/modifier.py
@@ -18,4 +18,8 @@ class SetEnvVarMod(BasicModifier):
 
     mode('test', description='This is a test mode')
 
+    modifier_variable('mask_test', default='0x0', description='Test mask var',
+                      modes=['test'], expandable=False)
+
     env_var_modification('test_var', modification='test_val', method='set', mode='test')
+    env_var_modification('mask_env_var', modification='{mask_test}', method='set', mode='test')


### PR DESCRIPTION
This merge fixes an issue where non-expandable variables defined within a modifier were not properly propagated into the expander objects.

A test is added to capture this in the future as well.