### PR TITLE
Add support for floorDiv operator (`//`)

### DIFF
--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -22,12 +22,23 @@ from ramble.util.logger import logger
 import spack.util.naming
 
 supported_math_operators = {
-    ast.Add: operator.add, ast.Sub: operator.sub,
-    ast.Mult: operator.mul, ast.Div: operator.truediv, ast.Pow:
-    operator.pow, ast.BitXor: operator.xor, ast.USub: operator.neg,
-    ast.Eq: operator.eq, ast.NotEq: operator.ne, ast.Gt: operator.gt,
-    ast.GtE: operator.ge, ast.Lt: operator.lt, ast.LtE: operator.le,
-    ast.And: operator.and_, ast.Or: operator.or_, ast.Mod: operator.mod
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.FloorDiv: operator.floordiv,
+    ast.Pow: operator.pow,
+    ast.BitXor: operator.xor,
+    ast.USub: operator.neg,
+    ast.Eq: operator.eq,
+    ast.NotEq: operator.ne,
+    ast.Gt: operator.gt,
+    ast.GtE: operator.ge,
+    ast.Lt: operator.lt,
+    ast.LtE: operator.le,
+    ast.And: operator.and_,
+    ast.Or: operator.or_,
+    ast.Mod: operator.mod,
 }
 
 supported_scalar_function_pointers = {

--- a/lib/ramble/ramble/test/expander.py
+++ b/lib/ramble/ramble/test/expander.py
@@ -127,7 +127,8 @@ def test_expansions(input, output, no_expand_vars, passes):
         ('"2.1.1" in ["2.1.1", "3.1.1", "4.2.1"]', True, set(), 1),
         ('"2.1.2" in ["2.1.1", "3.1.1", "4.2.1"]', False, set(), 1),
         ('{test_mask}', 0, set(['test_mask']), 1),
-    ]
+        ('{var3} // {processes_per_node}', 1, set(), 1),
+    ],
 )
 def test_typed_expansions(input, output, no_expand_vars, passes):
     expansion_vars = exp_dict()


### PR DESCRIPTION
This is useful when the output is expected to be an integer (which gets fed into `int()` and causes error when the input is say '44.0'.) The same can be achieved using `floor`, but the `//` operator is a bit more convenient.

Example usage:

```yaml
variables:
  # versus '{floor({cores_per_node}/{n_threads})}'
  processes_per_node: '{cores_per_node}//{n_threads}'
```