### PR TITLE
Fix env var setting in applications

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -803,6 +803,12 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                 action = vals['action']
                 value = vals['value']
 
+                # Since the type coming from the schema can either be None, or
+                # a complex polymorphic type we need to ensure it has a
+                # sensible base structure when it is not given
+                if not self._env_variable_sets:
+                    self._env_variable_sets.append({'set': {}})
+
                 for env_var_set in self._env_variable_sets:
                     if action in env_var_set:
                         if name not in env_var_set[action].keys():

--- a/var/ramble/repos/builtin.mock/applications/interleved-env-vars/application.py
+++ b/var/ramble/repos/builtin.mock/applications/interleved-env-vars/application.py
@@ -19,6 +19,9 @@ class InterlevedEnvVars(ExecutableApplication):
     input_file('input', url='file:///tmp/test_file.log',
                description='Not a file', extension='.log')
 
+    environment_variable('FROM_DIRECTIVE', 'set', description='Test env var',
+                         workloads=['test_wl', 'test_wl2', 'test_wl3'])
+
     workload('test_wl', executables=['builtin::env_vars', 'foo'], input='input')
     workload('test_wl2', executables=['bar', 'builtin::env_vars'], input='input')
     workload('test_wl3', executables=['baz'], input='input')


### PR DESCRIPTION
Previously, when an application.py sets environment variables (through the environment_variable directive) but a workspace doesn't define env_vars (as in `env_vars:set:OMP_NUM_THREADS:'{n_threads}'`) it fails to inject the environment variables into the rendered scripts properly.

This fixes it by ensuring a default format if the schema returns empty  