### PR TITLE
Add a deployment command and publish pipeline

### DIFF
--- a/lib/ramble/docs/workspace.rst
+++ b/lib/ramble/docs/workspace.rst
@@ -184,6 +184,70 @@ application definition files, one can use:
 
     $ ramble workspace concretize
 
+---------------------
+Workspace Deployments
+---------------------
+
+A deployment is one mechanism of transferring a configured workspace from one
+location to another. Ramble provides commands to handle creating (and pushing)
+a deployment from a local workspace to a remote location, or pulling a
+deployment from a remote location into a local workspace. 
+
+A deployment is a directory that contains the necessary artifacts required to
+recreate the experiments in the workspace on a separate machine. Deployments
+copy the workspace configuration file, along with creating an object
+repository, containing the application, modifier, and any package manager files
+needed for the experiments (that might not be upstreamed).  This section
+describes the commands that can be used to use deployments.
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Preparing a Workspace Deployment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Once a workspace is configured, it can be used to create a deployment.  To prepare a
+deployment, one can use:
+
+.. code-block:: console
+
+  $ ramble deployment push
+
+This will populate a directory named ``deployments``, where the default is the
+name of the workspace.
+
+The name of the created deployment can be controlled using:
+
+.. code-block:: console
+
+  $ ramble deployment push -d <deployment_name>
+
+Additionally, Ramble can create a tar of the deployment using:
+
+.. code-block:: console
+
+  $ ramble deployment push -t
+
+And upload the deployment to a remote URL using:
+
+.. code-block:: console
+
+  $ ramble deployment push -u <remote_url>
+
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Pulling a Workspace Deployment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To apply a deployment to an existing workspace, the ``pull`` sub-command can be used. For example:
+
+.. code-block:: console
+
+  ramble workspace pull -p file://path/to/deployment
+
+Will overwrite the contents of the currently active workspace with the contents
+from the deployment contained in ``file://path/to/deployment``.
+
+It is important to note that this command is destructive, and there is no way
+to revert a workspace back to its state prior to the pull action.
 
 .. _workspace-setup:
 

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -65,7 +65,8 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
     _builtin_required_key = 'required'
     _inventory_file_name = 'ramble_inventory.json'
     _status_file_name = 'ramble_status.json'
-    _pipelines = ['analyze', 'archive', 'mirror', 'setup', 'pushtocache', 'execute']
+    _pipelines = ['analyze', 'archive', 'mirror', 'setup',
+                  'pushdeployment', 'pushtocache', 'execute']
     _language_classes = [ApplicationMeta, SharedMeta]
 
     #: Lists of strings which contains GitHub usernames of attributes.
@@ -1822,6 +1823,22 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         if os.path.exists(exp_dir):
             with open(status_path, 'w+') as f:
                 spack.util.spack_json.dump(status_data, f)
+
+    register_phase('deploy_artifacts', pipeline='pushdeployment')
+
+    def _deploy_artifacts(self, workspace):
+        repo_path = os.path.join(workspace.named_deployment, 'object_repo')
+
+        app_dir_name = os.path.basename(os.path.dirname(self._file_path))
+        app_dir = os.path.join(repo_path, 'applications', app_dir_name)
+        fs.mkdirp(app_dir)
+        shutil.copyfile(self._file_path, os.path.join(app_dir, 'application.py'))
+
+        for mod_inst in self._modifier_instances:
+            mod_dir_name = os.path.basename(os.path.dirname(mod_inst._file_path))
+            mod_dir = os.path.join(repo_path, 'modifiers', mod_dir_name)
+            fs.mkdirp(mod_dir)
+            shutil.copyfile(mod_inst._file_path, os.path.join(mod_dir, 'modifier.py'))
 
     register_builtin('env_vars', required=True)
 

--- a/lib/ramble/ramble/cmd/deployment.py
+++ b/lib/ramble/ramble/cmd/deployment.py
@@ -1,0 +1,180 @@
+# Copyright 2022-2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+import sys
+import urllib.parse
+
+import llnl.util.filesystem as fs
+
+import spack.util.spack_json as sjson
+
+import ramble.cmd
+import ramble.cmd.common.arguments
+import ramble.cmd.common.arguments as arguments
+
+import ramble.fetch_strategy
+import ramble.config
+import ramble.stage
+import ramble.workspace
+import ramble.workspace.shell
+import ramble.pipeline
+import ramble.filters
+
+if sys.version_info >= (3, 3):
+    from collections.abc import Sequence  # novm noqa: F401
+else:
+    from collections import Sequence  # noqa: F401
+
+
+description = '(experimental) manage workspace deployments'
+section = 'workspaces'
+level = 'short'
+
+subcommands = [
+    'push',
+    'pull',
+]
+
+
+def deployment_push_setup_parser(subparser):
+    """Push a workspace deployment"""
+    subparser.add_argument(
+        '--tar-archive', '-t', action='store_true',
+        dest='tar_archive',
+        help='create a tar.gz of the deployment directory.')
+
+    subparser.add_argument(
+        '--deployment-name', '-d', dest='deployment_name',
+        default=None,
+        help='Name for deployment. Uses workspace name if not set.')
+
+    subparser.add_argument(
+        '--upload-url', '-u', dest='upload_url',
+        default=None,
+        help='URL to upload deployment into. Upload tar if `-t` is specified..')
+
+    arguments.add_common_arguments(subparser, ['phases', 'include_phase_dependencies',
+                                               'where', 'exclude_where', 'filter_tags'])
+
+
+def deployment_push(args):
+    current_pipeline = ramble.pipeline.pipelines.pushdeployment
+    ws = ramble.cmd.require_active_workspace(cmd_name='deployment push')
+
+    filters = ramble.filters.Filters(
+        phase_filters=args.phases,
+        include_where_filters=args.where,
+        exclude_where_filters=args.exclude_where,
+        tags=args.filter_tags
+    )
+
+    pipeline_cls = ramble.pipeline.pipeline_class(current_pipeline)
+
+    pipeline = pipeline_cls(ws,
+                            filters,
+                            create_tar=args.tar_archive,
+                            upload_url=args.upload_url,
+                            deployment_name=args.deployment_name)
+
+    with ws.write_transaction():
+        deployment_run_pipeline(args, pipeline)
+
+
+def deployment_pull_setup_parser(subparser):
+    """Pull a workspace deployment into current workspace"""
+    subparser.add_argument(
+        '--deployment-path', '-p', dest='deployment_path',
+        help='Path to deployment that should be pulled')
+
+
+def deployment_pull(args):
+    def pull_file(src, dest):
+        fetcher = ramble.fetch_strategy.URLFetchStrategy(url=src)
+        stage_dir = os.path.dirname(dest)
+        fs.mkdirp(stage_dir)
+        with ramble.stage.InputStage(fetcher, path=stage_dir,
+                                     name=os.path.basename(src)) as stage:
+            stage.fetch()
+
+    ws = ramble.cmd.require_active_workspace(cmd_name='deployment pull')
+
+    with ws.write_transaction():
+        # Fetch deployment index first:
+        push_cls = ramble.pipeline.PublishDeploymentPipeline
+
+        remote_index_path = urllib.parse.urljoin(
+            args.deployment_path, ramble.pipeline.PushDeploymentPipeline.index_filename
+        )
+        local_index_path = \
+            os.path.join(ws.root, push_cls.index_filename)
+
+        pull_file(remote_index_path, local_index_path)
+
+        with open(local_index_path, 'r') as f:
+            index_data = sjson.load(f)
+
+        for file in index_data[push_cls.index_namespace]:
+            src = urllib.parse.urljoin(args.deployment_path, file)
+            dest = os.path.join(ws.root, file)
+            if os.path.exists(dest):
+                fs.force_remove(dest)
+
+            pull_file(src, dest)
+
+
+def deployment_run_pipeline(args, pipeline):
+    include_phase_dependencies = getattr(args, 'include_phase_dependencies', None)
+    if include_phase_dependencies:
+        with ramble.config.override('config:include_phase_dependencies', True):
+            pipeline.run()
+    else:
+        pipeline.run()
+
+
+#: Dictionary mapping subcommand names and aliases to functions
+subcommand_functions = {}
+
+
+def sanitize_arg_name(base_name):
+    """Allow function names to be remapped (eg `-` to `_`) """
+    formatted_name = base_name.replace('-', '_')
+    return formatted_name
+
+
+def setup_parser(subparser):
+    sp = subparser.add_subparsers(metavar='SUBCOMMAND',
+                                  dest='deployment_command')
+
+    for name in subcommands:
+        if isinstance(name, (list, tuple)):
+            name, aliases = name[0], name[1:]
+        else:
+            aliases = []
+
+        # add commands to subcommands dict
+        function_name = sanitize_arg_name('deployment_%s' % name)
+
+        function = globals()[function_name]
+        for alias in [name] + aliases:
+            subcommand_functions[alias] = function
+
+        # make a subparser and run the command's setup function on it
+        setup_parser_cmd_name = sanitize_arg_name('deployment_%s_setup_parser' % name)
+        setup_parser_cmd = globals()[setup_parser_cmd_name]
+
+        subsubparser = sp.add_parser(
+            name, aliases=aliases, help=setup_parser_cmd.__doc__,
+            description=setup_parser_cmd.__doc__)
+        setup_parser_cmd(subsubparser)
+
+
+def deployment(parser, args):
+    """Look for a function called deployment_<name> and call it."""
+    action = subcommand_functions[args.deployment_command]
+    action(args)

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -857,6 +857,6 @@ def setup_parser(subparser):
 
 
 def workspace(parser, args):
-    """Look for a function called environment_<name> and call it."""
+    """Look for a function called workspace_<name> and call it."""
     action = subcommand_functions[args.workspace_command]
     action(args)

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -84,6 +84,9 @@ workspace_shared_path = 'shared'
 #: Name of the subdirectory where shared/sourale files are stored
 workspace_shared_license_path = 'licenses'
 
+#: Name of the subdirectory where deployments are stored
+workspace_deployments_path = 'deployments'
+
 #: regex for validating workspace names
 valid_workspace_name_re = r'^\w[\w-]*$'
 
@@ -521,6 +524,8 @@ class Workspace(object):
 
         # Create a logger to redirect certain prints from screen to log file
         self.logger = log.log_output(echo=False, debug=tty.debug_level())
+
+        self.deployment_name = self.name
 
     def _re_read(self):
         """Reinitialize the workspace object if it has been written (this
@@ -1243,6 +1248,16 @@ class Workspace(object):
     def shared_dir(self):
         """Path to the shared directory"""
         return os.path.join(self.root, workspace_shared_path)
+
+    @property
+    def deployments_dir(self):
+        """Path to the deployments directory"""
+        return os.path.join(self.root, workspace_deployments_path)
+
+    @property
+    def named_deployment(self):
+        """Path to the specific deployment directory"""
+        return os.path.join(self.deployments_dir, self.deployment_name)
 
     @property
     def shared_license_dir(self):

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -267,7 +267,7 @@ _ramble() {
     then
         RAMBLE_COMPREPLY="-h --help -H --all-help --color -c --config -C --config-scope -d --debug --disable-passthrough -N --disable-logger -P --disable-progress-bar --timestamp --pdb -w --workspace -D --workspace-dir -W --no-workspace --use-workspace-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -p --profile --sorted-profile --lines -v --verbose --stacktrace -V --version --print-shell-vars"
     else
-        RAMBLE_COMPREPLY="attributes clean commands config debug edit flake8 help info license list mirror mods on python repo results software-definitions unit-test workspace"
+        RAMBLE_COMPREPLY="attributes clean commands config debug deployment edit flake8 help info license list mirror mods on python repo results software-definitions unit-test workspace"
     fi
 }
 
@@ -389,6 +389,23 @@ _ramble_debug() {
 
 _ramble_debug_report() {
     RAMBLE_COMPREPLY="-h --help"
+}
+
+_ramble_deployment() {
+    if $list_options
+    then
+        RAMBLE_COMPREPLY="-h --help"
+    else
+        RAMBLE_COMPREPLY="push pull"
+    fi
+}
+
+_ramble_deployment_push() {
+    RAMBLE_COMPREPLY="-h --help --tar-archive -t --deployment-name -d --upload-url -u --phases --include-phase-dependencies --where --exclude-where --filter-tags"
+}
+
+_ramble_deployment_pull() {
+    RAMBLE_COMPREPLY="-h --help --deployment-path -p"
 }
 
 _ramble_edit() {


### PR DESCRIPTION
This merge adds a deployment command with publish and fetch as subcommands, and a publish deployment pipeline.

The deployment command can be used to publish (from) and fetch (into) deployments using a workspace definition.