### PR TITLE
Label `ramble flake8` as deprecated

### DIFF
--- a/lib/ramble/ramble/cmd/flake8.py
+++ b/lib/ramble/ramble/cmd/flake8.py
@@ -8,6 +8,7 @@
 
 from __future__ import print_function
 
+import deprecation
 import re
 import os
 import sys
@@ -21,7 +22,10 @@ import ramble.paths
 from spack.util.executable import which, ProcessError
 
 
-description = "runs source code style checks on Ramble. requires flake8"
+description = (
+    "(Deprecated, please use `ramble style` instead)"
+    "runs source code style checks on Ramble. requires flake8"
+)
 section = "developer"
 level = "long"
 
@@ -265,6 +269,12 @@ def setup_parser(subparser):
     subparser.add_argument("files", nargs=argparse.REMAINDER, help="specific files to check")
 
 
+@deprecation.deprecated(
+    deprecated_in="0.5.0",
+    removed_in="0.6.0",
+    current_version=str(ramble.ramble_version),
+    details="Use the `ramble style` command instead",
+)
 def flake8(parser, args):
     flake8_cmd = which("flake8", required=True)
     print(flake8_cmd)

--- a/lib/ramble/ramble/test/cmd/flake8.py
+++ b/lib/ramble/ramble/test/cmd/flake8.py
@@ -1,0 +1,19 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import deprecation
+
+from ramble.main import RambleCommand
+
+flake8 = RambleCommand("flake8")
+
+
+@deprecation.fail_if_not_removed
+def test_flake8_deprecation():
+    # Call `ramble flake8` to trigger the deprecation assertion.
+    flake8("-U")


### PR DESCRIPTION
Tested:

```sh
$ PYTHONWARNINGS="always::DeprecationWarning" ramble flake8 -U
==> Warning: flake8 is deprecated as of 0.5.0 and will be removed in 0.6.0. Use the `ramble style` command instead

$ ramble flake8 -h
usage: ramble flake8 [-hkaorU] [-b BASE] ...

(Deprecated, please use `ramble style` instead)runs source code style checks on Ramble. requires flake8
```