### PR TITLE
Update spack/util/debug.py to fix io.UnsupportedOperation paralell tests

### DIFF
--- a/lib/ramble/spack/util/debug.py
+++ b/lib/ramble/spack/util/debug.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)

--- a/lib/ramble/spack/util/debug.py
+++ b/lib/ramble/spack/util/debug.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -10,6 +10,7 @@ a stack trace and drops the user into an interpreter.
 
 """
 import code
+import io
 import os
 import pdb
 import signal
@@ -20,13 +21,13 @@ import traceback
 def debug_handler(sig, frame):
     """Interrupt running process, and provide a python prompt for
     interactive debugging."""
-    d = {'_frame': frame}         # Allow access to frame object.
-    d.update(frame.f_globals)    # Unless shadowed by global
+    d = {"_frame": frame}  # Allow access to frame object.
+    d.update(frame.f_globals)  # Unless shadowed by global
     d.update(frame.f_locals)
 
     i = code.InteractiveConsole(d)
-    message  = "Signal received : entering python shell.\nTraceback:\n"
-    message += ''.join(traceback.format_stack(frame))
+    message = "Signal received : entering python shell.\nTraceback:\n"
+    message += "".join(traceback.format_stack(frame))
     i.interact(message)
     os._exit(1)  # Use os._exit to avoid test harness.
 
@@ -53,7 +54,10 @@ class ForkablePdb(pdb.Pdb):
     the run of Spack.install, or any where else Spack spawns a child process.
     """
 
-    _original_stdin_fd = sys.stdin.fileno()
+    try:
+        _original_stdin_fd = sys.stdin.fileno()
+    except io.UnsupportedOperation:
+        _original_stdin_fd = None
     _original_stdin = None
 
     def __init__(self, stdout_fd=None, stderr_fd=None):

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,3 +14,4 @@ markers =
   enable_compiler_verification: enable compiler verification within unit tests
   enable_compiler_link_paths: verifies compiler link paths within unit tests
   disable_clean_stage_check: avoid failing tests if there are leftover files in the stage area
+  long: mark test as long running


### PR DESCRIPTION
Without this we get:

```
ERROR lib/ramble/ramble/test/workspace_hashing/workspace_setup_creates_inventory.py - io.UnsupportedOperation: redirected stdin is pseudofile, has no fileno()
```

(We previously fixed something like this)