### PR TITLE
Avoid printing default modes unless a log is active

### DIFF
--- a/lib/ramble/ramble/modifier.py
+++ b/lib/ramble/ramble/modifier.py
@@ -70,14 +70,20 @@ class ModifierBase(object, metaclass=ModifierMeta):
             self._usage_mode = mode
         elif hasattr(self, '_default_usage_mode'):
             self._usage_mode = self._default_usage_mode
-            logger.msg(f'    Using default usage mode {self._usage_mode} on modifier {self.name}')
+            if len(logger.log_stack) >= 1:
+                logger.msg(
+                    f'    Using default usage mode {self._usage_mode} on modifier {self.name}'
+                )
         else:
             if len(self.modes) > 1 or len(self.modes) == 0:
                 raise InvalidModeError('Cannot auto determine usage '
                                        f'mode for modifier {self.name}')
 
             self._usage_mode = list(self.modes.keys())[0]
-            logger.msg(f'    Using default usage mode {self._usage_mode} on modifier {self.name}')
+            if len(logger.log_stack) >= 1:
+                logger.msg(
+                    f'    Using default usage mode {self._usage_mode} on modifier {self.name}'
+                )
 
     def set_on_executables(self, on_executables):
         """Set the executables this modifier applies to.


### PR DESCRIPTION
Previously, tracking used variables caused modifiers to print their default mode many times.

This merge updates modifiers to only print their default usage information if at least one log is active.