### PR TITLE
Fix regular expression for `spack find`

### DIFF
--- a/lib/ramble/ramble/spack_runner.py
+++ b/lib/ramble/ramble/spack_runner.py
@@ -29,7 +29,7 @@ from ramble.util.logger import logger
 
 spack_namespace = 'spack'
 
-package_name_regex = re.compile(r"\s*(?P<package_name>[\w][\w-]+).*")
+package_name_regex = re.compile(r"[\s-]*(?P<package_name>[\w][\w-]+).*")
 
 
 class SpackRunner(object):


### PR DESCRIPTION
This merge fixes the regular expression for extracting package names from the output of `spack find` to include optional `-` character matches.