### PR TITLE
Implicitly ignore unused variables within experiment definitions

### DIFF
--- a/lib/ramble/ramble/application_types/spack.py
+++ b/lib/ramble/ramble/application_types/spack.py
@@ -77,6 +77,33 @@ class SpackApplication(ApplicationBase):
 
         return ''.join(out_str)
 
+    def build_used_variables(self, workspace):
+        """Build a set of all used variables
+
+        By expanding all necessary portions of this experiment (required /
+        reserved keywords, templates, commands, etc...), determine which
+        variables are used throughout the experiment definition.
+
+        Variables can have list definitions. These are iterated over to ensure
+        variables referenced by any of them are tracked properly.
+
+        Args:
+            workspace (Workspace): Workspace to extract templates from
+
+        Returns:
+            (set): All variable names used by this experiment.
+        """
+        _ = super().build_used_variables(workspace)
+
+        app_context = self.expander.expand_var_name(self.keywords.env_name)
+
+        software_environments = workspace.software_environments
+        software_environments.render_environment(app_context,
+                                                 self.expander,
+                                                 require=False)
+
+        return self.expander._used_variables
+
     register_phase('software_install_requested_compilers', pipeline='setup',
                    run_after=['software_create_env'])
 

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -539,10 +539,11 @@ def workspace_info(args):
     # Print workspace variables information
     workspace_vars = ws.get_workspace_vars()
 
+    ws.software_environments = ramble.software_environments.SoftwareEnvironments(ws)
+    software_environments = ws.software_environments
+
     # Build experiment set
     experiment_set = ws.build_experiment_set()
-
-    software_environments = ramble.software_environments.SoftwareEnvironments(ws)
 
     if args.tags:
         color.cprint('')

--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -108,7 +108,7 @@ class ExpansionNode(object):
 
     def define_value(self, expansion_dict, allow_passthrough=True,
                      expansion_func=str, evaluation_func=eval,
-                     no_expand_vars=set()):
+                     no_expand_vars=set(), used_vars=set()):
         """Define the value for this node.
 
         Construct the value of self. This builds up a string representation of
@@ -153,6 +153,7 @@ class ExpansionNode(object):
                 required_passthrough = False
 
                 if kw_parts[0] in expansion_dict:
+                    used_vars.add(kw_parts[0])
                     # Exit expansion for variables defined as no_expand
                     if kw_parts[0] in no_expand_vars:
                         self.value = expansion_dict[kw_parts[0]]
@@ -293,6 +294,7 @@ class Expander(object):
 
         self._variables = variables
         self._no_expand_vars = no_expand_vars
+        self._used_variables = set()
 
         self._experiment_set = experiment_set
 
@@ -561,7 +563,8 @@ class Expander(object):
                                   allow_passthrough=allow_passthrough,
                                   expansion_func=self._partial_expand,
                                   evaluation_func=self.perform_math_eval,
-                                  no_expand_vars=self._no_expand_vars)
+                                  no_expand_vars=self._no_expand_vars,
+                                  used_vars=self._used_variables)
 
             return str(str_graph.root.value)
 

--- a/lib/ramble/ramble/keywords.py
+++ b/lib/ramble/ramble/keywords.py
@@ -26,6 +26,7 @@ default_keys = {
     'workload_namespace': {'type': key_type.reserved, 'level': output_level.key},
     'simplified_workload_namespace': {'type': key_type.reserved, 'level': output_level.key},
     'license_input_dir': {'type': key_type.reserved, 'level': output_level.variable},
+    'experiments_file': {'type': key_type.reserved, 'level': output_level.key},
     'experiment_name': {'type': key_type.reserved, 'level': output_level.key},
     'experiment_run_dir': {'type': key_type.reserved, 'level': output_level.variable},
     'experiment_status': {'type': key_type.reserved, 'level': output_level.key},
@@ -121,6 +122,26 @@ class Keywords(object):
         if not self.is_valid(key):
             return False
         return self.keys[key]['level'] == output_level.variable
+
+    def all_required_keys(self):
+        """Yield all required keys
+
+        Yields:
+            (str): Key name
+        """
+        for key in self.keys.keys():
+            if self.is_required(key):
+                yield key
+
+    def all_reserved_keys(self):
+        """Yield all reserved keys
+
+        Yields:
+            (str): Key name
+        """
+        for key in self.keys.keys():
+            if self.is_reserved(key):
+                yield key
 
     def check_reserved_keys(self, definitions):
         """Check a dictionary of variable definitions for reserved keywords"""

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -72,9 +72,9 @@ class Pipeline(object):
         self.create_simlink(self.log_dir, self.log_dir_latest)
         self.create_simlink(self.log_path, self.log_path_latest)
 
-        self._experiment_set = workspace.build_experiment_set()
         self._software_environments = ramble.software_environments.SoftwareEnvironments(workspace)
         self.workspace.software_environments = self._software_environments
+        self._experiment_set = workspace.build_experiment_set()
 
     def _construct_hash(self):
         """Hash all of the experiments, construct workspace inventory"""

--- a/lib/ramble/ramble/software_environments.py
+++ b/lib/ramble/ramble/software_environments.py
@@ -668,7 +668,7 @@ class SoftwareEnvironments(object):
 
         self._deprecated_warnings()
 
-    def render_environment(self, env_name: str, expander: object):
+    def render_environment(self, env_name: str, expander: object, require=True):
         """Render an environment needed by an experiment
 
         Args:
@@ -707,9 +707,10 @@ class SoftwareEnvironments(object):
                     self._check_environment(rendered_env)
                     return rendered_env
 
-        raise RambleSoftwareEnvironmentError(
-            f'No defined environment matches required name {env_name}'
-        )
+        if require:
+            raise RambleSoftwareEnvironmentError(
+                f'No defined environment matches required name {env_name}'
+            )
 
 
 class RambleSoftwareEnvironmentError(ramble.error.RambleError):

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -465,7 +465,7 @@ class Workspace(object):
         self.input_mirror_stats = None
         self.input_mirror_cache = None
         self.software_mirror_cache = None
-        self._software_environments = None
+        self.software_environments = None
         self.hash_inventory = {
             'experiments': [],
             'versions': []

--- a/var/ramble/repos/builtin.mock/applications/expanded_foms/application.py
+++ b/var/ramble/repos/builtin.mock/applications/expanded_foms/application.py
@@ -12,7 +12,7 @@ from ramble.appkit import *
 class ExpandedFoms(ExecutableApplication):
     name = "expanded-Foms"
 
-    executable('foo', 'bar', use_mpi=False)
+    executable('foo', template=['bar', 'echo "{my_var}"'], use_mpi=False)
 
     input_file('input', url='file:///tmp/test_file.log',
                description='Not a file', extension='.log')


### PR DESCRIPTION
This merge allows experiments to determine which variables they will use. This information is then used when rendering experiments, so we can ignore variables that would cause an issue (for example, vectors that are incorrect lengths).

Tests are added to ensure the functionality behaves how we want.