### PR TITLE
Fix anonymous workspace setup with no log dir

### DIFF
--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -621,6 +621,24 @@ def test_setup_command():
         assert os.path.exists(ws.root + '/all_experiments')
 
 
+def test_setup_command_with_missing_log_dir():
+    ws_name = "test"
+    workspace("create", ws_name)
+
+    with ramble.workspace.read("test") as ws:
+        add_basic(ws)
+        check_basic(ws)
+        # Missing log directory shouldn't prevent workspace
+        # setup, as long as the workspace is considered valid
+        # by the `is_workspace_dir` check.
+        os.rmdir(ws.log_dir)
+
+        workspace("concretize")
+
+        workspace("setup")
+        assert os.path.exists(ws.root + "/all_experiments")
+
+
 def test_setup_nothing():
     ws_name = 'test'
     workspace('create', ws_name)

--- a/lib/ramble/ramble/util/logger.py
+++ b/lib/ramble/ramble/util/logger.py
@@ -11,6 +11,7 @@ import llnl.util.tty.log
 import llnl.util.tty.color
 
 from contextlib import contextmanager
+from pathlib import Path
 
 
 class Logger(object):
@@ -43,7 +44,7 @@ class Logger(object):
             path: File path for the new log file
         """
         if isinstance(path, str) and self.enabled:
-            stream = None
+            Path(path).parent.mkdir(parents=True, exist_ok=True)
             stream = llnl.util.tty.log.Unbuffered(open(path, 'a+'))
             self.log_stack.append((path, stream))
 


### PR DESCRIPTION
This enables more flexible workspace manipulation, as long as the workspace contains valid config yaml.

For instance (example provided by Doug):

```
mkdir -p test_workspace/configs
cp ramble.yaml test_workspace/configs/ramble.yaml
ramble -D test_workspace workspace setup
```

Tested with both added unit-test case and the example above.