### PR TITLE
Mock out python cache removal in unit test

### DIFF
--- a/lib/ramble/ramble/cmd/clean.py
+++ b/lib/ramble/ramble/cmd/clean.py
@@ -61,15 +61,20 @@ def clean(parser, args):
 
     if args.python_cache:
         logger.msg('Removing python cache files')
-        for directory in [lib_path, var_path]:
-            for root, dirs, files in os.walk(directory):
-                for f in files:
-                    if f.endswith('.pyc') or f.endswith('.pyo'):
-                        fname = os.path.join(root, f)
-                        logger.debug(f'Removing {fname}')
-                        os.remove(fname)
-                for d in dirs:
-                    if d == '__pycache__':
-                        dname = os.path.join(root, d)
-                        logger.debug(f'Removing {dname}')
-                        shutil.rmtree(dname)
+        remove_python_caches()
+
+
+def remove_python_caches():
+    logger.msg('Removing python cache files')
+    for directory in [lib_path, var_path]:
+        for root, dirs, files in os.walk(directory):
+            for f in files:
+                if f.endswith('.pyc') or f.endswith('.pyo'):
+                    fname = os.path.join(root, f)
+                    logger.debug(f'Removing {fname}')
+                    os.remove(fname)
+            for d in dirs:
+                if d == '__pycache__':
+                    dname = os.path.join(root, d)
+                    logger.debug(f'Removing {dname}')
+                    shutil.rmtree(dname)

--- a/lib/ramble/ramble/test/cmd/clean.py
+++ b/lib/ramble/ramble/test/cmd/clean.py
@@ -15,8 +15,9 @@ import ramble.main
 
 clean = ramble.main.RambleCommand('clean')
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32",
-                                reason="does not run on windows")
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="does not run on windows"
+)
 
 
 @pytest.fixture()
@@ -33,25 +34,29 @@ def mock_calls_for_clean(monkeypatch):
             counts[self.name] += 1
 
     monkeypatch.setattr(
-        ramble.caches.fetch_cache, 'destroy', Counter('downloads'),
-        raising=False)
+        ramble.caches.fetch_cache, 'destroy', Counter('downloads'), raising=False
+    )
+    monkeypatch.setattr(ramble.caches.misc_cache, 'destroy', Counter('caches'))
     monkeypatch.setattr(
-        ramble.caches.misc_cache, 'destroy', Counter('caches'))
+        ramble.cmd.clean, 'remove_python_caches', Counter('python_caches')
+    )
 
     yield counts
 
 
-all_effects = ['downloads', 'caches']
+all_effects = ['downloads', 'caches', 'python_caches']
 
 
-@pytest.mark.usefixtures(
-    'config'
+@pytest.mark.usefixtures('config')
+@pytest.mark.parametrize(
+    'command_line,effects',
+    [
+        ('-d', ['downloads']),
+        ('-m', ['caches']),
+        ('-p', ['python_caches']),
+        ('-a', all_effects),
+    ],
 )
-@pytest.mark.parametrize('command_line,effects', [
-    ('-d',       ['downloads']),
-    ('-m',       ['caches']),
-    ('-a',       all_effects),
-])
 def test_function_calls(command_line, effects, mock_calls_for_clean):
 
     # Call the command with the supplied command line


### PR DESCRIPTION
Otherwise running `ramble unit-test -k test_function_calls` has real side-effects and can get pretty slow.