### PR TITLE
Convert environment generation logic to lazy / implcit instead of explicit

### DIFF
--- a/lib/ramble/docs/configuration_files.rst
+++ b/lib/ramble/docs/configuration_files.rst
@@ -529,58 +529,9 @@ Below is an annotated example of the spack dictionary.
           - impi2018
           - gromacs
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Vector and Matrix Packages and Environments:
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Package and environment definitions can generate many packages and environments
-following Ramble's
-:ref:`vector<ramble-vector-logic>` / :ref:`matrix<ramble-matrix-logic>` logic.
-
-Below is an example of using this logic within the spack dictionary:
-
-.. code-block:: yaml
-
-    spack:
-      packages:
-        gcc-{ver}:
-          variables:
-            ver: ['9.3.0', '10.3.0', '12.2.0']
-          spack_spec: gcc@{ver} target=x86_64
-          compiler_spec: gcc@{ver}
-        intel-mpi-{comp}:
-          variables:
-            comp: gcc-{ver}
-            ver: ['9.3.0', '10.3.0', '12.2.0']
-          spack_spec: intel-mpi@2018.4.274
-          compiler: {comp}
-        openmpi-{comp}:
-          variables:
-            comp: gcc-{ver}
-            ver: ['9.3.0', '10.3.0', '12.2.0']
-          spack_spec: openmpi@4.1.4
-          compiler: {comp}
-        wrf-{comp}:
-          variables:
-            comp: gcc-{ver}
-            ver: ['9.3.0', '10.3.0', '12.2.0']
-          spack_spec: wrf@4.2
-          compiler: {comp}
-      environments:
-        wrf-{comp}-{mpi}:
-          variables:
-            comp: gcc-{ver}
-            ver: ['9.3.0', '10.3.0', '12.2.0']
-            mpi: [intel-mpi-{comp}, openmpi-{comp}']
-          matrix:
-          - mpi
-          packages:
-          - {mpi}
-          - wrf-{comp}
-
-The above file will generate 3 versions of ``gcc``, 3 versions each of ``wrf``,
-``intel-mpi`` and ``openmpi`` built with each ``gcc`` version, and 6 spack
-environments, with each combination of the 2 ``mpi`` libraries and 3 compilers.
+Packages and environments defined inside the ``spack`` config section are
+merely templates. They will be rendered into explicit environments and packages
+by each individual experiment.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 External Spack Environment Support:

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -542,6 +542,8 @@ def workspace_info(args):
     # Build experiment set
     experiment_set = ws.build_experiment_set()
 
+    software_environments = ramble.software_environments.SoftwareEnvironments(ws)
+
     if args.tags:
         color.cprint('')
         all_tags = experiment_set.all_experiment_tags()
@@ -587,6 +589,9 @@ def workspace_info(args):
 
                 for exp_name, _, _ in print_experiment_set.filtered_experiments(filters):
                     app_inst = experiment_set.get_experiment(exp_name)
+                    software_environments.render_environment(
+                        app_inst.expander.expand_var('{env_name}'), app_inst.expander
+                    )
 
                     if print_header:
                         color.cprint(rucolor.nested_1('  Application: ') +
@@ -650,8 +655,12 @@ def workspace_info(args):
     # Print software stack information
     if args.software:
         color.cprint('')
-        software_environments = ramble.software_environments.SoftwareEnvironments(ws)
-        software_environments.print_environments(verbosity=args.verbose)
+        #  software_environments.print_environments(verbosity=args.verbose)
+        color.cprint(rucolor.section_title('Software Stack:'))
+        color.cprint(software_environments.info(verbosity=args.verbose, indent=4, color_level=1))
+
+        #  print('All new envs:')
+        #  print(software_environments.new_envs)
 
 #
 # workspace list

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -589,9 +589,10 @@ def workspace_info(args):
 
                 for exp_name, _, _ in print_experiment_set.filtered_experiments(filters):
                     app_inst = experiment_set.get_experiment(exp_name)
-                    software_environments.render_environment(
-                        app_inst.expander.expand_var('{env_name}'), app_inst.expander
-                    )
+                    if app_inst.uses_spack:
+                        software_environments.render_environment(
+                            app_inst.expander.expand_var('{env_name}'), app_inst.expander
+                        )
 
                     if print_header:
                         color.cprint(rucolor.nested_1('  Application: ') +

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -660,9 +660,6 @@ def workspace_info(args):
         color.cprint(rucolor.section_title('Software Stack:'))
         color.cprint(software_environments.info(verbosity=args.verbose, indent=4, color_level=1))
 
-        #  print('All new envs:')
-        #  print(software_environments.new_envs)
-
 #
 # workspace list
 #

--- a/lib/ramble/ramble/software_environments.py
+++ b/lib/ramble/ramble/software_environments.py
@@ -6,7 +6,7 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-import llnl.util.tty.color as color
+from enum import Enum
 
 import ramble.repository
 import ramble.workspace
@@ -20,402 +20,634 @@ from ramble.util.logger import logger
 import ramble.util.matrices
 import ramble.util.colors as rucolor
 
+package_managers = Enum("package_managers", ['spack'])
 
-class SoftwareEnvironments(object):
-    """Class to represent a set of software environments
 
-    This class contains logic to take the dictionary representations of
-    software environments, and unify their format.
-    """
+class SoftwarePackage(object):
+    """Class to represent a single software package"""
 
-    supported_confs = ['v2']
+    def __init__(self, name: str, spec: str, compiler: str = None,
+                 compiler_spec: str = None, package_manager=None):
+        """Software package constructor
 
-    def __init__(self, workspace):
-        self.keywords = ramble.keywords.keywords
-
-        self._raw_packages = {}
-        self._packages = {}
-        self._package_map = {}
-        self._raw_environments = {}
-        self._environments = {}
-        self._environment_map = {}
-        self._workspace = workspace
-        self.spack_dict = self._workspace.get_spack_dict().copy()
-
-        conf_type = self._detect_conf_type()
-
-        if conf_type not in self.supported_confs:
-            raise RambleSoftwareEnvironmentError(
-                f'Software configuration type {conf_type} is not one of ' +
-                f'{str(self.supported_confs)}'
-            )
-
-        setup_method = getattr(self, f'_{conf_type}_setup')
-        setup_method()
-
-    def _detect_conf_type(self):
-        """Auto-detect the type of configuration provided.
-
-        Default configuration type is 'invalid'.
-
-        v2 configurations follow the format:
-
-        spack:
-          concretized: [true/false]
-          packages: {}
-          environments: {}
+        Args:
+            name (str): Name of package
+            spec (str): Package spec (used to install / load package)
+            compiler (optional str): Name of package definition to use as compiler
+                                     for this package
+            compiler_spec (optional str): Spec string to use when this package
+                                          is used as a compiler
+            package_manager (optional str): Name of package manager for this package
         """
 
-        conf_type = 'invalid'
+        self.name = name
+        self.spec = spec
+        self.compiler = compiler
+        self.compiler_spec = compiler_spec
+        self._package_type = 'Rendered'
 
-        if namespace.packages in self.spack_dict and \
-                namespace.environments in self.spack_dict:
-            conf_type = 'v2'
+        if package_manager and hasattr(package_managers, package_manager):
+            self.package_manager = getattr(package_managers, package_manager)
+        else:
+            self.package_manager = package_managers.spack
 
-        logger.debug(f'Detected config type of: {conf_type}')
+    def spec_str(self, all_packages: dict = {}, compiler=False):
+        """Return a spec string for this software package
 
-        return conf_type
+        Args:
+            all_packages (dict): Dictionary of all package definitions.
+                                 Used to look up compiler packages.
+            compiler (boolean): True of this package is used as a compiler for
+                                another package. False if this is just a primary package.
+                                Toggles returning compiler_spec vs. spec in case they are
+                                different.
 
-    def _v2_setup(self):
-        """Process a v2 `spack:` dictionary in the workspace configuration."""
-        logger.debug('Performing v2 software setup.')
+        Returns:
+            (str): String representation of the spec for this package definition
+        """
 
-        pkg_renderer = ramble.renderer.Renderer()
-        env_renderer = ramble.renderer.Renderer()
+        out_str = ''
+        if self.package_manager == package_managers.spack:
+            if compiler and self.compiler_spec:
+                out_str = self.compiler_spec
+            else:
+                out_str = self.spec
 
-        expander = ramble.expander.Expander({}, None)
+            if compiler:
+                return out_str
 
-        workspace_vars = self._workspace.get_workspace_vars().copy()
-        workspace_zips = self._workspace.get_workspace_zips().copy()
+            if self.compiler in all_packages:
+                out_str += ' %' + all_packages[self.compiler].spec_str(all_packages, compiler=True)
+            elif self.compiler:
+                out_str += f' (built with {self.compiler})'
+        else:
+            raise RambleSoftwareEnvironmentError(
+                f'Package {self.name} uses an unknown '
+                f'package manager {self.package_manager}'
+            )
 
-        if namespace.variables in self.spack_dict and \
-                self.spack_dict[namespace.variables] is not None:
-            workspace_vars.update(self.spack_dict[namespace.variables])
+        return out_str
 
-        if namespace.zips in self.spack_dict and \
-                self.spack_dict[namespace.zips] is not None:
-            workspace_zips.update(self.spack_dict[namespace.zips])
+    def info(self, indent: int = 0, verbosity: int = 0, color_level: int = 0):
+        """String representation of package information
 
-        if namespace.packages in self.spack_dict:
-            for pkg_template, pkg_info in self.spack_dict[namespace.packages].items():
-                self._raw_packages[pkg_template] = pkg_info
-                self._package_map[pkg_template] = {}
-                pkg_group = ramble.renderer.RenderGroup('package', 'create')
-                pkg_group.variables.update(workspace_vars)
-                pkg_group.zips.update(workspace_zips)
-                pkg_group.from_dict(pkg_template, pkg_info)
+        Args:
+            indent (int): Number of spaces to indent lines with
+            verbosity (int): Verbosity level
 
-                pkg_group.variables['package_name'] = pkg_template
+        Returns:
+            (str): String representation of this package
+        """
 
-                exclude_pkgs = set()
-                exclude_where = []
-                if namespace.exclude in pkg_info:
-                    exclude_group = ramble.renderer.RenderGroup('package', 'exclude')
-                    exclude_group.variables.update(workspace_vars)
-                    exclude_group.variables['package_name'] = pkg_template
-                    perform_explicit_exclude = \
-                        exclude_group.from_dict(pkg_template, pkg_info[namespace.exclude])
+        indentation = ''
+        for _ in range(0, indent):
+            indentation += ' '
+        color = rucolor.level_func(color_level)
+        out_str  = color(f'{indentation}{self._package_type} package: {self.name}\n')
+        out_str += f'{indentation}    Spec: {self.spec.replace("@", "@@")}\n'
+        if self.compiler:
+            out_str += f'{indentation}    Compiler: {self.compiler}\n'
+        if self.compiler_spec:
+            out_str += f'{indentation}    Compiler Spec: {self.compiler_spec.replace("@", "@@")}\n'
+        return out_str
 
-                    if namespace.where in pkg_info[namespace.exclude]:
-                        exclude_where = pkg_info[namespace.exclude][namespace.where].copy()
+    def __str__(self):
+        """String representation of software package
 
-                    if perform_explicit_exclude:
-                        for exclude_vars, _ in pkg_renderer.render_objects(exclude_group):
-                            final_name = expander.expand_var_name('package_name',
-                                                                  extra_vars=exclude_vars)
-                            exclude_pkgs.add(final_name)
+        Returns:
+            (str): String representation of this software package
+        """
 
-                for rendered_vars, _ in pkg_renderer.render_objects(pkg_group,
-                                                                    exclude_where=exclude_where):
-                    final_name = expander.expand_var_name('package_name',
-                                                          extra_vars=rendered_vars)
-                    if final_name in exclude_pkgs:
-                        continue
+        return self.info()
 
-                    self._packages[final_name] = {}
-                    self._package_map[pkg_template].update({final_name: None})
+    def __eq__(self, other):
+        """Equvialence test for two package definitions
 
-                    spack_spec = expander.expand_var(pkg_info['spack_spec'],
-                                                     extra_vars=rendered_vars)
-                    self._packages[final_name]['spack_spec'] = spack_spec
+        Args:
+            other (SoftwarePackage): Package to compare with self.
 
-                    if 'compiler_spec' in pkg_info:
-                        comp_spec = expander.expand_var(pkg_info['compiler_spec'],
-                                                        extra_vars=rendered_vars)
-                        self._packages[final_name]['compiler_spec'] = comp_spec
+        Returns:
+            (boolean): True if packages are the same, False otherwise
+        """
 
-                    if 'compiler' in pkg_info:
-                        comp = expander.expand_var(pkg_info['compiler'],
-                                                   extra_vars=rendered_vars)
-                        self._packages[final_name]['compiler'] = comp
+        return self.name == other.name and self.spec == other.spec and \
+            self.compiler == other.compiler and self.compiler_spec == other.compiler_spec
 
-        if namespace.environments in self.spack_dict:
-            for env_template, env_info in self.spack_dict[namespace.environments].items():
-                env_group = ramble.renderer.RenderGroup('environment', 'create')
-                env_group.variables.update(workspace_vars)
-                env_group.zips.update(workspace_zips)
-                env_group.from_dict(env_template, env_info)
-                self._raw_environments[env_template] = env_info
-                self._environment_map[env_template] = {}
 
-                env_group.variables['environment_name'] = env_template
+class TemplatePackage(SoftwarePackage):
+    """Class representing a template software package"""
 
-                exclude_envs = set()
-                exclude_where = []
-                if namespace.exclude in env_info:
-                    exclude_group = ramble.renderer.RenderGroup('environment', 'exclude')
-                    exclude_group.variables.update(workspace_vars)
-                    exclude_group.variables['environment_name'] = env_template
-                    perform_explicit_exclude = \
-                        exclude_group.from_dict(env_template, env_info[namespace.exclude])
+    def __init__(self, name: str, spec: str,
+                 compiler: str = None, compiler_spec: str = None,
+                 package_manager=None):
+        """Template package constructor
 
-                    if namespace.where in env_info[namespace.exclude]:
-                        exclude_where = env_info[namespace.exclude][namespace.where].copy()
+        Args:
+            name (str): Name of package
+            spec (str): Package spec (used to install / load package)
+            compiler (optional str): Name of package definition to use as compiler
+                                     for this package
+            compiler_spec (optional str): Spec string to use when this package
+                                          is used as a compiler
+            package_manager (optional str): Name of package manager for this package
+        """
+        super().__init__(name, spec, compiler=compiler,
+                         compiler_spec=compiler_spec,
+                         package_manager=None)
+        self._rendered_packages = {}
+        self._package_type = 'Template'
 
-                    if perform_explicit_exclude:
-                        for exclude_vars, _ in env_renderer.render_objects(exclude_group):
-                            final_name = expander.expand_var_name('environment_name',
-                                                                  extra_vars=exclude_vars)
-                            exclude_envs.add(final_name)
+    def info(self, indent: int = 0, verbosity: int = 0, color_level: int = 0):
+        """String representation of package information
 
-                for rendered_vars, _ in env_renderer.render_objects(env_group,
-                                                                    exclude_where=exclude_where):
-                    final_name = expander.expand_var_name('environment_name',
-                                                          extra_vars=rendered_vars)
+        Args:
+            indent (int): Number of spaces to indent lines with
+            verbosity (int): Verbosity level
 
-                    if final_name in exclude_envs:
-                        continue
+        Returns:
+            (str): String representation of this package
+        """
 
-                    self._environment_map[env_template].update({final_name: None})
+        out_str = super().info(indent, verbosity, color_level)
+        new_indent = indent + 4
+        for pkg in self._rendered_packages.values():
+            out_str += pkg.info(indent=new_indent, verbosity=verbosity,
+                                color_level=color_level + 1)
+        return out_str
 
-                    self._environments[final_name] = {}
+    def render_package(self, expander: object):
+        """Render a SoftwarePackage from this TemplatePackage
 
-                    if namespace.external_env in env_info:
-                        external_env = expander.expand_var(env_info[namespace.external_env],
-                                                           extra_vars=rendered_vars)
-                        self._environments[final_name][namespace.external_env] = \
-                            external_env
+        Args:
+            expander (Expander): Expander to use to render a package from this template
 
-                    if namespace.packages in env_info:
-                        self._environments[final_name][namespace.packages] = []
-                        env_packages = self._environments[final_name][namespace.packages]
+        Returns:
+            (SoftwarePackage): Rendered SoftwarePackage
+        """
+        name = expander.expand_var(self.name)
+        spec = expander.expand_var(self.spec)
+        compiler = expander.expand_var(self.compiler) if self.compiler else None
+        compiler_spec = expander.expand_var(self.compiler_spec) if self.compiler_spec else None
 
-                        for pkg_name in env_info[namespace.packages]:
-                            expanded_pkg = expander.expand_var(pkg_name,
-                                                               extra_vars=rendered_vars)
-                            if expanded_pkg:
-                                env_packages.append(expanded_pkg)
+        new_pkg = SoftwarePackage(name, spec, compiler, compiler_spec)
 
-                        pkgs_with_compiler = []
-                        missing_pkgs = set()
-                        for pkg_name in env_packages:
-                            if pkg_name in self._packages:
-                                pkg_info = self._packages[pkg_name]
+        if new_pkg.name in self._rendered_packages:
+            if new_pkg != self._rendered_packages[name]:
+                raise RambleSoftwareEnvironmentError(
+                    f'Package {new_pkg.name} defined multiple times with '
+                    'inconsistent definitions.\n'
+                    'New definition is:\n'
+                    f'{new_pkg}'
+                    'Old definition is:\n'
+                    f'{self._rendered_packages[name]}'
+                )
+            return self._rendered_packages[name]
+        else:
+            return new_pkg
 
-                                if 'compiler' in pkg_info and pkg_info['compiler'] in env_packages:
-                                    pkgs_with_compiler.append((pkg_name, pkg_info['compiler']))
-                            else:
-                                missing_pkgs.add(pkg_name)
+    def add_rendered_package(self, new_package: object, all_packages: dict):
+        """Add a rendered package to this template's list of rendered packages
 
-                        if pkgs_with_compiler:
-                            logger.warn(
-                                f'Environment {final_name} contains packages and their '
-                                'compilers in the package list. These include:'
-                            )
-                            for pkg_name, comp_name in pkgs_with_compiler:
-                                logger.warn(
-                                    f'    Package: {pkg_name}, Compiler: {comp_name}'
-                                )
-                            logger.warn(
-                                'This might cause problems when installing the packages.'
-                            )
-                        if missing_pkgs:
-                            err_msg = f'Environment {final_name} refers to the following ' \
-                                      'packages, which are not defined:\n'
-                            for pkg_name in missing_pkgs:
-                                err_msg += f'\t{pkg_name}\n'
-                            err_msg += 'Please make sure all packages are defined ' \
-                                       'before using this environment.'
-                            logger.die(err_msg)
+        Args:
+            new_package (SoftwarePackage): New package definition to add
+            all_packages (dict): Dictionary of all package definitions
+        """
 
-    def print_environments(self, verbosity=0):
-        color.cprint(rucolor.section_title('Software Stack:'))
-        color.cprint(rucolor.nested_1('  Packages:'))
-        for raw_pkg in self.all_raw_packages():
-            color.cprint(rucolor.nested_2(f'    {raw_pkg}:'))
+        if new_package.name not in self._rendered_packages:
+            self._rendered_packages[new_package.name] = new_package
+            all_packages[new_package.name] = new_package
 
-            pkg_info = self.raw_package_info(raw_pkg)
 
+class SoftwareEnvironment(object):
+    """Class representing a single software environment"""
+
+    def __init__(self, name: str):
+        """SoftwareEnvironment constructor
+
+        Args:
+            name (str): Name of the environment
+        """
+
+        self.name = name
+        self._packages = []
+        self._environment_type = 'Rendered'
+
+    def info(self, indent: int = 0, verbosity: int = 0, color_level: int = 0):
+        """Software environment information
+
+        Args:
+            indent (int): Number of spaces to inject as indentation
+            verbosity (int): Verbosity level
+
+        Returns:
+            (str): information of this environment
+        """
+
+        indentation = ''
+        for _ in range(0, indent):
+            indentation += ' '
+        color = rucolor.level_func(color_level)
+        out_str  = color(f'{indentation}{self._environment_type} environment: {self.name}\n')
+        out_str += f'{indentation}    Packages:\n'
+        for pkg in self._packages:
             if verbosity >= 1:
-                if namespace.variables in pkg_info and pkg_info[namespace.variables]:
-                    color.cprint(rucolor.nested_3('      Variables:'))
-                    for var, val in pkg_info[namespace.variables].items():
-                        color.cprint(f'        {var} = {val}')
+                out_str += f'{indentation}    - {pkg.name} = {pkg.spec_str().replace("@", "@@")}\n'
+            else:
+                out_str += f'{indentation}    - {pkg.name}\n'
+        return out_str
 
-                if namespace.matrices in pkg_info and pkg_info[namespace.matrices]:
-                    color.cprint(rucolor.nested_3('      Matrices:'))
-                    for matrix in pkg_info[namespace.matrices]:
-                        base_str = '        - '
-                        for var in matrix:
-                            color.cprint(f'{base_str}- {var}')
-                            base_str = '          '
+    def __str__(self):
+        """String representation of this environment
 
-                if namespace.matrix in pkg_info and pkg_info[namespace.matrix]:
-                    color.cprint(rucolor.nested_3('      Matrix:'))
-                    for var in pkg_info[namespace.matrix]:
-                        color.cprint(f'        - {var}')
+        Returns:
+            (str): Representation of this environment
+        """
+        return self.info(indent=0)
 
-            color.cprint(rucolor.nested_3('      Rendered Packages:'))
-            for pkg in self.mapped_packages(raw_pkg):
-                color.cprint(rucolor.nested_4(f'        {pkg}:'))
-                pkg_spec = self.get_spec(pkg)
-                spec_str = pkg_spec[namespace.spack_spec].replace('@', '@@')
-                color.cprint(f'          Spack spec: {spec_str}')
-                if namespace.compiler_spec in pkg_spec and pkg_spec[namespace.compiler_spec]:
-                    spec_str = pkg_spec[namespace.compiler_spec].replace('@', '@@')
-                    color.cprint(f'          Compiler spec: {spec_str}')
-                if namespace.compiler in pkg_spec and pkg_spec[namespace.compiler]:
-                    color.cprint(f'          Compiler: {pkg_spec[namespace.compiler]}')
+    def add_package(self, package: object):
+        """Add a package definition to this environment
 
-        color.cprint(rucolor.nested_1('  Environments:'))
-        for raw_env in self.all_raw_environments():
-            color.cprint(rucolor.nested_2(f'    {raw_env}:'))
+        Args:
+            package (SoftwarePackage): Package object
+        """
+        self._packages.append(package)
 
-            env_info = self.raw_environment_info(raw_env)
+    def __eq__(self, other):
+        """Equivalence test for environments
 
-            if verbosity >= 1:
-                if namespace.variables in env_info and env_info[namespace.variables]:
-                    color.cprint(rucolor.nested_3('      Variables:'))
-                    for var, val in env_info[namespace.variables].items():
-                        color.cprint(f'        {var} = {val}')
+        Args:
+            other (SoftwareEnvironment): Environment to compare with self
 
-                if namespace.matrices in env_info and env_info[namespace.matrices]:
-                    color.cprint(rucolor.nested_3('      Matrices:'))
-                    for matrix in env_info[namespace.matrices]:
-                        base_str = '        - '
-                        for var in matrix:
-                            color.cprint(f'{base_str}- {var}')
-                            base_str = '          '
+        Returns:
+            (boolean): True if environments are equivalent, False otherwise
+        """
+        equal = self.name == other.name and len(self._packages) == len(other._packages)
 
-                if namespace.matrix in env_info and env_info[namespace.matrix]:
-                    color.cprint(rucolor.nested_3('      Matrix:'))
-                    for var in env_info[namespace.matrix]:
-                        color.cprint(f'        - {var}')
+        if equal:
+            for self_pkg, other_pkg in zip(self._packages, other._packages):
+                equal = equal and self_pkg == other_pkg
 
-            color.cprint(rucolor.nested_3('      Rendered Environments:'))
-            for env in self.mapped_environments(raw_env):
-                color.cprint(rucolor.nested_4(f'        {env} Packages:'))
-                for pkg in self.get_env_packages(env):
-                    color.cprint(f'          - {pkg}')
+        return equal
 
-    def get_env(self, environment_name):
-        """Return a reference to the environment definition"""
-        if environment_name not in self._environments:
-            raise RambleSoftwareEnvironmentError(
-                f'Environment {environment_name} is not defined.'
-            )
 
-        return self._environments[environment_name]
+class ExternalEnvironment(SoftwareEnvironment):
+    """Class representing an externally defined software environment"""
 
-    def get_spec_string(self, package_name):
-        """Return the full spec string given a package name"""
-        if package_name not in self._packages:
-            raise RambleSoftwareEnvironmentError(
-                f'Package {package_name} is not defined.'
-            )
+    def __init__(self, name: str, name_or_path: str):
+        """Constructor for external software environment
 
-        spec_string = self._packages[package_name]['spack_spec']
-        compiler_str = ''
-        if 'compiler' in self._packages[package_name]:
-            comp_name = self._packages[package_name]['compiler']
-            comp_spec = self.get_spec(comp_name)
-            compiler_str = f' %{comp_spec["spack_spec"]}'
-            if 'compiler_spec' in comp_spec:
-                compiler_str = f' %{comp_spec["compiler_spec"]}'
-        return spec_string + compiler_str
+        """
+        super().__init__(name)
+        self.external_env = name_or_path
 
-    def get_spec(self, package_name):
-        """Return a single spec given its name"""
-        if package_name not in self._packages:
-            raise RambleSoftwareEnvironmentError(
-                f'Package {package_name} is not defined.'
-            )
 
-        return self._packages[package_name]
+class TemplateEnvironment(SoftwareEnvironment):
+    """Class representing a template software environment"""
 
-    def get_env_packages(self, environment_name):
-        """Return all of the packages used by an environment"""
-        if environment_name not in self._environments:
-            raise RambleSoftwareEnvironmentError(
-                f'Environment {environment_name} is not defined.'
-            )
+    def __init__(self, name: str):
+        """TemplateEnvironment constructor
 
-        if namespace.packages in self._environments[environment_name]:
-            for name in self._environments[environment_name][namespace.packages]:
-                yield name
+        Args:
+            name (str): Name of this environment
+        """
+        super().__init__(name)
+        self._rendered_environments = {}
+        self._environment_type = 'Template'
 
-    def _require_raw_package(self, pkg):
-        """Raise an error if the raw package is not defined"""
-        if pkg not in self._raw_packages.keys():
-            raise RambleSoftwareEnvironmentError(
-                f'Package {pkg} is not defined.'
-            )
+    def info(self, indent: int = 0, verbosity: int = 0, color_level: int = 0):
+        """Software environment information
 
-    def _require_raw_environment(self, env):
-        """Raise an error if the raw environment is not defined"""
-        if env not in self._raw_environments.keys():
-            raise RambleSoftwareEnvironmentError(
-                f'Environment {env} is not defined.'
-            )
+        Args:
+            indent (int): Number of spaces to inject as indentation
+            verbosity (int): Verbosity level
+
+        Returns:
+            (str): information of this environment
+        """
+        out_str = super().info(indent, verbosity, color_level=color_level)
+        new_indent = indent + 4
+        for env in self._rendered_environments.values():
+            out_str += env.info(new_indent, verbosity, color_level=color_level + 1)
+        return out_str
+
+    def __str__(self):
+        """String representation of this environment
+
+        Returns:
+            (str): String representation of this environment (none of it's rendered environments)
+        """
+
+        return super().info()
+
+    def render_environment(self, expander: object, all_packages: dict):
+        """Render a SoftwareEnvironment from this TemplateEnvironment
+
+        Args:
+            expander (Expander): Expander object to use when rendering
+            all_packages (dict): All package definitions
+
+        Returns:
+            (SoftwareEnvironment) Reference to the rendered SoftwareEnvironment
+        """
+        name = expander.expand_var(self.name)
+
+        new_env = SoftwareEnvironment(name)
+
+        for package in self._packages:
+            rendered_pkg = package.render_package(expander)
+
+            if rendered_pkg.name in all_packages:
+                if rendered_pkg != all_packages[rendered_pkg.name]:
+                    raise RambleSoftwareEnvironmentError(
+                        f'Environment {name} defined multiple times in inconsistent ways\n'
+                        f'Package with differences {rendered_pkg.name}'
+                    )
+                rendered_pkg = all_packages[rendered_pkg.name]
+            else:
+                all_packages[rendered_pkg.name] = rendered_pkg
+
+            new_env.add_package(rendered_pkg)
+
+        return new_env
+
+    def add_rendered_environment(self, environment: object, all_environments: dict,
+                                 all_packages: dict):
+        """Add a rendered environment to this template
+
+        Args:
+            environment (SoftwareEnvironment): Reference to rendered environment
+            all_environments (dict): Dictionary containing all environments
+            all_packages (dict): Dictionary containing all packages
+        """
+        if environment.name not in self._rendered_environments:
+            self._rendered_environments[environment.name] = environment
+            all_environments[environment.name] = environment
+            for template_pkg, rendered_pkg in zip(self._packages, environment._packages):
+                template_pkg.add_rendered_package(rendered_pkg, all_packages)
 
     def all_packages(self):
-        """Yield each package name"""
-        for pkg in self._packages.keys():
-            yield pkg
+        """Iterator over all packages in this environment
 
-    def all_raw_packages(self):
-        """Yield each raw package name"""
-        for pkg in self._raw_packages.keys():
-            yield pkg
+        Yields:
+            (SoftwarePackage) Each package in this environment
+        """
+        for _, pkg_obj in self._packages:
+            yield pkg_obj
 
-    def raw_package_info(self, raw_pkg):
-        """Return the information for a raw package"""
-        self._require_raw_package(raw_pkg)
 
-        return self._raw_packages[raw_pkg]
+class SoftwareEnvironments(object):
+    """Class representing a group of software environments"""
 
-    def mapped_packages(self, raw_pkg):
-        """Yield each package rendered from a raw package"""
-        self._require_raw_package(raw_pkg)
+    def __init__(self, workspace):
+        """SoftwareEnvironments constructor
 
-        for pkg in self._package_map[raw_pkg].keys():
-            yield pkg
+        Args:
+            workspace (Workspace): Reference to workspace owning the software descriptions
+        """
 
-    def all_environments(self):
-        """Yield each environment name"""
-        for env in self._environments.keys():
-            yield env
+        self._workspace = workspace
+        self._spack_dict = workspace.get_spack_dict().copy()
+        self._environment_templates = {}
+        self._package_templates = {}
+        self._rendered_packages = {}
+        self._rendered_environments = {}
 
-    def all_raw_environments(self):
-        """Yield raw environment names"""
-        for env in self._raw_environments.keys():
-            yield env
+        self._define_templates()
 
-    def raw_environment_info(self, env):
-        """Return the information for a raw environment"""
-        if env not in self._raw_environments.keys():
-            raise RambleSoftwareEnvironmentError(
-                f'Environment {env} is not defined.'
+    def info(self, indent: int = 0, verbosity: int = 0, color_level: int = 0):
+        """Information for all packages and environments
+
+        Args:
+            indent (int): Number of spaces to indent lines with
+            verbosity (int): Verbosity level
+
+        Returns:
+            (str): Representation of all packages and environments
+        """
+        out_str = ''
+        for pkg in self._package_templates.values():
+            out_str += pkg.info(indent, verbosity=verbosity, color_level=color_level)
+        for env in self._environment_templates.values():
+            out_str += env.info(indent, verbosity=verbosity, color_level=color_level)
+        return out_str
+
+    def __str__(self):
+        """String representation of all packages and environments in this object
+
+        Returns:
+            (str): Representation of all packages and environments
+        """
+        return self.info(indent=0)
+
+    def _define_templates(self):
+        """Process software dictionary to generate templates"""
+        if namespace.packages in self._spack_dict:
+            for pkg_template, pkg_info in self._spack_dict[namespace.packages].items():
+                spec = pkg_info['spack_spec'] if 'spack_spec' in pkg_info else pkg_info['spec']
+                compiler = pkg_info['compiler'] \
+                    if 'compiler' in pkg_info and pkg_info['compiler'] else None
+                compiler_spec = pkg_info['compiler_spec'] \
+                    if 'compiler_spec' in pkg_info and pkg_info['compiler_spec'] else None
+                new_pkg = TemplatePackage(
+                    pkg_template, spec, compiler=compiler, compiler_spec=compiler_spec
+                )
+                self._package_templates[pkg_template] = new_pkg
+
+        if namespace.environments in self._spack_dict:
+            for env_template, env_info in self._spack_dict[namespace.environments].items():
+                if namespace.external_env in env_info and env_info[namespace.external_env]:
+                    # External environments are considered rendered
+                    new_env = ExternalEnvironment(env_template, env_info[namespace.external_env])
+                    self._rendered_environments[env_template] = new_env
+                else:
+                    # Define a new template environment
+                    new_env = TemplateEnvironment(env_template)
+                    if namespace.packages in env_info:
+                        for package in env_info[namespace.packages]:
+                            if package not in self._package_templates:
+                                raise RambleSoftwareEnvironmentError(
+                                    f'Environment {env_template} references '
+                                    f'undefined package {package}'
+                                )
+                            pkg_obj = self._package_templates[package]
+                            new_env.add_package(pkg_obj)
+                    self._environment_templates[env_template] = new_env
+
+    def define_compiler_packages(self, environment, expander):
+        """Define packages for compilers in this environment
+
+        If compilers referenced by (environment) are not defined, create
+        definitions for them to properly create compiler specs.
+
+        Args:
+            environment (SoftwareEnvironment): Environment to extract necessary
+                                               compilers from
+            expander (Expander): Expander object to use when constructing
+                                 compiler package names
+        """
+        for pkg in environment._packages:
+            if pkg.compiler:
+                cur_compiler = pkg.compiler
+                while cur_compiler and cur_compiler not in self._rendered_packages:
+                    added = False
+                    for template_name, template_def in self._package_templates.items():
+                        rendered_name = expander.expand_var(template_name)
+
+                        if rendered_name == cur_compiler:
+                            rendered_pkg = template_def.render_package(expander)
+
+                            if cur_compiler in self._rendered_packages and \
+                                    rendered_pkg != self._rendered_packages[cur_compiler]:
+                                raise RambleSoftwareEnvironmentError(
+                                    f'Package {rendered_pkg.name} defined '
+                                    'multiple times in inconsistent ways'
+                                )
+                            added = True
+                            template_def.add_rendered_package(rendered_pkg,
+                                                              self._rendered_packages)
+                            self._rendered_packages[rendered_pkg.name] = rendered_pkg
+
+                            if rendered_pkg.compiler:
+                                cur_compiler = rendered_pkg.compiler
+                    if not added:
+                        raise RambleSoftwareEnvironmentError(
+                            f'Compiler {pkg.compiler} used, but not '
+                            f'defined in environment {environment.name} '
+                            f'by package {pkg.name}'
+                        )
+
+    def compiler_specs_for_environment(self, environment: object):
+        """Iterator over compiler specs for a given environment
+
+        Assumes all compilers have been defined via
+        self.define_compiler_packages()
+
+        Args:
+            environment (SoftwareEnvironment): Environment to extract compiler specs for
+
+        Yields:
+            (str) Spec string for each compiler
+        """
+
+        root_compilers = []
+        for pkg in environment._packages:
+            if pkg.compiler:
+                if pkg.compiler not in self._rendered_packages:
+                    raise RambleSoftwareEnvironmentError(
+                        f'Compiler {pkg.compiler} used, but not '
+                        f'defined in environment {environment.name} '
+                        f'by package {pkg.name}'
+                    )
+
+                root_compilers.append(pkg.compiler)
+
+        dep_compilers = []
+        for comp in root_compilers:
+            comp_pkg = self._rendered_packages[comp]
+
+            if comp_pkg.compiler:
+                cur_compiler = comp_pkg.compiler
+
+                while cur_compiler and cur_compiler not in dep_compilers:
+                    dep_compilers.append(cur_compiler)
+                    if comp_pkg.compiler:
+                        cur_compiler = self._rendered_packages[comp_pkg.compiler].name
+
+        for comp in reversed(root_compilers + dep_compilers):
+            comp_pkg = self._rendered_packages[comp]
+            yield comp_pkg.spec_str(all_packages=self._rendered_packages,
+                                    compiler=False)
+
+    def package_specs_for_environment(self, environment: object):
+        """Iterator over package specs for a given environment
+
+        Assumes all compilers have been defined via
+        self.define_compiler_packages()
+
+        Args:
+            environment (SoftwareEnvironment): Environment to extract package specs for
+
+        Yields:
+            (str) Spec string for each package
+        """
+
+        for pkg in environment._packages:
+            yield pkg.spec_str(all_packages=self._rendered_packages, compiler=False)
+
+    def _check_environment(self, environment):
+        """Check an environment for common issues
+
+        Args:
+            environment (SoftwareEnvironment): Environment to check for issues in
+        """
+
+        pkg_names = set()
+
+        for pkg in environment._packages:
+            pkg_names.add(pkg.name)
+
+        used_compilers = set()
+        compiler_warnings = []
+        for pkg in environment._packages:
+            if pkg.compiler and pkg.compiler in pkg_names:
+                compiler_warnings.append((pkg.name, pkg.compiler))
+
+        logger.debug(f' Used compilers: {used_compilers}')
+        logger.debug(f' Compiler warnings: {compiler_warnings}')
+        if compiler_warnings:
+            logger.warn(
+                f'Environment {environment.name} contains packages and their '
+                'compilers in the package list. These include:'
+            )
+            for pkg_name, comp_name in compiler_warnings:
+                logger.warn(
+                    f'    Package: {pkg_name}, Compiler: {comp_name}'
+                )
+            logger.warn(
+                'This might cause problems when installing the packages.'
             )
 
-        return self._raw_environments[env]
+    def render_environment(self, env_name: str, expander: object):
+        """Render an environment needed by an experiment
 
-    def mapped_environments(self, raw_env):
-        """Yield each environment rendered from a raw environment"""
-        self._require_raw_environment(raw_env)
+        Args:
+            env_name (str): Name of environment needed by the experiment
+            expander (Expander): Expander object from the experiment
 
-        for env in self._environment_map[raw_env].keys():
-            yield env
+        Returns:
+            (SoftwareEnvironment): Reference to software environment for
+                                   the experiment
+        """
+
+        # Check for an external environment before checking templates
+        if env_name in self._rendered_environments:
+            if isinstance(self._rendered_environments[env_name], ExternalEnvironment):
+                return self._rendered_environments[env_name]
+
+        for template_name, template_def in self._environment_templates.items():
+            rendered_name = expander.expand_var(template_name)
+            if rendered_name == env_name:
+                rendered_env = template_def.render_environment(expander, self._rendered_packages)
+
+                if rendered_env.name == env_name:
+                    if env_name in self._rendered_environments:
+                        if rendered_env != self._rendered_environments[env_name]:
+                            raise RambleSoftwareEnvironmentError(
+                                f'Environment {env_name} defined multiple times '
+                                'in inconsistent ways'
+                            )
+                        rendered_env = self._rendered_environments[env_name]
+
+                    template_def.add_rendered_environment(rendered_env,
+                                                          self._rendered_environments,
+                                                          self._rendered_packages)
+                    self.define_compiler_packages(rendered_env, expander)
+                    self._check_environment(rendered_env)
+                    return rendered_env
+
+        raise RambleSoftwareEnvironmentError(
+            f'No defined environment matches required name {env_name}'
+        )
 
 
 class RambleSoftwareEnvironmentError(ramble.error.RambleError):

--- a/lib/ramble/ramble/software_environments.py
+++ b/lib/ramble/ramble/software_environments.py
@@ -27,7 +27,7 @@ class SoftwarePackage(object):
     """Class to represent a single software package"""
 
     def __init__(self, name: str, spec: str, compiler: str = None,
-                 compiler_spec: str = None, package_manager=None):
+                 compiler_spec: str = None, package_manager: str = 'spack'):
         """Software package constructor
 
         Args:
@@ -45,11 +45,7 @@ class SoftwarePackage(object):
         self.compiler = compiler
         self.compiler_spec = compiler_spec
         self._package_type = 'Rendered'
-
-        if package_manager and hasattr(package_managers, package_manager):
-            self.package_manager = getattr(package_managers, package_manager)
-        else:
-            self.package_manager = package_managers.spack
+        self.package_manager = package_managers[package_manager]
 
     def spec_str(self, all_packages: dict = {}, compiler=False):
         """Return a spec string for this software package
@@ -99,9 +95,7 @@ class SoftwarePackage(object):
             (str): String representation of this package
         """
 
-        indentation = ''
-        for _ in range(0, indent):
-            indentation += ' '
+        indentation = ' ' * indent
         color = rucolor.level_func(color_level)
         out_str  = color(f'{indentation}{self._package_type} package: {self.name}\n')
         out_str += f'{indentation}    Spec: {self.spec.replace("@", "@@")}\n'
@@ -139,7 +133,7 @@ class TemplatePackage(SoftwarePackage):
 
     def __init__(self, name: str, spec: str,
                  compiler: str = None, compiler_spec: str = None,
-                 package_manager=None):
+                 package_manager: str = 'spack'):
         """Template package constructor
 
         Args:
@@ -153,7 +147,7 @@ class TemplatePackage(SoftwarePackage):
         """
         super().__init__(name, spec, compiler=compiler,
                          compiler_spec=compiler_spec,
-                         package_manager=None)
+                         package_manager=package_manager)
         self._rendered_packages = {}
         self._package_type = 'Template'
 
@@ -243,9 +237,7 @@ class SoftwareEnvironment(object):
             (str): information of this environment
         """
 
-        indentation = ''
-        for _ in range(0, indent):
-            indentation += ' '
+        indentation = ' ' * indent
         color = rucolor.level_func(color_level)
         out_str  = color(f'{indentation}{self._environment_type} environment: {self.name}\n')
         out_str += f'{indentation}    Packages:\n'
@@ -283,11 +275,14 @@ class SoftwareEnvironment(object):
         """
         equal = self.name == other.name and len(self._packages) == len(other._packages)
 
-        if equal:
-            for self_pkg, other_pkg in zip(self._packages, other._packages):
-                equal = equal and self_pkg == other_pkg
+        if not equal:
+            return False
 
-        return equal
+        for self_pkg, other_pkg in zip(self._packages, other._packages):
+            if self_pkg != other_pkg:
+                return False
+
+        return True
 
 
 class ExternalEnvironment(SoftwareEnvironment):

--- a/lib/ramble/ramble/test/software_environment.py
+++ b/lib/ramble/ramble/test/software_environment.py
@@ -6,12 +6,12 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-import os
 import pytest
 
 import ramble.workspace
 import ramble.software_environments
 import ramble.renderer
+import ramble.expander
 from ramble.main import RambleCommand
 
 pytestmark = pytest.mark.usefixtures('mutable_config',
@@ -22,8 +22,8 @@ pytestmark = pytest.mark.usefixtures('mutable_config',
 workspace  = RambleCommand('workspace')
 
 
-def test_basic_software_environment(mutable_mock_workspace_path):
-    ws_name = 'test_basic_software_environment'
+def test_basic_software_environment(request, mutable_mock_workspace_path):
+    ws_name = request.node.name
     workspace('create', ws_name)
 
     assert ws_name in workspace('list')
@@ -43,14 +43,24 @@ def test_basic_software_environment(mutable_mock_workspace_path):
 
         software_environments = ramble.software_environments.SoftwareEnvironments(ws)
 
-        assert len(software_environments._packages.keys()) == 1
-        assert 'basic' in software_environments._packages.keys()
-        assert 'basic' in software_environments._environments.keys()
-        assert 'basic' in software_environments._environments['basic']['packages']
+        assert 'basic' in software_environments._environment_templates
+        assert 'basic' in software_environments._package_templates
+
+        variables = {}
+        env_expander = ramble.expander.Expander(variables, None)
+
+        rendered_env = software_environments.render_environment('basic', env_expander)
+        assert rendered_env.name == 'basic'
+        pkg_found = False
+        for pkg in rendered_env._packages:
+            if pkg.name == 'basic':
+                pkg_found = True
+        assert pkg_found
 
 
-def test_package_vector_expansion(mutable_mock_workspace_path):
-    ws_name = 'test_package_vector_expansion'
+def test_template_software_environments(request, mutable_mock_workspace_path):
+    ws_name = request.node.name
+
     workspace('create', ws_name)
 
     assert ws_name in workspace('list')
@@ -59,30 +69,38 @@ def test_package_vector_expansion(mutable_mock_workspace_path):
         spack_dict = ws.get_spack_dict()
 
         spack_dict['packages'] = {}
-        spack_dict['packages']['basic-{arch}'] = {
-            'spack_spec': 'basic@1.1 target={arch}',
-            'variables': {
-                'arch': ['x86_64', 'x86_64_v4']
-            }
+        spack_dict['packages']['basic-{pkg_test}'] = {
+            'spack_spec': 'basic@1.1'
         }
         spack_dict['environments'] = {
-            'basic': {
-                'packages': ['basic-x86_64', 'basic-x86_64_v4']
+            'basic-{env_test}': {
+                'packages': ['basic-{pkg_test}']
             }
         }
 
         software_environments = ramble.software_environments.SoftwareEnvironments(ws)
 
-        assert len(software_environments._packages.keys()) == 2
-        assert 'basic-x86_64' in software_environments._packages.keys()
-        assert 'basic-x86_64_v4' in software_environments._packages.keys()
-        assert 'basic' in software_environments._environments.keys()
-        assert 'basic-x86_64' in software_environments._environments['basic']['packages']
-        assert 'basic-x86_64_v4' in software_environments._environments['basic']['packages']
+        assert 'basic-{env_test}' in software_environments._environment_templates
+        assert 'basic-{pkg_test}' in software_environments._package_templates
+
+        variables = {
+            'env_test': 'environment',
+            'pkg_test': 'package',
+        }
+        env_expander = ramble.expander.Expander(variables, None)
+
+        rendered_env = software_environments.render_environment('basic-environment', env_expander)
+        assert rendered_env.name == 'basic-environment'
+        pkg_found = False
+        for pkg in rendered_env._packages:
+            if pkg.name == 'basic-package':
+                pkg_found = True
+        assert pkg_found
 
 
-def test_package_vector_length_mismatch_errors(mutable_mock_workspace_path, capsys):
-    ws_name = 'test_package_vector_expansion'
+def test_multi_template_software_environments(request, mutable_mock_workspace_path):
+    ws_name = request.node.name
+
     workspace('create', ws_name)
 
     assert ws_name in workspace('list')
@@ -91,585 +109,220 @@ def test_package_vector_length_mismatch_errors(mutable_mock_workspace_path, caps
         spack_dict = ws.get_spack_dict()
 
         spack_dict['packages'] = {}
-        spack_dict['packages']['basic-{arch}'] = {
-            'spack_spec': 'basic@{ver} target={arch}',
-            'variables': {
-                'arch': ['x86_64', 'x86_64_v4'],
-                'ver': ['1.1']
-            }
+        spack_dict['packages']['basic1-{pkg_test}'] = {
+            'spack_spec': 'basic@1.1'
+        }
+        spack_dict['packages']['basic2-{pkg_test}'] = {
+            'spack_spec': 'basic@1.1'
         }
         spack_dict['environments'] = {
-            'basic': {
-                'packages': ['basic-x86_64', 'basic-x86_64_v4']
-            }
-        }
-
-        with pytest.raises(SystemExit):
-            ramble.software_environments.SoftwareEnvironments(ws)
-
-            captured = capsys.readouterr()
-
-            assert 'Length mismatch in vector variables in package basic-{arch}' in captured
-            assert 'Variable arch has length 2' in captured
-            assert 'Variable ver has length 1' in captured
-
-
-def test_package_matrix_expansion(mutable_mock_workspace_path):
-    ws_name = 'test_package_matrix_expansion'
-    workspace('create', ws_name)
-
-    assert ws_name in workspace('list')
-
-    with ramble.workspace.read(ws_name) as ws:
-        spack_dict = ws.get_spack_dict()
-
-        spack_dict['packages'] = {}
-        spack_dict['packages']['basic-{ver}-{arch}'] = {
-            'spack_spec': 'basic@{ver} target={arch}',
-            'variables': {
-                'arch': ['x86_64', 'x86_64_v4'],
-                'ver': ['1.1', '2.0']
+            'all-basic-{env_test}': {
+                'packages': ['basic1-{pkg_test}', 'basic2-{pkg_test}']
             },
-            'matrix': ['arch', 'ver']
-        }
-        spack_dict['environments'] = {
-            'basic': {
-                'packages': [
-                    'basic-1.1-x86_64',
-                    'basic-2.0-x86_64',
-                    'basic-1.1-x86_64_v4',
-                    'basic-2.0-x86_64_v4',
-                ]
-            }
-        }
-
-        software_environments = ramble.software_environments.SoftwareEnvironments(ws)
-
-        assert len(software_environments._packages.keys()) == 4
-        assert 'basic-1.1-x86_64' in software_environments._packages.keys()
-        assert 'basic-2.0-x86_64' in software_environments._packages.keys()
-        assert 'basic-1.1-x86_64_v4' in software_environments._packages.keys()
-        assert 'basic-2.0-x86_64_v4' in software_environments._packages.keys()
-        assert 'basic' in software_environments._environments.keys()
-        assert 'basic-1.1-x86_64' in software_environments._environments['basic']['packages']
-        assert 'basic-2.0-x86_64' in software_environments._environments['basic']['packages']
-        assert 'basic-1.1-x86_64_v4' in software_environments._environments['basic']['packages']
-        assert 'basic-2.0-x86_64_v4' in software_environments._environments['basic']['packages']
-
-
-def test_package_matrices_expansion(mutable_mock_workspace_path):
-    ws_name = 'test_package_matrices_expansion'
-    workspace('create', ws_name)
-
-    assert ws_name in workspace('list')
-
-    with ramble.workspace.read(ws_name) as ws:
-        spack_dict = ws.get_spack_dict()
-
-        spack_dict['packages'] = {}
-        spack_dict['packages']['basic-{ver}-{arch}'] = {
-            'spack_spec': 'basic@{ver} target={arch}',
-            'variables': {
-                'arch': ['x86_64', 'x86_64_v4'],
-                'ver': ['1.1', '2.0']
+            'basic1-{env_test}': {
+                'packages': ['basic1-{pkg_test}']
             },
-            'matrices': [['arch'], ['ver']]
+            'basic2-{env_test}': {
+                'packages': ['basic2-{pkg_test}']
+            }
+        }
+
+        software_environments = ramble.software_environments.SoftwareEnvironments(ws)
+
+        assert 'all-basic-{env_test}' in software_environments._environment_templates
+        assert 'basic1-{env_test}' in software_environments._environment_templates
+        assert 'basic2-{env_test}' in software_environments._environment_templates
+        assert 'basic1-{pkg_test}' in software_environments._package_templates
+        assert 'basic2-{pkg_test}' in software_environments._package_templates
+
+        variables = {
+            'env_test': 'environment',
+            'pkg_test': 'package',
+        }
+        env_expander = ramble.expander.Expander(variables, None)
+
+        env_tests = {
+            'all-basic-environment': ['basic1-package', 'basic2-package'],
+            'basic1-environment': ['basic1-package'],
+            'basic2-environment': ['basic2-package']
+        }
+
+        for env_name, env_packages in env_tests.items():
+            rendered_env = software_environments.render_environment(env_name, env_expander)
+            assert rendered_env.name == env_name
+
+            assert len(rendered_env._packages) == len(env_packages)
+            for pkg_name in env_packages:
+                pkg_found = False
+                for pkg in rendered_env._packages:
+                    if pkg.name == pkg_name:
+                        pkg_found = True
+                assert pkg_found
+
+
+def test_undefined_package_errors(request, mutable_mock_workspace_path):
+    ws_name = request.node.name
+
+    workspace('create', ws_name)
+
+    assert ws_name in workspace('list')
+
+    with ramble.workspace.read(ws_name) as ws:
+        spack_dict = ws.get_spack_dict()
+
+        spack_dict['packages'] = {}
+        spack_dict['packages']['basic-{pkg_test}'] = {
+            'spack_spec': 'basic@{pkg_ver}'
+        }
+        spack_dict['environments'] = {
+            'all-basic-{env_test}': {
+                'packages': ['foo-basic-{pkg_test}']
+            }
+        }
+
+        with pytest.raises(ramble.software_environments.RambleSoftwareEnvironmentError) as pkg_err:
+            _ = ramble.software_environments.SoftwareEnvironments(ws)
+
+        err_str = \
+            'Environment all-basic-{env_test} references undefined package foo-basic-{pkg_test}'
+        assert err_str in str(pkg_err)
+
+
+def test_invalid_packages_error(request, mutable_mock_workspace_path):
+    ws_name = request.node.name
+
+    workspace('create', ws_name)
+
+    assert ws_name in workspace('list')
+
+    with ramble.workspace.read(ws_name) as ws:
+        spack_dict = ws.get_spack_dict()
+
+        spack_dict['packages'] = {}
+        spack_dict['packages']['basic-{pkg_test}'] = {
+            'spack_spec': 'basic@{pkg_ver}'
+        }
+        spack_dict['environments'] = {
+            'all-basic-{env_test}': {
+                'packages': ['basic-{pkg_test}']
+            }
+        }
+
+        software_environments = ramble.software_environments.SoftwareEnvironments(ws)
+
+        assert 'all-basic-{env_test}' in software_environments._environment_templates
+        assert 'basic-{pkg_test}' in software_environments._package_templates
+
+        variables = {
+            'env_test': 'environment',
+            'pkg_test': 'package',
+            'pkg_ver': '1.1',
+        }
+        env_expander = ramble.expander.Expander(variables, None)
+
+        _ = software_environments.render_environment('all-basic-environment', env_expander)
+
+        with pytest.raises(ramble.software_environments.RambleSoftwareEnvironmentError) as pkg_err:
+            variables = {
+                'env_test': 'environment',
+                'pkg_test': 'package',
+                'pkg_ver': '1.4',
+            }
+            env_expander = ramble.expander.Expander(variables, None)
+
+            _ = software_environments.render_environment('all-basic-environment',
+                                                         env_expander)
+        assert 'Package basic-package defined multiple times' in str(pkg_err)
+
+
+def test_invalid_environment_error(request, mutable_mock_workspace_path):
+    ws_name = request.node.name
+
+    workspace('create', ws_name)
+
+    assert ws_name in workspace('list')
+
+    with ramble.workspace.read(ws_name) as ws:
+        spack_dict = ws.get_spack_dict()
+
+        spack_dict['packages'] = {}
+        spack_dict['packages']['basic1-{pkg_test}'] = {
+            'spack_spec': 'basic@1.1'
+        }
+        spack_dict['packages']['basic2-{pkg_test}'] = {
+            'spack_spec': 'basic@1.1'
+        }
+        spack_dict['environments'] = {
+            'all-basic-{env_test}': {
+                'packages': ['basic1-{pkg_test}', 'basic2-{pkg_test}']
+            }
+        }
+
+        software_environments = ramble.software_environments.SoftwareEnvironments(ws)
+
+        assert 'all-basic-{env_test}' in software_environments._environment_templates
+        assert 'basic1-{pkg_test}' in software_environments._package_templates
+        assert 'basic2-{pkg_test}' in software_environments._package_templates
+
+        variables = {
+            'env_test': 'environment',
+            'pkg_test': 'package',
+        }
+        env_expander = ramble.expander.Expander(variables, None)
+
+        _ = software_environments.render_environment('all-basic-environment', env_expander)
+
+        variables = {
+            'env_test': 'environment',
+            'pkg_test': 'other-package'
+        }
+
+        env_expander = ramble.expander.Expander(variables, None)
+
+        with pytest.raises(ramble.software_environments.RambleSoftwareEnvironmentError) as env_err:
+            _ = software_environments.render_environment('all-basic-environment', env_expander)
+
+        assert 'Environment all-basic-environment defined multiple times' in str(env_err)
+
+
+def test_undefined_compiler_errors(request, mutable_mock_workspace_path):
+    ws_name = request.node.name
+
+    workspace('create', ws_name)
+
+    assert ws_name in workspace('list')
+
+    with ramble.workspace.read(ws_name) as ws:
+        spack_dict = ws.get_spack_dict()
+
+        spack_dict['packages'] = {}
+        spack_dict['packages']['basic'] = {
+            'spack_spec': 'basic@1.1',
+            'compiler': 'foo_comp'
         }
         spack_dict['environments'] = {
             'basic': {
-                'packages': [
-                    'basic-1.1-x86_64',
-                    'basic-2.0-x86_64_v4',
-                ]
+                'packages': ['basic']
             }
         }
 
         software_environments = ramble.software_environments.SoftwareEnvironments(ws)
 
-        assert len(software_environments._packages.keys()) == 2
-        assert 'basic-1.1-x86_64' in software_environments._packages.keys()
-        assert 'basic-2.0-x86_64_v4' in software_environments._packages.keys()
-        assert 'basic' in software_environments._environments.keys()
-        assert 'basic-1.1-x86_64' in software_environments._environments['basic']['packages']
-        assert 'basic-2.0-x86_64_v4' in software_environments._environments['basic']['packages']
+        assert 'basic' in software_environments._environment_templates
+        assert 'basic' in software_environments._package_templates
 
+        variables = {}
+        env_expander = ramble.expander.Expander(variables, None)
 
-def test_package_matrix_vector_expansion(mutable_mock_workspace_path):
-    ws_name = 'test_package_matrix_vector_expansion'
-    workspace('create', ws_name)
+        with pytest.raises(ramble.software_environments.RambleSoftwareEnvironmentError) \
+                as comp_err:
+            _ = software_environments.render_environment('basic', env_expander)
+        assert 'Compiler foo_comp used, but not defined' in str(comp_err)
 
-    assert ws_name in workspace('list')
 
-    with ramble.workspace.read(ws_name) as ws:
-        spack_dict = ws.get_spack_dict()
+def test_compiler_in_environment_warns(request, mutable_mock_workspace_path, capsys):
+    ws_name = request.node.name
 
-        spack_dict['packages'] = {}
-        spack_dict['packages']['basic-{ver}-{arch}'] = {
-            'spack_spec': 'basic@{ver} target={arch}',
-            'variables': {
-                'arch': ['x86_64', 'x86_64_v4'],
-                'ver': ['1.1', '2.0']
-            },
-            'matrices': [['arch']]
-        }
-        spack_dict['environments'] = {
-            'basic': {
-                'packages': [
-                    'basic-1.1-x86_64',
-                    'basic-2.0-x86_64',
-                    'basic-1.1-x86_64_v4',
-                    'basic-2.0-x86_64_v4',
-                ]
-            }
-        }
-
-        software_environments = ramble.software_environments.SoftwareEnvironments(ws)
-
-        assert len(software_environments._packages.keys()) == 4
-        assert 'basic-1.1-x86_64' in software_environments._packages.keys()
-        assert 'basic-2.0-x86_64' in software_environments._packages.keys()
-        assert 'basic-1.1-x86_64_v4' in software_environments._packages.keys()
-        assert 'basic-2.0-x86_64_v4' in software_environments._packages.keys()
-        assert 'basic' in software_environments._environments.keys()
-        assert 'basic-1.1-x86_64' in software_environments._environments['basic']['packages']
-        assert 'basic-2.0-x86_64' in software_environments._environments['basic']['packages']
-        assert 'basic-1.1-x86_64_v4' in software_environments._environments['basic']['packages']
-        assert 'basic-2.0-x86_64_v4' in software_environments._environments['basic']['packages']
-
-
-def test_environment_vector_expansion(mutable_mock_workspace_path):
-    ws_name = 'test_environment_vector_expansion'
-    workspace('create', ws_name)
-
-    assert ws_name in workspace('list')
-
-    with ramble.workspace.read(ws_name) as ws:
-        spack_dict = ws.get_spack_dict()
-
-        spack_dict['packages'] = {}
-        spack_dict['packages']['basic-{arch}'] = {
-            'spack_spec': 'basic@1.1 target={arch}',
-            'variables': {
-                'arch': ['x86_64', 'x86_64_v4']
-            }
-        }
-        spack_dict['environments'] = {
-            'basic-{arch}': {
-                'packages': ['basic-{arch}'],
-                'variables': {
-                    'arch': ['x86_64', 'x86_64_v4']
-                }
-            }
-        }
-
-        software_environments = ramble.software_environments.SoftwareEnvironments(ws)
-
-        assert len(software_environments._packages.keys()) == 2
-        assert len(software_environments._environments.keys()) == 2
-        assert 'basic-x86_64' in software_environments._packages.keys()
-        assert 'basic-x86_64_v4' in software_environments._packages.keys()
-        assert 'basic-x86_64' in software_environments._environments.keys()
-        assert 'basic-x86_64_v4' in software_environments._environments.keys()
-        assert len(software_environments._environments['basic-x86_64']['packages']) == 1
-        assert 'basic-x86_64' in software_environments._environments['basic-x86_64']['packages']
-        assert len(software_environments._environments['basic-x86_64_v4']['packages']) == 1
-        assert 'basic-x86_64_v4' in \
-            software_environments._environments['basic-x86_64_v4']['packages']
-
-
-def test_environment_vector_length_mismatch_errors(mutable_mock_workspace_path, capsys):
-    ws_name = 'test_environment_vector_expansion'
-    workspace('create', ws_name)
-
-    assert ws_name in workspace('list')
-
-    with ramble.workspace.read(ws_name) as ws:
-        spack_dict = ws.get_spack_dict()
-
-        spack_dict['packages'] = {}
-        spack_dict['packages']['basic-{arch}'] = {
-            'spack_spec': 'basic@1.1 target={arch}',
-            'variables': {
-                'arch': ['x86_64', 'x86_64_v4']
-            }
-        }
-        spack_dict['environments'] = {
-            'basic-{ver}-{arch}': {
-                'packages': ['basic-{arch}'],
-                'variables': {
-                    'arch': ['x86_64', 'x86_64_v4'],
-                    'ver': ['1.1']
-                }
-            }
-        }
-
-        with pytest.raises(SystemExit):
-            ramble.software_environments.SoftwareEnvironments(ws)
-
-            captured = capsys.readouterr()
-
-            assert 'Length mismatch in vector variables in environment basic-{ver}-{arch}' \
-                in captured
-            assert 'Variable arch has length 2' in captured
-            assert 'Variable ver has length 1' in captured
-
-
-def test_environment_matrix_expansion(mutable_mock_workspace_path):
-    ws_name = 'test_environment_matrix_expansion'
-    workspace('create', ws_name)
-
-    assert ws_name in workspace('list')
-
-    with ramble.workspace.read(ws_name) as ws:
-        spack_dict = ws.get_spack_dict()
-
-        spack_dict['packages'] = {}
-        spack_dict['packages']['basic-{ver}-{arch}'] = {
-            'spack_spec': 'basic@{ver} target={arch}',
-            'variables': {
-                'arch': ['x86_64', 'x86_64_v4'],
-                'ver': ['1.1', '2.0']
-            },
-            'matrix': ['arch', 'ver']
-        }
-        spack_dict['environments'] = {
-            'basic-{ver}-{arch}': {
-                'packages': [
-                    'basic-{ver}-{arch}'
-                ],
-                'variables': {
-                    'arch': ['x86_64', 'x86_64_v4'],
-                    'ver': ['1.1', '2.0']
-                },
-                'matrix': ['arch', 'ver']
-            }
-        }
-
-        software_environments = ramble.software_environments.SoftwareEnvironments(ws)
-
-        assert len(software_environments._packages.keys()) == 4
-        assert len(software_environments._environments.keys()) == 4
-        assert 'basic-1.1-x86_64' in software_environments._packages.keys()
-        assert 'basic-2.0-x86_64' in software_environments._packages.keys()
-        assert 'basic-1.1-x86_64_v4' in software_environments._packages.keys()
-        assert 'basic-2.0-x86_64_v4' in software_environments._packages.keys()
-        assert 'basic-1.1-x86_64' in software_environments._environments.keys()
-        assert 'basic-2.0-x86_64' in software_environments._environments.keys()
-        assert 'basic-1.1-x86_64_v4' in software_environments._environments.keys()
-        assert 'basic-2.0-x86_64_v4' in software_environments._environments.keys()
-        assert 'basic-1.1-x86_64' in \
-            software_environments._environments['basic-1.1-x86_64']['packages']
-        assert 'basic-2.0-x86_64' in \
-            software_environments._environments['basic-2.0-x86_64']['packages']
-        assert 'basic-1.1-x86_64_v4' in \
-            software_environments._environments['basic-1.1-x86_64_v4']['packages']
-        assert 'basic-2.0-x86_64_v4' in \
-            software_environments._environments['basic-2.0-x86_64_v4']['packages']
-
-
-def test_environment_matrices_expansion(mutable_mock_workspace_path):
-    ws_name = 'test_environment_matrices_expansion'
-    workspace('create', ws_name)
-
-    assert ws_name in workspace('list')
-
-    with ramble.workspace.read(ws_name) as ws:
-        spack_dict = ws.get_spack_dict()
-
-        spack_dict['packages'] = {}
-        spack_dict['packages']['basic-{ver}-{arch}'] = {
-            'spack_spec': 'basic@{ver} target={arch}',
-            'variables': {
-                'arch': ['x86_64', 'x86_64_v4'],
-                'ver': ['1.1', '2.0']
-            },
-            'matrix': ['arch', 'ver']
-        }
-        spack_dict['environments'] = {
-            'basic-{ver}-{arch}': {
-                'packages': [
-                    'basic-{ver}-{arch}'
-                ],
-                'variables': {
-                    'arch': ['x86_64', 'x86_64_v4'],
-                    'ver': ['1.1', '2.0']
-                },
-                'matrices': [['arch'], ['ver']]
-            }
-        }
-
-        software_environments = ramble.software_environments.SoftwareEnvironments(ws)
-
-        assert len(software_environments._packages.keys()) == 4
-        assert len(software_environments._environments.keys()) == 2
-        assert 'basic-1.1-x86_64' in software_environments._packages.keys()
-        assert 'basic-2.0-x86_64' in software_environments._packages.keys()
-        assert 'basic-1.1-x86_64_v4' in software_environments._packages.keys()
-        assert 'basic-2.0-x86_64_v4' in software_environments._packages.keys()
-        assert 'basic-1.1-x86_64' in software_environments._environments.keys()
-        assert 'basic-2.0-x86_64_v4' in software_environments._environments.keys()
-        assert 'basic-1.1-x86_64' in \
-            software_environments._environments['basic-1.1-x86_64']['packages']
-        assert 'basic-2.0-x86_64_v4' in \
-            software_environments._environments['basic-2.0-x86_64_v4']['packages']
-
-
-def test_environment_vector_matrix_expansion(mutable_mock_workspace_path):
-    ws_name = 'test_environment_vector_matrix_expansion'
-    workspace('create', ws_name)
-
-    assert ws_name in workspace('list')
-
-    with ramble.workspace.read(ws_name) as ws:
-        spack_dict = ws.get_spack_dict()
-
-        spack_dict['packages'] = {}
-        spack_dict['packages']['basic-{ver}-{arch}'] = {
-            'spack_spec': 'basic@{ver} target={arch}',
-            'variables': {
-                'arch': ['x86_64', 'x86_64_v4'],
-                'ver': ['1.1', '2.0']
-            },
-            'matrices': [['ver']]
-        }
-        spack_dict['environments'] = {
-            'basic-{ver}-{arch}': {
-                'packages': [
-                    'basic-{ver}-{arch}'
-                ],
-                'variables': {
-                    'arch': ['x86_64', 'x86_64_v4'],
-                    'ver': ['1.1', '2.0']
-                },
-                'matrices': [['ver']]
-            }
-        }
-
-        software_environments = ramble.software_environments.SoftwareEnvironments(ws)
-
-        assert len(software_environments._packages.keys()) == 4
-        assert len(software_environments._environments.keys()) == 4
-        assert 'basic-1.1-x86_64' in software_environments._packages.keys()
-        assert 'basic-2.0-x86_64' in software_environments._packages.keys()
-        assert 'basic-1.1-x86_64_v4' in software_environments._packages.keys()
-        assert 'basic-2.0-x86_64_v4' in software_environments._packages.keys()
-        assert 'basic-1.1-x86_64' in software_environments._environments.keys()
-        assert 'basic-2.0-x86_64' in software_environments._environments.keys()
-        assert 'basic-1.1-x86_64_v4' in software_environments._environments.keys()
-        assert 'basic-2.0-x86_64_v4' in software_environments._environments.keys()
-        assert 'basic-1.1-x86_64' in \
-            software_environments._environments['basic-1.1-x86_64']['packages']
-        assert 'basic-2.0-x86_64' in \
-            software_environments._environments['basic-2.0-x86_64']['packages']
-        assert 'basic-1.1-x86_64_v4' in \
-            software_environments._environments['basic-1.1-x86_64_v4']['packages']
-        assert 'basic-2.0-x86_64_v4' in \
-            software_environments._environments['basic-2.0-x86_64_v4']['packages']
-
-
-def test_package_vector_expansion_spack_level(mutable_mock_workspace_path):
-    ws_name = 'test_package_vector_expansion_spack_level'
-    workspace('create', ws_name)
-
-    assert ws_name in workspace('list')
-
-    with ramble.workspace.read(ws_name) as ws:
-        spack_dict = ws.get_spack_dict()
-
-        spack_dict['variables'] = {}
-        spack_dict['variables']['arch'] = ['x86_64', 'x86_64_v4']
-        spack_dict['packages'] = {}
-        spack_dict['packages']['basic-{arch}'] = {
-            'spack_spec': 'basic@1.1 target={arch}'
-        }
-        spack_dict['environments'] = {
-            'basic': {
-                'packages': ['basic-x86_64', 'basic-x86_64_v4']
-            }
-        }
-
-        software_environments = ramble.software_environments.SoftwareEnvironments(ws)
-
-        assert len(software_environments._packages.keys()) == 2
-        assert 'basic-x86_64' in software_environments._packages.keys()
-        assert 'basic-x86_64_v4' in software_environments._packages.keys()
-        assert 'basic' in software_environments._environments.keys()
-        assert 'basic-x86_64' in software_environments._environments['basic']['packages']
-        assert 'basic-x86_64_v4' in software_environments._environments['basic']['packages']
-
-
-def test_package_vector_expansion_workspace_level(mutable_mock_workspace_path):
-    ws_name = 'test_package_vector_expansion_spack_level'
-    workspace('create', ws_name)
-
-    test_config = """
-ramble:
-  variables:
-    arch: ['x86_64', 'x86_64_v4']
-  applications: {}
-  spack: {}
-"""
-
-    assert ws_name in workspace('list')
-
-    with ramble.workspace.read(ws_name) as ws:
-        with open(os.path.join(ws.config_dir, 'ramble.yaml'), 'w+') as f:
-            f.write(test_config)
-
-        ws._re_read()
-        spack_dict = ws.get_spack_dict()
-
-        spack_dict['packages'] = {}
-        spack_dict['packages']['basic-{arch}'] = {
-            'spack_spec': 'basic@1.1 target={arch}'
-        }
-        spack_dict['environments'] = {
-            'basic': {
-                'packages': ['basic-x86_64', 'basic-x86_64_v4']
-            }
-        }
-
-        software_environments = ramble.software_environments.SoftwareEnvironments(ws)
-
-        assert len(software_environments._packages.keys()) == 2
-        assert 'basic-x86_64' in software_environments._packages.keys()
-        assert 'basic-x86_64_v4' in software_environments._packages.keys()
-        assert 'basic' in software_environments._environments.keys()
-        assert 'basic-x86_64' in software_environments._environments['basic']['packages']
-        assert 'basic-x86_64_v4' in software_environments._environments['basic']['packages']
-
-
-def test_package_vector_expansion_multi_level(mutable_mock_workspace_path):
-    ws_name = 'test_package_vector_expansion_multi_level'
-    workspace('create', ws_name)
-
-    test_config = """
-ramble:
-  variables:
-    arch: ['x86_64', 'x86_64_v4']
-  applications: {}
-  spack: {}
-"""
-
-    assert ws_name in workspace('list')
-
-    with ramble.workspace.read(ws_name) as ws:
-        with open(os.path.join(ws.config_dir, 'ramble.yaml'), 'w+') as f:
-            f.write(test_config)
-
-        ws._re_read()
-        spack_dict = ws.get_spack_dict()
-
-        spack_dict['variables'] = {}
-        spack_dict['variables']['test'] = ['test1', 'test2']
-        spack_dict['packages'] = {}
-        spack_dict['packages']['basic-{arch}-{test}-{pkg_level}'] = {
-            'spack_spec': 'basic@1.1 target={arch}',
-            'variables': {
-                'pkg_level': ['ll1', 'll2'],
-            }
-        }
-        spack_dict['environments'] = {
-            'basic': {
-                'packages': ['basic-x86_64-test1-ll1', 'basic-x86_64_v4-test2-ll2']
-            }
-        }
-
-        software_environments = ramble.software_environments.SoftwareEnvironments(ws)
-
-        assert len(software_environments._packages.keys()) == 2
-        assert 'basic-x86_64-test1-ll1' in software_environments._packages.keys()
-        assert 'basic-x86_64_v4-test2-ll2' in software_environments._packages.keys()
-        assert 'basic' in software_environments._environments.keys()
-        assert 'basic-x86_64-test1-ll1' in software_environments._environments['basic']['packages']
-        assert 'basic-x86_64_v4-test2-ll2' in \
-            software_environments._environments['basic']['packages']
-
-
-def test_environment_vector_expansion_spack_level(mutable_mock_workspace_path):
-    ws_name = 'test_environment_vector_expansion_spack_level'
-    workspace('create', ws_name)
-
-    assert ws_name in workspace('list')
-
-    with ramble.workspace.read(ws_name) as ws:
-        spack_dict = ws.get_spack_dict()
-
-        spack_dict['variables'] = {}
-        spack_dict['variables']['arch'] = ['x86_64', 'x86_64_v4']
-        spack_dict['packages'] = {}
-        spack_dict['packages']['basic-{arch}'] = {
-            'spack_spec': 'basic@1.1 target={arch}',
-        }
-        spack_dict['environments'] = {
-            'basic-{arch}': {
-                'packages': ['basic-{arch}'],
-            }
-        }
-
-        software_environments = ramble.software_environments.SoftwareEnvironments(ws)
-
-        assert len(software_environments._packages.keys()) == 2
-        assert len(software_environments._environments.keys()) == 2
-        assert 'basic-x86_64' in software_environments._packages.keys()
-        assert 'basic-x86_64_v4' in software_environments._packages.keys()
-        assert 'basic-x86_64' in software_environments._environments.keys()
-        assert 'basic-x86_64_v4' in software_environments._environments.keys()
-        assert len(software_environments._environments['basic-x86_64']['packages']) == 1
-        assert 'basic-x86_64' in software_environments._environments['basic-x86_64']['packages']
-        assert len(software_environments._environments['basic-x86_64_v4']['packages']) == 1
-        assert 'basic-x86_64_v4' in \
-            software_environments._environments['basic-x86_64_v4']['packages']
-
-
-def test_environment_vector_expansion_workspace_level(mutable_mock_workspace_path):
-    ws_name = 'test_environment_vector_expansion_workspace_level'
-    workspace('create', ws_name)
-
-    test_config = """
-ramble:
-  variables:
-    arch: ['x86_64', 'x86_64_v4']
-  applications: {}
-  spack: {}
-"""
-
-    assert ws_name in workspace('list')
-
-    with ramble.workspace.read(ws_name) as ws:
-        with open(os.path.join(ws.config_dir, 'ramble.yaml'), 'w+') as f:
-            f.write(test_config)
-
-        ws._re_read()
-        spack_dict = ws.get_spack_dict()
-
-        spack_dict['packages'] = {}
-        spack_dict['packages']['basic-{arch}'] = {
-            'spack_spec': 'basic@1.1 target={arch}',
-        }
-        spack_dict['environments'] = {
-            'basic-{arch}': {
-                'packages': ['basic-{arch}'],
-            }
-        }
-
-        software_environments = ramble.software_environments.SoftwareEnvironments(ws)
-
-        assert len(software_environments._packages.keys()) == 2
-        assert len(software_environments._environments.keys()) == 2
-        assert 'basic-x86_64' in software_environments._packages.keys()
-        assert 'basic-x86_64_v4' in software_environments._packages.keys()
-        assert 'basic-x86_64' in software_environments._environments.keys()
-        assert 'basic-x86_64_v4' in software_environments._environments.keys()
-        assert len(software_environments._environments['basic-x86_64']['packages']) == 1
-        assert 'basic-x86_64' in software_environments._environments['basic-x86_64']['packages']
-        assert len(software_environments._environments['basic-x86_64_v4']['packages']) == 1
-        assert 'basic-x86_64_v4' in \
-            software_environments._environments['basic-x86_64_v4']['packages']
-
-
-def test_environment_warns_with_pkg_compiler(mutable_mock_workspace_path, capsys):
-    ws_name = 'test_environment_warns_with_pkg_compiler'
     workspace('create', ws_name)
 
     assert ws_name in workspace('list')
@@ -679,7 +332,7 @@ def test_environment_warns_with_pkg_compiler(mutable_mock_workspace_path, capsys
 
         spack_dict['packages'] = {}
         spack_dict['packages']['test_comp'] = {
-            'spack_spec': 'test_comp@1.1'
+            'spack_spec': 'comp@2.1'
         }
         spack_dict['packages']['basic'] = {
             'spack_spec': 'basic@1.1',
@@ -687,174 +340,20 @@ def test_environment_warns_with_pkg_compiler(mutable_mock_workspace_path, capsys
         }
         spack_dict['environments'] = {
             'basic': {
-                'packages': [
-                    'basic',
-                    'test_comp'
-                ],
+                'packages': ['basic', 'test_comp']
             }
         }
 
-        ramble.software_environments.SoftwareEnvironments(ws)
+        software_environments = ramble.software_environments.SoftwareEnvironments(ws)
+
+        assert 'basic' in software_environments._environment_templates
+        assert 'basic' in software_environments._package_templates
+
+        variables = {}
+        env_expander = ramble.expander.Expander(variables, None)
+
+        _ = software_environments.render_environment('basic', env_expander)
         captured = capsys.readouterr()
 
-        assert 'Environment basic contains packages and their compilers ' + \
-               'in the package list. These include:' in captured.err
-
+        assert 'Environment basic contains packages and their compilers' in captured.err
         assert 'Package: basic, Compiler: test_comp' in captured.err
-
-
-def test_package_vector_expansion_exclusions(mutable_mock_workspace_path):
-    ws_name = 'test_package_vector_expansion_exclusions'
-    workspace('create', ws_name)
-
-    assert ws_name in workspace('list')
-
-    with ramble.workspace.read(ws_name) as ws:
-        spack_dict = ws.get_spack_dict()
-
-        spack_dict['packages'] = {}
-        spack_dict['packages']['basic-{arch}'] = {
-            'spack_spec': 'basic@1.1 target={arch}',
-            'variables': {
-                'arch': ['x86_64', 'x86_64_v4']
-            },
-            'exclude': {
-                'variables': {
-                    'arch': 'x86_64_v4'
-                }
-            }
-        }
-        spack_dict['environments'] = {
-            'basic': {
-                'packages': ['basic-x86_64']
-            }
-        }
-
-        software_environments = ramble.software_environments.SoftwareEnvironments(ws)
-
-        assert len(software_environments._packages.keys()) == 1
-        assert 'basic-x86_64' in software_environments._packages.keys()
-        assert 'basic' in software_environments._environments.keys()
-        assert 'basic-x86_64' in software_environments._environments['basic']['packages']
-        assert 'basic-x86_64_v4' not in software_environments._packages.keys()
-        assert 'basic-x86_64_v4' not in software_environments._environments['basic']['packages']
-
-
-def test_package_matrix_expansion_exclusions(mutable_mock_workspace_path):
-    ws_name = 'test_package_matrix_expansion_exclusions'
-    workspace('create', ws_name)
-
-    assert ws_name in workspace('list')
-
-    with ramble.workspace.read(ws_name) as ws:
-        spack_dict = ws.get_spack_dict()
-
-        spack_dict['packages'] = {}
-        spack_dict['packages']['basic-{ver}-{arch}'] = {
-            'spack_spec': 'basic@{ver} target={arch}',
-            'variables': {
-                'arch': ['x86_64', 'x86_64_v4'],
-                'ver': ['1.1', '2.0']
-            },
-            'matrix': ['arch', 'ver'],
-            'exclude': {
-                'variables': {
-                    'arch': ['x86_64_v4'],
-                    'ver': ['2.0'],
-                },
-                'matrix': ['arch', 'ver'],
-            }
-        }
-        spack_dict['environments'] = {
-            'basic': {
-                'packages': [
-                    'basic-1.1-x86_64',
-                    'basic-2.0-x86_64',
-                    'basic-1.1-x86_64_v4',
-                ]
-            }
-        }
-
-        software_environments = ramble.software_environments.SoftwareEnvironments(ws)
-
-        assert len(software_environments._packages.keys()) == 3
-        assert 'basic-1.1-x86_64' in software_environments._packages.keys()
-        assert 'basic-2.0-x86_64' in software_environments._packages.keys()
-        assert 'basic-1.1-x86_64_v4' in software_environments._packages.keys()
-        assert 'basic-2.0-x86_64_v4' not in software_environments._packages.keys()
-        assert 'basic' in software_environments._environments.keys()
-        assert 'basic-1.1-x86_64' in software_environments._environments['basic']['packages']
-        assert 'basic-2.0-x86_64' in software_environments._environments['basic']['packages']
-        assert 'basic-1.1-x86_64_v4' in software_environments._environments['basic']['packages']
-        assert 'basic-2.0-x86_64_v4' not in \
-            software_environments._environments['basic']['packages']
-
-
-def test_environment_vector_expansion_exclusion(mutable_mock_workspace_path):
-    ws_name = 'test_package_vector_expansion_exclusions'
-    workspace('create', ws_name)
-
-    assert ws_name in workspace('list')
-
-    with ramble.workspace.read(ws_name) as ws:
-        spack_dict = ws.get_spack_dict()
-
-        spack_dict['packages'] = {}
-        spack_dict['packages']['basic-{arch}'] = {
-            'spack_spec': 'basic@1.1 target={arch}',
-            'variables': {
-                'arch': ['x86_64', 'x86_64_v4']
-            },
-        }
-        spack_dict['environments'] = {
-            'basic-{arch}': {
-                'packages': ['basic-{arch}'],
-                'variables': {
-                    'arch': ['x86_64', 'x86_64_v4']
-                },
-                'exclude': {
-                    'variables': {
-                        'arch': 'x86_64_v4'
-                    }
-                }
-            }
-        }
-
-        software_environments = ramble.software_environments.SoftwareEnvironments(ws)
-
-        assert len(software_environments._packages.keys()) == 2
-        assert len(software_environments._environments.keys()) == 1
-        assert 'basic-x86_64' in software_environments._packages.keys()
-        assert 'basic-x86_64_v4' in software_environments._packages.keys()
-        assert 'basic-x86_64' in software_environments._environments.keys()
-        assert 'basic-x86_64_v4' not in software_environments._environments.keys()
-        assert 'basic-x86_64' in software_environments._environments['basic-x86_64']['packages']
-
-
-def test_environment_with_missing_package_errors(mutable_mock_workspace_path, capsys):
-    ws_name = 'test_environment_with_missing_package_errors'
-    workspace('create', ws_name)
-
-    assert ws_name in workspace('list')
-
-    with ramble.workspace.read(ws_name) as ws:
-        spack_dict = ws.get_spack_dict()
-
-        spack_dict['packages'] = {}
-        spack_dict['packages']['basic'] = {
-            'spack_spec': 'basic@1.1',
-        }
-        spack_dict['environments'] = {
-            'basic': {
-                'packages': ['basic', 'undefined_package']
-            }
-        }
-
-        with pytest.raises(SystemExit):
-            ramble.software_environments.SoftwareEnvironments(ws)
-            output = capsys.readouterr()
-
-            assert 'Error: Environment basic refers to the following packages' in output
-            assert 'undefined_package' in output
-            assert 'Please make sure all packages are defined before using this environment' \
-                in output

--- a/lib/ramble/ramble/util/colors.py
+++ b/lib/ramble/ramble/util/colors.py
@@ -15,6 +15,19 @@ level4_color = '@*m'
 plain_format = '@.'
 
 
+def level_func(level):
+    if level <= 0:
+        return section_title
+    elif level == 1:
+        return nested_1
+    elif level == 2:
+        return nested_2
+    elif level == 3:
+        return nested_3
+    elif level >= 4:
+        return nested_4
+
+
 def config_title(s):
     return config_color + s + plain_format
 


### PR DESCRIPTION
This merge converts the logic around generating software environments and packages away from being explicitly defined in the workspace configuration file.

Instead, packages and environments are now generated lazily when processing experiments. This avoids several issues related to vector / matrix logic causing problems rendering individual packages and environments.