### PR TITLE
Make deprecation import error less confusing

### DIFF
--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -6,7 +6,10 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-import deprecation
+try:
+    import deprecation
+except ImportError:
+    print('Please use pip to install the requirements.txt')
 
 import ramble.language.language_base
 import ramble.language.language_helpers


### PR DESCRIPTION
Currently if you miss installing this dep you get the error:

```
==> Error: Command workspace does not exist.
```
(ramble hides the real error)

This PR instead makes it appear as:

```
Please use pip to install the requirements.txt
==> Error: name 'deprecation' is not defined
```