### PR TITLE
Update tutorials to use intel-oneapi-mpi

### DIFF
--- a/examples/basic_expansion_config.yaml
+++ b/examples/basic_expansion_config.yaml
@@ -36,8 +36,8 @@ ramble:
       ompi412:
         spack_spec: openmpi@4.1.2 +legacylaunchers +pmi +thread_multiple +cxx target=x86_64
         compiler: gcc9
-      impi2018:
-        spack_spec: intel-mpi@2018.4.274
+      impi2021:
+        spack_spec: intel-oneapi-mpi@2021.11.0
         compiler: gcc9
       openfoam:
         spack_spec: openfoam-org@7
@@ -56,5 +56,5 @@ ramble:
         - openfoam
       wrfv4:
         packages:
-        - impi2018
+        - impi2021
         - wrfv4

--- a/examples/basic_gromacs_config.yaml
+++ b/examples/basic_gromacs_config.yaml
@@ -42,8 +42,8 @@ ramble:
       gcc9:
         spack_spec: gcc@9.4.0 target=x86_64
         compiler_spec: gcc@9.4.0
-      impi2018:
-        spack_spec: intel-mpi@2018.4.274 target=x86_64
+      impi2021:
+        spack_spec: intel-oneapi-mpi@2021.11.0 target=x86_64
         compiler: gcc9
       gromacs:
         spack_spec: gromacs@2021.6
@@ -52,4 +52,4 @@ ramble:
       gromacs:
         packages:
         - gromacs
-        - impi2018
+        - impi2021

--- a/examples/slurm_execute_experiment.tpl
+++ b/examples/slurm_execute_experiment.tpl
@@ -1,6 +1,7 @@
 #!/bin/bash
 #SBATCH -N {n_nodes}
 #SBATCH --ntasks-per-node {processes_per_node}
+#SBATCH -p {partition_name}
 #SBATCH -J {application_name}_{workload_name}_{experiment_name}
 
 # This is a template execution script for

--- a/examples/vector_gromacs_software_config.yaml
+++ b/examples/vector_gromacs_software_config.yaml
@@ -30,8 +30,8 @@ ramble:
       gcc9:
         spack_spec: gcc@9.4.0 target=x86_64
         compiler_spec: gcc@9.4.0
-      impi2018:
-        spack_spec: intel-mpi@2018.4.274 target=x86_64
+      impi2021:
+        spack_spec: intel-oneapi-mpi@2021.11.0 target=x86_64
         compiler: gcc9
       gromacs-{gromacs_version}:
         spack_spec: gromacs@{gromacs_version}
@@ -40,4 +40,4 @@ ramble:
       gromacs-{gromacs_version}:
         packages:
         - gromacs-{gromacs_version}
-        - impi2018
+        - impi2021

--- a/examples/vector_matrix_gromacs_config.yaml
+++ b/examples/vector_matrix_gromacs_config.yaml
@@ -27,8 +27,8 @@ ramble:
       gcc9:
         spack_spec: gcc@9.4.0 target=x86_64
         compiler_spec: gcc@9.4.0
-      impi2018:
-        spack_spec: intel-mpi@2018.4.274 target=x86_64
+      impi2021:
+        spack_spec: intel-oneapi-mpi@2021.11.0 target=x86_64
         compiler: gcc9
       gromacs:
         spack_spec: gromacs@2021.6
@@ -37,4 +37,4 @@ ramble:
       gromacs:
         packages:
         - gromacs
-        - impi2018
+        - impi2021

--- a/lib/ramble/docs/configuration_files.rst
+++ b/lib/ramble/docs/configuration_files.rst
@@ -521,8 +521,8 @@ Below is an annotated example of the spack dictionary.
         gcc9: # Abstract name to refer to this package
           spack_spec: gcc@9.3.0 target=x86_64 # Spack spec for this package
           compiler_spec: gcc@9.3.0 # Spack compiler spec for this package
-        impi2018:
-          spack_spec: intel-mpi@2018.4.274 target=x86_64
+        impi2021:
+          spack_spec: intel-oneapi-mpi@2021.11.0 target=x86_64
           compiler: gcc9 # Other package name to use as compiler for this package
         gromacs:
           spack_spec: gromacs@2022.4
@@ -530,7 +530,7 @@ Below is an annotated example of the spack dictionary.
       environments:
         gromacs:
           packages: # List of packages to include in this environment
-          - impi2018
+          - impi2021
           - gromacs
 
 Packages and environments defined inside the ``spack`` config section are

--- a/lib/ramble/docs/tutorials/10_using_modifiers.rst
+++ b/lib/ramble/docs/tutorials/10_using_modifiers.rst
@@ -148,7 +148,7 @@ The resulting configuration file should look like the following.
           gcc9:
             spack_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-mpi@2018.4.274
+            spack_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           wrfv4:
             spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
@@ -242,7 +242,7 @@ look like the following:
           gcc9:
             spack_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-mpi@2018.4.274
+            spack_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           wrfv4:
             spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
@@ -311,7 +311,7 @@ configuration file should look like the following:
           gcc9:
             spack_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-mpi@2018.4.274
+            spack_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           aps:
             spack_spec: intel-oneapi-vtune

--- a/lib/ramble/docs/tutorials/11_using_internals.rst
+++ b/lib/ramble/docs/tutorials/11_using_internals.rst
@@ -142,7 +142,7 @@ the following:
           gcc9:
             spack_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-mpi@2018.4.274
+            spack_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           wrfv4:
             spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
@@ -248,7 +248,7 @@ configuration file should look like the following:
           gcc9:
             spack_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-mpi@2018.4.274
+            spack_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           wrfv4:
             spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
@@ -339,7 +339,7 @@ following:
           gcc9:
             spack_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-mpi@2018.4.274
+            spack_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           wrfv4:
             spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem

--- a/lib/ramble/docs/tutorials/2_running_a_simple_gromacs_experiment.rst
+++ b/lib/ramble/docs/tutorials/2_running_a_simple_gromacs_experiment.rst
@@ -86,8 +86,8 @@ software configuration:
       spack_spec = gcc@9.3.0
 
     Software Specs:
-      impi2018:
-        spack_spec = intel-mpi@2018.4.274
+      impi2021:
+        spack_spec = intel-oneapi-mpi@2021.11.0
       gromacs:
         spack_spec = gromacs@2020.5
         compiler = gcc9

--- a/lib/ramble/docs/tutorials/5_changing_your_software_stack.rst
+++ b/lib/ramble/docs/tutorials/5_changing_your_software_stack.rst
@@ -48,10 +48,10 @@ environments:
             gcc9:
               Spack spec: gcc@9.4.0 target=x86_64
               Compiler spec: gcc@9.4.0
-        impi2018:
+        impi2021:
           Rendered Packages:
-            impi2018:
-              Spack spec: intel-mpi@2018.4.274 target=x86_64
+            impi2021:
+              Spack spec: intel-oneapi-mpi@2021.11.0 target=x86_64
               Compiler: gcc9
         gromacs:
           Rendered Packages:
@@ -63,7 +63,7 @@ environments:
           Rendered Environments:
             gromacs Packages:
               - gromacs
-              - impi2018
+              - impi2021
 
 
 Currently, this command outputs every package and software environment
@@ -84,8 +84,8 @@ The relevant portion of the workspace configuration file is:
         gcc9:
           spack_spec: gcc@9.4.0 target=x86_64
           compiler_spec: gcc@9.4.0
-        impi2018:
-          spack_spec: intel-mpi@2018.4.274 target=x86_64
+        impi2021:
+          spack_spec: intel-oneapi-mpi@2021.11.0 target=x86_64
           compiler: gcc9
         gromacs:
           spack_spec: gromacs@2021.6
@@ -94,7 +94,7 @@ The relevant portion of the workspace configuration file is:
         gromacs:
           packages:
           - gromacs
-          - impi2018
+          - impi2021
 
 In this configuration, the ``packages`` block defines software packages that
 can be used to build experiment environments out of. The ``environments`` block

--- a/lib/ramble/docs/tutorials/6_configuring_a_scaling_study.rst
+++ b/lib/ramble/docs/tutorials/6_configuring_a_scaling_study.rst
@@ -227,7 +227,7 @@ look like the following:
           gcc9:
             spack_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-mpi@2018.4.274
+            spack_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           wrfv4:
             spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem

--- a/lib/ramble/docs/tutorials/7_using_zips_and_matrices.rst
+++ b/lib/ramble/docs/tutorials/7_using_zips_and_matrices.rst
@@ -116,7 +116,7 @@ the above section. The result should look like the following:
           gcc9:
             spack_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-mpi@2018.4.274
+            spack_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           wrfv4:
             spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
@@ -206,7 +206,7 @@ should have the following in your ``ramble.yaml``:
           gcc9:
             spack_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-mpi@2018.4.274
+            spack_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           wrfv4:
             spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
@@ -268,7 +268,7 @@ Your final configuration file should look something like:
           gcc9:
             spack_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-mpi@2018.4.274
+            spack_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           wrfv4:
             spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem

--- a/lib/ramble/docs/tutorials/8_var_expansion_indirection_and_stack_parameterization.rst
+++ b/lib/ramble/docs/tutorials/8_var_expansion_indirection_and_stack_parameterization.rst
@@ -99,7 +99,7 @@ final configuration from the previous tutorial.
           gcc9:
             spack_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-mpi@2018.4.274
+            spack_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           wrfv4:
             spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
@@ -195,7 +195,7 @@ generation as well. The result might look like the following:
           gcc9:
             spack_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-mpi@2018.4.274
+            spack_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           openmpi:
             spack_spec: openmpi@3.1.6 +orterunprefix
@@ -265,7 +265,7 @@ into the matrix. The result might look like the following:
           gcc9:
             spack_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-mpi@2018.4.274
+            spack_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           openmpi:
             spack_spec: openmpi@3.1.6 +orterunprefix
@@ -374,7 +374,7 @@ resulting configuration might look like the following:
           gcc9:
             spack_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-mpi@2018.4.274
+            spack_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           openmpi:
             spack_spec: openmpi@3.1.6 +orterunprefix
@@ -463,7 +463,7 @@ The resulting configuration file might look like the following:
           gcc9:
             spack_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-mpi@2018.4.274
+            spack_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           openmpi:
             spack_spec: openmpi@3.1.6 +orterunprefix

--- a/lib/ramble/docs/tutorials/9_success_criteria.rst
+++ b/lib/ramble/docs/tutorials/9_success_criteria.rst
@@ -124,7 +124,7 @@ configuration file might look like the following:
           gcc9:
             spack_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-mpi@2018.4.274
+            spack_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           wrfv4:
             spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
@@ -198,7 +198,7 @@ resulting configuration file might look like the following:
           gcc9:
             spack_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-mpi@2018.4.274
+            spack_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           wrfv4:
             spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem

--- a/lib/ramble/docs/tutorials/mirrors.rst
+++ b/lib/ramble/docs/tutorials/mirrors.rst
@@ -97,7 +97,7 @@ will look something like this:
           gcc9:
             spack_spec: gcc@9.3.0
           intel-mpi:
-            spack_spec: intel-mpi@2018.4.274
+            spack_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           wrfv4:
             spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
@@ -125,8 +125,8 @@ this mirror in the first place.
 
     ==>     Executing phase mirror_inputs
     ==>     Executing phase create_spack_env
-    ==> Concretized intel-mpi@2018.4.274%gcc@<gcc-version>
-     -   <hash>   intel-mpi@2018.4.274%gcc@<version>_etc.
+    ==> Concretized intel-oneapi-mpi@2021.11.0%gcc@<gcc-version>
+     -   <hash>   intel-oneapi-mpi@2021.11.0%gcc@<version>_etc.
      -   <etc>        ^(short list of software prerequisistes for intel-mpi)
 
     ==> Concretized wrf@4.2%gcc@<version> <wrf options>
@@ -141,8 +141,8 @@ this mirror in the first place.
     ==> Concretized wrf@4.2%gcc@<version> <wrf options>
      -   (long list of software prerequisites for wrf@4.2)
 
-    ==> Concretized intel-mpi@2018.4.274%gcc@<gcc-version>
-     -   <hash>   intel-mpi@2018.4.274%gcc@<version>_etc.
+    ==> Concretized intel-oneapi-mpi@2021.11.0%gcc@<gcc-version>
+     -   <hash>   intel-oneapi-mpi@2021.11.0%gcc@<version>_etc.
      -   <etc>        ^(short list of software prerequisistes for intel-mpi)
 
     ==>     Executing phase mirror_software

--- a/lib/ramble/docs/tutorials/shared/wrf_scaling_workspace.rst
+++ b/lib/ramble/docs/tutorials/shared/wrf_scaling_workspace.rst
@@ -49,7 +49,7 @@ final configuration from a previous tutorial.
           gcc9:
             spack_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-mpi@2018.4.274
+            spack_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           wrfv4:
             spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem

--- a/lib/ramble/docs/workspace_config.rst
+++ b/lib/ramble/docs/workspace_config.rst
@@ -1069,8 +1069,8 @@ variable can be used to submit the same experiment to multiple batch systems.
       packages:
         gcc9:
           spack_spec: gcc@9.3.0 target=x86_64
-        impi2018:
-          spack_spec: intel-mpi@2018.4.274 target=x86_64
+        impi2021:
+          spack_spec: intel-oneapi-mpi@2021.11.0 target=x86_64
           compiler: gcc9
         gromacs:
           spack_spec: gromacs@2022.4
@@ -1078,7 +1078,7 @@ variable can be used to submit the same experiment to multiple batch systems.
       environments:
         gromacs:
           packages:
-          - impi2018
+          - impi2021
           - gromacs
 
 The above example overrides the generated ``batch_submit`` variable to change


### PR DESCRIPTION
The intel-mpi package is deprecated and results in errors when trying to run the tutorials.

Also a minor update on the slurm template to include in partition_name.