### PR TITLE
Update version of spelling CI action

### DIFF
--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -11,9 +11,9 @@ jobs:
   formatting:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Check Spelling
-      uses: crate-ci/typos@548ac37a5de9ce84871bf4db3c9b8c462896d480 # v1.16.24
+      uses: crate-ci/typos@v1.20.4
       with:
         files: ./lib/ramble/ramble ./lib/ramble/docs ./examples ./share ./bin ./etc ./var ./README.md
         config: ./.typos.toml

--- a/.typos.toml
+++ b/.typos.toml
@@ -17,6 +17,7 @@ extend-ignore-re = [
 "fom" = "fom"
 "namd" = "namd"
 "reord" = "reord"
+"PN" = "PN" # fixing tPN in IOR
 
 [default.extend-identifiers]
 "ATPase" = "ATPase"

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -310,7 +310,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         """Check if this instance has provided tags.
 
         Args:
-            tags (list): List of strings, where each string is an indivudal tag
+            tags (list): List of strings, where each string is an individual tag
         Returns:
             (bool): True if all tags are in this instance, False otherwise
         """


### PR DESCRIPTION
Brings it inline with
https://github.com/crate-ci/typos/blob/master/docs/github-action.md but using both a new action version (3->4) and updates to the latest version of the target repo