### PR TITLE
Enhance user experience around workspace archive

### DIFF
--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -266,6 +266,12 @@ class ArchivePipeline(Pipeline):
         self.archive_prefix = archive_prefix
         self.archive_name = None
 
+        if self.upload_url and not self.create_tar:
+            logger.warn(
+                'Upload URL is currently only supported when using tar format (-t)\n'
+                'Archive will not be uploaded.'
+            )
+
     def _prepare(self):
         import glob
         super()._construct_hash()
@@ -366,6 +372,7 @@ class ArchivePipeline(Pipeline):
                 tar_path = self.workspace.latest_archive_path + tar_extension
                 remote_tar_path = archive_url + '/' + self.workspace.latest_archive + tar_extension
                 _upload_file(tar_path, remote_tar_path)
+                logger.all_msg(f"Archive Uploaded to {remote_tar_path}")
 
 
 class MirrorPipeline(Pipeline):


### PR DESCRIPTION
- Add warning if -u is passed but not -t, since no action upload will be taken
- Add print to show the user the path the file was uploaded to