### PR TITLE
Add sphinx copy button to docs' code blocks

### DIFF
--- a/lib/ramble/docs/conf.py
+++ b/lib/ramble/docs/conf.py
@@ -130,6 +130,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinxcontrib.programoutput",
     "sphinxcontrib.jquery",
+    "sphinx_copybutton",
 ]
 
 # Set default graphviz options
@@ -396,3 +397,9 @@ texinfo_documents = [
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
 }
+
+# sphinx_copybutton
+# Do not copy the prompt, or any console outputs.
+copybutton_exclude = '.gp, .go'
+# Escape hatch for turning off the copy button.
+copybutton_selector = "div:not(.hide-copy) > div.highlight > pre"

--- a/lib/ramble/docs/requirements.txt
+++ b/lib/ramble/docs/requirements.txt
@@ -3,3 +3,4 @@ docutils
 sphinx_rtd_theme
 sphinxcontrib-programoutput
 sphinxcontrib-jquery
+sphinx-copybutton

--- a/lib/ramble/docs/tutorials/1_hello_world.rst
+++ b/lib/ramble/docs/tutorials/1_hello_world.rst
@@ -48,6 +48,7 @@ filter available application definitions. For example:
 
 might output the following:
 
+.. rst-class:: hide-copy
 .. code-block:: console
 
     ==> 10 applications
@@ -61,6 +62,7 @@ The ``ramble list`` command also accepts regular expressions. For example:
 
 might output the following:
 
+.. rst-class:: hide-copy
 .. code-block:: console
 
     ==> 5 applications


### PR DESCRIPTION
This makes it easier to copy snippets.

Changes included:

* Add the copybutton dependency
* Add a couple custom rules to
  - avoid copying prompts
  - provide a way (`hide-copy`) to opt out from the copy button
* Use `hide-copy` in a couple places as examples. There are likely more places that make sense to not show the button, but the default behavior isn't too intrusive, so leave them be for now.

Tested: Local doc build and manual inspection ![3DoXLz3sVniNAgL](https://github.com/GoogleCloudPlatform/ramble/assets/9145959/1a3c48a2-00fd-43ac-92d6-25629019c4a2)