### PR TITLE
Allow variables to be named the same as an application

### DIFF
--- a/lib/ramble/ramble/application_types/spack.py
+++ b/lib/ramble/ramble/application_types/spack.py
@@ -335,7 +335,11 @@ class SpackApplication(ApplicationBase):
         ):
             if pkg_spec in cache:
                 spack_pkg_name, pkg_path = cache.get(pkg_spec)
-                self.variables[spack_pkg_name] = pkg_path
+                if spack_pkg_name not in self.variables:
+                    self.variables[spack_pkg_name] = pkg_path
+                else:
+                    logger.msg(f'Variable {spack_pkg_name} defined. ' +
+                               'Skipping extraction from spack')
             else:
                 unresolved_specs.append(pkg_spec)
         if not unresolved_specs:
@@ -350,8 +354,12 @@ class SpackApplication(ApplicationBase):
 
             for pkg_spec in unresolved_specs:
                 spack_pkg_name, pkg_path = self.spack_runner.get_package_path(pkg_spec)
-                self.variables[spack_pkg_name] = pkg_path
-                cache[pkg_spec] = (spack_pkg_name, pkg_path)
+                if spack_pkg_name not in self.variables:
+                    self.variables[spack_pkg_name] = pkg_path
+                    cache[pkg_spec] = (spack_pkg_name, pkg_path)
+                else:
+                    logger.msg(f'Variable {spack_pkg_name} defined. ' +
+                               'Skipping extraction from spack')
 
         except ramble.spack_runner.RunnerError as e:
             logger.die(e)

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -349,7 +349,7 @@ class ExperimentSet(object):
         for context in self._contexts:
             if context not in no_var_contexts:
                 var_name = f'{context.name}_name'
-                if self._context[context].context_name not in final_context.variables:
+                if var_name not in final_context.variables:
                     final_context.variables[var_name] = self._context[context].context_name
 
         # Set namespaces

--- a/lib/ramble/ramble/test/end_to_end/define_package_paths.py
+++ b/lib/ramble/ramble/test/end_to_end/define_package_paths.py
@@ -93,3 +93,71 @@ ramble:
         assert 'Executing phase define_package_paths' in content
         assert gromacs_log_line not in content
         assert impi_log_line not in content
+
+
+def test_package_path_variables():
+    test_config = """
+ramble:
+  variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: '{execute_experiment}'
+    processes_per_node: '1'
+  applications:
+    gromacs:
+      workloads:
+        water_bare:
+          experiments:
+            test1:
+              variables:
+                gromacs: '/test/path'
+                n_nodes: '1'
+            test2:
+              variables:
+                n_nodes: '2'
+  spack:
+    packages:
+      gromacs:
+        spack_spec: gromacs
+      intel-mpi:
+        spack_spec: intel-oneapi-mpi@2021.11.0
+    environments:
+      gromacs:
+        packages:
+        - gromacs
+        - intel-mpi
+"""
+    workspace_name = 'test-define-package-paths'
+    ws = ramble.workspace.create(workspace_name)
+    ws.write()
+
+    config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+
+    with open(config_path, 'w+') as f:
+        f.write(test_config)
+
+    ws._re_read()
+
+    workspace(
+        'setup',
+        '--dry-run',
+        global_args=['-w', workspace_name],
+    )
+
+    # test1 should attempt to invoke `spack location -i` on dep packages.
+    # However this will not be cached in practice.
+    test1_log = os.path.join(ws.log_dir, 'setup.latest', 'gromacs.water_bare.test1.out')
+    gromacs_log_line = _spack_loc_log_line('gromacs')
+    impi_log_line = _spack_loc_log_line('intel-oneapi-mpi@2021.11.0')
+    with open(test1_log, 'r') as f:
+        content = f.read()
+        assert 'Executing phase define_package_paths' in content
+        assert content.count(gromacs_log_line) == 1
+        assert content.count(impi_log_line) == 1
+
+    # test2 should not use a path, as test1 has a variable for the path defined
+    test2_log = os.path.join(ws.log_dir, 'setup.latest', 'gromacs.water_bare.test2.out')
+    with open(test2_log, 'r') as f:
+        content = f.read()
+        assert 'Executing phase define_package_paths' in content
+        assert gromacs_log_line in content
+        assert impi_log_line not in content


### PR DESCRIPTION
This merge fixes an issue where an error would arise when a variable named the same as an application is defiend. As an example:

```
ramble:
  applications:
    gromacs:
      workloads:
        water_bare:
          experiments:
            test:
              variables:
                gromacs: '/test/path'
                n_ranks: 1
```

Previously failed due to the definition of the `gromacs` variable.