### PR TITLE
Update workload variables to use a dict

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -265,7 +265,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         self.no_expand_vars = set()
         workload_name = self.expander.workload_name
         if workload_name in self.workloads:
-            for var in self.workloads[workload_name].variables:
+            for name, var in self.workloads[workload_name].variables.items():
                 if not var.expandable:
                     self.no_expand_vars.add(var.name)
 
@@ -822,7 +822,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         # Set default experiment variables, if they haven't been set already
         var_sets = []
         if self.expander.workload_name in self.workloads:
-            var_sets.append(self.workloads[self.expander.workload_name].variable_dict())
+            var_sets.append(self.workloads[self.expander.workload_name].variables)
 
         for mod_inst in self._modifier_instances:
             var_sets.append(mod_inst.mode_variables())
@@ -830,12 +830,12 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         for var_set in var_sets:
             for var, val in var_set.items():
                 if var not in self.variables.keys():
-                    self.variables[var] = val
+                    self.variables[var] = val.default
 
         if self.expander.workload_name in self.workloads:
             workload = self.workloads[self.expander.workload_name]
 
-            for env_var in workload.environment_variables:
+            for name, env_var in workload.environment_variables.items():
                 action = 'set'
                 value = env_var.value
 

--- a/lib/ramble/ramble/language/modifier_language.py
+++ b/lib/ramble/ramble/language/modifier_language.py
@@ -269,14 +269,10 @@ def modifier_variable(name: str, default, description: str, values: Optional[lis
             if mode_name not in mod.modifier_variables:
                 mod.modifier_variables[mode_name] = {}
 
-            mod.modifier_variables[mode_name][name] = {
-                'default': default,
-                'description': description,
-                'expandable': expandable
-            }
-
-            if values:
-                mod.modifier_variables[mode_name][name]['values'] = values
+            mod.modifier_variables[mode_name][name] = ramble.workload.WorkloadVariable(
+                name, default=default, description=description,
+                values=values, expandable=expandable
+            )
 
     return _define_modifier_variable
 

--- a/lib/ramble/ramble/modifier.py
+++ b/lib/ramble/ramble/modifier.py
@@ -127,10 +127,10 @@ class ModifierBase(object, metaclass=ModifierMeta):
                     indent = '\t\t'
                     for var, conf in self.modifier_variables[mode_name].items():
                         out_str.append(rucolor.nested_2(f'{indent}{var}:\n'))
-                        out_str.append(f'{indent}\tDescription: {conf["description"]}\n')
-                        out_str.append(f'{indent}\tDefault: {conf["default"]}\n')
-                        if 'values' in conf:
-                            out_str.append(f'{indent}\tSuggested Values: {conf["values"]}\n')
+                        out_str.append(f'{indent}\tDescription: {conf.description}\n')
+                        out_str.append(f'{indent}\tDefault: {conf.default}\n')
+                        if conf.values:
+                            out_str.append(f'{indent}\tSuggested Values: {conf.values}\n')
 
                 if mode_name in self.variable_modifications:
                     out_str.append(rucolor.nested_1('\tVariable Modifications:\n'))
@@ -287,17 +287,16 @@ class ModifierBase(object, metaclass=ModifierMeta):
 
         if self._usage_mode in self.modifier_variables:
             for var, var_conf in self.modifier_variables[self._usage_mode].items():
-                if not var_conf['expandable']:
+                if not var_conf.expandable:
                     yield var
 
     def mode_variables(self):
         """Return a dict of variables that should be defined for the current mode"""
 
-        var_dict = {}
         if self._usage_mode in self.modifier_variables:
-            for var, conf in self.modifier_variables[self._usage_mode].items():
-                var_dict[var] = conf['default']
-        return var_dict
+            return self.modifier_variables[self._usage_mode]
+        else:
+            return {}
 
     def run_phase_hook(self, workspace, pipeline, hook_name):
         """Run a modifier hook.

--- a/lib/ramble/ramble/test/application_inheritance.py
+++ b/lib/ramble/ramble/test/application_inheritance.py
@@ -60,11 +60,7 @@ def test_basic_inheritance(mutable_mock_apps_repo):
     assert app_inst.inputs['inherited_input']['description'] == \
         'Again, not a file'
 
-    assert 'my_var' in app_inst.workloads['test_wl'].variable_dict()
-    found = False
-    for var in app_inst.workloads['test_wl'].variables:
-        if var.name == 'my_var':
-            found = True
-            assert var.default == '1.0'
-            assert var.description == 'Example var'
-    assert found
+    assert 'my_base_var' in app_inst.workloads['test_wl'].variables
+    assert 'my_var' in app_inst.workloads['test_wl'].variables
+    assert 'Shadowed' in app_inst.workloads['test_wl'].variables['my_var'].description
+    assert app_inst.workloads['test_wl'].variables['my_var'].default == '1.0'

--- a/lib/ramble/ramble/test/application_tests.py
+++ b/lib/ramble/ramble/test/application_tests.py
@@ -48,7 +48,7 @@ def test_basic_app(mutable_mock_apps_repo):
     example_input = basic_inst.workloads['test_wl'].find_input('input')
     assert example_input is not None
 
-    assert len(basic_inst.workloads['test_wl'].variables) == 1
+    assert len(basic_inst.workloads['test_wl'].variables) == 2
     my_var = basic_inst.workloads['test_wl'].find_variable('my_var')
     assert my_var is not None
     assert my_var.default == '1.0'

--- a/lib/ramble/ramble/test/modifier_language.py
+++ b/lib/ramble/ramble/test/modifier_language.py
@@ -547,5 +547,5 @@ def test_modifier_variable_directive(mod_class, func_type):
 
         assert mode in mod_inst.modifier_variables
         assert test_def['name'] in mod_inst.modifier_variables[mode]
-        for attr in ['description', 'default']:
-            assert test_def[attr] == mod_inst.modifier_variables[mode][var_name][attr]
+        assert test_def['description'] == mod_inst.modifier_variables[mode][var_name].description
+        assert test_def['default'] == mod_inst.modifier_variables[mode][var_name].default

--- a/lib/ramble/ramble/workload.py
+++ b/lib/ramble/ramble/workload.py
@@ -30,14 +30,6 @@ class WorkloadVariable(object):
         self.values = values.copy() if isinstance(values, list) else [values]
         self.expandable = expandable
 
-    def as_dict(self):
-        """Dictionary representation of this variable
-
-        Returns:
-            dict: Key is variable name, value is default value of variable
-        """
-        return {self.name: self.default}
-
     def as_str(self, n_indent: int = 0):
         """String representation of this variable
 
@@ -79,16 +71,6 @@ class WorkloadEnvironmentVariable(object):
         self.value = value
         self.description = description
 
-    def as_dict(self):
-        """Dictionary representation of environment variable
-
-        Returns:
-            (dict): Dictionary with single environment variable in it. Key is
-                    var name, value is a dict representing the specific action and
-                    value.
-        """
-        return {self.name: {'action': 'set', 'value': self.value}}
-
     def as_str(self, n_indent: int = 0):
         """String representation of environment variable
 
@@ -125,8 +107,8 @@ class Workload(object):
             tags (list(str)): List of tags for this workload
         """
         self.name = name
-        self.variables = []
-        self.environment_variables = []
+        self.variables = {}
+        self.environment_variables = {}
 
         attr_names = ['executables', 'inputs', 'tags']
         attr_vals = [executables, inputs, tags]
@@ -164,12 +146,12 @@ class Workload(object):
 
         if self.variables:
             out_str += rucolor.nested_1(f'{indentation}    Variables:\n')
-            for var in self.variables:
+            for name, var in self.variables.items():
                 out_str += var.as_str(n_indent + 4)
 
         if self.environment_variables:
             out_str += rucolor.nested_1(f'{indentation}    Environment Variables:\n')
-            for env_var in self.environment_variables:
+            for name, env_var in self.environment_variables.items():
                 out_str += env_var.as_str(n_indent + 4)
 
         return out_str
@@ -180,7 +162,7 @@ class Workload(object):
         Args:
             variable (WorkloadVariable): New variable to add to this workload
         """
-        self.variables.append(variable)
+        self.variables[variable.name] = variable
 
     def add_environment_variable(self, env_var: WorkloadEnvironmentVariable):
         """Add an environment variable to this workload
@@ -188,7 +170,7 @@ class Workload(object):
         Args:
             env_var (WorkloadEnvironmentVariable): New environment variable to add to this workload
         """
-        self.environment_variables.append(env_var)
+        self.environment_variables[env_var.name] = env_var
 
     def add_executable(self, executable: str):
         """Add an executable to this workload
@@ -196,6 +178,7 @@ class Workload(object):
         Args:
             executable (str): Name of executable to add to this workload
         """
+        # TODO: should this be a map too? It makes more sense that we'd want 2 colliding to be overwritten in a child class?
         self.executables.append(executable)
 
     def add_input(self, input: str):
@@ -213,30 +196,6 @@ class Workload(object):
             tag (str): Tag to add to this workload
         """
         self.tags.append(tag)
-
-    def variable_dict(self):
-        """Dictionary representation of all workload variables for this workload
-
-        Returns:
-            (dict): Dictionary with variable names as keys and variable default values as values.
-        """
-        var_dict = {}
-        for var in self.variables:
-            var_dict.update(var.as_dict())
-        return var_dict
-
-    def environment_variable_dict(self):
-        """Dictionary representation of all environment variables for this workload
-
-        Returns:
-            (dict): Dictionary with all environment variable in it. Keys are
-                    var name, values are dicts representing the specific actions and
-                    values.
-        """
-        env_var_dict = {}
-        for env_var in self.environment_variables:
-            env_var_dict.update(env_var.as_dict())
-        return env_var_dict
 
     def is_valid(self):
         """Test if this workload is considered valid
@@ -277,7 +236,7 @@ class Workload(object):
                 return input
         return None
 
-    def find_variable(self, var_name):
+    def find_variable(self, name):
         """Find a variable in this workload
 
         Args:
@@ -286,12 +245,12 @@ class Workload(object):
         Returns:
             (WorkloadVariable / None): Variable instance if it exists, None if it is not found
         """
-        for var in self.variables:
-            if var.name == var_name:
-                return var
-        return None
+        if name in self.variables:
+            return self.variables[name]
+        else:
+            return None
 
-    def find_environment_variable(self, env_var_name):
+    def find_environment_variable(self, name):
         """Find an environment variable in this workload
 
         Args:
@@ -301,7 +260,7 @@ class Workload(object):
             (WorkloadEnvironmentVariable / None): Environment variable instance
                                                   if it exists, None if it is not found
         """
-        for env_var in self.environment_variables:
-            if env_var.name == env_var_name:
-                return env_var
-        return None
+        if name in self.environment_variables:
+            return self.environment_variables[name]
+        else:
+            return None

--- a/lib/ramble/ramble/workload.py
+++ b/lib/ramble/ramble/workload.py
@@ -178,7 +178,6 @@ class Workload(object):
         Args:
             executable (str): Name of executable to add to this workload
         """
-        # TODO: should this be a map too? It makes more sense that we'd want 2 colliding to be overwritten in a child class?
         self.executables.append(executable)
 
     def add_input(self, input: str):

--- a/var/ramble/repos/builtin.mock/applications/basic-inherited/application.py
+++ b/var/ramble/repos/builtin.mock/applications/basic-inherited/application.py
@@ -18,3 +18,7 @@ class BasicInherited(BaseBasic):
                description='Again, not a file', extension='.log')
 
     workload('test_wl3', executable='foo', input='inherited_input')
+
+    workload_variable('my_var', default='1.0',
+                      description='Shadowed Example var',
+                      workload='test_wl')

--- a/var/ramble/repos/builtin.mock/applications/basic/application.py
+++ b/var/ramble/repos/builtin.mock/applications/basic/application.py
@@ -23,6 +23,10 @@ class Basic(ExecutableApplication):
     workload('test_wl2', executable='bar', input='input')
     workload('working_wl', executable='echo')
 
+    workload_variable('my_base_var', default='0.0',
+                      description='Example var',
+                      workload='test_wl')
+
     workload_variable('my_var', default='1.0',
                       description='Example var',
                       workload='test_wl')

--- a/var/ramble/repos/builtin/applications/hpl/application.py
+++ b/var/ramble/repos/builtin/applications/hpl/application.py
@@ -260,7 +260,7 @@ class Hpl(SpackApplication):
             problemSize = blockSize * nBlocks
             usedPercentage = int(problemSize**2 / fullMemWords * 100)
 
-            for var in self.workloads['standard'].variables:
+            for name, var in self.workloads['standard'].variables.items():
                 self.variables[var.name] = var.default
 
             pfact = expander.expand_var_name('pfact')

--- a/var/ramble/repos/builtin/applications/intel-hpl/application.py
+++ b/var/ramble/repos/builtin/applications/intel-hpl/application.py
@@ -261,7 +261,7 @@ class IntelHpl(SpackApplication):
             problemSize = blockSize * nBlocks
             usedPercentage = int(problemSize**2 / fullMemWords * 100)
 
-            for var in self.workloads['standard'].variables:
+            for name, var in self.workloads['standard'].variables.items():
                 self.variables[var.name] = var.default
 
             pfact = expander.expand_var_name('pfact')


### PR DESCRIPTION
This was causing undesirable behavior where applications that used inheritence could define could the same variable twice, since the list did not allow for collision detection on the name

This PR updates it to use a dict, so a given var name can only be used once with the child class taking precendence