### PR TITLE
Add support for typed expansion, and yaml type passthrough

### DIFF
--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -13,6 +13,8 @@ import operator
 import math
 import random
 
+from typing import Dict
+
 import ramble.error
 import ramble.keywords
 from ramble.util.logger import logger
@@ -461,7 +463,8 @@ class Expander(object):
         except SyntaxError:
             return var
 
-    def expand_var_name(self, var_name, extra_vars=None, allow_passthrough=True):
+    def expand_var_name(self, var_name: str, extra_vars: Dict = None,
+                        allow_passthrough: bool = True, typed: bool = False):
         """Convert a variable name to an expansion string, and expand it
 
         Take a variable name (var) and convert it to an expansion string by
@@ -469,26 +472,30 @@ class Expander(object):
         expand_var, and return the result.
 
         Args:
-            var_name: String name of variable to expand
-            extra_vars: Variable definitions to use with highest precedence
-            allow_passthrough: Whether the string is allowed to have keywords
-                               after expansion
+            var_name (str): String name of variable to expand
+            extra_vars (dict): Variable definitions to use with highest precedence
+            allow_passthrough (bool): Whether the string is allowed to have keywords
+                                      after expansion
+            typed (bool): Whether the return type should be typed or not
         """
         return self.expand_var(self.expansion_str(var_name),
                                extra_vars=extra_vars,
-                               allow_passthrough=allow_passthrough)
+                               allow_passthrough=allow_passthrough,
+                               typed=typed)
 
-    def expand_var(self, var, extra_vars=None, allow_passthrough=True):
+    def expand_var(self, var: str, extra_vars: Dict = None,
+                   allow_passthrough: bool = True, typed: bool = False):
         """Perform expansion of a string
 
         Expand a string by building up a dict of all
         expansion variables.
 
         Args:
-            var: String variable to expand
-            extra_vars: Variable definitions to use with highest precedence
-            allow_passthrough: Whether the string is allowed to have keywords
-                               after expansion
+            var (str): String variable to expand
+            extra_vars (dict): Variable definitions to use with highest precedence
+            allow_passthrough (bool): Whether the string is allowed to have keywords
+                                      after expansion
+            typed (bool): Whether the return type should be typed or not
         """
 
         passthrough_setting = allow_passthrough
@@ -513,6 +520,15 @@ class Expander(object):
                                         f'{e}')
 
         logger.debug(f'END OF EXPAND_VAR STACK {value}')
+        if typed:
+            logger.debug(f'BEGINNING OF TYPING ON {value}')
+            try:
+                value = ast.literal_eval(value)
+                logger.debug(f'END OF TYPING {value}')
+            except ValueError:
+                logger.debug('END OF TYPING Failed with ValueError')
+            except SyntaxError:
+                logger.debug('END OF TYPING Failed with SyntaxError')
         return value
 
     def evaluate_predicate(self, in_str, extra_vars=None):

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -422,7 +422,7 @@ class ExperimentSet(object):
 
         used_variables = set()
         for tracking_vars, repeats in \
-                renderer.render_objects(render_group, exclude_where=exclude_where,
+                renderer.render_objects(tracking_group, exclude_where=exclude_where,
                                         remove=False, fatal=False):
             app_inst = self._prepare_experiment(experiment_template_name,
                                                 tracking_vars, final_context, repeats)

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -401,7 +401,8 @@ class ExperimentSet(object):
                                         final_context.exclude)
 
             if perform_explicit_exclude:
-                for exclude_exp_vars, _ in renderer.render_objects(exclude_group, remove=False):
+                for exclude_exp_vars, _ in renderer.render_objects(exclude_group,
+                                                                   ignore_used=False):
                     expander = ramble.expander.Expander(exclude_exp_vars, self)
                     self._compute_mpi_vars(expander, exclude_exp_vars)
                     exclude_exp_name = expander.expand_var(experiment_template_name,
@@ -423,7 +424,7 @@ class ExperimentSet(object):
         used_variables = set()
         for tracking_vars, repeats in \
                 renderer.render_objects(tracking_group, exclude_where=exclude_where,
-                                        remove=False, fatal=False):
+                                        ignore_used=False, fatal=False):
             app_inst = self._prepare_experiment(experiment_template_name,
                                                 tracking_vars, final_context, repeats)
 

--- a/lib/ramble/ramble/schema/variables.py
+++ b/lib/ramble/ramble/schema/variables.py
@@ -12,14 +12,11 @@
    :lines: 12-
 """  # noqa E501
 
-import ramble.schema.types
-
-
 variables_def = {
     'type': ['object', 'null'],
     'default': {},
     'properties': {},
-    'additionalProperties': ramble.schema.types.array_or_scalar_of_strings_or_nums
+    'additionalProperties': True
 }
 
 properties = {

--- a/lib/ramble/ramble/test/spack_runner.py
+++ b/lib/ramble/ramble/test/spack_runner.py
@@ -279,33 +279,35 @@ def test_new_compiler_installs(tmpdir, capsys):
 
     import os
 
-    compilers_config = """
+    with tmpdir.as_cwd():
+        compilers_config = """
 compilers::
 - compiler:
     spec: gcc@12.1.0
     paths:
-      cc: /path/to/gcc
-      cxx: /path/to/g++
-      f77: /path/to/gfortran
-      fc: /path/to/gfortran
+      cc: tmpdir_path/gcc
+      cxx: tmpdir_path/g++
+      f77: tmpdir_path/gfortran
+      fc: tmpdir_path/gfortran
     flags: {}
     operating_system: 'ramble'
     target: 'x86_64'
     modules: []
     environment: {}
     extra_rpaths: []
-"""
+""".replace('tmpdir_path', os.path.join(os.getcwd(), 'bin'))
 
-    packages_config = """
+        packages_config = f"""
 packages:
   gcc:
     externals:
     - spec: gcc@12.1.0 languages=c,fortran
-      prefix: /path/to
+      prefix: {os.getcwd()}
     buildable: false
 """
 
-    with tmpdir.as_cwd():
+        os.mkdir(os.path.join(os.getcwd(), 'bin'))
+
         packages_path = os.path.join(os.getcwd(), 'packages.yaml')
         compilers_path = os.path.join(os.getcwd(), 'compilers.yaml')
         # Write spack_configs


### PR DESCRIPTION
This merge changes some of the logic around implicitly identifying variable usage through rendering, and removing unused variables. No variable definitions are removed anymore after this merge.

Zips and matrices convey usage information to the rendered now, and are used to generate experiments from multiple lists.

Variables in the ramble.yaml are now allowed to have any type (i.e. lists or dicts).

Additionally, the `expander.expand_var` and `expander.expand_var_name` have a `typed=False` attribute (false by default) which will force the expander to return a python typed version of the expanded variable.