### PR TITLE
Revert "Allow expander to return string representation of invalid operators"

### DIFF
--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -28,15 +28,6 @@ supported_math_operators = {
     ast.And: operator.and_, ast.Or: operator.or_, ast.Mod: operator.mod
 }
 
-op_str_map = {
-    operator.add: '+', operator.sub: '-',
-    operator.mul: '*', operator.truediv: '/',
-    operator.pow: '**', operator.xor: '^', operator.neg: '-',
-    operator.gt: '>',
-    operator.ge: '>=', operator.lt: '<', operator.le: '<=',
-    operator.and_: 'and', operator.or_: 'or', operator.mod: '%'
-}
-
 supported_scalar_function_pointers = {
     'str': str,
     'int': int,
@@ -783,7 +774,7 @@ class Expander(object):
             right_eval = self.eval_math(node.right)
             op = supported_math_operators[type(node.op)]
             if isinstance(left_eval, six.string_types) or isinstance(right_eval, six.string_types):
-                return f'{left_eval}{op_str_map[op]}{right_eval}'
+                raise SyntaxError('Unsupported operand type in binary operator')
             return op(left_eval, right_eval)
         except TypeError:
             raise SyntaxError('Unsupported operand type in binary operator')

--- a/lib/ramble/ramble/test/expander.py
+++ b/lib/ramble/ramble/test/expander.py
@@ -46,8 +46,7 @@ def exp_dict():
         ('{n_nodes}*{processes_per_node}', '4', set(), 1),
         ('2**4', '16', set(), 1),
         ('{((((16-10+2)/4)**2)*4)}', '16.0', set(), 1),
-        ('"gromacs +blas"', 'gromacs +blas', set(), 1),
-        ('gromacs +blas', 'gromacs+blas', set(), 1),
+        ('gromacs +blas', 'gromacs +blas', set(), 1),
         ('range(0, 5)', '[0, 1, 2, 3, 4]', set(), 1),
         ('{decimal.06.var}', 'foo', set(), 1),
         ('{}', '{}', set(), 1),
@@ -74,7 +73,6 @@ def exp_dict():
         ('"2.1.1" in ["2.1.1", "3.1.1", "4.2.1"]', 'True', set(), 1),
         ('"2.1.2" in ["2.1.1", "3.1.1", "4.2.1"]', 'False', set(), 1),
         ('{test_mask}', '0x0', set(['test_mask']), 1),
-        ('intel-mpi-benchmarks == intel-mpi-benchmarks', 'True', set(), 1),
     ]
 )
 def test_expansions(input, output, no_expand_vars, passes):


### PR DESCRIPTION
This reverts commit ce7f02528cc344e521e5ab303fa19649966379c1.

That commit unintentionally caused spaces in strings that contain binary operators (such as / to represent a path) as logical statements, and stripped spaces from them.