### PR TITLE
Skip tests when encounter FileNotFound error

### DIFF
--- a/lib/ramble/ramble/test/dry_run_helpers.py
+++ b/lib/ramble/ramble/test/dry_run_helpers.py
@@ -7,6 +7,9 @@
 # except according to those terms.
 
 from enum import Enum
+from functools import wraps
+
+import pytest
 
 import spack.util.spack_yaml as syaml
 
@@ -84,3 +87,15 @@ def search_files_for_string(file_list, string):
             if string in f.read():
                 return True
     return False
+
+
+def skip_upon_exception(skipped_exceptions, reason):
+    def _decorator(func):
+        @wraps(func)
+        def _wrapper(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except skipped_exceptions as err:
+                raise pytest.skip(f'{reason} with error {err}')
+        return _wrapper
+    return _decorator

--- a/lib/ramble/ramble/test/end_to_end/known_applications.py
+++ b/lib/ramble/ramble/test/end_to_end/known_applications.py
@@ -17,6 +17,7 @@ import ramble.workspace
 import ramble.config
 import ramble.software_environments
 from ramble.main import RambleCommand
+from ramble.test.dry_run_helpers import skip_upon_exception
 
 
 # everything here uses the mock_workspace_path
@@ -27,6 +28,7 @@ workspace = RambleCommand('workspace')
 
 
 @pytest.mark.long
+@skip_upon_exception(FileNotFoundError, 'Expected non-existent file during dry-run')
 def test_known_applications(application, capsys):
     info_cmd = RambleCommand('info')
 


### PR DESCRIPTION
This can happen legitimately for apps (for instance reading a config file it installs in prior stages.) However they causes a failure in the dry-mode due to the install stage never happened. Skipping instead of failing such tests as a temporary workaround.