### PR TITLE
Ensure consistent spec ordering

### DIFF
--- a/lib/ramble/ramble/spack_runner.py
+++ b/lib/ramble/ramble/spack_runner.py
@@ -519,7 +519,9 @@ class SpackRunner(object):
         env_file[spack_namespace]['concretizer']['unify'] = True
 
         env_file[spack_namespace]['specs'] = syaml.syaml_list()
-        env_file[spack_namespace]['specs'].extend(self.env_contents)
+        # Ensure the specs content are consistently sorted.
+        # Otherwise the hash checking may artificially miss due to ordering.
+        env_file[spack_namespace]['specs'].extend(sorted(self.env_contents))
 
         env_file[spack_namespace]['include'] = self.includes
 

--- a/lib/ramble/ramble/test/spack_runner.py
+++ b/lib/ramble/ramble/test/spack_runner.py
@@ -79,6 +79,7 @@ def test_env_concretize_skips_already_concretized_envs(tmpdir, capsys):
         sr.create_env(env_path)
         sr.activate()
         sr.add_spec('zlib')
+        sr.add_spec('intel-oneapi-mpi')
 
         # Generate an initial env file
         sr.generate_env_file()


### PR DESCRIPTION
Otherwise the hash comparison will fail, since the json serialization only sort objects but not arrays.

```sh
// The workspace has already been concretized
$ ls $RAMBLE_WORKSPACE/software/gromacs/
ramble.hash  spack.lock  spack.yaml

// With the fix
$ time for run in {1..3}; do ramble workspace setup --where '{experiment_index} in [1]' &> /dev/null; done

real    0m24.469s
user    0m25.277s
sys     0m9.835s

// Without the fix
$ git stash

// Normally 1 out of 2 to 3 times the ordering issue will appear and
cause unnecessary concretization
$ time for run in {1..3}; do ramble workspace setup --where '{experiment_index} in [1]' &> /dev/null; done

real    1m22.763s
user    1m20.679s
sys     0m12.826s
```