### PR TITLE
Update context output format to reduce duplication

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -1427,8 +1427,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                     if group[1]:
                         context_val[group[1]] = context_match[group[1]]
 
-            context_string = context_format.replace('{', '').replace('}', '') \
-                + ' = ' + context_format.format(**context_val)
+            context_string = context_format.format(**context_val)
             return context_string
 
         fom_values = {}

--- a/var/ramble/repos/builtin/applications/cloverleaf/application.py
+++ b/var/ramble/repos/builtin/applications/cloverleaf/application.py
@@ -82,7 +82,7 @@ class Cloverleaf(SpackApplication):
 
     figure_of_merit_context('step',
                             regex=step_count_regex,
-                            output_format='{step}')
+                            output_format='Step {step}')
 
     step_summary_regex = (r'\s*step:\s+(?P<step>[0-9]+)\s+' +
                           r'(?P<volume>'          + floating_point_regex + r')\s+' +

--- a/var/ramble/repos/builtin/applications/hpl/application.py
+++ b/var/ramble/repos/builtin/applications/hpl/application.py
@@ -202,7 +202,7 @@ class Hpl(SpackApplication):
                     group_name='gflops', units='GFLOP/s',
                     contexts=['problem-name'])
 
-    figure_of_merit_context('problem-name', regex=r'.*\s+(?P<N>[0-9]+)\s+(?P<NB>[0-9]+)\s+(?P<P>[0-9]+)\s+(?P<Q>[0-9]+)\s+(?P<time>[0-9]+\.[0-9]+)\s+(?P<gflops>[0-9].*)\n', output_format='{N}-{NB}-{P}-{Q}')
+    figure_of_merit_context('problem-name', regex=r'.*\s+(?P<N>[0-9]+)\s+(?P<NB>[0-9]+)\s+(?P<P>[0-9]+)\s+(?P<Q>[0-9]+)\s+(?P<time>[0-9]+\.[0-9]+)\s+(?P<gflops>[0-9].*)\n', output_format='N-NB-P-Q = {N}-{NB}-{P}-{Q}')
 
     # Integer sqrt
     def _isqrt(self, n):

--- a/var/ramble/repos/builtin/applications/intel-hpl/application.py
+++ b/var/ramble/repos/builtin/applications/intel-hpl/application.py
@@ -203,7 +203,7 @@ class IntelHpl(SpackApplication):
                     group_name='gflops', units='GFLOP/s',
                     contexts=['problem-name'])
 
-    figure_of_merit_context('problem-name', regex=r'.*\s+(?P<N>[0-9]+)\s+(?P<NB>[0-9]+)\s+(?P<P>[0-9]+)\s+(?P<Q>[0-9]+)\s+(?P<time>[0-9]+\.[0-9]+)\s+(?P<gflops>[0-9].*)\n', output_format='{N}-{NB}-{P}-{Q}')
+    figure_of_merit_context('problem-name', regex=r'.*\s+(?P<N>[0-9]+)\s+(?P<NB>[0-9]+)\s+(?P<P>[0-9]+)\s+(?P<Q>[0-9]+)\s+(?P<time>[0-9]+\.[0-9]+)\s+(?P<gflops>[0-9].*)\n', output_format='N-NB-P-Q = {N}-{NB}-{P}-{Q}')
 
     # Integer sqrt
     def _isqrt(self, n):

--- a/var/ramble/repos/builtin/applications/ior/application.py
+++ b/var/ramble/repos/builtin/applications/ior/application.py
@@ -64,7 +64,7 @@ class Ior(SpackApplication):
 
     access_regex = '(?P<access>(read|write))' + iter_regex
     figure_of_merit_context('iter', regex=access_regex,
-                            output_format='{iter}')
+                            output_format='iter {iter}')
 
     log_str = Expander.expansion_str('log_file')
 


### PR DESCRIPTION
This is a **breaking change** for anyone who consumes our output format wrt contexts

This PR makes it so that contexts only use the format string when printing, to reduce how repetitive and annoying to construct the format is.

The new output looks like:

txt
```
 10   Bytes: 0 (BW) figures of merit:
 11     Bandwidth = 0.00 Mbytes/sec
```

json
```
131         {
132           "name": "Bytes: 0 (BW)",
133           "foms": [
134             {
135               "value": "0.00",
136               "units": "Mbytes/sec",
137               "origin": "IntelMpiBenchmarks",
138               "origin_type": "application",
139               "name": "Bandwidth"
140             }
141           ]
142         },
```

This is also reflected the same way in the upload db

The old formats looked like:

txt
```
 10   Bytes: bytes (BW) = Bytes: 0 (BW) figures of merit:
 11     Bandwidth = 0.00 Mbytes/sec
```

json
```
  "name": "Bytes: bytes (BW) = Bytes: 0 (BW)",
133           "foms": [
134             {
135               "value": "0.00",
136               "units": "Mbytes/sec",
137               "origin": "IntelMpiBenchmarks",
138               "origin_type": "application",
139               "name": "Bandwidth"
140             }
141           ]
142         },
```