### PR TITLE
Add caching for `define_package_paths` step

### DIFF
--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -504,6 +504,10 @@ class Workspace(object):
 
         self.install_cache = ramble.util.install_cache.SetCache()
 
+        # A dict mapping (concretized) package spec to its install prefix.
+        # This can be re-used by all experiments of the workspace.
+        self.pkg_path_cache = {}
+
         self.results = self.default_results()
 
         self.success_list = ramble.success_criteria.ScopedCriteriaList()


### PR DESCRIPTION
This change adds a workspace-level cache for resolving package install prefix.

Example run (against a workspace with 24 experiments, for an app with 2 spack package deps):

```sh
$ time ramble workspace setup --phase define_package_paths

real    0m3.266s
user    0m2.847s
sys     0m0.445s

$ git -C ramble stash
$ time ramble workspace setup --phase define_package_paths

real    0m52.139s
user    0m43.868s
sys     0m8.750s
```

Tested: tested locally to ensure the variable expansion works as expected. (TODO: Add unit-test for it.)