### PR TITLE
Add the ability for CI tests to parameterize dependencies

### DIFF
--- a/share/ramble/cloud-build/Dockerfile-yum
+++ b/share/ramble/cloud-build/Dockerfile-yum
@@ -1,10 +1,16 @@
-FROM centos:7 as builder
+ARG BASE_IMG=centos
+ARG BASE_VER=7
+FROM ${BASE_IMG}:${BASE_VER} as builder
 
+ARG SPACK_REF=releases/latest
+ARG CONDA_VER=4.10.3
 RUN yum install -yq git python3 python3-pip wget mercurial which svn curl gcc && rm -rf /var/lib/apt/lists/*
 RUN cd /opt && \
-    git clone https://github.com/spack/spack -b v0.19.2 && \
+    git clone https://github.com/spack/spack && \
+    cd spack && \
+    git checkout $SPACK_REF && \
     . /opt/spack/share/spack/setup-env.sh && \
-    spack install miniconda3 && \
+    spack install miniconda3@${CONDA_VER} && \
     spack clean -a
 RUN echo -e "export PATH=$(. /opt/spack/share/spack/setup-env.sh && spack location -i miniconda3)/bin:${PATH}\n. /opt/spack/share/spack/setup-env.sh" > /etc/profile.d/ramble.sh
 RUN cd /opt &&  \
@@ -14,7 +20,7 @@ RUN cd /opt &&  \
     conda install -qy pip && \
     python -m pip install -r /opt/requirements.txt
 
-FROM centos:7
+FROM ${BASE_IMG}:${BASE_VER}
 
 COPY --from=builder / /
 

--- a/share/ramble/cloud-build/ramble-image-builder.yaml
+++ b/share/ramble/cloud-build/ramble-image-builder.yaml
@@ -13,13 +13,27 @@ steps:
     args:
     - 'build'
     - '-t'
-    - 'us-central1-docker.pkg.dev/$PROJECT_ID/ramble-repo/ramble-centos7:latest'
+    - 'us-central1-docker.pkg.dev/$PROJECT_ID/ramble-repo/ramble-${_BASE_IMG}-${_BASE_VER}-spack${_SPACK_REF}-conda${_CONDA_VER}:latest'
     - '--cache-from'
-    - 'us-central1-docker.pkg.dev/$PROJECT_ID/ramble-repo/ramble-centos7:latest'
+    - 'us-central1-docker.pkg.dev/$PROJECT_ID/ramble-repo/ramble-${_BASE_IMG}-${_BASE_VER}-spack${_SPACK_REF}-conda${_CONDA_VER}:latest'
     - '-f'
-    - 'share/ramble/cloud-build/Dockerfile-centos7'
+    - 'share/ramble/cloud-build/Dockerfile-${_PKG_MANAGER}'
+    - '--build-arg'
+    - 'BASE_IMG=${_BASE_IMG}'
+    - '--build-arg'
+    - 'BASE_VER=${_BASE_VER}'
+    - '--build-arg'
+    - 'SPACK_REF=${_SPACK_REF}'
+    - '--build-arg'
+    - 'CONDA_VER=${_CONDA_VER}'
     - '.'
-images: ['us-central1-docker.pkg.dev/$PROJECT_ID/ramble-repo/ramble-centos7']
+substitutions:
+  _SPACK_REF: v0.21.2
+  _CONDA_VER: 22.11.1
+  _BASE_IMG: centos
+  _BASE_VER: '7'
+  _PKG_MANAGER: 'yum'
+images: ['us-central1-docker.pkg.dev/$PROJECT_ID/ramble-repo/ramble-${_BASE_IMG}-${_BASE_VER}-spack${_SPACK_REF}-conda${_CONDA_VER}']
 timeout: 1500s
 options:
   machineType: N1_HIGHCPU_8

--- a/share/ramble/cloud-build/ramble-pr-software-conflicts.yaml
+++ b/share/ramble/cloud-build/ramble-pr-software-conflicts.yaml
@@ -13,7 +13,7 @@ steps:
       - fetch
       - '--unshallow'
     id: ramble-clone
-  - name: us-central1-docker.pkg.dev/$PROJECT_ID/ramble-repo/ramble-centos7:latest
+  - name: us-central1-docker.pkg.dev/$PROJECT_ID/ramble-repo/ramble-${_BASE_IMG}-${_BASE_VER}-spack${_SPACK_REF}-conda${_CONDA_VER}:latest
     args:
       - '-c'
       - |
@@ -25,6 +25,9 @@ steps:
 
         . /opt/spack/share/spack/setup-env.sh
         . /workspace/share/ramble/setup-env.sh
+
+        echo "Spack version is $(spack --version)"
+        echo "Python version is $(python3 --version)"
 
         ramble software-definitions -s
 
@@ -43,7 +46,11 @@ steps:
         exit $$error
     id: ramble-style-tests
     entrypoint: /bin/bash
-
+substitutions:
+  _SPACK_REF: v0.21.2
+  _CONDA_VER: 22.11.1
+  _BASE_IMG: centos
+  _BASE_VER: '7'
 timeout: 600s
 options:
   machineType: N1_HIGHCPU_8

--- a/share/ramble/cloud-build/ramble-pr-style.yaml
+++ b/share/ramble/cloud-build/ramble-pr-style.yaml
@@ -13,7 +13,7 @@ steps:
       - fetch
       - '--unshallow'
     id: ramble-clone
-  - name: us-central1-docker.pkg.dev/$PROJECT_ID/ramble-repo/ramble-centos7:latest
+  - name: us-central1-docker.pkg.dev/$PROJECT_ID/ramble-repo/ramble-${_BASE_IMG}-${_BASE_VER}-spack${_SPACK_REF}-conda${_CONDA_VER}:latest
     args:
       - '-c'
       - |
@@ -25,6 +25,9 @@ steps:
 
         . /opt/spack/share/spack/setup-env.sh
         . /workspace/share/ramble/setup-env.sh
+
+        echo "Spack version is $(spack --version)"
+        echo "Python version is $(python3 --version)"
 
         ramble flake8 -U
         # $$ characters are required for cloud-build:
@@ -87,7 +90,11 @@ steps:
         exit $$error
     id: ramble-style-tests
     entrypoint: /bin/bash
-
+substitutions:
+  _SPACK_REF: v0.21.2
+  _CONDA_VER: 22.11.1
+  _BASE_IMG: centos
+  _BASE_VER: '7'
 timeout: 600s
 options:
   machineType: N1_HIGHCPU_8

--- a/share/ramble/cloud-build/ramble-pr-unit-tests.yaml
+++ b/share/ramble/cloud-build/ramble-pr-unit-tests.yaml
@@ -13,7 +13,7 @@ steps:
       - fetch
       - '--unshallow'
     id: ramble-clone
-  - name: us-central1-docker.pkg.dev/$PROJECT_ID/ramble-repo/ramble-centos7:latest
+  - name: us-central1-docker.pkg.dev/$PROJECT_ID/ramble-repo/ramble-${_BASE_IMG}-${_BASE_VER}-spack${_SPACK_REF}-conda${_CONDA_VER}:latest
     args:
       - '-c'
       - |
@@ -25,6 +25,9 @@ steps:
 
         . /opt/spack/share/spack/setup-env.sh
         . /workspace/share/ramble/setup-env.sh
+
+        echo "Spack version is $(spack --version)"
+        echo "Python version is $(python3 --version)"
 
         COVERAGE=true LONG=true /workspace/share/ramble/qa/run-unit-tests
         # $$ characters are required for cloud-build:
@@ -64,7 +67,11 @@ steps:
         exit $$error
     id: ramble-unit-tests
     entrypoint: /bin/bash
-
+substitutions:
+  _SPACK_REF: v0.21.2
+  _CONDA_VER: 22.11.1
+  _BASE_IMG: centos
+  _BASE_VER: '7'
 timeout: 900s
 options:
   machineType: N1_HIGHCPU_8


### PR DESCRIPTION
This merge updates the CI test runners so they can be parameterized.

Currently exposed parameterization includes:
- Spack version
- Base image OS
- Base image OS Version
- Conda version (currently for python version)