### PR TITLE
Ensure chained experiment definitions are copies of base

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -555,7 +555,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                                                   f'    Primary experiment {parent_namespace}\n' +
                                                   f'    Chained expeirment name: {exp_name}\n' +
                                                   f'    Chain definition: {str(exp)}')
-                chain_stack.append((exp_name, exp))
+                chain_stack.append((exp_name, exp.copy()))
 
         parent_run_dir = self.expander.expand_var(
             self.expander.expansion_str(self.keywords.experiment_run_dir)


### PR DESCRIPTION
This merge fixes an issue where chained experiment definitions were all references to the base experiment definition. As a result, when an experiment generated the commands for its chained experiments the commands were never allowed to render again. This caused repeat experiments (which clone a base experiment) to have the incorrect execution command (which only referred to the base experiment).