### PR TITLE
Fix removal of scalars, and ignoring modifier variables

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -435,12 +435,19 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         Returns:
             (set): All variable names used by this experiment.
         """
+        self.build_modifier_instances()
         self.add_expand_vars(workspace)
 
         # Add all known keywords
         for key in self.keywords.keys:
             self.expander._used_variables.add(key)
             self.expander.expand_var_name(key)
+
+        # Add modifier mode variables:
+        for mod_inst in self._modifier_instances:
+            for var in mod_inst.mode_variables().keys():
+                self.expander._used_variables.add(var)
+                self.expander.expand_var_name(var)
 
         if self.chained_experiments:
             for chained_exp in self.chained_experiments:

--- a/lib/ramble/ramble/renderer.py
+++ b/lib/ramble/ramble/renderer.py
@@ -191,7 +191,7 @@ class Renderer(object):
             # Remove any variables that are not used by the render group
             all_vars = set(object_variables.keys())
             for var in all_vars:
-                if var not in used_variables:
+                if var not in used_variables and isinstance(object_variables[var], list):
                     del object_variables[var]
 
         if zips:

--- a/lib/ramble/ramble/test/experiment_set.py
+++ b/lib/ramble/ramble/test/experiment_set.py
@@ -1268,7 +1268,7 @@ def test_chained_invalid_order_errors(mutable_mock_workspace_path, capsys):
             assert "Invalid experiment chain defined:" in captured
 
 
-def test_modifiers_set_correctly(mutable_mock_workspace_path, capsys):
+def test_modifiers_set_correctly(mutable_mock_workspace_path, mock_modifiers, capsys):
     workspace('create', 'test')
 
     assert 'test' in workspace('list')
@@ -1287,8 +1287,8 @@ def test_modifiers_set_correctly(mutable_mock_workspace_path, capsys):
         }
         application_context.modifiers = [
             {
-                'name': 'test_app_mod',
-                'mode': 'test_app',
+                'name': 'test-mod',
+                'mode': 'app-scope',
                 'on_executable': [
                     'builtin::env_vars'
                 ]
@@ -1303,8 +1303,8 @@ def test_modifiers_set_correctly(mutable_mock_workspace_path, capsys):
         }
         workload_context.modifiers = [
             {
-                'name': 'test_wl_mod',
-                'mode': 'test_wl',
+                'name': 'test-mod',
+                'mode': 'wl-scope',
                 'on_executable': [
                     'builtin::env_vars'
                 ]
@@ -1318,8 +1318,8 @@ def test_modifiers_set_correctly(mutable_mock_workspace_path, capsys):
         }
         experiment_context.modifiers = [
             {
-                'name': 'test_exp1_mod',
-                'mode': 'test_exp1',
+                'name': 'test-mod',
+                'mode': 'exp-scope',
                 'on_executable': [
                     'builtin::env_vars'
                 ]
@@ -1334,11 +1334,11 @@ def test_modifiers_set_correctly(mutable_mock_workspace_path, capsys):
         app_inst = exp_set.experiments['basic.test_wl.test1']
         assert app_inst.modifiers is not None
 
-        expected_modifiers = set(['test_app_mod', 'test_wl_mod', 'test_exp1_mod'])
+        expected_modifier_modes = set(['app-scope', 'wl-scope', 'exp-scope'])
         for mod_def in app_inst.modifiers:
-            assert mod_def['name'] in expected_modifiers
-            expected_modifiers.remove(mod_def['name'])
-        assert len(expected_modifiers) == 0
+            assert mod_def['mode'] in expected_modifier_modes
+            expected_modifier_modes.remove(mod_def['mode'])
+        assert len(expected_modifier_modes) == 0
 
 
 def test_explicit_zips_work(mutable_mock_workspace_path):

--- a/var/ramble/repos/builtin.mock/modifiers/test-mod/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/test-mod/modifier.py
@@ -19,6 +19,13 @@ class TestMod(BasicModifier):
     tags('test')
 
     mode('test', description='This is a test mode')
+    default_mode('test')
+
+    mode('app-scope', description='This is a test mode at the application scope')
+
+    mode('wl-scope', description='This is a test mode at the workload scope')
+
+    mode('exp-scope', description='This is a test mode at the experiment scope')
 
     variable_modification('mpi_command', 'echo "prefix_mpi_command" >> {log_file}; ', method='prepend', modes=['test'])
 


### PR DESCRIPTION
This merge fixes two issues with removal of unused variables, primarily related to removing variables that modifiers might use.

The first fix updates the removal code to only remove list variables (as they are problematic for rendering experiments).

The second fix propagates variables defined in a modifier (using the modifier_variable directive) as used variables even if they are not used in an expansion to ensure they are not removed accidentally.