### PR TITLE
Fix issues with package name rendering and empty string packages in environments

### DIFF
--- a/lib/ramble/ramble/software_environments.py
+++ b/lib/ramble/ramble/software_environments.py
@@ -510,13 +510,14 @@ class SoftwareEnvironments(object):
                     new_env = TemplateEnvironment(env_template)
                     if namespace.packages in env_info:
                         for package in env_info[namespace.packages]:
-                            if package not in self._package_templates:
-                                raise RambleSoftwareEnvironmentError(
-                                    f'Environment {env_template} references '
-                                    f'undefined package {package}'
-                                )
-                            pkg_obj = self._package_templates[package]
-                            new_env.add_package(pkg_obj)
+                            if package:
+                                if package not in self._package_templates:
+                                    raise RambleSoftwareEnvironmentError(
+                                        f'Environment {env_template} references '
+                                        f'undefined package {package}'
+                                    )
+                                pkg_obj = self._package_templates[package]
+                                new_env.add_package(pkg_obj)
                     self._environment_templates[env_template] = new_env
 
     def define_compiler_packages(self, environment, expander):

--- a/lib/ramble/ramble/software_environments.py
+++ b/lib/ramble/ramble/software_environments.py
@@ -306,8 +306,12 @@ class TemplateEnvironment(SoftwareEnvironment):
             name (str): Name of this environment
         """
         super().__init__(name)
+        self._package_names = set()
         self._rendered_environments = {}
         self._environment_type = 'Template'
+
+    def add_package_name(self, package: str = None):
+        self._package_names.add(package)
 
     def info(self, indent: int = 0, verbosity: int = 0, color_level: int = 0):
         """Software environment information
@@ -334,7 +338,8 @@ class TemplateEnvironment(SoftwareEnvironment):
 
         return super().info()
 
-    def render_environment(self, expander: object, all_packages: dict):
+    def render_environment(self, expander: object, all_package_templates: dict,
+                           all_packages: dict):
         """Render a SoftwareEnvironment from this TemplateEnvironment
 
         Args:
@@ -348,20 +353,34 @@ class TemplateEnvironment(SoftwareEnvironment):
 
         new_env = SoftwareEnvironment(name)
 
-        for package in self._packages:
-            rendered_pkg = package.render_package(expander)
+        for env_pkg_template in self._package_names:
+            rendered_env_pkg_name = expander.expand_var(env_pkg_template)
 
-            if rendered_pkg.name in all_packages:
-                if rendered_pkg != all_packages[rendered_pkg.name]:
+            if rendered_env_pkg_name:
+                added = False
+                for template_pkg in all_package_templates.values():
+                    rendered_pkg = template_pkg.render_package(expander)
+
+                    if rendered_env_pkg_name == rendered_pkg.name:
+                        if rendered_pkg.name in all_packages:
+                            if rendered_pkg != all_packages[rendered_pkg.name]:
+                                raise RambleSoftwareEnvironmentError(
+                                    f'Environment {name} defined multiple times in inconsistent '
+                                    f'ways.\nPackage with differences is {rendered_pkg.name}'
+                                )
+                            rendered_pkg = all_packages[rendered_pkg.name]
+                        else:
+                            all_packages[rendered_pkg.name] = rendered_pkg
+
+                        added = True
+                        template_pkg.add_rendered_package(rendered_pkg, all_packages)
+                        new_env.add_package(rendered_pkg)
+
+                if not added:
                     raise RambleSoftwareEnvironmentError(
-                        f'Environment {name} defined multiple times in inconsistent ways\n'
-                        f'Package with differences {rendered_pkg.name}'
+                        f'Environment template {self.name} references '
+                        f'undefined package {env_pkg_template} rendered to {rendered_env_pkg_name}'
                     )
-                rendered_pkg = all_packages[rendered_pkg.name]
-            else:
-                all_packages[rendered_pkg.name] = rendered_pkg
-
-            new_env.add_package(rendered_pkg)
 
         return new_env
 
@@ -510,14 +529,7 @@ class SoftwareEnvironments(object):
                     new_env = TemplateEnvironment(env_template)
                     if namespace.packages in env_info:
                         for package in env_info[namespace.packages]:
-                            if package:
-                                if package not in self._package_templates:
-                                    raise RambleSoftwareEnvironmentError(
-                                        f'Environment {env_template} references '
-                                        f'undefined package {package}'
-                                    )
-                                pkg_obj = self._package_templates[package]
-                                new_env.add_package(pkg_obj)
+                            new_env.add_package_name(package)
                     self._environment_templates[env_template] = new_env
 
     def define_compiler_packages(self, environment, expander):
@@ -676,7 +688,8 @@ class SoftwareEnvironments(object):
         for template_name, template_def in self._environment_templates.items():
             rendered_name = expander.expand_var(template_name)
             if rendered_name == env_name:
-                rendered_env = template_def.render_environment(expander, self._rendered_packages)
+                rendered_env = template_def.render_environment(expander, self._package_templates,
+                                                               self._rendered_packages)
 
                 if rendered_env.name == env_name:
                     if env_name in self._rendered_environments:

--- a/lib/ramble/ramble/test/software_environment.py
+++ b/lib/ramble/ramble/test/software_environment.py
@@ -58,6 +58,36 @@ def test_basic_software_environment(request, mutable_mock_workspace_path):
         assert pkg_found
 
 
+def test_software_environments_no_packages(request, mutable_mock_workspace_path):
+    ws_name = request.node.name
+
+    workspace('create', ws_name)
+
+    assert ws_name in workspace('list')
+
+    with ramble.workspace.read(ws_name) as ws:
+        spack_dict = ws.get_spack_dict()
+
+        spack_dict['packages'] = {}
+        spack_dict['environments'] = {
+            'basic-{env_test}': {
+                'packages': ['']
+            }
+        }
+
+        software_environments = ramble.software_environments.SoftwareEnvironments(ws)
+
+        assert 'basic-{env_test}' in software_environments._environment_templates
+
+        variables = {
+            'env_test': 'environment',
+        }
+        env_expander = ramble.expander.Expander(variables, None)
+
+        rendered_env = software_environments.render_environment('basic-environment', env_expander)
+        assert rendered_env.name == 'basic-environment'
+
+
 def test_template_software_environments(request, mutable_mock_workspace_path):
     ws_name = request.node.name
 

--- a/lib/ramble/ramble/test/software_environment.py
+++ b/lib/ramble/ramble/test/software_environment.py
@@ -88,6 +88,37 @@ def test_software_environments_no_packages(request, mutable_mock_workspace_path)
         assert rendered_env.name == 'basic-environment'
 
 
+def test_software_environments_no_rendered_packages(request, mutable_mock_workspace_path):
+    ws_name = request.node.name
+
+    workspace('create', ws_name)
+
+    assert ws_name in workspace('list')
+
+    with ramble.workspace.read(ws_name) as ws:
+        spack_dict = ws.get_spack_dict()
+
+        spack_dict['packages'] = {}
+        spack_dict['environments'] = {
+            'basic-{env_test}': {
+                'packages': ['{var_pkg_name}']
+            }
+        }
+
+        software_environments = ramble.software_environments.SoftwareEnvironments(ws)
+
+        assert 'basic-{env_test}' in software_environments._environment_templates
+
+        variables = {
+            'env_test': 'environment',
+            'var_pkg_name': ''
+        }
+        env_expander = ramble.expander.Expander(variables, None)
+
+        rendered_env = software_environments.render_environment('basic-environment', env_expander)
+        assert rendered_env.name == 'basic-environment'
+
+
 def test_template_software_environments(request, mutable_mock_workspace_path):
     ws_name = request.node.name
 
@@ -210,11 +241,20 @@ def test_undefined_package_errors(request, mutable_mock_workspace_path):
             }
         }
 
+        software_environments = ramble.software_environments.SoftwareEnvironments(ws)
+
+        variables = {
+            'env_test': 'environment'
+        }
+
+        env_expander = ramble.expander.Expander(variables, None)
+
         with pytest.raises(ramble.software_environments.RambleSoftwareEnvironmentError) as pkg_err:
-            _ = ramble.software_environments.SoftwareEnvironments(ws)
+            _  = software_environments.render_environment('all-basic-environment', env_expander)
 
         err_str = \
-            'Environment all-basic-{env_test} references undefined package foo-basic-{pkg_test}'
+            'Environment template all-basic-{env_test} references undefined ' \
+            + 'package foo-basic-{pkg_test}'
         assert err_str in str(pkg_err)
 
 


### PR DESCRIPTION
This merge fixes two issues introduced with the #433.

The first was that environments were previously allowed to have empty string packages defined in them, and that PR broke this support.

The second was that environments used to be able to contain packages who's names were not known until experiment time. Something of the form:

```
variables:
  foo: 'bar'
spack:
  packages:
    bar:
    ...
  environments:
    hostname:
      packages:
      - '{foo}'
```

This PR fixes both of these issues.