### PR TITLE
fix off by one in indentation calculation

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -909,7 +909,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
 
             n_indentation = 0
             if namespace.indentation in formatted_conf:
-                n_indentation = int(formatted_conf[namespace.indentation]) + 1
+                n_indentation = int(formatted_conf[namespace.indentation])
 
             prefix = ''
             if namespace.prefix in formatted_conf:
@@ -919,9 +919,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
             if namespace.join_separator in formatted_conf:
                 join_separator = formatted_conf[namespace.join_separator].replace(r'\n', '\n')
 
-            indentation = ''
-            for _ in range(0, n_indentation + 1):
-                indentation += ' '
+            indentation = ' ' * n_indentation
 
             formatted_str = ''
             for cmd in self._command_list:

--- a/lib/ramble/ramble/test/end_to_end/formatted_executables.py
+++ b/lib/ramble/ramble/test/end_to_end/formatted_executables.py
@@ -86,10 +86,10 @@ ramble:
 
         with open(exp_script, 'r') as f:
             data = f.read()
-            assert ';           from_ws echo' in data
             assert 'from_app echo' in data
-            assert '           from_wl echo' in data
-            assert '          from_exp echo' in data
+            assert ';' + ' ' * 9 + 'from_ws echo' in data
+            assert '\n' + ' ' * 11 + 'from_wl echo' in data
+            assert '\n' + ' ' * 10 + 'from_exp echo' in data
 
 
 def test_redefined_executable_errors(mutable_config, mutable_mock_workspace_path,


### PR DESCRIPTION
Previously this was causing an `n_indentation` of 0 to emit one space, because a `range(0,1)` runs once. I think the +1 is not needed here (and the loop would not be needed at all if we did the `*`)