### PR TITLE
Presubmit verify lic header for changed files only

### DIFF
--- a/lib/ramble/ramble/cmd/license.py
+++ b/lib/ramble/ramble/cmd/license.py
@@ -65,20 +65,30 @@ lgpl_exceptions = [
 ]
 
 
-def _all_ramble_files(root=ramble.paths.prefix):
+def _get_modified_files(root):
+    """Get a list of modified files in the current repository."""
+    diff_args = ['-C', root, 'diff', 'HEAD', '--name-only']
+    files = git(*diff_args, output=str).split()
+    return files
+
+
+def _all_ramble_files(root=ramble.paths.prefix, modified_only=False):
     """Generates root-relative paths of all files in the ramble repository."""
-    visited = set()
-    for cur_root, folders, files in os.walk(root):
-        for filename in files:
-            path = os.path.realpath(os.path.join(cur_root, filename))
+    if modified_only:
+        yield from _get_modified_files(root)
+    else:
+        visited = set()
+        for cur_root, folders, files in os.walk(root):
+            for filename in files:
+                path = os.path.realpath(os.path.join(cur_root, filename))
 
-            if path not in visited:
-                yield os.path.relpath(path, root)
-                visited.add(path)
+                if path not in visited:
+                    yield os.path.relpath(path, root)
+                    visited.add(path)
 
 
-def _licensed_files(root=ramble.paths.prefix):
-    for relpath in _all_ramble_files(root):
+def _licensed_files(root=ramble.paths.prefix, modified_only=False):
+    for relpath in _all_ramble_files(root, modified_only=modified_only):
         if any(regex.match(relpath) for regex in licensed_files):
             yield relpath
 
@@ -178,7 +188,7 @@ def verify(args):
 
     license_errors = LicenseError()
 
-    for relpath in _licensed_files(args.root):
+    for relpath in _licensed_files(args.root, modified_only=args.modified):
         path = os.path.join(args.root, relpath)
         with open(path) as f:
             lines = [line for line in f][:license_lines]
@@ -203,6 +213,13 @@ def setup_parser(subparser):
     verify_parser.add_argument(
         '--root', action='store', default=ramble.paths.prefix,
         help='scan a different prefix for license issues')
+    verify_parser.add_argument(
+        '--modified',
+        '-m',
+        action='store_true',
+        default=False,
+        help='verify only the modified files as outputted by `git ls-files --modified`',
+    )
 
 
 def license(parser, args):

--- a/share/ramble/qa/run-flake8-tests
+++ b/share/ramble/qa/run-flake8-tests
@@ -33,7 +33,9 @@ if [ $? != 0 ]; then
 fi
 
 # verify that the license headers are present
-ramble license verify
+# Only check for modified files as this is for pre-commit.
+# The other PR check ramble-pr-style still verifies all files.
+ramble license verify --modified
 if [ $? != 0 ]; then
   ERROR=1
 fi

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -458,7 +458,7 @@ _ramble_license_list_files() {
 }
 
 _ramble_license_verify() {
-    RAMBLE_COMPREPLY="-h --help --root"
+    RAMBLE_COMPREPLY="-h --help --root --modified -m"
 }
 
 _ramble_list() {


### PR DESCRIPTION
The full scan will still happen in the pr-style check.

This makes it a bit faster for local commits.

Tested:

```sh
$ sed -i '1d' lib/ramble/ramble/cmd/license.py

$ git commit -a
...
Flake8 checks were clean.
Modified files:
 ['lib/ramble/ramble/cmd/license.py', 'share/ramble/qa/run-flake8-tests']
/usr/local/google/home/linsword/hpc-dev/ramble/lib/ramble/ramble/cmd/license.py: the license does not match the expected format
==> Error: 1 improperly licensed files
  files with wrong SPDX-License-Identifier:   0
  files with old license header:              0
  files not containing expected license:      1
```