### PR TITLE
Create instance variables for directives

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -45,6 +45,7 @@ import ramble.util.env
 import ramble.util.directives
 import ramble.util.stats
 import ramble.util.graph
+import ramble.util.class_attributes
 from ramble.util.logger import logger
 
 from ramble.workspace import namespace
@@ -88,6 +89,8 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
 
     def __init__(self, file_path):
         super().__init__()
+
+        ramble.util.class_attributes.convert_class_attributes(self)
 
         self.keywords = ramble.keywords.keywords
 

--- a/lib/ramble/ramble/language/language_base.py
+++ b/lib/ramble/ramble/language/language_base.py
@@ -95,7 +95,8 @@ class DirectiveMeta(type):
 
             directive_attrs = {
                 '_directive_functions': {},
-                '_directive_classes': {}
+                '_directive_classes': {},
+                '_directive_names': DirectiveMeta._directive_names.copy()
             }
 
             for attr in directive_attrs.keys():

--- a/lib/ramble/ramble/modifier.py
+++ b/lib/ramble/ramble/modifier.py
@@ -20,6 +20,7 @@ from ramble.language.shared_language import SharedMeta, register_builtin  # noqa
 from ramble.error import RambleError
 import ramble.util.colors as rucolor
 import ramble.util.directives
+import ramble.util.class_attributes
 from ramble.util.logger import logger
 
 
@@ -40,6 +41,8 @@ class ModifierBase(object, metaclass=ModifierMeta):
 
     def __init__(self, file_path):
         super().__init__()
+
+        ramble.util.class_attributes.convert_class_attributes(self)
 
         self._file_path = file_path
         self._on_executables = ['*']

--- a/lib/ramble/ramble/test/application_tests.py
+++ b/lib/ramble/ramble/test/application_tests.py
@@ -533,3 +533,18 @@ ramble:
     test_answer = "/workspace/experiments/bar/test_wl2/baz/execute_experiment"
     executable_application_instance._derive_variables_for_template_path(ws1)
     assert executable_application_instance.variables['execute_experiment'] == test_answer
+
+
+def test_class_attributes(mutable_mock_apps_repo):
+    basic_inst = mutable_mock_apps_repo.get('basic')
+    basic_copy = basic_inst.copy()
+
+    instances = [basic_inst, basic_copy]
+    for inst in instances:
+        assert hasattr(inst, 'workloads')
+        assert 'test_wl' in inst.workloads
+
+    basic_copy.workload('added_workload', executables=['foo'])
+
+    assert 'added_workload' in basic_copy.workloads
+    assert 'added_workload' not in basic_inst.workloads

--- a/lib/ramble/ramble/test/modifier_language.py
+++ b/lib/ramble/ramble/test/modifier_language.py
@@ -549,3 +549,16 @@ def test_modifier_variable_directive(mod_class, func_type):
         assert test_def['name'] in mod_inst.modifier_variables[mode]
         assert test_def['description'] == mod_inst.modifier_variables[mode][var_name].description
         assert test_def['default'] == mod_inst.modifier_variables[mode][var_name].default
+
+
+@pytest.mark.parametrize('func_type', func_types)
+@pytest.mark.parametrize('mod_class', mod_types)
+def test_modifier_class_attributes(mod_class, func_type):
+    test_class = generate_mod_class(mod_class)
+    mod_inst = test_class('/not/a/path')
+    mod_copy = mod_inst.copy()
+
+    mod_copy.mode('added_mode', description='Mode added to test attributes')
+
+    assert 'added_mode' in mod_copy.modes
+    assert 'added_mode' not in mod_inst.modes

--- a/lib/ramble/ramble/util/class_attributes.py
+++ b/lib/ramble/ramble/util/class_attributes.py
@@ -1,0 +1,24 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+def convert_class_attributes(obj):
+    """Convert class attributes defined from directives to instance attributes
+    Class attributes that are valid for conversion are stored in the _directive_names
+    attribute.
+
+    Args:
+        obj (Object): Input object instance to convert attributes in
+    """
+
+    if hasattr(obj, '_directive_names'):
+        dir_set = dir(obj)
+        var_set = vars(obj)
+        for attr in obj._directive_names:
+            if attr in dir_set and attr not in var_set:
+                inst_val = getattr(obj, attr).copy()
+                setattr(obj, attr, inst_val)


### PR DESCRIPTION
This merge changes the type of attributes created from directives from class attributes to instance attributes. This allows modification of an instance's attributes without affecting all of other instances.