### PR TITLE
Format Ramble's object files with `black`

### DIFF
--- a/lib/ramble/ramble/cmd/style.py
+++ b/lib/ramble/ramble/cmd/style.py
@@ -503,6 +503,7 @@ def style(parser, args):
             try:
                 base, untracked, list_all = arg_flags.pop(0)
                 file_list = changed_files(base, untracked, list_all)
+                break
             except ProcessError as e:
                 file_list = None
                 if not arg_flags:

--- a/pyproject_objects.toml
+++ b/pyproject_objects.toml
@@ -1,0 +1,8 @@
+# Config file for Ramble's object files (apps and mods)
+
+[tool.black]
+line-length = 79
+target-version = ["py36", "py37", "py38", "py39", "py310", "py311", "py312"]
+include = '''
+    \.pyi?$
+'''

--- a/var/ramble/repos/builtin.mock/applications/basic-inherited/application.py
+++ b/var/ramble/repos/builtin.mock/applications/basic-inherited/application.py
@@ -14,11 +14,18 @@ from ramble.app.builtin.mock.basic import Basic as BaseBasic
 class BasicInherited(BaseBasic):
     name = "basic-inherited"
 
-    input_file('inherited_input', url='file:///tmp/inherited_file.log',
-               description='Again, not a file', extension='.log')
+    input_file(
+        "inherited_input",
+        url="file:///tmp/inherited_file.log",
+        description="Again, not a file",
+        extension=".log",
+    )
 
-    workload('test_wl3', executable='foo', input='inherited_input')
+    workload("test_wl3", executable="foo", input="inherited_input")
 
-    workload_variable('my_var', default='1.0',
-                      description='Shadowed Example var',
-                      workload='test_wl')
+    workload_variable(
+        "my_var",
+        default="1.0",
+        description="Shadowed Example var",
+        workload="test_wl",
+    )

--- a/var/ramble/repos/builtin.mock/applications/basic/application.py
+++ b/var/ramble/repos/builtin.mock/applications/basic/application.py
@@ -12,30 +12,41 @@ from ramble.appkit import *
 class Basic(ExecutableApplication):
     name = "basic"
 
-    executable('foo', 'bar', use_mpi=False)
-    executable('bar', 'baz', use_mpi=True)
-    executable('echo', 'echo "0.25 seconds"', use_mpi=False)
+    executable("foo", "bar", use_mpi=False)
+    executable("bar", "baz", use_mpi=True)
+    executable("echo", 'echo "0.25 seconds"', use_mpi=False)
 
-    input_file('input', url='file:///tmp/test_file.log',
-               description='Not a file', extension='.log')
+    input_file(
+        "input",
+        url="file:///tmp/test_file.log",
+        description="Not a file",
+        extension=".log",
+    )
 
-    workload('test_wl', executable='foo', input='input')
-    workload('test_wl2', executable='bar', input='input')
-    workload('working_wl', executable='echo')
+    workload("test_wl", executable="foo", input="input")
+    workload("test_wl2", executable="bar", input="input")
+    workload("working_wl", executable="echo")
 
-    workload_variable('my_base_var', default='0.0',
-                      description='Example var',
-                      workload='test_wl')
+    workload_variable(
+        "my_base_var",
+        default="0.0",
+        description="Example var",
+        workload="test_wl",
+    )
 
-    workload_variable('my_var', default='1.0',
-                      description='Example var',
-                      workload='test_wl')
+    workload_variable(
+        "my_var", default="1.0", description="Example var", workload="test_wl"
+    )
 
-    environment_variable('TEST_ENV', value="1",
-                         description="test var", workload="test_wl")
+    environment_variable(
+        "TEST_ENV", value="1", description="test var", workload="test_wl"
+    )
 
-    archive_pattern('{experiment_run_dir}/archive_test.*')
+    archive_pattern("{experiment_run_dir}/archive_test.*")
 
-    figure_of_merit('test_fom',
-                    fom_regex=r'(?P<test>[0-9]+\.[0-9]+).*seconds.*',
-                    group_name='test', units='s')
+    figure_of_merit(
+        "test_fom",
+        fom_regex=r"(?P<test>[0-9]+\.[0-9]+).*seconds.*",
+        group_name="test",
+        units="s",
+    )

--- a/var/ramble/repos/builtin.mock/applications/expanded_foms/application.py
+++ b/var/ramble/repos/builtin.mock/applications/expanded_foms/application.py
@@ -12,23 +12,29 @@ from ramble.appkit import *
 class ExpandedFoms(ExecutableApplication):
     name = "expanded-Foms"
 
-    executable('foo', template=['bar', 'echo "{my_var}"'], use_mpi=False)
+    executable("foo", template=["bar", 'echo "{my_var}"'], use_mpi=False)
 
-    input_file('input', url='file:///tmp/test_file.log',
-               description='Not a file', extension='.log')
+    input_file(
+        "input",
+        url="file:///tmp/test_file.log",
+        description="Not a file",
+        extension=".log",
+    )
 
-    workload('test_wl', executables=['foo'], input='input')
+    workload("test_wl", executables=["foo"], input="input")
 
-    workload_variable('my_var', default='1.0',
-                      description='Example var',
-                      workload='test_wl')
+    workload_variable(
+        "my_var", default="1.0", description="Example var", workload="test_wl"
+    )
 
-    archive_pattern('{experiment_run_dir}/archive_test.*')
+    archive_pattern("{experiment_run_dir}/archive_test.*")
 
-    figure_of_merit('test_fom {var}',
-                    fom_regex=r'Collect FOM (?P<var>\w+)\s=\s(?P<test>[0-9]+\.[0-9]+) seconds',
-                    log_file='{log_file}',
-                    group_name='test', units='s')
+    figure_of_merit(
+        "test_fom {var}",
+        fom_regex=r"Collect FOM (?P<var>\w+)\s=\s(?P<test>[0-9]+\.[0-9]+) seconds",
+        log_file="{log_file}",
+        group_name="test",
+        units="s",
+    )
 
-    success_criteria('Run', mode='string',
-                     match=r'Collect', file='{log_file}')
+    success_criteria("Run", mode="string", match=r"Collect", file="{log_file}")

--- a/var/ramble/repos/builtin.mock/applications/glob-patterns/application.py
+++ b/var/ramble/repos/builtin.mock/applications/glob-patterns/application.py
@@ -12,46 +12,98 @@ from ramble.appkit import *
 class GlobPatterns(ExecutableApplication):
     name = "glob-patterns"
 
-    executable('test', 'base test {test_var} {glob_var} {baz_var}', use_mpi=False)
-    executable('test-foo', 'test foo {test_var} {glob_var} {baz_var} {mod_var}', use_mpi=False)
-    executable('test-bar', 'test bar {test_var} {glob_var} {baz_var}', use_mpi=True)
-    executable('baz', 'baz {test_var} {glob_var} {baz_var}', use_mpi=True)
+    executable(
+        "test", "base test {test_var} {glob_var} {baz_var}", use_mpi=False
+    )
+    executable(
+        "test-foo",
+        "test foo {test_var} {glob_var} {baz_var} {mod_var}",
+        use_mpi=False,
+    )
+    executable(
+        "test-bar", "test bar {test_var} {glob_var} {baz_var}", use_mpi=True
+    )
+    executable("baz", "baz {test_var} {glob_var} {baz_var}", use_mpi=True)
 
-    input_file('input', url='file:///tmp/test_file.log',
-               description='Not a file', extension='.log')
-    input_file('input-foo', url='file:///tmp/test_foo_file.log',
-               description='Not a file', extension='.log')
-    input_file('input-bar', url='file:///tmp/test_bar_file.log',
-               description='Not a file', extension='.log')
-    input_file('baz', url='file:///tmp/baz_file.log',
-               description='Not a file', extension='.log')
+    input_file(
+        "input",
+        url="file:///tmp/test_file.log",
+        description="Not a file",
+        extension=".log",
+    )
+    input_file(
+        "input-foo",
+        url="file:///tmp/test_foo_file.log",
+        description="Not a file",
+        extension=".log",
+    )
+    input_file(
+        "input-bar",
+        url="file:///tmp/test_bar_file.log",
+        description="Not a file",
+        extension=".log",
+    )
+    input_file(
+        "baz",
+        url="file:///tmp/baz_file.log",
+        description="Not a file",
+        extension=".log",
+    )
 
-    workload('test_one_exec', executables=['test'], inputs=['input'])
-    workload('test_three_exec', executables=['test*'], inputs=['input*'])
-    workload('one_baz_exec', executables=['baz'], inputs=['baz'])
+    workload("test_one_exec", executables=["test"], inputs=["input"])
+    workload("test_three_exec", executables=["test*"], inputs=["input*"])
+    workload("one_baz_exec", executables=["baz"], inputs=["baz"])
 
-    environment_variable('env_var_test', 'set', description='Test env var',
-                         workloads=['test_one_exec'])
-    environment_variable('env_var_glob', 'set', description='Test env var',
-                         workloads=['test*'])
-    environment_variable('env_var_baz', 'set', description='Test env var',
-                         workloads=['one_baz_exec'])
-    environment_variable('env_var_mod', 'set', description='Env var to be modified',
-                         workloads=['test_three_exec'])
+    environment_variable(
+        "env_var_test",
+        "set",
+        description="Test env var",
+        workloads=["test_one_exec"],
+    )
+    environment_variable(
+        "env_var_glob", "set", description="Test env var", workloads=["test*"]
+    )
+    environment_variable(
+        "env_var_baz",
+        "set",
+        description="Test env var",
+        workloads=["one_baz_exec"],
+    )
+    environment_variable(
+        "env_var_mod",
+        "set",
+        description="Env var to be modified",
+        workloads=["test_three_exec"],
+    )
 
-    workload_variable('test_var', default='wl_var_test',
-                      description='Example var',
-                      workloads=['test_one_exec'])
-    workload_variable('glob_var', default='wl_var_glob',
-                      description='Example var',
-                      workloads=['test*'])
-    workload_variable('baz_var', default='wl_var_baz',
-                      description='Example var',
-                      workloads=['one_baz_exec'])
-    workload_variable('var_mod', default='wl_var_mod',
-                      description='Variable to be modified',
-                      workloads=['test_three_exec'])
+    workload_variable(
+        "test_var",
+        default="wl_var_test",
+        description="Example var",
+        workloads=["test_one_exec"],
+    )
+    workload_variable(
+        "glob_var",
+        default="wl_var_glob",
+        description="Example var",
+        workloads=["test*"],
+    )
+    workload_variable(
+        "baz_var",
+        default="wl_var_baz",
+        description="Example var",
+        workloads=["one_baz_exec"],
+    )
+    workload_variable(
+        "var_mod",
+        default="wl_var_mod",
+        description="Variable to be modified",
+        workloads=["test_three_exec"],
+    )
 
-    figure_of_merit('test_fom',
-                    fom_regex=r'(?P<test>[0-9]+\.[0-9]+).*seconds.*',
-                    group_name='test', units='s')
+    figure_of_merit(
+        "test_fom",
+        fom_regex=r"(?P<test>[0-9]+\.[0-9]+).*seconds.*",
+        group_name="test",
+        units="s",
+    )

--- a/var/ramble/repos/builtin.mock/applications/input-test/application.py
+++ b/var/ramble/repos/builtin.mock/applications/input-test/application.py
@@ -13,17 +13,30 @@ from ramble.appkit import *
 class InputTest(ExecutableApplication):
     name = "input-test"
 
-    executable('test', 'echo "repo test"', use_mpi=False)
+    executable("test", 'echo "repo test"', use_mpi=False)
 
     cwd = os.getcwd()
-    input_file('test-input1', url=f'file://{cwd}/input1.tar.gz',
-               description='Test input')
+    input_file(
+        "test-input1",
+        url=f"file://{cwd}/input1.tar.gz",
+        description="Test input",
+    )
 
-    input_file('test-input2', url=f'file://{cwd}/input2.tar.gz',
-               description='Test input')
+    input_file(
+        "test-input2",
+        url=f"file://{cwd}/input2.tar.gz",
+        description="Test input",
+    )
 
-    input_file('test-input3', url=f'file://{cwd}/input3.txt',
-               expand=False,
-               description='Test input')
+    input_file(
+        "test-input3",
+        url=f"file://{cwd}/input3.txt",
+        expand=False,
+        description="Test input",
+    )
 
-    workload('test', executables=['test'], inputs=['test-input1', 'test-input2', 'test-input3'])
+    workload(
+        "test",
+        executables=["test"],
+        inputs=["test-input1", "test-input2", "test-input3"],
+    )

--- a/var/ramble/repos/builtin.mock/applications/interleved-env-vars/application.py
+++ b/var/ramble/repos/builtin.mock/applications/interleved-env-vars/application.py
@@ -12,26 +12,41 @@ from ramble.appkit import *
 class InterlevedEnvVars(ExecutableApplication):
     name = "interleved-env-vars"
 
-    executable('foo', 'bar', use_mpi=False)
-    executable('bar', 'baz', use_mpi=True)
-    executable('baz', 'foo', use_mpi=True)
+    executable("foo", "bar", use_mpi=False)
+    executable("bar", "baz", use_mpi=True)
+    executable("baz", "foo", use_mpi=True)
 
-    input_file('input', url='file:///tmp/test_file.log',
-               description='Not a file', extension='.log')
+    input_file(
+        "input",
+        url="file:///tmp/test_file.log",
+        description="Not a file",
+        extension=".log",
+    )
 
-    workload('test_wl', executables=['builtin::env_vars', 'foo'], input='input')
-    workload('test_wl2', executables=['bar', 'builtin::env_vars'], input='input')
-    workload('test_wl3', executables=['baz'], input='input')
+    workload(
+        "test_wl", executables=["builtin::env_vars", "foo"], input="input"
+    )
+    workload(
+        "test_wl2", executables=["bar", "builtin::env_vars"], input="input"
+    )
+    workload("test_wl3", executables=["baz"], input="input")
 
-    environment_variable('FROM_DIRECTIVE', 'set', description='Test env var',
-                         workloads=['test_wl', 'test_wl2', 'test_wl3'])
+    environment_variable(
+        "FROM_DIRECTIVE",
+        "set",
+        description="Test env var",
+        workloads=["test_wl", "test_wl2", "test_wl3"],
+    )
 
-    workload_variable('my_var', default='1.0',
-                      description='Example var',
-                      workload='test_wl')
+    workload_variable(
+        "my_var", default="1.0", description="Example var", workload="test_wl"
+    )
 
-    archive_pattern('{experiment_run_dir}/archive_test.*')
+    archive_pattern("{experiment_run_dir}/archive_test.*")
 
-    figure_of_merit('test_fom',
-                    fom_regex=r'(?P<test>[0-9]+\.[0-9]+).*seconds.*',
-                    group_name='test', units='s')
+    figure_of_merit(
+        "test_fom",
+        fom_regex=r"(?P<test>[0-9]+\.[0-9]+).*seconds.*",
+        group_name="test",
+        units="s",
+    )

--- a/var/ramble/repos/builtin.mock/applications/maintained-1/application.py
+++ b/var/ramble/repos/builtin.mock/applications/maintained-1/application.py
@@ -12,8 +12,11 @@ from ramble.appkit import *
 class Maintained1(ExecutableApplication):
     name = "maintained-1"
 
-    maintainers('maintainer-1')
+    maintainers("maintainer-1")
 
-    executable('foo', 'bar', use_mpi=False)
+    executable("foo", "bar", use_mpi=False)
 
-    workload('test_wl', executable='foo',)
+    workload(
+        "test_wl",
+        executable="foo",
+    )

--- a/var/ramble/repos/builtin.mock/applications/maintained-2/application.py
+++ b/var/ramble/repos/builtin.mock/applications/maintained-2/application.py
@@ -12,8 +12,11 @@ from ramble.appkit import *
 class Maintained2(ExecutableApplication):
     name = "maintained-2"
 
-    maintainers('maintainer-1')
+    maintainers("maintainer-1")
 
-    executable('foo', 'bar', use_mpi=False)
+    executable("foo", "bar", use_mpi=False)
 
-    workload('test_wl', executable='foo',)
+    workload(
+        "test_wl",
+        executable="foo",
+    )

--- a/var/ramble/repos/builtin.mock/applications/register-builtin/application.py
+++ b/var/ramble/repos/builtin.mock/applications/register-builtin/application.py
@@ -12,30 +12,37 @@ from ramble.appkit import *
 class RegisterBuiltin(ExecutableApplication):
     name = "register-builtin"
 
-    executable('foo', 'bar', use_mpi=False)
-    executable('bar', 'baz', use_mpi=True)
-    executable('baz', 'foo', use_mpi=True)
+    executable("foo", "bar", use_mpi=False)
+    executable("bar", "baz", use_mpi=True)
+    executable("baz", "foo", use_mpi=True)
 
-    input_file('input', url='file:///tmp/test_file.log',
-               description='Not a file', extension='.log')
+    input_file(
+        "input",
+        url="file:///tmp/test_file.log",
+        description="Not a file",
+        extension=".log",
+    )
 
-    workload('test_wl', executables=['foo'], input='input')
-    workload('test_wl2', executables=['bar'], input='input')
-    workload('test_wl3', executables=['baz'], input='input')
+    workload("test_wl", executables=["foo"], input="input")
+    workload("test_wl2", executables=["bar"], input="input")
+    workload("test_wl3", executables=["baz"], input="input")
 
-    workload_variable('my_var', default='1.0',
-                      description='Example var',
-                      workload='test_wl')
+    workload_variable(
+        "my_var", default="1.0", description="Example var", workload="test_wl"
+    )
 
-    archive_pattern('{experiment_run_dir}/archive_test.*')
+    archive_pattern("{experiment_run_dir}/archive_test.*")
 
-    figure_of_merit('test_fom',
-                    fom_regex=r'(?P<test>[0-9]+\.[0-9]+).*seconds.*',
-                    group_name='test', units='s')
+    figure_of_merit(
+        "test_fom",
+        fom_regex=r"(?P<test>[0-9]+\.[0-9]+).*seconds.*",
+        group_name="test",
+        units="s",
+    )
 
     # Test disabling the typically included env_vars builtin.
-    register_builtin('env_vars', required=False)
-    register_builtin('test_builtin', required=True)
+    register_builtin("env_vars", required=False)
+    register_builtin("test_builtin", required=True)
 
     def test_builtin(self):
         return ['echo "foo"']

--- a/var/ramble/repos/builtin.mock/applications/shared-context/application.py
+++ b/var/ramble/repos/builtin.mock/applications/shared-context/application.py
@@ -12,23 +12,35 @@ from ramble.appkit import *
 class SharedContext(ExecutableApplication):
     name = "shared-context"
 
-    executable('foo', 'bar', use_mpi=False)
-    executable('bar', 'baz', use_mpi=True)
+    executable("foo", "bar", use_mpi=False)
+    executable("bar", "baz", use_mpi=True)
 
-    input_file('input', url='file:///tmp/test_file.log',
-               description='Not a file', extension='.log')
+    input_file(
+        "input",
+        url="file:///tmp/test_file.log",
+        description="Not a file",
+        extension=".log",
+    )
 
-    workload('test_wl', executable='foo', input='input')
-    workload('test_wl2', executable='bar', input='input')
+    workload("test_wl", executable="foo", input="input")
+    workload("test_wl2", executable="bar", input="input")
 
-    workload_variable('my_var', default='1.0',
-                      description='Example var',
-                      workload='test_wl')
+    workload_variable(
+        "my_var", default="1.0", description="Example var", workload="test_wl"
+    )
 
-    archive_pattern('{experiment_run_dir}/archive_test.*')
+    archive_pattern("{experiment_run_dir}/archive_test.*")
 
-    figure_of_merit('test_fom',
-                    fom_regex=r'(?P<test>[0-9]+\.[0-9]+).*seconds.*',
-                    group_name='test', units='s', contexts=['test_shared_context'])
+    figure_of_merit(
+        "test_fom",
+        fom_regex=r"(?P<test>[0-9]+\.[0-9]+).*seconds.*",
+        group_name="test",
+        units="s",
+        contexts=["test_shared_context"],
+    )
 
-    figure_of_merit_context('test_shared_context', regex=r'(?P<test>[0-9]+\.[0-9]+).*seconds.*', output_format='matched_shared_context')
+    figure_of_merit_context(
+        "test_shared_context",
+        regex=r"(?P<test>[0-9]+\.[0-9]+).*seconds.*",
+        output_format="matched_shared_context",
+    )

--- a/var/ramble/repos/builtin.mock/applications/success-function/application.py
+++ b/var/ramble/repos/builtin.mock/applications/success-function/application.py
@@ -12,13 +12,16 @@ from ramble.appkit import *
 class SuccessFunction(ExecutableApplication):
     name = "success-function"
 
-    executable('foo', 'echo "0.9 seconds"', use_mpi=False)
+    executable("foo", 'echo "0.9 seconds"', use_mpi=False)
 
-    workload('test_wl', executable='foo')
+    workload("test_wl", executable="foo")
 
-    figure_of_merit('test_fom',
-                    fom_regex=r'(?P<test>[0-9]+\.[0-9]+).*seconds.*',
-                    group_name='test', units='s')
+    figure_of_merit(
+        "test_fom",
+        fom_regex=r"(?P<test>[0-9]+\.[0-9]+).*seconds.*",
+        group_name="test",
+        units="s",
+    )
 
     def evaluate_success(self):
         """Always fail, to help testing success functions"""

--- a/var/ramble/repos/builtin.mock/applications/tagged-1/application.py
+++ b/var/ramble/repos/builtin.mock/applications/tagged-1/application.py
@@ -12,8 +12,8 @@ from ramble.appkit import *
 class Tagged1(ExecutableApplication):
     name = "tagged-1"
 
-    tags('tag-1')
+    tags("tag-1")
 
-    executable('foo', 'bar', use_mpi=False)
+    executable("foo", "bar", use_mpi=False)
 
-    workload('test_wl', executable='foo')
+    workload("test_wl", executable="foo")

--- a/var/ramble/repos/builtin.mock/applications/unmaintained-1/application.py
+++ b/var/ramble/repos/builtin.mock/applications/unmaintained-1/application.py
@@ -12,6 +12,9 @@ from ramble.appkit import *
 class Unmaintained1(ExecutableApplication):
     name = "unmaintained-1"
 
-    executable('foo', 'bar', use_mpi=False)
+    executable("foo", "bar", use_mpi=False)
 
-    workload('test_wl', executable='foo',)
+    workload(
+        "test_wl",
+        executable="foo",
+    )

--- a/var/ramble/repos/builtin.mock/applications/untagged-1/application.py
+++ b/var/ramble/repos/builtin.mock/applications/untagged-1/application.py
@@ -12,6 +12,6 @@ from ramble.appkit import *
 class Untagged1(ExecutableApplication):
     name = "untagged-1"
 
-    executable('foo', 'bar', use_mpi=False)
+    executable("foo", "bar", use_mpi=False)
 
-    workload('test_wl', executable='foo')
+    workload("test_wl", executable="foo")

--- a/var/ramble/repos/builtin.mock/applications/workload-groups-inherited/application.py
+++ b/var/ramble/repos/builtin.mock/applications/workload-groups-inherited/application.py
@@ -14,9 +14,7 @@ from ramble.app.builtin.mock.workload_groups import WorkloadGroups
 class WorkloadGroupsInherited(WorkloadGroups):
     name = "workload-groups-inherited"
 
-    workload('test_wl3', executable='baz')
+    workload("test_wl3", executable="baz")
 
     # Test populated group applies existing vars to new workload
-    workload_group('test_wlg',
-                   workloads=['test_wl3'],
-                   mode='append')
+    workload_group("test_wlg", workloads=["test_wl3"], mode="append")

--- a/var/ramble/repos/builtin.mock/applications/workload-groups/application.py
+++ b/var/ramble/repos/builtin.mock/applications/workload-groups/application.py
@@ -12,27 +12,31 @@ from ramble.appkit import *
 class WorkloadGroups(ExecutableApplication):
     name = "workload-groups"
 
-    executable('foo', 'echo "bar"', use_mpi=False)
-    executable('bar', 'echo "baz"', use_mpi=False)
+    executable("foo", 'echo "bar"', use_mpi=False)
+    executable("bar", 'echo "baz"', use_mpi=False)
 
-    workload('test_wl', executable='foo')
-    workload('test_wl2', executable='bar')
+    workload("test_wl", executable="foo")
+    workload("test_wl2", executable="bar")
 
     # Test empty group
-    workload_group('empty',
-                   workloads=[])
+    workload_group("empty", workloads=[])
 
     # Test populated group
-    workload_group('test_wlg',
-                   workloads=['test_wl', 'test_wl2'])
+    workload_group("test_wlg", workloads=["test_wl", "test_wl2"])
 
     # Test workload_variable that uses a group
-    workload_variable('test_var', default='2.0',
-                      description='Test workload vars and groups',
-                      workload_group='test_wlg')
+    workload_variable(
+        "test_var",
+        default="2.0",
+        description="Test workload vars and groups",
+        workload_group="test_wlg",
+    )
 
     # Test passing both groups an explicit workloads
-    workload_variable('test_var_mixed', default='3.0',
-                      description='Test vars for workload and groups',
-                      workload='test_wl',
-                      workload_group='test_wlg')
+    workload_variable(
+        "test_var_mixed",
+        default="3.0",
+        description="Test vars for workload and groups",
+        workload="test_wl",
+        workload_group="test_wlg",
+    )

--- a/var/ramble/repos/builtin.mock/applications/workload-tags/application.py
+++ b/var/ramble/repos/builtin.mock/applications/workload-tags/application.py
@@ -12,8 +12,8 @@ from ramble.appkit import *
 class WorkloadTags(ExecutableApplication):
     name = "workload-tags"
 
-    executable('foo', 'echo "bar"', use_mpi=False)
-    executable('bar', 'echo "baz"', use_mpi=False)
+    executable("foo", 'echo "bar"', use_mpi=False)
+    executable("bar", 'echo "baz"', use_mpi=False)
 
-    workload('test_wl', executable='foo', tags=['wl-tag1', 'wl-shared-tag'])
-    workload('test_wl2', executable='bar', tags=['wl-tag2', 'wl-shared-tag'])
+    workload("test_wl", executable="foo", tags=["wl-tag1", "wl-shared-tag"])
+    workload("test_wl2", executable="bar", tags=["wl-tag2", "wl-shared-tag"])

--- a/var/ramble/repos/builtin.mock/applications/zlib-configs/application.py
+++ b/var/ramble/repos/builtin.mock/applications/zlib-configs/application.py
@@ -12,17 +12,21 @@ from ramble.appkit import *
 class ZlibConfigs(SpackApplication):
     name = "zlib-configs"
 
-    software_spec('zlib', spack_spec='zlib')
+    software_spec("zlib", spack_spec="zlib")
 
-    executable('list_lib', 'ls {zlib}/lib', use_mpi=False)
+    executable("list_lib", "ls {zlib}/lib", use_mpi=False)
 
-    workload('ensure_installed', executable='list_lib')
+    workload("ensure_installed", executable="list_lib")
 
-    package_manager_config('enable_debug', 'config:debug:true')
+    package_manager_config("enable_debug", "config:debug:true")
 
-    figure_of_merit('zlib_installed',
-                    fom_regex=r'(?P<lib_name>libz.so.*)', group_name='lib_name',
-                    units='')
+    figure_of_merit(
+        "zlib_installed",
+        fom_regex=r"(?P<lib_name>libz.so.*)",
+        group_name="lib_name",
+        units="",
+    )
 
-    success_criteria('zlib_installed', mode='string',
-                     match=r'libz.so', file='{log_file}')
+    success_criteria(
+        "zlib_installed", mode="string", match=r"libz.so", file="{log_file}"
+    )

--- a/var/ramble/repos/builtin.mock/applications/zlib/application.py
+++ b/var/ramble/repos/builtin.mock/applications/zlib/application.py
@@ -12,15 +12,19 @@ from ramble.appkit import *
 class Zlib(SpackApplication):
     name = "zlib"
 
-    software_spec('zlib', spack_spec='zlib')
+    software_spec("zlib", spack_spec="zlib")
 
-    executable('list_lib', 'ls {zlib}/lib', use_mpi=False)
+    executable("list_lib", "ls {zlib}/lib", use_mpi=False)
 
-    workload('ensure_installed', executable='list_lib')
+    workload("ensure_installed", executable="list_lib")
 
-    figure_of_merit('zlib_installed',
-                    fom_regex=r'(?P<lib_name>libz.so.*)', group_name='lib_name',
-                    units='')
+    figure_of_merit(
+        "zlib_installed",
+        fom_regex=r"(?P<lib_name>libz.so.*)",
+        group_name="lib_name",
+        units="",
+    )
 
-    success_criteria('zlib_installed', mode='string',
-                     match=r'libz.so', file='{log_file}')
+    success_criteria(
+        "zlib_installed", mode="string", match=r"libz.so", file="{log_file}"
+    )

--- a/var/ramble/repos/builtin.mock/modifiers/append-env-var-mod-paths/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/append-env-var-mod-paths/modifier.py
@@ -12,11 +12,13 @@ from ramble.modkit import *
 class AppendEnvVarModPaths(BasicModifier):
     """Define a modifier with only an environment variable modification using
     the append method and a colon separator"""
+
     name = "append-env-var-mod-paths"
 
-    tags('test')
+    tags("test")
 
-    mode('test', description='This is a test mode')
+    mode("test", description="This is a test mode")
 
-    env_var_modification('test_var', modification='test_val', method='append',
-                         mode='test')
+    env_var_modification(
+        "test_var", modification="test_val", method="append", mode="test"
+    )

--- a/var/ramble/repos/builtin.mock/modifiers/append-env-var-mod-vars/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/append-env-var-mod-vars/modifier.py
@@ -12,11 +12,17 @@ from ramble.modkit import *
 class AppendEnvVarModVars(BasicModifier):
     """Define a modifier with only an environment variable modification using
     the append method and a non-colon separator"""
+
     name = "append-env-var-mod-vars"
 
-    tags('test')
+    tags("test")
 
-    mode('test', description='This is a test mode')
+    mode("test", description="This is a test mode")
 
-    env_var_modification('test_var', modification='test_val', method='append',
-                         mode='test', separator=',')
+    env_var_modification(
+        "test_var",
+        modification="test_val",
+        method="append",
+        mode="test",
+        separator=",",
+    )

--- a/var/ramble/repos/builtin.mock/modifiers/glob-patterns-mod/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/glob-patterns-mod/modifier.py
@@ -14,17 +14,24 @@ class GlobPatternsMod(BasicModifier):
 
     This modifier tests globbing in the modifier language.
     """
+
     name = "glob-patterns-mod"
 
-    tags('test')
+    tags("test")
 
-    mode('base', description='This is a base mode with no modifications')
-    mode('test-glob', description='This test mode turns on mods using globbing')
-    default_mode('base')
+    mode("base", description="This is a base mode with no modifications")
+    mode(
+        "test-glob", description="This test mode turns on mods using globbing"
+    )
+    default_mode("base")
 
-    variable_modification('var_mod', '{mod_var}', modes=['test*'])
+    variable_modification("var_mod", "{mod_var}", modes=["test*"])
 
-    env_var_modification('env_var_mod', 'modded', modes=['test*'])
+    env_var_modification("env_var_mod", "modded", modes=["test*"])
 
-    modifier_variable('mod_var', default='var_mod_modified',
-                      description='This is a modifier variable', modes=['test*'])
+    modifier_variable(
+        "mod_var",
+        default="var_mod_modified",
+        description="This is a modifier variable",
+        modes=["test*"],
+    )

--- a/var/ramble/repos/builtin.mock/modifiers/maintained-1/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/maintained-1/modifier.py
@@ -11,10 +11,11 @@ from ramble.modkit import *
 
 class Maintained1(BasicModifier):
     """Define a maintained modifier"""
+
     name = "maintained-1"
 
-    tags('test')
+    tags("test")
 
-    maintainers('maintainer-1')
+    maintainers("maintainer-1")
 
-    mode('test', description='This is a test mode')
+    mode("test", description="This is a test mode")

--- a/var/ramble/repos/builtin.mock/modifiers/maintained-2/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/maintained-2/modifier.py
@@ -11,10 +11,11 @@ from ramble.modkit import *
 
 class Maintained2(BasicModifier):
     """Define a maintained modifier"""
+
     name = "maintained-2"
 
-    tags('test')
+    tags("test")
 
-    maintainers('maintainer-1')
+    maintainers("maintainer-1")
 
-    mode('test', description='This is a test mode')
+    mode("test", description="This is a test mode")

--- a/var/ramble/repos/builtin.mock/modifiers/mod-phase/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/mod-phase/modifier.py
@@ -12,18 +12,23 @@ from ramble.util.logger import logger
 
 class ModPhase(BasicModifier):
     """Define a modifier that defines a new phase with register_phase"""
+
     name = "mod-phase"
 
-    tags('test')
+    tags("test")
 
-    mode('test', description='This is a test mode')
+    mode("test", description="This is a test mode")
 
-    register_phase('first_phase', pipeline='setup', run_before=['get_inputs'])
+    register_phase("first_phase", pipeline="setup", run_before=["get_inputs"])
 
     def _first_phase(self, workspace, app_inst=None):
-        logger.all_msg('Inside a phase: first_phase')
+        logger.all_msg("Inside a phase: first_phase")
 
-    register_phase('after_make_experiments', pipeline='setup', run_after=['make_experiments'])
+    register_phase(
+        "after_make_experiments",
+        pipeline="setup",
+        run_after=["make_experiments"],
+    )
 
     def _after_make_experiments(self, workspace, app_inst=None):
-        logger.all_msg('Inside a phase: after_make_experiments')
+        logger.all_msg("Inside a phase: after_make_experiments")

--- a/var/ramble/repos/builtin.mock/modifiers/multiple-modes-no-default/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/multiple-modes-no-default/modifier.py
@@ -11,10 +11,11 @@ from ramble.modkit import *
 
 class MultipleModesNoDefault(BasicModifier):
     """Define modifier with multiple modes and no default mode"""
+
     name = "multiple-modes-no-default"
 
-    tags('test')
+    tags("test")
 
-    mode('test_mode1', description='This is the first test mode')
+    mode("test_mode1", description="This is the first test mode")
 
-    mode('test_mode2', description='This is the second test mode')
+    mode("test_mode2", description="This is the second test mode")

--- a/var/ramble/repos/builtin.mock/modifiers/multiple-modes-with-default/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/multiple-modes-with-default/modifier.py
@@ -11,12 +11,13 @@ from ramble.modkit import *
 
 class MultipleModesWithDefault(BasicModifier):
     """Define modifier with multiple modes and a default mode"""
+
     name = "multiple-modes-with-default"
 
-    tags('test')
+    tags("test")
 
-    mode('test_mode1', description='This is the first test mode')
+    mode("test_mode1", description="This is the first test mode")
 
-    mode('test_mode2', description='This is the second test mode')
+    mode("test_mode2", description="This is the second test mode")
 
-    default_mode('test_mode2')
+    default_mode("test_mode2")

--- a/var/ramble/repos/builtin.mock/modifiers/no-docstring-mod/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/no-docstring-mod/modifier.py
@@ -12,6 +12,6 @@ from ramble.modkit import *
 class NoDocstringMod(BasicModifier):
     name = "no-docstring-mod"
 
-    tags('test')
+    tags("test")
 
-    mode('test', description='This is a test mode')
+    mode("test", description="This is a test mode")

--- a/var/ramble/repos/builtin.mock/modifiers/no-variable-mods/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/no-variable-mods/modifier.py
@@ -11,8 +11,9 @@ from ramble.modkit import *
 
 class NoVariableMods(BasicModifier):
     """Define modifier with no variable modifications"""
+
     name = "no-variable-mods"
 
-    tags('test')
+    tags("test")
 
-    mode('test', description='This is a test mode')
+    mode("test", description="This is a test mode")

--- a/var/ramble/repos/builtin.mock/modifiers/prepare-analysis/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/prepare-analysis/modifier.py
@@ -11,17 +11,23 @@ from ramble.modkit import *
 
 class PrepareAnalysis(BasicModifier):
     """Define a modifier that defines a prepare_analysis hook"""
+
     name = "prepare-analysis"
 
-    tags('test')
+    tags("test")
 
-    mode('test', description='This is a test mode')
+    mode("test", description="This is a test mode")
 
-    _log_file = '{experiment_run_dir}/.prepare_analysis_hook_data'
+    _log_file = "{experiment_run_dir}/.prepare_analysis_hook_data"
 
-    figure_of_merit('test-fom', fom_regex='Test fom = (?P<fom>.*)', log_file=_log_file,
-                    units='', group_name='fom')
+    figure_of_merit(
+        "test-fom",
+        fom_regex="Test fom = (?P<fom>.*)",
+        log_file=_log_file,
+        units="",
+        group_name="fom",
+    )
 
     def _prepare_analysis(self, workspace):
-        with open(self.expander.expand_var(self._log_file), 'w+') as f:
-            f.write('Test fom = This test worked')
+        with open(self.expander.expand_var(self._log_file), "w+") as f:
+            f.write("Test fom = This test worked")

--- a/var/ramble/repos/builtin.mock/modifiers/prepend-env-var-mod-paths/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/prepend-env-var-mod-paths/modifier.py
@@ -12,11 +12,13 @@ from ramble.modkit import *
 class PrependEnvVarModPaths(BasicModifier):
     """Define a modifier with only an environment variable modification using
     the prepend method and a colon separator"""
+
     name = "prepend-env-var-mod-paths"
 
-    tags('test')
+    tags("test")
 
-    mode('test', description='This is a test mode')
+    mode("test", description="This is a test mode")
 
-    env_var_modification('test_var', modification='test_val', method='prepend',
-                         mode='test')
+    env_var_modification(
+        "test_var", modification="test_val", method="prepend", mode="test"
+    )

--- a/var/ramble/repos/builtin.mock/modifiers/set-env-var-mod/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/set-env-var-mod/modifier.py
@@ -12,14 +12,24 @@ from ramble.modkit import *
 class SetEnvVarMod(BasicModifier):
     """Define a modifier with only an environment variable modification using
     the set method"""
+
     name = "set-env-var-mod"
 
-    tags('test')
+    tags("test")
 
-    mode('test', description='This is a test mode')
+    mode("test", description="This is a test mode")
 
-    modifier_variable('mask_test', default='0x0', description='Test mask var',
-                      modes=['test'], expandable=False)
+    modifier_variable(
+        "mask_test",
+        default="0x0",
+        description="Test mask var",
+        modes=["test"],
+        expandable=False,
+    )
 
-    env_var_modification('test_var', modification='test_val', method='set', mode='test')
-    env_var_modification('mask_env_var', modification='{mask_test}', method='set', mode='test')
+    env_var_modification(
+        "test_var", modification="test_val", method="set", mode="test"
+    )
+    env_var_modification(
+        "mask_env_var", modification="{mask_test}", method="set", mode="test"
+    )

--- a/var/ramble/repos/builtin.mock/modifiers/spack-failed-reqs/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/spack-failed-reqs/modifier.py
@@ -11,22 +11,30 @@ from ramble.modkit import *
 
 class SpackFailedReqs(SpackModifier):
     """Define spack modifier requirements that will fail"""
+
     name = "spack-mod"
 
-    tags('test')
+    tags("test")
 
-    mode('default', description='This is the default mode for the spack-failed-reqs modifier')
+    mode(
+        "default",
+        description="This is the default mode for the spack-failed-reqs modifier",
+    )
 
-    define_compiler('mod_compiler',
-                    spack_spec='mod_compiler@1.1 target=x86_64',
-                    compiler_spec='mod_compiler@1.1')
+    define_compiler(
+        "mod_compiler",
+        spack_spec="mod_compiler@1.1 target=x86_64",
+        compiler_spec="mod_compiler@1.1",
+    )
 
-    software_spec('mod_package1',
-                  spack_spec='mod_package1@1.1',
-                  compiler='mod_compiler')
+    software_spec(
+        "mod_package1", spack_spec="mod_package1@1.1", compiler="mod_compiler"
+    )
 
-    software_spec('mod_package2',
-                  spack_spec='mod_package2@1.1',
-                  compiler='mod_compiler')
+    software_spec(
+        "mod_package2", spack_spec="mod_package2@1.1", compiler="mod_compiler"
+    )
 
-    package_manager_requirement('list not-a-package', validation_type='not_empty', modes=['default'])
+    package_manager_requirement(
+        "list not-a-package", validation_type="not_empty", modes=["default"]
+    )

--- a/var/ramble/repos/builtin.mock/modifiers/spack-mod/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/spack-mod/modifier.py
@@ -11,29 +11,44 @@ from ramble.modkit import *
 
 class SpackMod(SpackModifier):
     """Define spack modifier with various software aspects"""
+
     name = "spack-mod"
 
-    tags('test')
+    tags("test")
 
-    mode('default', description='This is the default mode for the spack-mod')
+    mode("default", description="This is the default mode for the spack-mod")
 
-    package_manager_config('enable_debug', 'config:debug:true')
+    package_manager_config("enable_debug", "config:debug:true")
 
-    define_compiler('mod_compiler',
-                    spack_spec='mod_compiler@1.1 target=x86_64',
-                    compiler_spec='mod_compiler@1.1')
+    define_compiler(
+        "mod_compiler",
+        spack_spec="mod_compiler@1.1 target=x86_64",
+        compiler_spec="mod_compiler@1.1",
+    )
 
-    software_spec('mod_package1',
-                  spack_spec='mod_package1@1.1',
-                  compiler='mod_compiler')
+    software_spec(
+        "mod_package1", spack_spec="mod_package1@1.1", compiler="mod_compiler"
+    )
 
-    software_spec('mod_package2',
-                  spack_spec='mod_package2@1.1',
-                  compiler='mod_compiler')
+    software_spec(
+        "mod_package2", spack_spec="mod_package2@1.1", compiler="mod_compiler"
+    )
 
-    package_manager_requirement('list not-a-package', validation_type='empty', modes=['default'])
-    package_manager_requirement('list zlib', validation_type='not_empty', modes=['default'])
-    package_manager_requirement('info zlib', validation_type='contains_regex', modes=['default'],
-                                regex=r'\s*Safe versions:\s*')
-    package_manager_requirement('info zlib', validation_type='does_not_contain_regex',
-                                modes=['default'], regex=r'\s*Broken versions:\s*')
+    package_manager_requirement(
+        "list not-a-package", validation_type="empty", modes=["default"]
+    )
+    package_manager_requirement(
+        "list zlib", validation_type="not_empty", modes=["default"]
+    )
+    package_manager_requirement(
+        "info zlib",
+        validation_type="contains_regex",
+        modes=["default"],
+        regex=r"\s*Safe versions:\s*",
+    )
+    package_manager_requirement(
+        "info zlib",
+        validation_type="does_not_contain_regex",
+        modes=["default"],
+        regex=r"\s*Broken versions:\s*",
+    )

--- a/var/ramble/repos/builtin.mock/modifiers/success-criteria/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/success-criteria/modifier.py
@@ -11,15 +11,26 @@ from ramble.modkit import *
 
 class SuccessCriteria(BasicModifier):
     """Define a modifier with a success criteria"""
+
     name = "success-criteria"
 
-    mode('test', description='This is a test mode')
+    mode("test", description="This is a test mode")
 
-    success_criteria('status', mode='string', match='.*Experiment status: SUCCESS', file='{log_file}')
+    success_criteria(
+        "status",
+        mode="string",
+        match=".*Experiment status: SUCCESS",
+        file="{log_file}",
+    )
 
-    variable_modification('experiment_status', modification='Experiment status: SUCCESS', method='set', mode='test')
+    variable_modification(
+        "experiment_status",
+        modification="Experiment status: SUCCESS",
+        method="set",
+        mode="test",
+    )
 
-    register_builtin('echo_status', required=True)
+    register_builtin("echo_status", required=True)
 
     def echo_status(self):
         return ['echo "Experiment status: {experiment_status}" >> {log_file}']

--- a/var/ramble/repos/builtin.mock/modifiers/tagged-1/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/tagged-1/modifier.py
@@ -11,8 +11,9 @@ from ramble.modkit import *
 
 class Tagged1(BasicModifier):
     """Define a tagged modifier"""
+
     name = "tagged-1"
 
-    tags('tag-1')
+    tags("tag-1")
 
-    mode('test', description='This is a test mode')
+    mode("test", description="This is a test mode")

--- a/var/ramble/repos/builtin.mock/modifiers/test-mod/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/test-mod/modifier.py
@@ -14,41 +14,78 @@ class TestMod(BasicModifier):
 
     This modifier is just a test of various aspects of the modifier language.
     """
+
     name = "test-mod"
 
-    tags('test')
+    tags("test")
 
-    mode('test', description='This is a test mode')
-    default_mode('test')
+    mode("test", description="This is a test mode")
+    default_mode("test")
 
-    mode('app-scope', description='This is a test mode at the application scope')
+    mode(
+        "app-scope", description="This is a test mode at the application scope"
+    )
 
-    mode('wl-scope', description='This is a test mode at the workload scope')
+    mode("wl-scope", description="This is a test mode at the workload scope")
 
-    mode('exp-scope', description='This is a test mode at the experiment scope')
+    mode(
+        "exp-scope", description="This is a test mode at the experiment scope"
+    )
 
-    variable_modification('mpi_command', 'echo "prefix_mpi_command" >> {log_file}; ', method='prepend', modes=['test'])
+    variable_modification(
+        "mpi_command",
+        'echo "prefix_mpi_command" >> {log_file}; ',
+        method="prepend",
+        modes=["test"],
+    )
 
-    variable_modification('analysis_log', '{experiment_run_dir}/test_analysis.log', method='set', modes=['test'])
+    variable_modification(
+        "analysis_log",
+        "{experiment_run_dir}/test_analysis.log",
+        method="set",
+        modes=["test"],
+    )
 
-    software_spec('analysis_spec', spack_spec='analysis_pkg@1.1', compiler='gcc')
+    software_spec(
+        "analysis_spec", spack_spec="analysis_pkg@1.1", compiler="gcc"
+    )
 
-    fom_regex = r'(?P<context>fom_context)(?P<fom>.*)'
+    fom_regex = r"(?P<context>fom_context)(?P<fom>.*)"
 
-    figure_of_merit('test_mod_fom', fom_regex=fom_regex, group_name='fom',
-                    units='', log_file='{analysis_log}', contexts=['test_mod_context'])
+    figure_of_merit(
+        "test_mod_fom",
+        fom_regex=fom_regex,
+        group_name="fom",
+        units="",
+        log_file="{analysis_log}",
+        contexts=["test_mod_context"],
+    )
 
-    figure_of_merit('shared_context_fom', fom_regex=fom_regex, group_name='fom',
-                    units='', log_file='{analysis_log}', contexts=['test_shared_context'])
+    figure_of_merit(
+        "shared_context_fom",
+        fom_regex=fom_regex,
+        group_name="fom",
+        units="",
+        log_file="{analysis_log}",
+        contexts=["test_shared_context"],
+    )
 
-    figure_of_merit_context('test_mod_context', regex=fom_regex, output_format='{context}')
+    figure_of_merit_context(
+        "test_mod_context", regex=fom_regex, output_format="{context}"
+    )
 
-    figure_of_merit_context('test_shared_context', regex=fom_regex, output_format='matched_shared_context')
+    figure_of_merit_context(
+        "test_shared_context",
+        regex=fom_regex,
+        output_format="matched_shared_context",
+    )
 
-    register_builtin('test_builtin', required=True, injection_method='append')
+    register_builtin("test_builtin", required=True, injection_method="append")
 
-    test_attr = 'test_value'
+    test_attr = "test_value"
 
     def test_builtin(self):
-        return ['echo "fom_contextFOM_GOES_HERE" >> {analysis_log}',
-                f'echo "{self.test_attr}"' + ' >> {analysis_log}']
+        return [
+            'echo "fom_contextFOM_GOES_HERE" >> {analysis_log}',
+            f'echo "{self.test_attr}"' + " >> {analysis_log}",
+        ]

--- a/var/ramble/repos/builtin.mock/modifiers/unmaintained-1/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/unmaintained-1/modifier.py
@@ -11,8 +11,9 @@ from ramble.modkit import *
 
 class Unmaintained1(BasicModifier):
     """Define an unmaintained modifier"""
+
     name = "test-mod"
 
-    tags('test')
+    tags("test")
 
-    mode('test', description='This is a test mode')
+    mode("test", description="This is a test mode")

--- a/var/ramble/repos/builtin.mock/modifiers/unset-env-var-mod/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/unset-env-var-mod/modifier.py
@@ -12,10 +12,11 @@ from ramble.modkit import *
 class UnsetEnvVarMod(BasicModifier):
     """Define a modifier with only an environment variable modification using
     the unset method"""
+
     name = "unset-env-var-mod"
 
-    tags('test')
+    tags("test")
 
-    mode('test', description='This is a test mode')
+    mode("test", description="This is a test mode")
 
-    env_var_modification('test_var', method='unset', mode='test')
+    env_var_modification("test_var", method="unset", mode="test")

--- a/var/ramble/repos/builtin.mock/modifiers/untagged-1/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/untagged-1/modifier.py
@@ -11,6 +11,7 @@ from ramble.modkit import *
 
 class Untagged1(BasicModifier):
     """Define an untagged modifier"""
+
     name = "untagged-1"
 
-    mode('test', description='This is a test mode')
+    mode("test", description="This is a test mode")

--- a/var/ramble/repos/builtin/applications/cloverleaf/application.py
+++ b/var/ramble/repos/builtin/applications/cloverleaf/application.py
@@ -13,106 +13,171 @@ from ramble.expander import Expander
 
 
 class Cloverleaf(SpackApplication):
-    '''Define CLOVERLEAF application'''
-    name = 'cloverleaf'
+    """Define CLOVERLEAF application"""
 
-    maintainers('rfbgo')
+    name = "cloverleaf"
 
-    tags('cfd', 'fluid', 'dynamics', 'euler', 'miniapp', 'minibenchmark', 'mini-benchmark')
+    maintainers("rfbgo")
 
-    define_compiler('gcc12', spack_spec='gcc@12.2.0')
+    tags(
+        "cfd",
+        "fluid",
+        "dynamics",
+        "euler",
+        "miniapp",
+        "minibenchmark",
+        "mini-benchmark",
+    )
 
-    software_spec('ompi414', spack_spec='openmpi@4.1.4 +legacylaunchers +cxx',
-                  compiler='gcc12')
-    software_spec('cloverleaf',
-                  spack_spec='cloverleaf@1.1 build=ref',
-                  compiler='gcc12')
+    define_compiler("gcc12", spack_spec="gcc@12.2.0")
 
-    required_package('cloverleaf')
+    software_spec(
+        "ompi414",
+        spack_spec="openmpi@4.1.4 +legacylaunchers +cxx",
+        compiler="gcc12",
+    )
+    software_spec(
+        "cloverleaf", spack_spec="cloverleaf@1.1 build=ref", compiler="gcc12"
+    )
 
-    executable('execute', 'clover_leaf', use_mpi=True)
+    required_package("cloverleaf")
 
-    executable('get_input',
-               template=['cp {cloverleaf}/doc/tests/clover_{workload_name}.in {experiment_run_dir}/clover.in'],
-               use_mpi=False)
+    executable("execute", "clover_leaf", use_mpi=True)
 
-    executable('get_default_input', template=['cp {cloverleaf}/doc/tests/clover.in {experiment_run_dir}/clover.in'],
-               use_mpi=False)
+    executable(
+        "get_input",
+        template=[
+            "cp {cloverleaf}/doc/tests/clover_{workload_name}.in {experiment_run_dir}/clover.in"
+        ],
+        use_mpi=False,
+    )
 
-    workload('bm_short_c', executables=['get_input', 'execute'])
-    workload('bm_short',   executables=['get_input', 'execute'])
-    workload('qa',         executables=['get_input', 'execute'])
-    workload('sodbig',     executables=['get_input', 'execute'])
-    workload('sodx',       executables=['get_input', 'execute'])
-    workload('sodxy',      executables=['get_input', 'execute'])
-    workload('sody',       executables=['get_input', 'execute'])
-    workload('clover',     executables=['get_default_input', 'execute'])
+    executable(
+        "get_default_input",
+        template=[
+            "cp {cloverleaf}/doc/tests/clover.in {experiment_run_dir}/clover.in"
+        ],
+        use_mpi=False,
+    )
+
+    workload("bm_short_c", executables=["get_input", "execute"])
+    workload("bm_short", executables=["get_input", "execute"])
+    workload("qa", executables=["get_input", "execute"])
+    workload("sodbig", executables=["get_input", "execute"])
+    workload("sodx", executables=["get_input", "execute"])
+    workload("sodxy", executables=["get_input", "execute"])
+    workload("sody", executables=["get_input", "execute"])
+    workload("clover", executables=["get_default_input", "execute"])
 
     # 2 through 8K
     for k in range(1, 14):
-        workload('bm' + str(2**k), executables=['get_input', 'execute'])
+        workload("bm" + str(2**k), executables=["get_input", "execute"])
 
     # 2 through 8K
     for k in range(1, 14):
-        workload('bm' + str(2**k) + '_short', executables=['get_input', 'execute'])
+        workload(
+            "bm" + str(2**k) + "_short", executables=["get_input", "execute"]
+        )
 
     # 1 through 16K
     for k in range(15):
-        workload('bm' + str(2**k) + 's_short', executables=['get_input', 'execute'])
+        workload(
+            "bm" + str(2**k) + "s_short", executables=["get_input", "execute"]
+        )
 
-    log_str = os.path.join(Expander.expansion_str('experiment_run_dir'), 'clover.out')
+    log_str = os.path.join(
+        Expander.expansion_str("experiment_run_dir"), "clover.out"
+    )
 
-    floating_point_regex = r'[\+\-]*[0-9]*\.*[0-9]+E*[\+\-]*[0-9]*'
+    floating_point_regex = r"[\+\-]*[0-9]*\.*[0-9]+E*[\+\-]*[0-9]*"
 
-    step_count_regex = r'\s*Step\s+(?P<step>[0-9]+).*\s+timestep\s+(?P<timestep>' + floating_point_regex + r')'
+    step_count_regex = (
+        r"\s*Step\s+(?P<step>[0-9]+).*\s+timestep\s+(?P<timestep>"
+        + floating_point_regex
+        + r")"
+    )
 
-    wall_clock_regex = r'\s*Wall clock\s+(?P<wall_clock>[0-9]+\.[0-9]+)'
+    wall_clock_regex = r"\s*Wall clock\s+(?P<wall_clock>[0-9]+\.[0-9]+)"
 
-    figure_of_merit('Timestep', log_file=log_str,
-                    fom_regex=step_count_regex,
-                    group_name='timestep',
-                    units='s', contexts=['step']
-                    )
+    figure_of_merit(
+        "Timestep",
+        log_file=log_str,
+        fom_regex=step_count_regex,
+        group_name="timestep",
+        units="s",
+        contexts=["step"],
+    )
 
-    figure_of_merit('Wall Clock', log_file=log_str,
-                    fom_regex=wall_clock_regex,
-                    group_name='wall_clock',
-                    units='s', contexts=['step']
-                    )
+    figure_of_merit(
+        "Wall Clock",
+        log_file=log_str,
+        fom_regex=wall_clock_regex,
+        group_name="wall_clock",
+        units="s",
+        contexts=["step"],
+    )
 
-    figure_of_merit_context('step',
-                            regex=step_count_regex,
-                            output_format='Step {step}')
+    figure_of_merit_context(
+        "step", regex=step_count_regex, output_format="Step {step}"
+    )
 
-    step_summary_regex = (r'\s*step:\s+(?P<step>[0-9]+)\s+' +
-                          r'(?P<volume>'          + floating_point_regex + r')\s+' +
-                          r'(?P<mass>'            + floating_point_regex + r')\s+' +
-                          r'(?P<density>'         + floating_point_regex + r')\s+' +
-                          r'(?P<pressure>'        + floating_point_regex + r')\s+' +
-                          r'(?P<internal_energy>' + floating_point_regex + r')\s+' +
-                          r'(?P<kinetic_energy>'  + floating_point_regex + r')\s+' +
-                          r'(?P<total_energy>'    + floating_point_regex + r')')
+    step_summary_regex = (
+        r"\s*step:\s+(?P<step>[0-9]+)\s+"
+        + r"(?P<volume>"
+        + floating_point_regex
+        + r")\s+"
+        + r"(?P<mass>"
+        + floating_point_regex
+        + r")\s+"
+        + r"(?P<density>"
+        + floating_point_regex
+        + r")\s+"
+        + r"(?P<pressure>"
+        + floating_point_regex
+        + r")\s+"
+        + r"(?P<internal_energy>"
+        + floating_point_regex
+        + r")\s+"
+        + r"(?P<kinetic_energy>"
+        + floating_point_regex
+        + r")\s+"
+        + r"(?P<total_energy>"
+        + floating_point_regex
+        + r")"
+    )
 
-    figure_of_merit('Total step count', log_file=log_str,
-                    fom_regex=step_summary_regex,
-                    group_name='step',
-                    units=''
-                    )
+    figure_of_merit(
+        "Total step count",
+        log_file=log_str,
+        fom_regex=step_summary_regex,
+        group_name="step",
+        units="",
+    )
 
-    figure_of_merit('Final Kinetic Energy', log_file=log_str,
-                    fom_regex=step_summary_regex,
-                    group_name='kinetic_energy',
-                    units='Joules'
-                    )
+    figure_of_merit(
+        "Final Kinetic Energy",
+        log_file=log_str,
+        fom_regex=step_summary_regex,
+        group_name="kinetic_energy",
+        units="Joules",
+    )
 
-    figure_of_merit('Total Elapsed Time', log_file=log_str,
-                    fom_regex=wall_clock_regex,
-                    group_name='wall_clock',
-                    units='s'
-                    )
+    figure_of_merit(
+        "Total Elapsed Time",
+        log_file=log_str,
+        fom_regex=wall_clock_regex,
+        group_name="wall_clock",
+        units="s",
+    )
 
-    figure_of_merit('First step overhead', log_file=log_str,
-                    fom_regex=(r'\s*First step overhead\s+(?P<overhead>' + floating_point_regex + r')'),
-                    group_name='overhead',
-                    units='s'
-                    )
+    figure_of_merit(
+        "First step overhead",
+        log_file=log_str,
+        fom_regex=(
+            r"\s*First step overhead\s+(?P<overhead>"
+            + floating_point_regex
+            + r")"
+        ),
+        group_name="overhead",
+        units="s",
+    )

--- a/var/ramble/repos/builtin/applications/elk/application.py
+++ b/var/ramble/repos/builtin/applications/elk/application.py
@@ -10,7 +10,7 @@ from ramble.appkit import *
 
 
 class Elk(ExecutableApplication):
-    '''
+    """
     An all-electron full-potential linearised augmented-plane wave (LAPW) code
     with many advanced features. Written originally at
     Karl-Franzens-Universität Graz as a milestone of the EXCITING EU Research
@@ -25,40 +25,70 @@ class Elk(ExecutableApplication):
     user to manage both the package install (eg via yum), and the environment
     through explicit paths. By default, yum installs to
     /usr/lib64/openmpi/bin/elk_openmpi
-    '''
+    """
 
-    name = 'elk'
+    name = "elk"
 
-    tags('LAPW', 'density-functional-theory')
+    tags("LAPW", "density-functional-theory")
 
-    input_file('examples',
-               url='https://master.dl.sourceforge.net/project/elk/elk-4.3.6.tgz',
-               sha256='efd2893a55143ac045656d2acd1407becf773408a116c90771ed3ee9fede35c9',
-               description='Main installer which contains various example input decks and species'
-               )
+    input_file(
+        "examples",
+        url="https://master.dl.sourceforge.net/project/elk/elk-4.3.6.tgz",
+        sha256="efd2893a55143ac045656d2acd1407becf773408a116c90771ed3ee9fede35c9",
+        description="Main installer which contains various example input decks and species",
+    )
 
-    executable('execute', '{install_prefix}/elk_openmpi', use_mpi=True)
-    executable('copy', 'cp {input_path}/elk.in {experiment_run_dir}/.', use_mpi=False)
-    executable('update_input', "sed -i 's|../../../species/|{examples}/species/|g' elk.in", use_mpi=False)
+    executable("execute", "{install_prefix}/elk_openmpi", use_mpi=True)
+    executable(
+        "copy", "cp {input_path}/elk.in {experiment_run_dir}/.", use_mpi=False
+    )
+    executable(
+        "update_input",
+        "sed -i 's|../../../species/|{examples}/species/|g' elk.in",
+        use_mpi=False,
+    )
 
-    workload('Cu', executables=['copy', 'update_input', 'execute'], input='examples')
+    workload(
+        "Cu", executables=["copy", "update_input", "execute"], input="examples"
+    )
 
-    workload_variable('install_prefix', default='/usr/lib64/openmpi/bin',
-                      description='Install path to main executable',
-                      workloads=['Cu'])
+    workload_variable(
+        "install_prefix",
+        default="/usr/lib64/openmpi/bin",
+        description="Install path to main executable",
+        workloads=["Cu"],
+    )
 
-    workload_variable('input_path', default='{examples}/examples/basic/Cu',
-                      description='Path to input deck',
-                      workloads=['Cu'])
+    workload_variable(
+        "input_path",
+        default="{examples}/examples/basic/Cu",
+        description="Path to input deck",
+        workloads=["Cu"],
+    )
 
-    success_criteria('prints_done', mode='string', match=r'.*Elk code stopped.*', file='{experiment_run_dir}/{experiment_name}.out')
+    success_criteria(
+        "prints_done",
+        mode="string",
+        match=r".*Elk code stopped.*",
+        file="{experiment_run_dir}/{experiment_name}.out",
+    )
 
-    output_file = 'INFO.OUT'
-    metrics = ['Timings (CPU seconds)', 'initialisation', 'Hamiltonian and overlap matrix set up', 'first-variational eigenvalue equation', 'charge density calculation', 'potential calculation', 'total']
+    output_file = "INFO.OUT"
+    metrics = [
+        "Timings (CPU seconds)",
+        "initialisation",
+        "Hamiltonian and overlap matrix set up",
+        "first-variational eigenvalue equation",
+        "charge density calculation",
+        "potential calculation",
+        "total",
+    ]
 
     for metric in metrics:
-        figure_of_merit(metric,
-                        log_file=output_file,
-                        fom_regex=rf'\s*(?P<metric>{metric})\s+:\s+(?P<value>[0-9]+\.[0-9]*).*',
-                        group_name='value', units='s'
-                        )
+        figure_of_merit(
+            metric,
+            log_file=output_file,
+            fom_regex=rf"\s*(?P<metric>{metric})\s+:\s+(?P<value>[0-9]+\.[0-9]*).*",
+            group_name="value",
+            units="s",
+        )

--- a/var/ramble/repos/builtin/applications/gromacs/application.py
+++ b/var/ramble/repos/builtin/applications/gromacs/application.py
@@ -12,220 +12,400 @@ from ramble.expander import Expander
 
 
 class Gromacs(SpackApplication):
-    '''Define a Gromacs application'''
-    name = 'gromacs'
+    """Define a Gromacs application"""
 
-    maintainers('douglasjacobsen')
+    name = "gromacs"
 
-    tags('molecular-dynamics')
+    maintainers("douglasjacobsen")
 
-    define_compiler('gcc9', spack_spec='gcc@9.3.0')
-    software_spec('impi2018', spack_spec='intel-mpi@2018.4.274')
-    software_spec('gromacs', spack_spec='gromacs@2020.5', compiler='gcc9')
+    tags("molecular-dynamics")
 
-    executable('pre-process', '{grompp} ' +
-               '-f {input_path}/{type}.mdp ' +
-               '-c {input_path}/conf.gro ' +
-               '-p {input_path}/topol.top ' +
-               '-o exp_input.tpr', use_mpi=False, output_capture=OUTPUT_CAPTURE.ALL)
-    executable('execute-gen', '{mdrun} {notunepme} -dlb {dlb} ' +
-               '{verbose} -resetstep {resetstep} -noconfout -nsteps {nsteps} ' +
-               '-s exp_input.tpr', use_mpi=True, output_capture=OUTPUT_CAPTURE.ALL)
-    executable('execute', '{mdrun} {notunepme} -dlb {dlb} ' +
-               '{verbose} -resetstep {resetstep} -noconfout -nsteps {nsteps} ' +
-               '-s {input_path}', use_mpi=True, output_capture=OUTPUT_CAPTURE.ALL)
+    define_compiler("gcc9", spack_spec="gcc@9.3.0")
+    software_spec("impi2018", spack_spec="intel-mpi@2018.4.274")
+    software_spec("gromacs", spack_spec="gromacs@2020.5", compiler="gcc9")
 
-    input_file('water_gmx50_bare', url='https://ftp.gromacs.org/pub/benchmarks/water_GMX50_bare.tar.gz',
-               sha256='2219c10acb97787f80f6638132bad3ff2ca1e68600eef1bc8b89d9560e74c66a',
-               description='')
-    input_file('water_bare_hbonds', url='https://ftp.gromacs.org/pub/benchmarks/water_bare_hbonds.tar.gz',
-               sha256='b2e09d30f5c6b00ecf1c13ea6fa715ad132747863ef89f983f6c09a872cf2776',
-               description='')
-    input_file('lignocellulose',
-               url='https://repository.prace-ri.eu/ueabs/GROMACS/1.2/GROMACS_TestCaseB.tar.gz',
-               sha256='8a12db0232465e1d47c6a4eb89f615cdbbdc8fc360a86088b131331bd462f35c',
-               description='A model of cellulose and lignocellulosic biomass in an aqueous ' +
-                           'solution. This system of 3.3M atoms is inhomogeneous, at ' +
-                           'least with GROMACS 4.5. This system uses reaction-field' +
-                           'electrostatics instead of PME and therefore should scale well.')
-    input_file('HECBioSim',
-               url='https://github.com/victorusu/GROMACS_Benchmark_Suite/archive/refs/tags/1.0.0.tar.gz',
-               sha256='9cb2ad61ec2a422fc33578047e7cb2fd2c37ae9a75a6162d662fa2b711e9737f',
-               description='https://www.hecbiosim.ac.uk/access-hpc/benchmarks')
+    executable(
+        "pre-process",
+        "{grompp} "
+        + "-f {input_path}/{type}.mdp "
+        + "-c {input_path}/conf.gro "
+        + "-p {input_path}/topol.top "
+        + "-o exp_input.tpr",
+        use_mpi=False,
+        output_capture=OUTPUT_CAPTURE.ALL,
+    )
+    executable(
+        "execute-gen",
+        "{mdrun} {notunepme} -dlb {dlb} "
+        + "{verbose} -resetstep {resetstep} -noconfout -nsteps {nsteps} "
+        + "-s exp_input.tpr",
+        use_mpi=True,
+        output_capture=OUTPUT_CAPTURE.ALL,
+    )
+    executable(
+        "execute",
+        "{mdrun} {notunepme} -dlb {dlb} "
+        + "{verbose} -resetstep {resetstep} -noconfout -nsteps {nsteps} "
+        + "-s {input_path}",
+        use_mpi=True,
+        output_capture=OUTPUT_CAPTURE.ALL,
+    )
 
-    input_file('BenchPEP', url='https://www.mpinat.mpg.de/benchPEP.zip',
-               sha256='f11745201dbb9e6a29a39cb016ee8123f6b0f519b250c94660f0a9623e497b22',
-               description='12M Atoms, Peptides in Water, 2fs time step, all bonds constrained. https://www.mpinat.mpg.de/grubmueller/bench')
+    input_file(
+        "water_gmx50_bare",
+        url="https://ftp.gromacs.org/pub/benchmarks/water_GMX50_bare.tar.gz",
+        sha256="2219c10acb97787f80f6638132bad3ff2ca1e68600eef1bc8b89d9560e74c66a",
+        description="",
+    )
+    input_file(
+        "water_bare_hbonds",
+        url="https://ftp.gromacs.org/pub/benchmarks/water_bare_hbonds.tar.gz",
+        sha256="b2e09d30f5c6b00ecf1c13ea6fa715ad132747863ef89f983f6c09a872cf2776",
+        description="",
+    )
+    input_file(
+        "lignocellulose",
+        url="https://repository.prace-ri.eu/ueabs/GROMACS/1.2/GROMACS_TestCaseB.tar.gz",
+        sha256="8a12db0232465e1d47c6a4eb89f615cdbbdc8fc360a86088b131331bd462f35c",
+        description="A model of cellulose and lignocellulosic biomass in an aqueous "
+        + "solution. This system of 3.3M atoms is inhomogeneous, at "
+        + "least with GROMACS 4.5. This system uses reaction-field"
+        + "electrostatics instead of PME and therefore should scale well.",
+    )
+    input_file(
+        "HECBioSim",
+        url="https://github.com/victorusu/GROMACS_Benchmark_Suite/archive/refs/tags/1.0.0.tar.gz",
+        sha256="9cb2ad61ec2a422fc33578047e7cb2fd2c37ae9a75a6162d662fa2b711e9737f",
+        description="https://www.hecbiosim.ac.uk/access-hpc/benchmarks",
+    )
 
-    input_file('BenchPEP_h', url='https://www.mpinat.mpg.de/benchPEP-h.zip',
-               sha256='3ca8902fd9a6cf005b266f83b57217397b4ba4af987b97dc01e04185bd098bce',
-               description='12M Atoms, Peptides in Water, 2fs time step, h-bonds constrained. https://www.mpinat.mpg.de/grubmueller/bench')
+    input_file(
+        "BenchPEP",
+        url="https://www.mpinat.mpg.de/benchPEP.zip",
+        sha256="f11745201dbb9e6a29a39cb016ee8123f6b0f519b250c94660f0a9623e497b22",
+        description="12M Atoms, Peptides in Water, 2fs time step, all bonds constrained. https://www.mpinat.mpg.de/grubmueller/bench",
+    )
 
-    input_file('BenchMEM', url='https://www.mpinat.mpg.de/benchMEM.zip',
-               sha256='3c1c8cd4f274d532f48c4668e1490d389486850d6b3b258dfad4581aa11380a4',
-               description='82k atoms, protein in membrane surrounded by water, 2 fs time step. https://www.mpinat.mpg.de/grubmueller/bench')
+    input_file(
+        "BenchPEP_h",
+        url="https://www.mpinat.mpg.de/benchPEP-h.zip",
+        sha256="3ca8902fd9a6cf005b266f83b57217397b4ba4af987b97dc01e04185bd098bce",
+        description="12M Atoms, Peptides in Water, 2fs time step, h-bonds constrained. https://www.mpinat.mpg.de/grubmueller/bench",
+    )
 
-    input_file('BenchRIB', url='https://www.mpinat.mpg.de/benchRIB.zip',
-               sha256='39acb014a79ed9a9ff2ad6294a2c09f9b85ea6986dfc204a3639814503eeb60a',
-               description='2 M atoms, ribosome in water, 4 fs time step. https://www.mpinat.mpg.de/grubmueller/bench')
+    input_file(
+        "BenchMEM",
+        url="https://www.mpinat.mpg.de/benchMEM.zip",
+        sha256="3c1c8cd4f274d532f48c4668e1490d389486850d6b3b258dfad4581aa11380a4",
+        description="82k atoms, protein in membrane surrounded by water, 2 fs time step. https://www.mpinat.mpg.de/grubmueller/bench",
+    )
 
-    input_file('JCP_benchmarks',
-               url='https://zenodo.org/record/3893789/files/GROMACS_heterogeneous_parallelization_benchmark_info_and_systems_JCP.tar.gz?download=1',
-               sha256='82449291f44f4d5b7e5c192d688b57b7c2a2e267fe8b12e7a15b5d68f96c7b20',
-               description='GROMACS_heterogeneous_parallelization_benchmark_info_and_systems_JCP')
+    input_file(
+        "BenchRIB",
+        url="https://www.mpinat.mpg.de/benchRIB.zip",
+        sha256="39acb014a79ed9a9ff2ad6294a2c09f9b85ea6986dfc204a3639814503eeb60a",
+        description="2 M atoms, ribosome in water, 4 fs time step. https://www.mpinat.mpg.de/grubmueller/bench",
+    )
 
-    workload('water_gmx50', executables=['pre-process', 'execute-gen'],
-             input='water_gmx50_bare')
-    workload('water_bare', executables=['pre-process', 'execute-gen'],
-             input='water_bare_hbonds')
-    workload('lignocellulose', executables=['execute'],
-             input='lignocellulose')
-    workload('hecbiosim', executables=['execute'],
-             input='HECBioSim')
-    workload('benchpep', executables=['execute'],
-             input='BenchPEP')
-    workload('benchpep_h', executables=['execute'],
-             input='BenchPEP_h')
-    workload('benchmem', executables=['execute'],
-             input='BenchMEM')
-    workload('benchrib', executables=['execute'],
-             input='BenchRIB')
-    workload('stmv_rf', executables=['pre-process', 'execute-gen'],
-             input='JCP_benchmarks')
-    workload('stmv_pme', executables=['pre-process', 'execute-gen'],
-             input='JCP_benchmarks')
-    workload('rnase_cubic', executables=['pre-process', 'execute-gen'],
-             input='JCP_benchmarks')
-    workload('ion_channel', executables=['pre-process', 'execute-gen'],
-             input='JCP_benchmarks')
-    workload('adh_dodec', executables=['pre-process', 'execute-gen'],
-             input='JCP_benchmarks')
+    input_file(
+        "JCP_benchmarks",
+        url="https://zenodo.org/record/3893789/files/GROMACS_heterogeneous_parallelization_benchmark_info_and_systems_JCP.tar.gz?download=1",
+        sha256="82449291f44f4d5b7e5c192d688b57b7c2a2e267fe8b12e7a15b5d68f96c7b20",
+        description="GROMACS_heterogeneous_parallelization_benchmark_info_and_systems_JCP",
+    )
+
+    workload(
+        "water_gmx50",
+        executables=["pre-process", "execute-gen"],
+        input="water_gmx50_bare",
+    )
+    workload(
+        "water_bare",
+        executables=["pre-process", "execute-gen"],
+        input="water_bare_hbonds",
+    )
+    workload("lignocellulose", executables=["execute"], input="lignocellulose")
+    workload("hecbiosim", executables=["execute"], input="HECBioSim")
+    workload("benchpep", executables=["execute"], input="BenchPEP")
+    workload("benchpep_h", executables=["execute"], input="BenchPEP_h")
+    workload("benchmem", executables=["execute"], input="BenchMEM")
+    workload("benchrib", executables=["execute"], input="BenchRIB")
+    workload(
+        "stmv_rf",
+        executables=["pre-process", "execute-gen"],
+        input="JCP_benchmarks",
+    )
+    workload(
+        "stmv_pme",
+        executables=["pre-process", "execute-gen"],
+        input="JCP_benchmarks",
+    )
+    workload(
+        "rnase_cubic",
+        executables=["pre-process", "execute-gen"],
+        input="JCP_benchmarks",
+    )
+    workload(
+        "ion_channel",
+        executables=["pre-process", "execute-gen"],
+        input="JCP_benchmarks",
+    )
+    workload(
+        "adh_dodec",
+        executables=["pre-process", "execute-gen"],
+        input="JCP_benchmarks",
+    )
 
     all_workloads = [
-        'water_gmx50',
-        'water_bare',
-        'lignocellulose',
-        'hecbiosim',
-        'benchpep',
-        'benchpep_h',
-        'benchmem',
-        'benchrib',
-        'stmv_rf',
-        'stmv_pme',
-        'rnase_cubic',
-        'ion_channel',
-        'adh_dodec',
+        "water_gmx50",
+        "water_bare",
+        "lignocellulose",
+        "hecbiosim",
+        "benchpep",
+        "benchpep_h",
+        "benchmem",
+        "benchrib",
+        "stmv_rf",
+        "stmv_pme",
+        "rnase_cubic",
+        "ion_channel",
+        "adh_dodec",
     ]
 
-    workload_variable('gmx', default='gmx_mpi',
-                      description='Name of the gromacs binary',
-                      workloads=all_workloads)
-    workload_variable('grompp', default='{gmx} grompp',
-                      description='How to run grompp',
-                      workloads=all_workloads)
-    workload_variable('mdrun', default='{gmx} mdrun',
-                      description='How to run mdrun',
-                      workloads=all_workloads)
-    workload_variable('nsteps', default=str(20000),
-                      description='Simulation steps',
-                      workloads=all_workloads)
-    workload_variable('resetstep', default='{str(int(0.9*{nsteps}))}',
-                      description='Reset performance counters at this step',
-                      workloads=all_workloads)
-    workload_variable('verbose', default="", values=['', '-v'],
-                      description='Set to empty string to run without verbose mode',
-                      workloads=all_workloads)
-    workload_variable('notunepme', default='-notunepme', values=['', '-notunepme'],
-                      description='Whether to set -notunepme for mdrun',
-                      workloads=all_workloads)
-    workload_variable('dlb', default='yes', values=['yes', 'no'],
-                      description='Whether to use dynamic load balancing for mdrun',
-                      workloads=all_workloads)
+    workload_variable(
+        "gmx",
+        default="gmx_mpi",
+        description="Name of the gromacs binary",
+        workloads=all_workloads,
+    )
+    workload_variable(
+        "grompp",
+        default="{gmx} grompp",
+        description="How to run grompp",
+        workloads=all_workloads,
+    )
+    workload_variable(
+        "mdrun",
+        default="{gmx} mdrun",
+        description="How to run mdrun",
+        workloads=all_workloads,
+    )
+    workload_variable(
+        "nsteps",
+        default=str(20000),
+        description="Simulation steps",
+        workloads=all_workloads,
+    )
+    workload_variable(
+        "resetstep",
+        default="{str(int(0.9*{nsteps}))}",
+        description="Reset performance counters at this step",
+        workloads=all_workloads,
+    )
+    workload_variable(
+        "verbose",
+        default="",
+        values=["", "-v"],
+        description="Set to empty string to run without verbose mode",
+        workloads=all_workloads,
+    )
+    workload_variable(
+        "notunepme",
+        default="-notunepme",
+        values=["", "-notunepme"],
+        description="Whether to set -notunepme for mdrun",
+        workloads=all_workloads,
+    )
+    workload_variable(
+        "dlb",
+        default="yes",
+        values=["yes", "no"],
+        description="Whether to use dynamic load balancing for mdrun",
+        workloads=all_workloads,
+    )
 
-    workload_variable('size', default='1536',
-                      values=['0000.65', '0000.96', '0001.5',
-                              '0003', '0006', '0012', '0024',
-                              '0048', '0096', '0192', '0384',
-                              '0768', '1536', '3072'],
-                      description='Workload size',
-                      workloads=['water_gmx50', 'water_bare'],
-                      expandable=False)
-    workload_variable('type', default='pme',
-                      description='Workload type.',
-                      values=['pme', 'rf'],
-                      workloads=['water_gmx50', 'water_bare'])
-    workload_variable('input_path', default='{water_gmx50_bare}/{size}',
-                      description='Input path for water GMX50',
-                      workload='water_gmx50')
-    workload_variable('input_path', default='{water_bare_hbonds}/{size}',
-                      description='Input path for water bare hbonds',
-                      workload='water_bare')
-    workload_variable('input_path', default='{lignocellulose}/lignocellulose-rf.tpr',
-                      description='Input path for lignocellulose',
-                      workload='lignocellulose')
-    workload_variable('type', default='Crambin',
-                      description='Workload type. Valid values are ''Crambin'', ''Glutamine-Binding-Protein'', ''hEGFRDimer'', ''hEGFRDimerPair'', ''hEGFRDimerSmallerPL'', ''hEGFRtetramerPair''',
-                      workload='hecbiosim')
-    workload_variable('input_path', default='{HECBioSim}/HECBioSim/{type}/benchmark.tpr',
-                      description='Input path for hecbiosim',
-                      workload='hecbiosim')
-    workload_variable('input_path', default='{BenchPEP}/benchPEP.tpr',
-                      description='Input path for Bench PEP workload',
-                      workload='benchpep')
-    workload_variable('input_path', default='{BenchMEM}/benchMEM.tpr',
-                      description='Input path for Bench MEM workload',
-                      workload='benchmem')
-    workload_variable('input_path', default='{BenchRIB}/benchRIB.tpr',
-                      description='Input path for Bench RIB workload',
-                      workload='benchrib')
-    workload_variable('input_path', default='{BenchPEP_h}/benchPEP-h.tpr',
-                      description='Input path for Bench PEP-h workload',
-                      workload='benchpep_h')
-    workload_variable('type', default='rf_nvt',
-                      description='Workload type for JCP_benchmarks',
-                      workload='stmv_rf')
-    workload_variable('type', default='pme_nvt',
-                      description='Workload type for JCP_benchmarks',
-                      workload='stmv_pme')
-    workload_variable('type', default='grompp',
-                      description='Workload type for JCP_benchmarks',
-                      workloads=['ion_channel', 'rnase_cubic'])
-    workload_variable('input_path', default='{JCP_benchmarks}/stmv',
-                      description='Input path for JCP_benchmark {workload_name}',
-                      workloads=['stmv_rf', 'stmv_pme'])
-    workload_variable('input_path', default='{JCP_benchmarks}/{workload_name}',
-                      description='Input path for JCP_benchmark {workload_name}',
-                      workloads=['ion_channel', 'rnase_cubic'])
-    workload_variable('input_path', default='{JCP_benchmarks}/{workload_name}',
-                      description='Input path for JCP_benchmark {workload_name}',
-                      workloads=['adh_dodec'])
-    workload_variable('type', default='pme_verlet',
-                      description='Workload type for JCP_benchmarks',
-                      workloads=['adh_dodec'])
+    workload_variable(
+        "size",
+        default="1536",
+        values=[
+            "0000.65",
+            "0000.96",
+            "0001.5",
+            "0003",
+            "0006",
+            "0012",
+            "0024",
+            "0048",
+            "0096",
+            "0192",
+            "0384",
+            "0768",
+            "1536",
+            "3072",
+        ],
+        description="Workload size",
+        workloads=["water_gmx50", "water_bare"],
+        expandable=False,
+    )
+    workload_variable(
+        "type",
+        default="pme",
+        description="Workload type.",
+        values=["pme", "rf"],
+        workloads=["water_gmx50", "water_bare"],
+    )
+    workload_variable(
+        "input_path",
+        default="{water_gmx50_bare}/{size}",
+        description="Input path for water GMX50",
+        workload="water_gmx50",
+    )
+    workload_variable(
+        "input_path",
+        default="{water_bare_hbonds}/{size}",
+        description="Input path for water bare hbonds",
+        workload="water_bare",
+    )
+    workload_variable(
+        "input_path",
+        default="{lignocellulose}/lignocellulose-rf.tpr",
+        description="Input path for lignocellulose",
+        workload="lignocellulose",
+    )
+    workload_variable(
+        "type",
+        default="Crambin",
+        description="Workload type. Valid values are "
+        "Crambin"
+        ", "
+        "Glutamine-Binding-Protein"
+        ", "
+        "hEGFRDimer"
+        ", "
+        "hEGFRDimerPair"
+        ", "
+        "hEGFRDimerSmallerPL"
+        ", "
+        "hEGFRtetramerPair"
+        "",
+        workload="hecbiosim",
+    )
+    workload_variable(
+        "input_path",
+        default="{HECBioSim}/HECBioSim/{type}/benchmark.tpr",
+        description="Input path for hecbiosim",
+        workload="hecbiosim",
+    )
+    workload_variable(
+        "input_path",
+        default="{BenchPEP}/benchPEP.tpr",
+        description="Input path for Bench PEP workload",
+        workload="benchpep",
+    )
+    workload_variable(
+        "input_path",
+        default="{BenchMEM}/benchMEM.tpr",
+        description="Input path for Bench MEM workload",
+        workload="benchmem",
+    )
+    workload_variable(
+        "input_path",
+        default="{BenchRIB}/benchRIB.tpr",
+        description="Input path for Bench RIB workload",
+        workload="benchrib",
+    )
+    workload_variable(
+        "input_path",
+        default="{BenchPEP_h}/benchPEP-h.tpr",
+        description="Input path for Bench PEP-h workload",
+        workload="benchpep_h",
+    )
+    workload_variable(
+        "type",
+        default="rf_nvt",
+        description="Workload type for JCP_benchmarks",
+        workload="stmv_rf",
+    )
+    workload_variable(
+        "type",
+        default="pme_nvt",
+        description="Workload type for JCP_benchmarks",
+        workload="stmv_pme",
+    )
+    workload_variable(
+        "type",
+        default="grompp",
+        description="Workload type for JCP_benchmarks",
+        workloads=["ion_channel", "rnase_cubic"],
+    )
+    workload_variable(
+        "input_path",
+        default="{JCP_benchmarks}/stmv",
+        description="Input path for JCP_benchmark {workload_name}",
+        workloads=["stmv_rf", "stmv_pme"],
+    )
+    workload_variable(
+        "input_path",
+        default="{JCP_benchmarks}/{workload_name}",
+        description="Input path for JCP_benchmark {workload_name}",
+        workloads=["ion_channel", "rnase_cubic"],
+    )
+    workload_variable(
+        "input_path",
+        default="{JCP_benchmarks}/{workload_name}",
+        description="Input path for JCP_benchmark {workload_name}",
+        workloads=["adh_dodec"],
+    )
+    workload_variable(
+        "type",
+        default="pme_verlet",
+        description="Workload type for JCP_benchmarks",
+        workloads=["adh_dodec"],
+    )
 
-    log_str = os.path.join(Expander.expansion_str('experiment_run_dir'),
-                           'md.log')
+    log_str = os.path.join(
+        Expander.expansion_str("experiment_run_dir"), "md.log"
+    )
 
-    figure_of_merit('Core Time', log_file=log_str,
-                    fom_regex=r'\s+Time:\s+(?P<core_time>[0-9]+\.[0-9]+).*',
-                    group_name='core_time', units='s')
+    figure_of_merit(
+        "Core Time",
+        log_file=log_str,
+        fom_regex=r"\s+Time:\s+(?P<core_time>[0-9]+\.[0-9]+).*",
+        group_name="core_time",
+        units="s",
+    )
 
-    figure_of_merit('Wall Time', log_file=log_str,
-                    fom_regex=r'\s+Time:\s+[0-9]+\.[0-9]+\s+' +
-                              r'(?P<wall_time>[0-9]+\.[0-9]+).*',
-                    group_name='wall_time', units='s')
+    figure_of_merit(
+        "Wall Time",
+        log_file=log_str,
+        fom_regex=r"\s+Time:\s+[0-9]+\.[0-9]+\s+"
+        + r"(?P<wall_time>[0-9]+\.[0-9]+).*",
+        group_name="wall_time",
+        units="s",
+    )
 
-    figure_of_merit('Percent Core Time', log_file=log_str,
-                    fom_regex=r'\s+Time:\s+[0-9]+\.[0-9]+\s+[0-9]+\.[0-9]+\s+' +
-                              r'(?P<perc_core_time>[0-9]+\.[0-9]+).*',
-                    group_name='perc_core_time', units='%')
+    figure_of_merit(
+        "Percent Core Time",
+        log_file=log_str,
+        fom_regex=r"\s+Time:\s+[0-9]+\.[0-9]+\s+[0-9]+\.[0-9]+\s+"
+        + r"(?P<perc_core_time>[0-9]+\.[0-9]+).*",
+        group_name="perc_core_time",
+        units="%",
+    )
 
-    figure_of_merit('Nanosecs per day', log_file=log_str,
-                    fom_regex=r'Performance:\s+' +
-                              r'(?P<ns_per_day>[0-9]+\.[0-9]+).*',
-                    group_name='ns_per_day', units='ns/day')
+    figure_of_merit(
+        "Nanosecs per day",
+        log_file=log_str,
+        fom_regex=r"Performance:\s+" + r"(?P<ns_per_day>[0-9]+\.[0-9]+).*",
+        group_name="ns_per_day",
+        units="ns/day",
+    )
 
-    figure_of_merit('Hours per nanosec', log_file=log_str,
-                    fom_regex=r'Performance:\s+[0-9]+\.[0-9]+\s+' +
-                              r'(?P<hours_per_ns>[0-9]+\.[0-9]+).*',
-                    group_name='hours_per_ns', units='hours/ns')
+    figure_of_merit(
+        "Hours per nanosec",
+        log_file=log_str,
+        fom_regex=r"Performance:\s+[0-9]+\.[0-9]+\s+"
+        + r"(?P<hours_per_ns>[0-9]+\.[0-9]+).*",
+        group_name="hours_per_ns",
+        units="hours/ns",
+    )

--- a/var/ramble/repos/builtin/applications/hmmer/application.py
+++ b/var/ramble/repos/builtin/applications/hmmer/application.py
@@ -12,7 +12,7 @@ from ramble.expander import Expander
 
 
 class Hmmer(SpackApplication):
-    '''HMMER is used for searching sequence databases for sequence homologs,
+    """HMMER is used for searching sequence databases for sequence homologs,
     and for making sequence alignments. It implements methods using
     probabilistic models called profile hidden Markov models (profile HMMs).
 
@@ -20,64 +20,88 @@ class Hmmer(SpackApplication):
     families), Rfam (for non-coded RNA families), Dfam (for repetitive
     DNA based), etc.
 
-    Homepage: www.hmmer.org'''
+    Homepage: www.hmmer.org"""
 
-    name = 'hmmer'
+    name = "hmmer"
 
-    maintainers('rfbgo')
+    maintainers("rfbgo")
 
-    tags('molecular-dynamics', 'hidden-markov-models', 'bio-molecule')
+    tags("molecular-dynamics", "hidden-markov-models", "bio-molecule")
 
-    define_compiler('gcc9', spack_spec='gcc@9.3.0')
+    define_compiler("gcc9", spack_spec="gcc@9.3.0")
 
-    software_spec('impi_2018', spack_spec='intel-mpi@2018.4.274')
+    software_spec("impi_2018", spack_spec="intel-mpi@2018.4.274")
 
-    software_spec('hmmer', spack_spec='hmmer@3.3.2', compiler='gcc9')
+    software_spec("hmmer", spack_spec="hmmer@3.3.2", compiler="gcc9")
 
     # This would ideally not use the current_release, as the package will need to be manually updated per release
     # Here current_release == 'Pfam36.0'
-    input_file('Pfam_A',
-               url='http://ftp.ebi.ac.uk/pub/databases/Pfam/current_release/Pfam-A.hmm.gz',
-               sha256='8779125bd2ed533886c559a5808903800f5c262798e5b086d276c2b829566b3a',
-               description='The Pfam database is a large collection of protein families, ' +
-               'each represented by multiple sequence alignments and hidden Markov models (HMMs).')
+    input_file(
+        "Pfam_A",
+        url="http://ftp.ebi.ac.uk/pub/databases/Pfam/current_release/Pfam-A.hmm.gz",
+        sha256="8779125bd2ed533886c559a5808903800f5c262798e5b086d276c2b829566b3a",
+        description="The Pfam database is a large collection of protein families, "
+        + "each represented by multiple sequence alignments and hidden Markov models (HMMs).",
+    )
 
-    input_file('uniprot_sprot_fasta',
-               url='https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/complete/uniprot_sprot.fasta.gz',
-               sha256='b0cacbf62fbf02f410dfd5e7963099762e53ed9f6fb123ba655583a9f7f0adab',
-               description='Uniprot Swiss Prot fasta search input')
+    input_file(
+        "uniprot_sprot_fasta",
+        url="https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/complete/uniprot_sprot.fasta.gz",
+        sha256="b0cacbf62fbf02f410dfd5e7963099762e53ed9f6fb123ba655583a9f7f0adab",
+        description="Uniprot Swiss Prot fasta search input",
+    )
 
-    executable('execute',
-               'hmmsearch --mpi -o hmmsearch.out {database_path} {input_path}',
-               use_mpi=True)
+    executable(
+        "execute",
+        "hmmsearch --mpi -o hmmsearch.out {database_path} {input_path}",
+        use_mpi=True,
+    )
 
-    executable('tail_hmmsearch_out',
-               'tail -100 hmmsearch.out',
-               use_mpi=False)
+    executable("tail_hmmsearch_out", "tail -100 hmmsearch.out", use_mpi=False)
 
-    workload('fasta_pfam', executables=['execute', 'tail_hmmsearch_out'],
-             inputs=['Pfam_A', 'uniprot_sprot_fasta'])
+    workload(
+        "fasta_pfam",
+        executables=["execute", "tail_hmmsearch_out"],
+        inputs=["Pfam_A", "uniprot_sprot_fasta"],
+    )
 
-    workload_variable('database_path', default='{Pfam_A}/Pfam-A.hmm',
-                      description='Database path for Pfam-A',
-                      workloads=['fasta_pfam'])
+    workload_variable(
+        "database_path",
+        default="{Pfam_A}/Pfam-A.hmm",
+        description="Database path for Pfam-A",
+        workloads=["fasta_pfam"],
+    )
 
-    workload_variable('input_path', default='{uniprot_sprot_fasta}/uniprot_sprot.fasta',
-                      description='Input path for uniprot_sprot.fasta',
-                      workloads=['fasta_pfam'])
+    workload_variable(
+        "input_path",
+        default="{uniprot_sprot_fasta}/uniprot_sprot.fasta",
+        description="Input path for uniprot_sprot.fasta",
+        workloads=["fasta_pfam"],
+    )
 
-    hmmsearch_out = os.path.join(Expander.expansion_str('experiment_run_dir'),
-                                 'hmmsearch.out')
+    hmmsearch_out = os.path.join(
+        Expander.expansion_str("experiment_run_dir"), "hmmsearch.out"
+    )
 
-    out_file = os.path.join(Expander.expansion_str('experiment_run_dir'),
-                            Expander.expansion_str('experiment_name') + '.out')
+    out_file = os.path.join(
+        Expander.expansion_str("experiment_run_dir"),
+        Expander.expansion_str("experiment_name") + ".out",
+    )
 
-    figure_of_merit('Elapsed time',
-                    fom_regex=r'# CPU.*Elapsed:\s+(?P<elapsed_time>[0-9]+:[0-9]+:[0-9]+\.*[0-9]*)\s*$',
-                    group_name='elapsed_time', log_file=out_file, units='hms')
+    figure_of_merit(
+        "Elapsed time",
+        fom_regex=r"# CPU.*Elapsed:\s+(?P<elapsed_time>[0-9]+:[0-9]+:[0-9]+\.*[0-9]*)\s*$",
+        group_name="elapsed_time",
+        log_file=out_file,
+        units="hms",
+    )
 
-    figure_of_merit('Million dynamic programming cells per second',
-                    fom_regex=r'^#\s*Mc/sec:\s+(?P<mc_per_sec>[0-9]+)\s*',
-                    group_name='mc_per_sec', log_file=out_file, units='Mc/s')
+    figure_of_merit(
+        "Million dynamic programming cells per second",
+        fom_regex=r"^#\s*Mc/sec:\s+(?P<mc_per_sec>[0-9]+)\s*",
+        group_name="mc_per_sec",
+        log_file=out_file,
+        units="Mc/s",
+    )
 
-    success_criteria('ok', mode='string', match=r'^\[ok\]$', file=out_file)
+    success_criteria("ok", mode="string", match=r"^\[ok\]$", file=out_file)

--- a/var/ramble/repos/builtin/applications/hostname/application.py
+++ b/var/ramble/repos/builtin/applications/hostname/application.py
@@ -1,4 +1,3 @@
-
 # Copyright 2022-2024 The Ramble Authors
 #
 # Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
@@ -14,32 +13,56 @@ from ramble.expander import Expander
 
 class Hostname(ExecutableApplication):
     """This is an example application that will simply run the hostname command"""  # noqa: E501
+
     name = "hostname"
 
     tags("test-app")
 
-    maintainers('douglasjacobsen')
+    maintainers("douglasjacobsen")
 
-    time_file = os.path.join(Expander.expansion_str('experiment_run_dir'),
-                             'time_output')
-    executable('local', 'hostname', use_mpi=False, output_capture=OUTPUT_CAPTURE.ALL)
-    executable('serial', '/usr/bin/time hostname', use_mpi=False, output_capture=OUTPUT_CAPTURE.ALL)
-    executable('parallel', '/usr/bin/time hostname', use_mpi=True, output_capture=OUTPUT_CAPTURE.ALL)
+    time_file = os.path.join(
+        Expander.expansion_str("experiment_run_dir"), "time_output"
+    )
+    executable(
+        "local", "hostname", use_mpi=False, output_capture=OUTPUT_CAPTURE.ALL
+    )
+    executable(
+        "serial",
+        "/usr/bin/time hostname",
+        use_mpi=False,
+        output_capture=OUTPUT_CAPTURE.ALL,
+    )
+    executable(
+        "parallel",
+        "/usr/bin/time hostname",
+        use_mpi=True,
+        output_capture=OUTPUT_CAPTURE.ALL,
+    )
 
-    workload('local', executable='local')
-    workload('serial', executable='serial')
-    workload('parallel', executable='parallel')
+    workload("local", executable="local")
+    workload("serial", executable="serial")
+    workload("parallel", executable="parallel")
 
-    figure_of_merit('user time from file', log_file=time_file,
-                    fom_regex=r'(?P<user_time>[0-9]+\.[0-9]+)user.*',
-                    group_name='user_time', units='s')
+    figure_of_merit(
+        "user time from file",
+        log_file=time_file,
+        fom_regex=r"(?P<user_time>[0-9]+\.[0-9]+)user.*",
+        group_name="user_time",
+        units="s",
+    )
 
-    figure_of_merit('user time',
-                    fom_regex=r'(?P<user_time>[0-9]+\.[0-9]+)user.*',
-                    group_name='user_time', units='s')
+    figure_of_merit(
+        "user time",
+        fom_regex=r"(?P<user_time>[0-9]+\.[0-9]+)user.*",
+        group_name="user_time",
+        units="s",
+    )
 
-    figure_of_merit('possible hostname',
-                    fom_regex=r'(?P<hostname>\S+)\s*',
-                    group_name='hostname', units='')
+    figure_of_merit(
+        "possible hostname",
+        fom_regex=r"(?P<hostname>\S+)\s*",
+        group_name="hostname",
+        units="",
+    )
 
-    success_criteria('wrote_anything', mode='string', match=r'.*')
+    success_criteria("wrote_anything", mode="string", match=r".*")

--- a/var/ramble/repos/builtin/applications/hpcc/application.py
+++ b/var/ramble/repos/builtin/applications/hpcc/application.py
@@ -11,7 +11,7 @@ from ramble.expander import Expander
 
 
 class Hpcc(SpackApplication):
-    '''Define the HPCC application
+    """Define the HPCC application
 
     HPCC is a collection of multiple benchmarks, which include:
       - HPL
@@ -21,89 +21,121 @@ class Hpcc(SpackApplication):
       - MPIRandomAccess
       - FFT
       - LatencyBandwidth
-    '''
-    name = 'hpcc'
+    """
 
-    maintainers('rfbgo')
+    name = "hpcc"
 
-    tags('benchmark-app', 'mini-app', 'benchmark', 'DGEMM')
+    maintainers("rfbgo")
 
-    define_compiler('gcc9', spack_spec='gcc@9.3.0')
+    tags("benchmark-app", "mini-app", "benchmark", "DGEMM")
 
-    software_spec('impi2018',
-                  spack_spec='intel-mpi@2018.4.274')
+    define_compiler("gcc9", spack_spec="gcc@9.3.0")
 
-    software_spec('hpcc',
-                  spack_spec='hpcc@1.5.0',
-                  compiler='gcc9')
+    software_spec("impi2018", spack_spec="intel-mpi@2018.4.274")
 
-    required_package('hpcc')
+    software_spec("hpcc", spack_spec="hpcc@1.5.0", compiler="gcc9")
 
-    input_file('hpccinf', url='{config_file}', expand=False,
-               sha256='fe9e5f4118c1b40980e162dc3c52d224fd6287e9706b95bb40ae7dfc96b38622',
-               description='Input/Config file for HPCC benchmark')
+    required_package("hpcc")
 
-    executable('copy-config', template='cp -R {workload_input_dir}/* {experiment_run_dir}/.', use_mpi=False)
+    input_file(
+        "hpccinf",
+        url="{config_file}",
+        expand=False,
+        sha256="fe9e5f4118c1b40980e162dc3c52d224fd6287e9706b95bb40ae7dfc96b38622",
+        description="Input/Config file for HPCC benchmark",
+    )
 
-    executable('execute', 'hpcc', use_mpi=True)
+    executable(
+        "copy-config",
+        template="cp -R {workload_input_dir}/* {experiment_run_dir}/.",
+        use_mpi=False,
+    )
 
-    workload('standard', executables=['copy-config', 'execute'], input='hpccinf')
+    executable("execute", "hpcc", use_mpi=True)
 
-    workload_variable('config_file', default='https://raw.githubusercontent.com/icl-utk-edu/hpcc/1.5.0/_hpccinf.txt',
-                      description='Default config file',
-                      workloads=['standard'])
+    workload(
+        "standard", executables=["copy-config", "execute"], input="hpccinf"
+    )
 
-    workload_variable('out_file', default='{experiment_run_dir}/hpccoutf.txt',
-                      description='Output file for results',
-                      workloads=['standard'])
+    workload_variable(
+        "config_file",
+        default="https://raw.githubusercontent.com/icl-utk-edu/hpcc/1.5.0/_hpccinf.txt",
+        description="Default config file",
+        workloads=["standard"],
+    )
 
-    output_sections = ['HPL', 'LatencyBandwidth', 'MPIFFT', 'MPIRandomAccess_LCG',
-                       'MPIRandomAccess', 'PTRANS', 'SingleDGEMM', 'SingleFFT',
-                       'SingleRandomAccess_LCG', 'SingleRandomAccess', 'SingleSTREAM',
-                       'StarDGEMM', 'StarFFT', 'StarRandomAccess_LCG', 'StarRandomAccess',
-                       'StarSTREAM', 'Summary']
+    workload_variable(
+        "out_file",
+        default="{experiment_run_dir}/hpccoutf.txt",
+        description="Output file for results",
+        workloads=["standard"],
+    )
 
-    context_regex = 'Begin of Summary section'
-    figure_of_merit_context('Summary', regex=context_regex, output_format='Summary')
-
-    summary_metrics = [
-        ('HPL_Tflops', 'Tflops'),
-        ('StarDGEMM_Gflops', 'Gflops'),
-        ('SingleDGEMM_Gflops', 'Gflops'),
-        ('PTRANS_GBs', 'GB/s'),
-        ('MPIRandomAccess_GUPs', 'GUP/s'),
-        ('MPIRandomAccess_LCG_GUPs', 'GUP/s'),
-        ('StarRandomAccess_GUPs', 'GUP/s'),
-        ('SingleRandomAccess_GUPs', 'GUP/s'),
-        ('StarSTREAM_Copy', 'GB/s'),
-        ('StarSTREAM_Scale', 'GB/s'),
-        ('StarSTREAM_Add', 'GB/s'),
-        ('StarSTREAM_Triad', 'GB/s'),
-        ('SingleSTREAM_Copy', 'GB/s'),
-        ('SingleSTREAM_Scale', 'GB/s'),
-        ('SingleSTREAM_Add', 'GB/s'),
-        ('SingleSTREAM_Triad', 'GB/s'),
-        ('StarFFT_Gflops', 'Gflops'),
-        ('SingleFFT_Gflops', 'Gflops'),
-        ('MPIFFT_Gflops', 'Gflops'),
-        ('MaxPingPongLatency_usec', 'usec'),
-        ('RandomlyOrderedRingLatency_usec', 'usec'),
-        ('MinPingPongBandwidth_GBytes', 'GB/s'),
-        ('NaturallyOrderedRingBandwidth_GBytes', 'GB/s'),
-        ('RandomlyOrderedRingBandwidth_GBytes', 'GB/s')
+    output_sections = [
+        "HPL",
+        "LatencyBandwidth",
+        "MPIFFT",
+        "MPIRandomAccess_LCG",
+        "MPIRandomAccess",
+        "PTRANS",
+        "SingleDGEMM",
+        "SingleFFT",
+        "SingleRandomAccess_LCG",
+        "SingleRandomAccess",
+        "SingleSTREAM",
+        "StarDGEMM",
+        "StarFFT",
+        "StarRandomAccess_LCG",
+        "StarRandomAccess",
+        "StarSTREAM",
+        "Summary",
     ]
 
-    log_str = Expander.expansion_str('out_file')
+    context_regex = "Begin of Summary section"
+    figure_of_merit_context(
+        "Summary", regex=context_regex, output_format="Summary"
+    )
+
+    summary_metrics = [
+        ("HPL_Tflops", "Tflops"),
+        ("StarDGEMM_Gflops", "Gflops"),
+        ("SingleDGEMM_Gflops", "Gflops"),
+        ("PTRANS_GBs", "GB/s"),
+        ("MPIRandomAccess_GUPs", "GUP/s"),
+        ("MPIRandomAccess_LCG_GUPs", "GUP/s"),
+        ("StarRandomAccess_GUPs", "GUP/s"),
+        ("SingleRandomAccess_GUPs", "GUP/s"),
+        ("StarSTREAM_Copy", "GB/s"),
+        ("StarSTREAM_Scale", "GB/s"),
+        ("StarSTREAM_Add", "GB/s"),
+        ("StarSTREAM_Triad", "GB/s"),
+        ("SingleSTREAM_Copy", "GB/s"),
+        ("SingleSTREAM_Scale", "GB/s"),
+        ("SingleSTREAM_Add", "GB/s"),
+        ("SingleSTREAM_Triad", "GB/s"),
+        ("StarFFT_Gflops", "Gflops"),
+        ("SingleFFT_Gflops", "Gflops"),
+        ("MPIFFT_Gflops", "Gflops"),
+        ("MaxPingPongLatency_usec", "usec"),
+        ("RandomlyOrderedRingLatency_usec", "usec"),
+        ("MinPingPongBandwidth_GBytes", "GB/s"),
+        ("NaturallyOrderedRingBandwidth_GBytes", "GB/s"),
+        ("RandomlyOrderedRingBandwidth_GBytes", "GB/s"),
+    ]
+
+    log_str = Expander.expansion_str("out_file")
 
     for metric, unit in summary_metrics:
-        summary_regex = metric + r'=(?P<val>[0-9]+\.[0-9]+)'
-        figure_of_merit(metric,
-                        log_file=log_str,
-                        fom_regex=summary_regex,
-                        group_name='val', units=unit,
-                        contexts=['Summary']
-                        )
-    '''
+        summary_regex = metric + r"=(?P<val>[0-9]+\.[0-9]+)"
+        figure_of_merit(
+            metric,
+            log_file=log_str,
+            fom_regex=summary_regex,
+            group_name="val",
+            units=unit,
+            contexts=["Summary"],
+        )
+    """
     # Below is a list of the full metrics available in the output. The current
     # implementation captures the summary metrics, which is sufficient,  but it
     # is possible a feature user wants to expand the FOM capture to include the
@@ -168,4 +200,4 @@ class Hpcc(SpackApplication):
             # Min Ping Pong Bandwidth:           10958.338341 MB/s
             # Naturally Ordered Ring Bandwidth:  13421.772800 MB/s
             # Randomly  Ordered Ring Bandwidth:  12860.856132 MB/s
-    '''
+    """

--- a/var/ramble/repos/builtin/applications/hpcg/application.py
+++ b/var/ramble/repos/builtin/applications/hpcg/application.py
@@ -12,85 +12,126 @@ from ramble.expander import Expander
 
 
 class Hpcg(SpackApplication):
-    '''Define HPCG application'''
-    name = 'hpcg'
+    """Define HPCG application"""
 
-    maintainers('douglasjacobsen')
+    name = "hpcg"
 
-    tags('benchmark-app', 'mini-app', 'benchmark')
+    maintainers("douglasjacobsen")
 
-    define_compiler('gcc9', spack_spec='gcc@9.3.0')
+    tags("benchmark-app", "mini-app", "benchmark")
 
-    software_spec('impi2018',
-                  spack_spec='intel-mpi@2018.4.274')
+    define_compiler("gcc9", spack_spec="gcc@9.3.0")
 
-    software_spec('hpcg',
-                  spack_spec='hpcg@3.1 +openmp',
-                  compiler='gcc9')
+    software_spec("impi2018", spack_spec="intel-mpi@2018.4.274")
 
-    required_package('hpcg')
+    software_spec("hpcg", spack_spec="hpcg@3.1 +openmp", compiler="gcc9")
 
-    executable('execute', 'xhpcg', use_mpi=True)
+    required_package("hpcg")
 
-    executable('move-log', 'mv HPCG-Benchmark*.txt {out_file}',
-               use_mpi=False)
+    executable("execute", "xhpcg", use_mpi=True)
 
-    workload('standard', executables=['execute', 'move-log'])
+    executable("move-log", "mv HPCG-Benchmark*.txt {out_file}", use_mpi=False)
 
-    workload_variable('matrix_size', default='104 104 104',
-                      description='Dimensions of the matrix to use',
-                      workloads=['standard'])
+    workload("standard", executables=["execute", "move-log"])
 
-    workload_variable('iterations', default='60',
-                      description='Number of iterations to perform',
-                      workloads=['standard'])
+    workload_variable(
+        "matrix_size",
+        default="104 104 104",
+        description="Dimensions of the matrix to use",
+        workloads=["standard"],
+    )
 
-    workload_variable('out_file', default='{experiment_run_dir}/hpcg_result.out',
-                      description='Output file for results',
-                      workloads=['standard'])
+    workload_variable(
+        "iterations",
+        default="60",
+        description="Number of iterations to perform",
+        workloads=["standard"],
+    )
 
-    log_str = Expander.expansion_str('out_file')
+    workload_variable(
+        "out_file",
+        default="{experiment_run_dir}/hpcg_result.out",
+        description="Output file for results",
+        workloads=["standard"],
+    )
 
-    figure_of_merit('Status', log_file=log_str,
-                    fom_regex=r'Final Summary::HPCG result is (?P<status>[a-zA-Z]+) with a GFLOP/s rating of=(?P<gflops>[0-9]+\.[0-9]+)',
-                    group_name='status', units='')
+    log_str = Expander.expansion_str("out_file")
 
-    figure_of_merit('Gflops', log_file=log_str,
-                    fom_regex=r'Final Summary::HPCG result is (?P<status>[a-zA-Z]+) with a GFLOP/s rating of=(?P<gflops>[0-9]+\.[0-9]+)',
-                    group_name='gflops', units='GFLOP/s')
+    figure_of_merit(
+        "Status",
+        log_file=log_str,
+        fom_regex=r"Final Summary::HPCG result is (?P<status>[a-zA-Z]+) with a GFLOP/s rating of=(?P<gflops>[0-9]+\.[0-9]+)",
+        group_name="status",
+        units="",
+    )
 
-    figure_of_merit('Time', log_file=log_str,
-                    fom_regex=r'Final Summary::Results are.* execution time.*is=(?P<exec_time>[0-9]+\.[0-9]*)',
-                    group_name='exec_time', units='s')
+    figure_of_merit(
+        "Gflops",
+        log_file=log_str,
+        fom_regex=r"Final Summary::HPCG result is (?P<status>[a-zA-Z]+) with a GFLOP/s rating of=(?P<gflops>[0-9]+\.[0-9]+)",
+        group_name="gflops",
+        units="GFLOP/s",
+    )
 
-    figure_of_merit('ComputeDotProductMsg', log_file=log_str,
-                    fom_regex=r'Final Summary::Reference version of ComputeDotProduct used.*=(?P<msg>.*)',
-                    group_name='msg', units='')
+    figure_of_merit(
+        "Time",
+        log_file=log_str,
+        fom_regex=r"Final Summary::Results are.* execution time.*is=(?P<exec_time>[0-9]+\.[0-9]*)",
+        group_name="exec_time",
+        units="s",
+    )
 
-    figure_of_merit('ComputeSPMVMsg', log_file=log_str,
-                    fom_regex=r'Final Summary::Reference version of ComputeSPMV used.*=(?P<msg>.*)',
-                    group_name='msg', units='')
+    figure_of_merit(
+        "ComputeDotProductMsg",
+        log_file=log_str,
+        fom_regex=r"Final Summary::Reference version of ComputeDotProduct used.*=(?P<msg>.*)",
+        group_name="msg",
+        units="",
+    )
 
-    figure_of_merit('ComputeMGMsg', log_file=log_str,
-                    fom_regex=r'Final Summary::Reference version of ComputeMG used.*=(?P<msg>.*)',
-                    group_name='msg', units='')
+    figure_of_merit(
+        "ComputeSPMVMsg",
+        log_file=log_str,
+        fom_regex=r"Final Summary::Reference version of ComputeSPMV used.*=(?P<msg>.*)",
+        group_name="msg",
+        units="",
+    )
 
-    figure_of_merit('ComputeWAXPBYMsg', log_file=log_str,
-                    fom_regex=r'Final Summary::Reference version of ComputeWAXPBY used.*=(?P<msg>.*)',
-                    group_name='msg', units='')
+    figure_of_merit(
+        "ComputeMGMsg",
+        log_file=log_str,
+        fom_regex=r"Final Summary::Reference version of ComputeMG used.*=(?P<msg>.*)",
+        group_name="msg",
+        units="",
+    )
 
-    figure_of_merit('HPCG 2.4 Rating', log_file=log_str,
-                    fom_regex=r'Final Summary::HPCG 2\.4 rating.*=(?P<rating>[0-9]+\.*[0-9]*)',
-                    group_name='rating', units='')
+    figure_of_merit(
+        "ComputeWAXPBYMsg",
+        log_file=log_str,
+        fom_regex=r"Final Summary::Reference version of ComputeWAXPBY used.*=(?P<msg>.*)",
+        group_name="msg",
+        units="",
+    )
+
+    figure_of_merit(
+        "HPCG 2.4 Rating",
+        log_file=log_str,
+        fom_regex=r"Final Summary::HPCG 2\.4 rating.*=(?P<rating>[0-9]+\.*[0-9]*)",
+        group_name="rating",
+        units="",
+    )
 
     def _make_experiments(self, workspace, app_inst=None):
         super()._make_experiments(workspace)
 
-        input_path = os.path.join(self.expander.expand_var_name('experiment_run_dir'),
-                                  'hpcg.dat')
+        input_path = os.path.join(
+            self.expander.expand_var_name("experiment_run_dir"), "hpcg.dat"
+        )
 
-        with open(input_path, 'w+') as f:
-            f.write('HPCG benchmark input file\n')
-            f.write('Sandia National Laboratories; University of Tennessee, Knoxville\n')
-            f.write(self.expander.expand_var_name('matrix_size') + '\n')
-            f.write(self.expander.expand_var_name('iterations') + '\n')
+        with open(input_path, "w+") as f:
+            f.write("HPCG benchmark input file\n")
+            f.write(
+                "Sandia National Laboratories; University of Tennessee, Knoxville\n"
+            )
+            f.write(self.expander.expand_var_name("matrix_size") + "\n")
+            f.write(self.expander.expand_var_name("iterations") + "\n")

--- a/var/ramble/repos/builtin/applications/hpl/application.py
+++ b/var/ramble/repos/builtin/applications/hpl/application.py
@@ -14,222 +14,326 @@ import math
 
 
 def pad_value(val, desc):
-    return ('{:<14}'.format(val) + desc)
+    return "{:<14}".format(val) + desc
 
 
 class Hpl(SpackApplication):
-    '''Define HPL application'''
-    name = 'hpl'
+    """Define HPL application"""
 
-    maintainers('douglasjacobsen')
+    name = "hpl"
 
-    tags('benchmark-app', 'benchmark', 'linpack')
+    maintainers("douglasjacobsen")
 
-    define_compiler('gcc9', spack_spec='gcc@9.3.0')
+    tags("benchmark-app", "benchmark", "linpack")
 
-    software_spec('impi_2018', spack_spec='intel-mpi@2018.4.274')
+    define_compiler("gcc9", spack_spec="gcc@9.3.0")
 
-    software_spec('hpl', spack_spec='hpl@2.3 +openmp', compiler='gcc9')
+    software_spec("impi_2018", spack_spec="intel-mpi@2018.4.274")
 
-    required_package('hpl')
+    software_spec("hpl", spack_spec="hpl@2.3 +openmp", compiler="gcc9")
 
-    executable('execute', 'xhpl', use_mpi=True)
+    required_package("hpl")
 
-    workload('standard', executables=['execute'])
-    workload('calculator', executables=['execute'])
+    executable("execute", "xhpl", use_mpi=True)
 
-    workload_variable('output_file',
-                      default=pad_value('HPL.out', 'output file name (if any)'),
-                      description='Output file name (if any)',
-                      workloads=['standard'])
-    workload_variable('device_out',
-                      default=pad_value('6', 'device out (6=stdout,7=stderr,file)'),
-                      description='Output device',
-                      workloads=['standard'])
-    workload_variable('N-Ns',
-                      default=pad_value('4', 'Number of problems sizes (N)'),
-                      description='Number of problems sizes',
-                      workloads=['standard'])
-    workload_variable('Ns',
-                      default=pad_value('29 30 34 35', 'Ns'),
-                      description='Problem sizes',
-                      workloads=['standard'])
-    workload_variable('N-NBs',
-                      default=pad_value('4', 'Number of NBs'),
-                      description='Number of NBs',
-                      workloads=['standard'])
-    workload_variable('NBs',
-                      default=pad_value('1 2 3 4', 'NBs'),
-                      description='NB values',
-                      workloads=['standard'])
-    workload_variable('PMAP',
-                      default=pad_value('0', 'PMAP process mapping (0=Row-,1=Column-major)'),
-                      description='PMAP Process mapping. (0=Row-, 1=Column-Major)',
-                      workloads=['standard'])
-    workload_variable('N-Grids',
-                      default=pad_value('3', 'Number of process grids (P x Q)'),
-                      description='Number of process grids (P x Q)',
-                      workloads=['standard'])
-    workload_variable('Ps',
-                      default=pad_value('2 1 4', 'Ps'),
-                      description='P values',
-                      workloads=['standard'])
-    workload_variable('Qs',
-                      default=pad_value('2 4 1', 'Qs'),
-                      description='Q values',
-                      workloads=['standard'])
-    workload_variable('threshold',
-                      default=pad_value('16.0', 'threshold'),
-                      description='Residual threshold',
-                      workloads=['standard'])
-    workload_variable('NPFACTs',
-                      default=pad_value('3', 'Number of PFACTs, panel fact'),
-                      description='Number of PFACTs',
-                      workloads=['standard'])
-    workload_variable('PFACTs',
-                      default=pad_value('0 1 2', 'PFACTs (0=left, 1=Crout, 2=Right)'),
-                      description='PFACT Values',
-                      workloads=['standard'])
-    workload_variable('N-NBMINs',
-                      default=pad_value('2', 'Number of NBMINs, recursive stopping criteria'),
-                      description='Number of NBMINs',
-                      workloads=['standard'])
-    workload_variable('NBMINs',
-                      default=pad_value('2 4', 'NBMINs (>= 1)'),
-                      description='NBMIN values',
-                      workloads=['standard'])
-    workload_variable('N-NDIVs',
-                      default=pad_value('1', 'Number of NDIVs, panels in recursion'),
-                      description='Number of NDIVs',
-                      workloads=['standard'])
-    workload_variable('NDIVs',
-                      default=pad_value('2', 'NDIVs'),
-                      description='NDIV values',
-                      workloads=['standard'])
-    workload_variable('N-RFACTs',
-                      default=pad_value('3', 'Number of RFACTs, recursive panel fact.'),
-                      description='Number of RFACTs',
-                      workloads=['standard'])
-    workload_variable('RFACTs',
-                      default=pad_value('0 1 2', 'RFACTs (0=left, 1=Crout, 2=Right)'),
-                      description='RFACT values',
-                      workloads=['standard'])
-    workload_variable('N-BCASTs',
-                      default=pad_value('1', 'Number of BCASTs, broadcast'),
-                      description='Number of BCASTs',
-                      workloads=['standard'])
-    workload_variable('BCASTs',
-                      default=pad_value('0', 'BCASTs (0=1rg,1=1rM,2=2rg,3=2rM,4=Lng,5=LnM)'),
-                      description='BCAST values',
-                      workloads=['standard'])
-    workload_variable('N-DEPTHs',
-                      default=pad_value('1', 'Number of DEPTHs, lookahead depth'),
-                      description='Number of DEPTHs',
-                      workloads=['standard'])
-    workload_variable('DEPTHs',
-                      default=pad_value('0', 'DEPTHs (>=0)'),
-                      description='DEPTH values',
-                      workloads=['standard'])
-    workload_variable('SWAP',
-                      default=pad_value('2', 'SWAP (0=bin-exch,1=long,2=mix)'),
-                      description='Swapping algorithm',
-                      workloads=['standard'])
-    workload_variable('swapping_threshold',
-                      default=pad_value('64', 'swapping threshold'),
-                      description='Swapping threshold',
-                      workloads=['standard'])
-    workload_variable('L1',
-                      default=pad_value('0', 'L1 in (0=transposed,1=no-transposed) form'),
-                      description='Storage for upper triangular portion of columns',
-                      workloads=['standard'])
-    workload_variable('U',
-                      default=pad_value('0', 'U  in (0=transposed,1=no-transposed) form'),
-                      description='Storage for the rows of U',
-                      workloads=['standard'])
-    workload_variable('Equilibration',
-                      default=pad_value('1', 'Equilibration (0=no,1=yes)'),
-                      description='Determines if equilibration should be enabled or disabled.',
-                      workloads=['standard'])
-    workload_variable('mem_alignment',
-                      default=pad_value('8', 'memory alignment in double (> 0)'),
-                      description='Sets the alignment in doubles for memory addresses',
-                      workloads=['standard'])
+    workload("standard", executables=["execute"])
+    workload("calculator", executables=["execute"])
+
+    workload_variable(
+        "output_file",
+        default=pad_value("HPL.out", "output file name (if any)"),
+        description="Output file name (if any)",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "device_out",
+        default=pad_value("6", "device out (6=stdout,7=stderr,file)"),
+        description="Output device",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "N-Ns",
+        default=pad_value("4", "Number of problems sizes (N)"),
+        description="Number of problems sizes",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "Ns",
+        default=pad_value("29 30 34 35", "Ns"),
+        description="Problem sizes",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "N-NBs",
+        default=pad_value("4", "Number of NBs"),
+        description="Number of NBs",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "NBs",
+        default=pad_value("1 2 3 4", "NBs"),
+        description="NB values",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "PMAP",
+        default=pad_value("0", "PMAP process mapping (0=Row-,1=Column-major)"),
+        description="PMAP Process mapping. (0=Row-, 1=Column-Major)",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "N-Grids",
+        default=pad_value("3", "Number of process grids (P x Q)"),
+        description="Number of process grids (P x Q)",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "Ps",
+        default=pad_value("2 1 4", "Ps"),
+        description="P values",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "Qs",
+        default=pad_value("2 4 1", "Qs"),
+        description="Q values",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "threshold",
+        default=pad_value("16.0", "threshold"),
+        description="Residual threshold",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "NPFACTs",
+        default=pad_value("3", "Number of PFACTs, panel fact"),
+        description="Number of PFACTs",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "PFACTs",
+        default=pad_value("0 1 2", "PFACTs (0=left, 1=Crout, 2=Right)"),
+        description="PFACT Values",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "N-NBMINs",
+        default=pad_value(
+            "2", "Number of NBMINs, recursive stopping criteria"
+        ),
+        description="Number of NBMINs",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "NBMINs",
+        default=pad_value("2 4", "NBMINs (>= 1)"),
+        description="NBMIN values",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "N-NDIVs",
+        default=pad_value("1", "Number of NDIVs, panels in recursion"),
+        description="Number of NDIVs",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "NDIVs",
+        default=pad_value("2", "NDIVs"),
+        description="NDIV values",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "N-RFACTs",
+        default=pad_value("3", "Number of RFACTs, recursive panel fact."),
+        description="Number of RFACTs",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "RFACTs",
+        default=pad_value("0 1 2", "RFACTs (0=left, 1=Crout, 2=Right)"),
+        description="RFACT values",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "N-BCASTs",
+        default=pad_value("1", "Number of BCASTs, broadcast"),
+        description="Number of BCASTs",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "BCASTs",
+        default=pad_value("0", "BCASTs (0=1rg,1=1rM,2=2rg,3=2rM,4=Lng,5=LnM)"),
+        description="BCAST values",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "N-DEPTHs",
+        default=pad_value("1", "Number of DEPTHs, lookahead depth"),
+        description="Number of DEPTHs",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "DEPTHs",
+        default=pad_value("0", "DEPTHs (>=0)"),
+        description="DEPTH values",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "SWAP",
+        default=pad_value("2", "SWAP (0=bin-exch,1=long,2=mix)"),
+        description="Swapping algorithm",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "swapping_threshold",
+        default=pad_value("64", "swapping threshold"),
+        description="Swapping threshold",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "L1",
+        default=pad_value("0", "L1 in (0=transposed,1=no-transposed) form"),
+        description="Storage for upper triangular portion of columns",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "U",
+        default=pad_value("0", "U  in (0=transposed,1=no-transposed) form"),
+        description="Storage for the rows of U",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "Equilibration",
+        default=pad_value("1", "Equilibration (0=no,1=yes)"),
+        description="Determines if equilibration should be enabled or disabled.",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "mem_alignment",
+        default=pad_value("8", "memory alignment in double (> 0)"),
+        description="Sets the alignment in doubles for memory addresses",
+        workloads=["standard"],
+    )
 
     # calculator workload-specific variables:
 
-    workload_variable('percent_mem', default='85',
-                      description='Percent of memory to use (default 85)',
-                      workloads=['calculator'])
+    workload_variable(
+        "percent_mem",
+        default="85",
+        description="Percent of memory to use (default 85)",
+        workloads=["calculator"],
+    )
 
-    workload_variable('memory_per_node', default='240',
-                      description='Memory per node in GB',
-                      workloads=['calculator'])
+    workload_variable(
+        "memory_per_node",
+        default="240",
+        description="Memory per node in GB",
+        workloads=["calculator"],
+    )
 
-    workload_variable('block_size', default='384',
-                      description='Size of each block',
-                      workloads=['calculator'])
+    workload_variable(
+        "block_size",
+        default="384",
+        description="Size of each block",
+        workloads=["calculator"],
+    )
 
-    workload_variable('pfact', default='0',
-                      description='PFACT for optimized calculator',
-                      workloads=['calculator'])
+    workload_variable(
+        "pfact",
+        default="0",
+        description="PFACT for optimized calculator",
+        workloads=["calculator"],
+    )
 
-    workload_variable('nbmin', default='2',
-                      description='NBMIN for optimized calculator',
-                      workloads=['calculator'])
+    workload_variable(
+        "nbmin",
+        default="2",
+        description="NBMIN for optimized calculator",
+        workloads=["calculator"],
+    )
 
-    workload_variable('rfact', default='0',
-                      description='RFACT for optimized calculator',
-                      workloads=['calculator'])
+    workload_variable(
+        "rfact",
+        default="0",
+        description="RFACT for optimized calculator",
+        workloads=["calculator"],
+    )
 
-    workload_variable('bcast', default='0',
-                      description='BCAST for optimized calculator',
-                      workloads=['calculator'])
+    workload_variable(
+        "bcast",
+        default="0",
+        description="BCAST for optimized calculator",
+        workloads=["calculator"],
+    )
 
-    workload_variable('depth', default='0',
-                      description='DEPTH for optimized calculator',
-                      workloads=['calculator'])
+    workload_variable(
+        "depth",
+        default="0",
+        description="DEPTH for optimized calculator",
+        workloads=["calculator"],
+    )
 
     # FOMs:
-    log_str = os.path.join(Expander.expansion_str('experiment_run_dir'),
-                           Expander.expansion_str('experiment_name') + '.out')
+    log_str = os.path.join(
+        Expander.expansion_str("experiment_run_dir"),
+        Expander.expansion_str("experiment_name") + ".out",
+    )
 
-    figure_of_merit('Time', log_file=log_str,
-                    fom_regex=r'.*\s+(?P<N>[0-9]+)\s+(?P<NB>[0-9]+)\s+(?P<P>[0-9]+)\s+(?P<Q>[0-9]+)\s+(?P<time>[0-9]+\.[0-9]+)\s+(?P<gflops>[0-9].*)\n',
-                    group_name='time', units='s', contexts=['problem-name'])
+    figure_of_merit(
+        "Time",
+        log_file=log_str,
+        fom_regex=r".*\s+(?P<N>[0-9]+)\s+(?P<NB>[0-9]+)\s+(?P<P>[0-9]+)\s+(?P<Q>[0-9]+)\s+(?P<time>[0-9]+\.[0-9]+)\s+(?P<gflops>[0-9].*)\n",
+        group_name="time",
+        units="s",
+        contexts=["problem-name"],
+    )
 
-    figure_of_merit('GFlops', log_file=log_str,
-                    fom_regex=r'.*\s+(?P<N>[0-9]+)\s+(?P<NB>[0-9]+)\s+(?P<P>[0-9]+)\s+(?P<Q>[0-9]+)\s+(?P<time>[0-9]+\.[0-9]+)\s+(?P<gflops>[0-9].*)\n',
-                    group_name='gflops', units='GFLOP/s',
-                    contexts=['problem-name'])
+    figure_of_merit(
+        "GFlops",
+        log_file=log_str,
+        fom_regex=r".*\s+(?P<N>[0-9]+)\s+(?P<NB>[0-9]+)\s+(?P<P>[0-9]+)\s+(?P<Q>[0-9]+)\s+(?P<time>[0-9]+\.[0-9]+)\s+(?P<gflops>[0-9].*)\n",
+        group_name="gflops",
+        units="GFLOP/s",
+        contexts=["problem-name"],
+    )
 
-    figure_of_merit_context('problem-name', regex=r'.*\s+(?P<N>[0-9]+)\s+(?P<NB>[0-9]+)\s+(?P<P>[0-9]+)\s+(?P<Q>[0-9]+)\s+(?P<time>[0-9]+\.[0-9]+)\s+(?P<gflops>[0-9].*)\n', output_format='N-NB-P-Q = {N}-{NB}-{P}-{Q}')
+    figure_of_merit_context(
+        "problem-name",
+        regex=r".*\s+(?P<N>[0-9]+)\s+(?P<NB>[0-9]+)\s+(?P<P>[0-9]+)\s+(?P<Q>[0-9]+)\s+(?P<time>[0-9]+\.[0-9]+)\s+(?P<gflops>[0-9].*)\n",
+        output_format="N-NB-P-Q = {N}-{NB}-{P}-{Q}",
+    )
 
     # Integer sqrt
     def _isqrt(self, n):
         if n < 0:
             raise Exception
         elif n < 2:
-            return (n)
+            return n
         else:
             lo = self._isqrt(n >> 2) << 1
             hi = lo + 1
-            if ((hi * hi) > n):
-                return (lo)
+            if (hi * hi) > n:
+                return lo
             else:
-                return (hi)
+                return hi
 
     def _calculate_values(self, workspace):
         expander = self.expander
-        if expander.workload_name == 'calculator':
+        if expander.workload_name == "calculator":
             # Find the best P and Q whose product is the number of available
             # cores, with P less than Q
-            nNodes = int(expander.expand_var_name('n_nodes'))
-            processesPerNode = int(expander.expand_var_name('processes_per_node'))
+            nNodes = int(expander.expand_var_name("n_nodes"))
+            processesPerNode = int(
+                expander.expand_var_name("processes_per_node")
+            )
 
             totalCores = nNodes * processesPerNode
 
             bestP = self._isqrt(totalCores)
-            while ((totalCores % bestP) > 0):     # stops at 1 because any int % 1 = 0
+            while (
+                totalCores % bestP
+            ) > 0:  # stops at 1 because any int % 1 = 0
                 bestP -= 1
 
             bestQ = totalCores // bestP
@@ -237,15 +341,15 @@ class Hpl(SpackApplication):
             # Find LCM(P,Q)
             P = int(bestP)
             Q = int(bestQ)
-            lcmPQ = Q             # Q is always the larger of P and Q
-            while ((lcmPQ % P) > 0):
+            lcmPQ = Q  # Q is always the larger of P and Q
+            while (lcmPQ % P) > 0:
                 lcmPQ += Q
 
             # HPL maintainers recommend basing the target problem size on
             # the square root of 80% of total memory in words.
-            memoryPerNode = int(expander.expand_var_name('memory_per_node'))
-            memFraction = int(expander.expand_var_name('percent_mem')) / 100
-            blockSize = int(expander.expand_var_name('block_size'))
+            memoryPerNode = int(expander.expand_var_name("memory_per_node"))
+            memFraction = int(expander.expand_var_name("percent_mem")) / 100
+            blockSize = int(expander.expand_var_name("block_size"))
             one_gb_mem_in_words = (1 << 30) / 8
 
             fullMemWords = nNodes * memoryPerNode * one_gb_mem_in_words
@@ -254,84 +358,141 @@ class Hpl(SpackApplication):
 
             # Ensure that N is divisible by NB * LCM(P,Q)
             problemSize = int(targetProblemSize)
-            problemSize -= (problemSize % blockSize)
+            problemSize -= problemSize % blockSize
             nBlocks = problemSize // blockSize
             nBlocks -= nBlocks % lcmPQ
             problemSize = blockSize * nBlocks
             usedPercentage = int(problemSize**2 / fullMemWords * 100)
 
-            for name, var in self.workloads['standard'].variables.items():
+            for name, var in self.workloads["standard"].variables.items():
                 self.variables[var.name] = var.default
 
-            pfact = expander.expand_var_name('pfact')
-            nbmin = expander.expand_var_name('nbmin')
-            rfact = expander.expand_var_name('rfact')
-            bcast = expander.expand_var_name('bcast')
-            depth = expander.expand_var_name('depth')
+            pfact = expander.expand_var_name("pfact")
+            nbmin = expander.expand_var_name("nbmin")
+            rfact = expander.expand_var_name("rfact")
+            bcast = expander.expand_var_name("bcast")
+            depth = expander.expand_var_name("depth")
 
-            self.variables['N-Ns'] = pad_value('1', 'Number of problems sizes (N)')  # vs 4
-
-            # Calculated:
-            self.variables['Ns'] = pad_value(int(problemSize),
-                                             f"Ns (= {usedPercentage}% of total available memory)")
-
-            self.variables['N-NBs'] = pad_value('1', 'Number of NBs')  # vs 4
+            self.variables["N-Ns"] = pad_value(
+                "1", "Number of problems sizes (N)"
+            )  # vs 4
 
             # Calculated:
-            self.variables['NBs'] = pad_value(blockSize, "NBs")  # calculated, vs 4 samples
+            self.variables["Ns"] = pad_value(
+                int(problemSize),
+                f"Ns (= {usedPercentage}% of total available memory)",
+            )
 
-            self.variables['N-Grids'] = pad_value('1', 'Number of Grids, process grids (P x Q)')  # vs 3
+            self.variables["N-NBs"] = pad_value("1", "Number of NBs")  # vs 4
 
             # Calculated:
-            self.variables['Ps'] = pad_value(int(bestP), "Ps")
+            self.variables["NBs"] = pad_value(
+                blockSize, "NBs"
+            )  # calculated, vs 4 samples
+
+            self.variables["N-Grids"] = pad_value(
+                "1", "Number of Grids, process grids (P x Q)"
+            )  # vs 3
 
             # Calculated:
-            self.variables['Qs'] = pad_value(int(bestQ), "Qs")
+            self.variables["Ps"] = pad_value(int(bestP), "Ps")
 
-            self.variables['NPFACTs'] = pad_value('1', 'Number of PFACTs, panel fact')  # vs 3
+            # Calculated:
+            self.variables["Qs"] = pad_value(int(bestQ), "Qs")
 
-            # ramble.yaml configurable
-            self.variables['PFACTs'] = pad_value(pfact, 'PFACT Values (0=left, 1=Crout, 2=Right)')  # vs 0 1 2
-
-            self.variables['N-NBMINs'] = pad_value('1', 'Number of NBMINs, recursive stopping criteria')  # vs 2
-
-            # ramble.yaml configurable
-            self.variables['NBMINs'] = pad_value(nbmin, 'NBMINs (>= 1)')  # vs '2 4'
-
-            self.variables['N-RFACTs'] = pad_value('1', 'Number of RFACTS, recursive panel fact.')  # vs '3'
+            self.variables["NPFACTs"] = pad_value(
+                "1", "Number of PFACTs, panel fact"
+            )  # vs 3
 
             # ramble.yaml configurable
-            self.variables['RFACTs'] = pad_value(rfact, 'RFACTs (0=left, 1=Crout, 2=Right)')  # vs '0 1 2'
+            self.variables["PFACTs"] = pad_value(
+                pfact, "PFACT Values (0=left, 1=Crout, 2=Right)"
+            )  # vs 0 1 2
+
+            self.variables["N-NBMINs"] = pad_value(
+                "1", "Number of NBMINs, recursive stopping criteria"
+            )  # vs 2
 
             # ramble.yaml configurable
-            self.variables['BCASTs'] = pad_value(bcast, 'BCASTs (0=1rg,1=1rM,2=2rg,3=2rM,4=Lng,5=LnM,6=MKL BPUSH,7=AMD Hybrid Panel)')  # vs '0'
+            self.variables["NBMINs"] = pad_value(
+                nbmin, "NBMINs (>= 1)"
+            )  # vs '2 4'
+
+            self.variables["N-RFACTs"] = pad_value(
+                "1", "Number of RFACTS, recursive panel fact."
+            )  # vs '3'
 
             # ramble.yaml configurable
-            self.variables['DEPTHs'] = pad_value(depth, 'DEPTHs (>=0)')  # vs '0'
+            self.variables["RFACTs"] = pad_value(
+                rfact, "RFACTs (0=left, 1=Crout, 2=Right)"
+            )  # vs '0 1 2'
+
+            # ramble.yaml configurable
+            self.variables["BCASTs"] = pad_value(
+                bcast,
+                "BCASTs (0=1rg,1=1rM,2=2rg,3=2rM,4=Lng,5=LnM,6=MKL BPUSH,7=AMD Hybrid Panel)",
+            )  # vs '0'
+
+            # ramble.yaml configurable
+            self.variables["DEPTHs"] = pad_value(
+                depth, "DEPTHs (>=0)"
+            )  # vs '0'
 
     def _make_experiments(self, workspace, app_inst=None):
         super()._make_experiments(workspace)
         self._calculate_values(workspace)
 
-        input_path = os.path.join(self.expander.expand_var_name('experiment_run_dir'),
-                                  'HPL.dat')
+        input_path = os.path.join(
+            self.expander.expand_var_name("experiment_run_dir"), "HPL.dat"
+        )
 
-        settings = ['output_file', 'device_out', 'N-Ns', 'Ns', 'N-NBs', 'NBs',
-                    'PMAP', 'N-Grids', 'Ps', 'Qs', 'threshold', 'NPFACTs',
-                    'PFACTs', 'N-NBMINs', 'NBMINs', 'N-NDIVs', 'NDIVs', 'N-RFACTs',
-                    'RFACTs', 'N-BCASTs', 'BCASTs', 'N-DEPTHs', 'DEPTHs', 'SWAP',
-                    'swapping_threshold', 'L1', 'U', 'Equilibration',
-                    'mem_alignment']
+        settings = [
+            "output_file",
+            "device_out",
+            "N-Ns",
+            "Ns",
+            "N-NBs",
+            "NBs",
+            "PMAP",
+            "N-Grids",
+            "Ps",
+            "Qs",
+            "threshold",
+            "NPFACTs",
+            "PFACTs",
+            "N-NBMINs",
+            "NBMINs",
+            "N-NDIVs",
+            "NDIVs",
+            "N-RFACTs",
+            "RFACTs",
+            "N-BCASTs",
+            "BCASTs",
+            "N-DEPTHs",
+            "DEPTHs",
+            "SWAP",
+            "swapping_threshold",
+            "L1",
+            "U",
+            "Equilibration",
+            "mem_alignment",
+        ]
 
-        with open(input_path, 'w+') as f:
-            f.write('    HPLinpack benchmark input file\n')
-            f.write('Innovative Computing Laboratory, University of Tennessee\n')
+        with open(input_path, "w+") as f:
+            f.write("    HPLinpack benchmark input file\n")
+            f.write(
+                "Innovative Computing Laboratory, University of Tennessee\n"
+            )
 
             for setting in settings:
                 # This gets around an issue in expander where trailing comments
                 # after '#' are not printed
-                hash_replace_str = self.expander.expand_var_name(setting).replace('Number', '#')
-                f.write(hash_replace_str + '\n')
+                hash_replace_str = self.expander.expand_var_name(
+                    setting
+                ).replace("Number", "#")
+                f.write(hash_replace_str + "\n")
 
             # Write some documentation at the bottom of the input file:
-            f.write('##### This line (no. 32) is ignored (it serves as a separator). ######')
+            f.write(
+                "##### This line (no. 32) is ignored (it serves as a separator). ######"
+            )

--- a/var/ramble/repos/builtin/applications/intel-hpl/application.py
+++ b/var/ramble/repos/builtin/applications/intel-hpl/application.py
@@ -14,223 +14,333 @@ import math
 
 
 def pad_value(val, desc):
-    return ('{:<14}'.format(val) + desc)
+    return "{:<14}".format(val) + desc
 
 
 class IntelHpl(SpackApplication):
-    '''Define HPL application using Intel MKL optimized binary from intel-oneapi-mpi package'''
-    name = 'intel-hpl'
+    """Define HPL application using Intel MKL optimized binary from intel-oneapi-mpi package"""
 
-    maintainers('rfbgo')
+    name = "intel-hpl"
 
-    tags('benchmark-app', 'benchmark', 'linpack', 'optimized', 'intel', 'mkl')
+    maintainers("rfbgo")
 
-    define_compiler('gcc9', spack_spec='gcc@9.3.0')
-    software_spec('imkl_2023p1', spack_spec='intel-oneapi-mkl@2023.1.0 threads=openmp', compiler='gcc9')
-    software_spec('impi_2018', spack_spec='intel-mpi@2018.4.274')
+    tags("benchmark-app", "benchmark", "linpack", "optimized", "intel", "mkl")
 
-    required_package('intel-oneapi-mkl')
+    define_compiler("gcc9", spack_spec="gcc@9.3.0")
+    software_spec(
+        "imkl_2023p1",
+        spack_spec="intel-oneapi-mkl@2023.1.0 threads=openmp",
+        compiler="gcc9",
+    )
+    software_spec("impi_2018", spack_spec="intel-mpi@2018.4.274")
 
-    executable('execute',
-               '{intel-oneapi-mkl}/mkl/latest/benchmarks/mp_linpack/xhpl_intel64_dynamic',
-               use_mpi=True)
+    required_package("intel-oneapi-mkl")
 
-    workload('standard', executables=['execute'])
-    workload('calculator', executables=['execute'])
+    executable(
+        "execute",
+        "{intel-oneapi-mkl}/mkl/latest/benchmarks/mp_linpack/xhpl_intel64_dynamic",
+        use_mpi=True,
+    )
 
-    workload_variable('output_file',
-                      default=pad_value('HPL.out', 'output file name (if any)'),
-                      description='Output file name (if any)',
-                      workloads=['standard'])
-    workload_variable('device_out',
-                      default=pad_value('6', 'device out (6=stdout,7=stderr,file)'),
-                      description='Output device',
-                      workloads=['standard'])
-    workload_variable('N-Ns',
-                      default=pad_value('4', 'Number of problems sizes (N)'),
-                      description='Number of problems sizes',
-                      workloads=['standard'])
-    workload_variable('Ns',
-                      default=pad_value('29 30 34 35', 'Ns'),
-                      description='Problem sizes',
-                      workloads=['standard'])
-    workload_variable('N-NBs',
-                      default=pad_value('4', 'Number of NBs'),
-                      description='Number of NBs',
-                      workloads=['standard'])
-    workload_variable('NBs',
-                      default=pad_value('1 2 3 4', 'NBs'),
-                      description='NB values',
-                      workloads=['standard'])
-    workload_variable('PMAP',
-                      default=pad_value('0', 'PMAP process mapping (0=Row-,1=Column-major)'),
-                      description='PMAP Process mapping. (0=Row-, 1=Column-Major)',
-                      workloads=['standard'])
-    workload_variable('N-Grids',
-                      default=pad_value('3', 'Number of process grids (P x Q)'),
-                      description='Number of process grids (P x Q)',
-                      workloads=['standard'])
-    workload_variable('Ps',
-                      default=pad_value('2 1 4', 'Ps'),
-                      description='P values',
-                      workloads=['standard'])
-    workload_variable('Qs',
-                      default=pad_value('2 4 1', 'Qs'),
-                      description='Q values',
-                      workloads=['standard'])
-    workload_variable('threshold',
-                      default=pad_value('16.0', 'threshold'),
-                      description='Residual threshold',
-                      workloads=['standard'])
-    workload_variable('NPFACTs',
-                      default=pad_value('3', 'Number of PFACTs, panel fact'),
-                      description='Number of PFACTs',
-                      workloads=['standard'])
-    workload_variable('PFACTs',
-                      default=pad_value('0 1 2', 'PFACTs (0=left, 1=Crout, 2=Right)'),
-                      description='PFACT Values',
-                      workloads=['standard'])
-    workload_variable('N-NBMINs',
-                      default=pad_value('2', 'Number of NBMINs, recursive stopping criteria'),
-                      description='Number of NBMINs',
-                      workloads=['standard'])
-    workload_variable('NBMINs',
-                      default=pad_value('2 4', 'NBMINs (>= 1)'),
-                      description='NBMIN values',
-                      workloads=['standard'])
-    workload_variable('N-NDIVs',
-                      default=pad_value('1', 'Number of NDIVs, panels in recursion'),
-                      description='Number of NDIVs',
-                      workloads=['standard'])
-    workload_variable('NDIVs',
-                      default=pad_value('2', 'NDIVs'),
-                      description='NDIV values',
-                      workloads=['standard'])
-    workload_variable('N-RFACTs',
-                      default=pad_value('3', 'Number of RFACTs, recursive panel fact.'),
-                      description='Number of RFACTs',
-                      workloads=['standard'])
-    workload_variable('RFACTs',
-                      default=pad_value('0 1 2', 'RFACTs (0=left, 1=Crout, 2=Right)'),
-                      description='RFACT values',
-                      workloads=['standard'])
-    workload_variable('N-BCASTs',
-                      default=pad_value('1', 'Number of BCASTs, broadcast'),
-                      description='Number of BCASTs',
-                      workloads=['standard'])
-    workload_variable('BCASTs',
-                      default=pad_value('0', 'BCASTs (0=1rg,1=1rM,2=2rg,3=2rM,4=Lng,5=LnM)'),
-                      description='BCAST values',
-                      workloads=['standard'])
-    workload_variable('N-DEPTHs',
-                      default=pad_value('1', 'Number of DEPTHs, lookahead depth'),
-                      description='Number of DEPTHs',
-                      workloads=['standard'])
-    workload_variable('DEPTHs',
-                      default=pad_value('0', 'DEPTHs (>=0)'),
-                      description='DEPTH values',
-                      workloads=['standard'])
-    workload_variable('SWAP',
-                      default=pad_value('2', 'SWAP (0=bin-exch,1=long,2=mix)'),
-                      description='Swapping algorithm',
-                      workloads=['standard'])
-    workload_variable('swapping_threshold',
-                      default=pad_value('64', 'swapping threshold'),
-                      description='Swapping threshold',
-                      workloads=['standard'])
-    workload_variable('L1',
-                      default=pad_value('0', 'L1 in (0=transposed,1=no-transposed) form'),
-                      description='Storage for upper triangular portion of columns',
-                      workloads=['standard'])
-    workload_variable('U',
-                      default=pad_value('0', 'U  in (0=transposed,1=no-transposed) form'),
-                      description='Storage for the rows of U',
-                      workloads=['standard'])
-    workload_variable('Equilibration',
-                      default=pad_value('1', 'Equilibration (0=no,1=yes)'),
-                      description='Determines if equilibration should be enabled or disabled.',
-                      workloads=['standard'])
-    workload_variable('mem_alignment',
-                      default=pad_value('8', 'memory alignment in double (> 0)'),
-                      description='Sets the alignment in doubles for memory addresses',
-                      workloads=['standard'])
+    workload("standard", executables=["execute"])
+    workload("calculator", executables=["execute"])
+
+    workload_variable(
+        "output_file",
+        default=pad_value("HPL.out", "output file name (if any)"),
+        description="Output file name (if any)",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "device_out",
+        default=pad_value("6", "device out (6=stdout,7=stderr,file)"),
+        description="Output device",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "N-Ns",
+        default=pad_value("4", "Number of problems sizes (N)"),
+        description="Number of problems sizes",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "Ns",
+        default=pad_value("29 30 34 35", "Ns"),
+        description="Problem sizes",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "N-NBs",
+        default=pad_value("4", "Number of NBs"),
+        description="Number of NBs",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "NBs",
+        default=pad_value("1 2 3 4", "NBs"),
+        description="NB values",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "PMAP",
+        default=pad_value("0", "PMAP process mapping (0=Row-,1=Column-major)"),
+        description="PMAP Process mapping. (0=Row-, 1=Column-Major)",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "N-Grids",
+        default=pad_value("3", "Number of process grids (P x Q)"),
+        description="Number of process grids (P x Q)",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "Ps",
+        default=pad_value("2 1 4", "Ps"),
+        description="P values",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "Qs",
+        default=pad_value("2 4 1", "Qs"),
+        description="Q values",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "threshold",
+        default=pad_value("16.0", "threshold"),
+        description="Residual threshold",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "NPFACTs",
+        default=pad_value("3", "Number of PFACTs, panel fact"),
+        description="Number of PFACTs",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "PFACTs",
+        default=pad_value("0 1 2", "PFACTs (0=left, 1=Crout, 2=Right)"),
+        description="PFACT Values",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "N-NBMINs",
+        default=pad_value(
+            "2", "Number of NBMINs, recursive stopping criteria"
+        ),
+        description="Number of NBMINs",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "NBMINs",
+        default=pad_value("2 4", "NBMINs (>= 1)"),
+        description="NBMIN values",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "N-NDIVs",
+        default=pad_value("1", "Number of NDIVs, panels in recursion"),
+        description="Number of NDIVs",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "NDIVs",
+        default=pad_value("2", "NDIVs"),
+        description="NDIV values",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "N-RFACTs",
+        default=pad_value("3", "Number of RFACTs, recursive panel fact."),
+        description="Number of RFACTs",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "RFACTs",
+        default=pad_value("0 1 2", "RFACTs (0=left, 1=Crout, 2=Right)"),
+        description="RFACT values",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "N-BCASTs",
+        default=pad_value("1", "Number of BCASTs, broadcast"),
+        description="Number of BCASTs",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "BCASTs",
+        default=pad_value("0", "BCASTs (0=1rg,1=1rM,2=2rg,3=2rM,4=Lng,5=LnM)"),
+        description="BCAST values",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "N-DEPTHs",
+        default=pad_value("1", "Number of DEPTHs, lookahead depth"),
+        description="Number of DEPTHs",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "DEPTHs",
+        default=pad_value("0", "DEPTHs (>=0)"),
+        description="DEPTH values",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "SWAP",
+        default=pad_value("2", "SWAP (0=bin-exch,1=long,2=mix)"),
+        description="Swapping algorithm",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "swapping_threshold",
+        default=pad_value("64", "swapping threshold"),
+        description="Swapping threshold",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "L1",
+        default=pad_value("0", "L1 in (0=transposed,1=no-transposed) form"),
+        description="Storage for upper triangular portion of columns",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "U",
+        default=pad_value("0", "U  in (0=transposed,1=no-transposed) form"),
+        description="Storage for the rows of U",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "Equilibration",
+        default=pad_value("1", "Equilibration (0=no,1=yes)"),
+        description="Determines if equilibration should be enabled or disabled.",
+        workloads=["standard"],
+    )
+    workload_variable(
+        "mem_alignment",
+        default=pad_value("8", "memory alignment in double (> 0)"),
+        description="Sets the alignment in doubles for memory addresses",
+        workloads=["standard"],
+    )
 
     # calculator workload-specific variables:
 
-    workload_variable('percent_mem', default='85',
-                      description='Percent of memory to use (default 85)',
-                      workloads=['calculator'])
+    workload_variable(
+        "percent_mem",
+        default="85",
+        description="Percent of memory to use (default 85)",
+        workloads=["calculator"],
+    )
 
-    workload_variable('memory_per_node', default='240',
-                      description='Memory per node in GB',
-                      workloads=['calculator'])
+    workload_variable(
+        "memory_per_node",
+        default="240",
+        description="Memory per node in GB",
+        workloads=["calculator"],
+    )
 
-    workload_variable('block_size', default='384',
-                      description='Size of each block',
-                      workloads=['calculator'])
+    workload_variable(
+        "block_size",
+        default="384",
+        description="Size of each block",
+        workloads=["calculator"],
+    )
 
-    workload_variable('pfact', default='0',
-                      description='PFACT for optimized calculator',
-                      workloads=['calculator'])
+    workload_variable(
+        "pfact",
+        default="0",
+        description="PFACT for optimized calculator",
+        workloads=["calculator"],
+    )
 
-    workload_variable('nbmin', default='2',
-                      description='NBMIN for optimized calculator',
-                      workloads=['calculator'])
+    workload_variable(
+        "nbmin",
+        default="2",
+        description="NBMIN for optimized calculator",
+        workloads=["calculator"],
+    )
 
-    workload_variable('rfact', default='0',
-                      description='RFACT for optimized calculator',
-                      workloads=['calculator'])
+    workload_variable(
+        "rfact",
+        default="0",
+        description="RFACT for optimized calculator",
+        workloads=["calculator"],
+    )
 
     # Redefine default bcast to 6 for the MKL-optimized case
-    workload_variable('bcast', default='6',
-                      description='BCAST for Intel MKL optimized calculator',
-                      workloads=['calculator'])
+    workload_variable(
+        "bcast",
+        default="6",
+        description="BCAST for Intel MKL optimized calculator",
+        workloads=["calculator"],
+    )
 
-    workload_variable('depth', default='0',
-                      description='DEPTH for optimized calculator',
-                      workloads=['calculator'])
+    workload_variable(
+        "depth",
+        default="0",
+        description="DEPTH for optimized calculator",
+        workloads=["calculator"],
+    )
 
     # FOMs:
-    log_str = os.path.join(Expander.expansion_str('experiment_run_dir'),
-                           Expander.expansion_str('experiment_name') + '.out')
+    log_str = os.path.join(
+        Expander.expansion_str("experiment_run_dir"),
+        Expander.expansion_str("experiment_name") + ".out",
+    )
 
-    figure_of_merit('Time', log_file=log_str,
-                    fom_regex=r'.*\s+(?P<N>[0-9]+)\s+(?P<NB>[0-9]+)\s+(?P<P>[0-9]+)\s+(?P<Q>[0-9]+)\s+(?P<time>[0-9]+\.[0-9]+)\s+(?P<gflops>[0-9].*)\n',
-                    group_name='time', units='s', contexts=['problem-name'])
+    figure_of_merit(
+        "Time",
+        log_file=log_str,
+        fom_regex=r".*\s+(?P<N>[0-9]+)\s+(?P<NB>[0-9]+)\s+(?P<P>[0-9]+)\s+(?P<Q>[0-9]+)\s+(?P<time>[0-9]+\.[0-9]+)\s+(?P<gflops>[0-9].*)\n",
+        group_name="time",
+        units="s",
+        contexts=["problem-name"],
+    )
 
-    figure_of_merit('GFlops', log_file=log_str,
-                    fom_regex=r'.*\s+(?P<N>[0-9]+)\s+(?P<NB>[0-9]+)\s+(?P<P>[0-9]+)\s+(?P<Q>[0-9]+)\s+(?P<time>[0-9]+\.[0-9]+)\s+(?P<gflops>[0-9].*)\n',
-                    group_name='gflops', units='GFLOP/s',
-                    contexts=['problem-name'])
+    figure_of_merit(
+        "GFlops",
+        log_file=log_str,
+        fom_regex=r".*\s+(?P<N>[0-9]+)\s+(?P<NB>[0-9]+)\s+(?P<P>[0-9]+)\s+(?P<Q>[0-9]+)\s+(?P<time>[0-9]+\.[0-9]+)\s+(?P<gflops>[0-9].*)\n",
+        group_name="gflops",
+        units="GFLOP/s",
+        contexts=["problem-name"],
+    )
 
-    figure_of_merit_context('problem-name', regex=r'.*\s+(?P<N>[0-9]+)\s+(?P<NB>[0-9]+)\s+(?P<P>[0-9]+)\s+(?P<Q>[0-9]+)\s+(?P<time>[0-9]+\.[0-9]+)\s+(?P<gflops>[0-9].*)\n', output_format='N-NB-P-Q = {N}-{NB}-{P}-{Q}')
+    figure_of_merit_context(
+        "problem-name",
+        regex=r".*\s+(?P<N>[0-9]+)\s+(?P<NB>[0-9]+)\s+(?P<P>[0-9]+)\s+(?P<Q>[0-9]+)\s+(?P<time>[0-9]+\.[0-9]+)\s+(?P<gflops>[0-9].*)\n",
+        output_format="N-NB-P-Q = {N}-{NB}-{P}-{Q}",
+    )
 
     # Integer sqrt
     def _isqrt(self, n):
         if n < 0:
             raise Exception
         elif n < 2:
-            return (n)
+            return n
         else:
             lo = self._isqrt(n >> 2) << 1
             hi = lo + 1
-            if ((hi * hi) > n):
-                return (lo)
+            if (hi * hi) > n:
+                return lo
             else:
-                return (hi)
+                return hi
 
     def _calculate_values(self, workspace):
         expander = self.expander
-        if expander.workload_name == 'calculator':
+        if expander.workload_name == "calculator":
             # Find the best P and Q whose product is the number of available
             # cores, with P less than Q
-            nNodes = int(expander.expand_var_name('n_nodes'))
-            processesPerNode = int(expander.expand_var_name('processes_per_node'))
+            nNodes = int(expander.expand_var_name("n_nodes"))
+            processesPerNode = int(
+                expander.expand_var_name("processes_per_node")
+            )
 
             totalCores = nNodes * processesPerNode
 
             bestP = self._isqrt(totalCores)
-            while ((totalCores % bestP) > 0):     # stops at 1 because any int % 1 = 0
+            while (
+                totalCores % bestP
+            ) > 0:  # stops at 1 because any int % 1 = 0
                 bestP -= 1
 
             bestQ = totalCores // bestP
@@ -238,15 +348,15 @@ class IntelHpl(SpackApplication):
             # Find LCM(P,Q)
             P = int(bestP)
             Q = int(bestQ)
-            lcmPQ = Q             # Q is always the larger of P and Q
-            while ((lcmPQ % P) > 0):
+            lcmPQ = Q  # Q is always the larger of P and Q
+            while (lcmPQ % P) > 0:
                 lcmPQ += Q
 
             # HPL maintainers recommend basing the target problem size on
             # the square root of 80% of total memory in words.
-            memoryPerNode = int(expander.expand_var_name('memory_per_node'))
-            memFraction = int(expander.expand_var_name('percent_mem')) / 100
-            blockSize = int(expander.expand_var_name('block_size'))
+            memoryPerNode = int(expander.expand_var_name("memory_per_node"))
+            memFraction = int(expander.expand_var_name("percent_mem")) / 100
+            blockSize = int(expander.expand_var_name("block_size"))
             one_gb_mem_in_words = (1 << 30) / 8
 
             fullMemWords = nNodes * memoryPerNode * one_gb_mem_in_words
@@ -255,84 +365,141 @@ class IntelHpl(SpackApplication):
 
             # Ensure that N is divisible by NB * LCM(P,Q)
             problemSize = int(targetProblemSize)
-            problemSize -= (problemSize % blockSize)
+            problemSize -= problemSize % blockSize
             nBlocks = problemSize // blockSize
             nBlocks -= nBlocks % lcmPQ
             problemSize = blockSize * nBlocks
             usedPercentage = int(problemSize**2 / fullMemWords * 100)
 
-            for name, var in self.workloads['standard'].variables.items():
+            for name, var in self.workloads["standard"].variables.items():
                 self.variables[var.name] = var.default
 
-            pfact = expander.expand_var_name('pfact')
-            nbmin = expander.expand_var_name('nbmin')
-            rfact = expander.expand_var_name('rfact')
-            bcast = expander.expand_var_name('bcast')
-            depth = expander.expand_var_name('depth')
+            pfact = expander.expand_var_name("pfact")
+            nbmin = expander.expand_var_name("nbmin")
+            rfact = expander.expand_var_name("rfact")
+            bcast = expander.expand_var_name("bcast")
+            depth = expander.expand_var_name("depth")
 
-            self.variables['N-Ns'] = pad_value('1', 'Number of problems sizes (N)')  # vs 4
-
-            # Calculated:
-            self.variables['Ns'] = pad_value(int(problemSize),
-                                             f"Ns (= {usedPercentage}% of total available memory)")
-
-            self.variables['N-NBs'] = pad_value('1', 'Number of NBs')  # vs 4
+            self.variables["N-Ns"] = pad_value(
+                "1", "Number of problems sizes (N)"
+            )  # vs 4
 
             # Calculated:
-            self.variables['NBs'] = pad_value(blockSize, "NBs")  # calculated, vs 4 samples
+            self.variables["Ns"] = pad_value(
+                int(problemSize),
+                f"Ns (= {usedPercentage}% of total available memory)",
+            )
 
-            self.variables['N-Grids'] = pad_value('1', 'Number of Grids, process grids (P x Q)')  # vs 3
+            self.variables["N-NBs"] = pad_value("1", "Number of NBs")  # vs 4
 
             # Calculated:
-            self.variables['Ps'] = pad_value(int(bestP), "Ps")
+            self.variables["NBs"] = pad_value(
+                blockSize, "NBs"
+            )  # calculated, vs 4 samples
+
+            self.variables["N-Grids"] = pad_value(
+                "1", "Number of Grids, process grids (P x Q)"
+            )  # vs 3
 
             # Calculated:
-            self.variables['Qs'] = pad_value(int(bestQ), "Qs")
+            self.variables["Ps"] = pad_value(int(bestP), "Ps")
 
-            self.variables['NPFACTs'] = pad_value('1', 'Number of PFACTs, panel fact')  # vs 3
+            # Calculated:
+            self.variables["Qs"] = pad_value(int(bestQ), "Qs")
 
-            # ramble.yaml configurable
-            self.variables['PFACTs'] = pad_value(pfact, 'PFACT Values (0=left, 1=Crout, 2=Right)')  # vs 0 1 2
-
-            self.variables['N-NBMINs'] = pad_value('1', 'Number of NBMINs, recursive stopping criteria')  # vs 2
-
-            # ramble.yaml configurable
-            self.variables['NBMINs'] = pad_value(nbmin, 'NBMINs (>= 1)')  # vs '2 4'
-
-            self.variables['N-RFACTs'] = pad_value('1', 'Number of RFACTS, recursive panel fact.')  # vs '3'
+            self.variables["NPFACTs"] = pad_value(
+                "1", "Number of PFACTs, panel fact"
+            )  # vs 3
 
             # ramble.yaml configurable
-            self.variables['RFACTs'] = pad_value(rfact, 'RFACTs (0=left, 1=Crout, 2=Right)')  # vs '0 1 2'
+            self.variables["PFACTs"] = pad_value(
+                pfact, "PFACT Values (0=left, 1=Crout, 2=Right)"
+            )  # vs 0 1 2
+
+            self.variables["N-NBMINs"] = pad_value(
+                "1", "Number of NBMINs, recursive stopping criteria"
+            )  # vs 2
 
             # ramble.yaml configurable
-            self.variables['BCASTs'] = pad_value(bcast, 'BCASTs (0=1rg,1=1rM,2=2rg,3=2rM,4=Lng,5=LnM,6=MKL BPUSH,7=AMD Hybrid Panel)')  # vs '0'
+            self.variables["NBMINs"] = pad_value(
+                nbmin, "NBMINs (>= 1)"
+            )  # vs '2 4'
+
+            self.variables["N-RFACTs"] = pad_value(
+                "1", "Number of RFACTS, recursive panel fact."
+            )  # vs '3'
 
             # ramble.yaml configurable
-            self.variables['DEPTHs'] = pad_value(depth, 'DEPTHs (>=0)')  # vs '0'
+            self.variables["RFACTs"] = pad_value(
+                rfact, "RFACTs (0=left, 1=Crout, 2=Right)"
+            )  # vs '0 1 2'
+
+            # ramble.yaml configurable
+            self.variables["BCASTs"] = pad_value(
+                bcast,
+                "BCASTs (0=1rg,1=1rM,2=2rg,3=2rM,4=Lng,5=LnM,6=MKL BPUSH,7=AMD Hybrid Panel)",
+            )  # vs '0'
+
+            # ramble.yaml configurable
+            self.variables["DEPTHs"] = pad_value(
+                depth, "DEPTHs (>=0)"
+            )  # vs '0'
 
     def _make_experiments(self, workspace, app_inst=None):
         super()._make_experiments(workspace)
         self._calculate_values(workspace)
 
-        input_path = os.path.join(self.expander.expand_var_name('experiment_run_dir'),
-                                  'HPL.dat')
+        input_path = os.path.join(
+            self.expander.expand_var_name("experiment_run_dir"), "HPL.dat"
+        )
 
-        settings = ['output_file', 'device_out', 'N-Ns', 'Ns', 'N-NBs', 'NBs',
-                    'PMAP', 'N-Grids', 'Ps', 'Qs', 'threshold', 'NPFACTs',
-                    'PFACTs', 'N-NBMINs', 'NBMINs', 'N-NDIVs', 'NDIVs', 'N-RFACTs',
-                    'RFACTs', 'N-BCASTs', 'BCASTs', 'N-DEPTHs', 'DEPTHs', 'SWAP',
-                    'swapping_threshold', 'L1', 'U', 'Equilibration',
-                    'mem_alignment']
+        settings = [
+            "output_file",
+            "device_out",
+            "N-Ns",
+            "Ns",
+            "N-NBs",
+            "NBs",
+            "PMAP",
+            "N-Grids",
+            "Ps",
+            "Qs",
+            "threshold",
+            "NPFACTs",
+            "PFACTs",
+            "N-NBMINs",
+            "NBMINs",
+            "N-NDIVs",
+            "NDIVs",
+            "N-RFACTs",
+            "RFACTs",
+            "N-BCASTs",
+            "BCASTs",
+            "N-DEPTHs",
+            "DEPTHs",
+            "SWAP",
+            "swapping_threshold",
+            "L1",
+            "U",
+            "Equilibration",
+            "mem_alignment",
+        ]
 
-        with open(input_path, 'w+') as f:
-            f.write('    HPLinpack benchmark input file\n')
-            f.write('Innovative Computing Laboratory, University of Tennessee\n')
+        with open(input_path, "w+") as f:
+            f.write("    HPLinpack benchmark input file\n")
+            f.write(
+                "Innovative Computing Laboratory, University of Tennessee\n"
+            )
 
             for setting in settings:
                 # This gets around an issue in expander where trailing comments
                 # after '#' are not printed
-                hash_replace_str = self.expander.expand_var_name(setting).replace('Number', '#')
-                f.write(hash_replace_str + '\n')
+                hash_replace_str = self.expander.expand_var_name(
+                    setting
+                ).replace("Number", "#")
+                f.write(hash_replace_str + "\n")
 
             # Write some documentation at the bottom of the input file:
-            f.write('##### This line (no. 32) is ignored (it serves as a separator). ######')
+            f.write(
+                "##### This line (no. 32) is ignored (it serves as a separator). ######"
+            )

--- a/var/ramble/repos/builtin/applications/intel-mpi-benchmarks/application.py
+++ b/var/ramble/repos/builtin/applications/intel-mpi-benchmarks/application.py
@@ -16,153 +16,240 @@ from ramble.expander import Expander
 
 
 class IntelMpiBenchmarks(SpackApplication):
-    '''Intel MPI Benchmark application.
+    """Intel MPI Benchmark application.
 
     https://www.intel.com/content/www/us/en/developer/articles/technical/intel-mpi-benchmarks.html
     https://github.com/intel/mpi-benchmarks
     https://www.intel.com/content/www/us/en/develop/documentation/imb-user-guide/top.html
-    '''
+    """
 
-    name = 'IntelMpiBenchmarks'
+    name = "IntelMpiBenchmarks"
 
-    maintainers('rfbgo')
+    maintainers("rfbgo")
 
-    tags('micro-benchmark', 'benchmark', 'mpi')
+    tags("micro-benchmark", "benchmark", "mpi")
 
-    define_compiler('gcc9', spack_spec='gcc@9.3.0')
-    software_spec('impi2018', spack_spec='intel-mpi@2018.4.274')
-    software_spec('intel-mpi-benchmarks',
-                  spack_spec='intel-mpi-benchmarks@2019.6',
-                  compiler='gcc9')
+    define_compiler("gcc9", spack_spec="gcc@9.3.0")
+    software_spec("impi2018", spack_spec="intel-mpi@2018.4.274")
+    software_spec(
+        "intel-mpi-benchmarks",
+        spack_spec="intel-mpi-benchmarks@2019.6",
+        compiler="gcc9",
+    )
 
-    required_package('intel-mpi-benchmarks')
+    required_package("intel-mpi-benchmarks")
 
-    executable('pingpong',
-               '{install_path}/IMB-MPI1 {pingpong_type} -msglog {msglog_min}:{msglog_max} '
-               '-iter {num_iterations} {additional_args}',
-               use_mpi=True)
+    executable(
+        "pingpong",
+        "{install_path}/IMB-MPI1 {pingpong_type} -msglog {msglog_min}:{msglog_max} "
+        "-iter {num_iterations} {additional_args}",
+        use_mpi=True,
+    )
 
-    executable('multi-pingpong',
-               '{install_path}/IMB-MPI1 Pingpong -msglog {msglog_min}:{msglog_max} '
-               '-iter {num_iterations} -multi {multi_val} -map {map_args} {additional_args}',
-               use_mpi=True)
+    executable(
+        "multi-pingpong",
+        "{install_path}/IMB-MPI1 Pingpong -msglog {msglog_min}:{msglog_max} "
+        "-iter {num_iterations} -multi {multi_val} -map {map_args} {additional_args}",
+        use_mpi=True,
+    )
 
-    workload('pingpong', executable='pingpong')
-    workload('multi-pingpong', executable='multi-pingpong')
-    workload('collective', executable='collective')
+    workload("pingpong", executable="pingpong")
+    workload("multi-pingpong", executable="multi-pingpong")
+    workload("collective", executable="collective")
 
-    workload_variable('num_cores',
-                      default='{{{n_ranks}/2}:0.0f}',
-                      description='Number of cores',
-                      workloads=['multi-pingpong'])
+    workload_variable(
+        "num_cores",
+        default="{{{n_ranks}/2}:0.0f}",
+        description="Number of cores",
+        workloads=["multi-pingpong"],
+    )
 
-    workload_variable('multi_val',
-                      default='0',
-                      description='Value to pass to the multi arg',
-                      workloads=['multi-pingpong'])
+    workload_variable(
+        "multi_val",
+        default="0",
+        description="Value to pass to the multi arg",
+        workloads=["multi-pingpong"],
+    )
 
-    workload_variable('map_args',
-                      default='{num_cores}x2',
-                      description='Args to map by',
-                      workloads=['multi-pingpong'])
+    workload_variable(
+        "map_args",
+        default="{num_cores}x2",
+        description="Args to map by",
+        workloads=["multi-pingpong"],
+    )
 
-    executable('collective',
-               '{install_path}/IMB-MPI1 {collective_type} -msglog {msglog_min}:{msglog_max} '
-               '-iter {num_iterations} -npmin {min_collective_ranks} {additional_args}',
-               use_mpi=True)
+    executable(
+        "collective",
+        "{install_path}/IMB-MPI1 {collective_type} -msglog {msglog_min}:{msglog_max} "
+        "-iter {num_iterations} -npmin {min_collective_ranks} {additional_args}",
+        use_mpi=True,
+    )
 
     # Multiple spack packages (specifically intel-oneapi-mpi) provide the
     # binary we need. It's fairly common to want to decouple the version of MPI
     # from the version of the benchmark, so this variable gives a user an
     # explicit way to control that, as well as more strongly implies the binary
     # from intel-mpi-benchmarks by default
-    workload_variable('install_path',
-                      default='{intel-mpi-benchmarks}/bin',
-                      description='User configurable dir to executables',
-                      workloads=['pingpong', 'multi-pingpong', 'collective'])
+    workload_variable(
+        "install_path",
+        default="{intel-mpi-benchmarks}/bin",
+        description="User configurable dir to executables",
+        workloads=["pingpong", "multi-pingpong", "collective"],
+    )
 
-    workload_variable('pingpong_type',
-                      default='Pingpong',
-                      values=['Pingpong', 'Unirandom', 'Multi-Pingpong', 'Birandom', 'Corandom'],
-                      description='Pingpong Algorithm to Use',
-                      workloads=['pingpong'])
+    workload_variable(
+        "pingpong_type",
+        default="Pingpong",
+        values=[
+            "Pingpong",
+            "Unirandom",
+            "Multi-Pingpong",
+            "Birandom",
+            "Corandom",
+        ],
+        description="Pingpong Algorithm to Use",
+        workloads=["pingpong"],
+    )
 
-    workload_variable('collective_type',
-                      # FIXME: should default just be denoted by the
-                      # first value in the values list?
-                      default='Allgather',
-                      values=['Allgather', 'Allgatherv', 'Alltoall',
-                              'Alltoallv', 'Bcast', 'Scatter', 'Scatterv',
-                              'Gather', 'Gatherv', 'Reduce', 'Reduce_scatter',
-                              'Allreduce', 'Barrier'],
-                      description='Collective type to test',
-                      workloads=['collective'])
+    workload_variable(
+        "collective_type",
+        # FIXME: should default just be denoted by the
+        # first value in the values list?
+        default="Allgather",
+        values=[
+            "Allgather",
+            "Allgatherv",
+            "Alltoall",
+            "Alltoallv",
+            "Bcast",
+            "Scatter",
+            "Scatterv",
+            "Gather",
+            "Gatherv",
+            "Reduce",
+            "Reduce_scatter",
+            "Allreduce",
+            "Barrier",
+        ],
+        description="Collective type to test",
+        workloads=["collective"],
+    )
 
-    workload_variable('min_collective_ranks', default='{n_ranks}',
-                      description='Minimum number of ranks to use in a collective operation',
-                      workloads=['collective'])
+    workload_variable(
+        "min_collective_ranks",
+        default="{n_ranks}",
+        description="Minimum number of ranks to use in a collective operation",
+        workloads=["collective"],
+    )
 
-    workload_variable('num_iterations', default='1000',
-                      description='Number of iterations to test over',
-                      workloads=['pingpong', 'multi-pingpong', 'collective'])
+    workload_variable(
+        "num_iterations",
+        default="1000",
+        description="Number of iterations to test over",
+        workloads=["pingpong", "multi-pingpong", "collective"],
+    )
 
-    workload_variable('msglog_min', default='1',
-                      description='Min Message Size (power of 2)',
-                      workloads=['pingpong', 'multi-pingpong', 'collective'])
+    workload_variable(
+        "msglog_min",
+        default="1",
+        description="Min Message Size (power of 2)",
+        workloads=["pingpong", "multi-pingpong", "collective"],
+    )
 
-    workload_variable('msglog_max', default='30',
-                      description='Max Message Size (power of 2)',
-                      workloads=['pingpong', 'multi-pingpong', 'collective'])
+    workload_variable(
+        "msglog_max",
+        default="30",
+        description="Max Message Size (power of 2)",
+        workloads=["pingpong", "multi-pingpong", "collective"],
+    )
 
-    workload_variable('additional_args', default='',
-                      description='Number of iterations to test over',
-                      workloads=['pingpong', 'multi-pingpong', 'collective'])
+    workload_variable(
+        "additional_args",
+        default="",
+        description="Number of iterations to test over",
+        workloads=["pingpong", "multi-pingpong", "collective"],
+    )
 
     # Matches tables like:
     #  bytes #repetitions  t_min[usec]  t_max[usec]  t_avg[usec]
-    latency_regex = r'^\s+(?P<bytes>\d+)\s+(?P<repetitions>\d+)\s+' + \
-                    r'(?P<t_min>\d+\.\d+)\s+(?P<t_avg>\d+\.\d+)\s+(?P<t_max>\d+\.\d+)$'
+    latency_regex = (
+        r"^\s+(?P<bytes>\d+)\s+(?P<repetitions>\d+)\s+"
+        + r"(?P<t_min>\d+\.\d+)\s+(?P<t_avg>\d+\.\d+)\s+(?P<t_max>\d+\.\d+)$"
+    )
 
-    log_str = os.path.join(Expander.expansion_str('experiment_run_dir'),
-                           Expander.expansion_str('experiment_name') + '.out')
+    log_str = os.path.join(
+        Expander.expansion_str("experiment_run_dir"),
+        Expander.expansion_str("experiment_name") + ".out",
+    )
 
-    figure_of_merit('Latency min', log_file=log_str,
-                    fom_regex=latency_regex,
-                    group_name='t_min', units='usec', contexts=['latency-bytes'])
+    figure_of_merit(
+        "Latency min",
+        log_file=log_str,
+        fom_regex=latency_regex,
+        group_name="t_min",
+        units="usec",
+        contexts=["latency-bytes"],
+    )
 
-    figure_of_merit('Latency avg', log_file=log_str,
-                    fom_regex=latency_regex,
-                    group_name='t_avg', units='usec', contexts=['latency-bytes'])
+    figure_of_merit(
+        "Latency avg",
+        log_file=log_str,
+        fom_regex=latency_regex,
+        group_name="t_avg",
+        units="usec",
+        contexts=["latency-bytes"],
+    )
 
-    figure_of_merit('Latency max', log_file=log_str,
-                    fom_regex=latency_regex,
-                    group_name='t_max', units='usec', contexts=['latency-bytes'])
+    figure_of_merit(
+        "Latency max",
+        log_file=log_str,
+        fom_regex=latency_regex,
+        group_name="t_max",
+        units="usec",
+        contexts=["latency-bytes"],
+    )
 
     # Matches tables like:
     #  bytes #repetitions      t[usec]   Mbytes/sec
-    bw_regex = r'^\s+(?P<bytes>\d+)\s+(?P<repetitions>\d+)\s+(?P<t_avg>\d+\.\d+)\s+(?P<bw>\d+\.\d+)$'
-    figure_of_merit('Bandwidth', log_file=log_str,
-                    fom_regex=bw_regex,
-                    group_name='bw', units='Mbytes/sec', contexts=['bw-bytes'])
+    bw_regex = r"^\s+(?P<bytes>\d+)\s+(?P<repetitions>\d+)\s+(?P<t_avg>\d+\.\d+)\s+(?P<bw>\d+\.\d+)$"
+    figure_of_merit(
+        "Bandwidth",
+        log_file=log_str,
+        fom_regex=bw_regex,
+        group_name="bw",
+        units="Mbytes/sec",
+        contexts=["bw-bytes"],
+    )
 
     # Combiend tables like:
     #  bytes #repetitions  t_min[usec]  t_max[usec]  t_avg[usec]   Mbytes/sec
     #   (happens in sendrecv and exchange)
-    combined_regex = r'^\s+(?P<bytes>\d+)\s+(?P<repetitions>\d+)\s+' + \
-                     r'(?P<t_min>\d+\.\d+)\s+(?P<t_max>\d+\.\d+)\s+' + \
-                     r'(?P<t_avg>\d+\.\d+)\s+(?P<bw>\d+\.\d+)$'
-    figure_of_merit('Combo', log_file=log_str,
-                    fom_regex=combined_regex,
-                    group_name='bw', units='Mbytes/sec', contexts=['combo-bytes'])
+    combined_regex = (
+        r"^\s+(?P<bytes>\d+)\s+(?P<repetitions>\d+)\s+"
+        + r"(?P<t_min>\d+\.\d+)\s+(?P<t_max>\d+\.\d+)\s+"
+        + r"(?P<t_avg>\d+\.\d+)\s+(?P<bw>\d+\.\d+)$"
+    )
+    figure_of_merit(
+        "Combo",
+        log_file=log_str,
+        fom_regex=combined_regex,
+        group_name="bw",
+        units="Mbytes/sec",
+        contexts=["combo-bytes"],
+    )
 
-    figure_of_merit_context('latency-bytes',
-                            regex=latency_regex,
-                            output_format='Bytes: {bytes} (Latency)')
+    figure_of_merit_context(
+        "latency-bytes",
+        regex=latency_regex,
+        output_format="Bytes: {bytes} (Latency)",
+    )
 
-    figure_of_merit_context('bw-bytes',
-                            regex=bw_regex,
-                            output_format='Bytes: {bytes} (BW)')
+    figure_of_merit_context(
+        "bw-bytes", regex=bw_regex, output_format="Bytes: {bytes} (BW)"
+    )
 
-    figure_of_merit_context('combo-bytes',
-                            regex=combined_regex,
-                            output_format='Bytes: {bytes} (Combo)')
+    figure_of_merit_context(
+        "combo-bytes",
+        regex=combined_regex,
+        output_format="Bytes: {bytes} (Combo)",
+    )

--- a/var/ramble/repos/builtin/applications/ior/application.py
+++ b/var/ramble/repos/builtin/applications/ior/application.py
@@ -11,72 +11,107 @@ from ramble.expander import Expander
 
 
 class Ior(SpackApplication):
-    '''Define the IOR parallel IO benchmark. Also includes'''
-    name = 'ior'
+    """Define the IOR parallel IO benchmark. Also includes"""
 
-    maintainers('rfbgo')
+    name = "ior"
 
-    tags('synthetic-benchmarks', 'IO')
+    maintainers("rfbgo")
 
-    define_compiler('gcc', spack_spec='gcc')
-    software_spec('openmpi', spack_spec='openmpi')
-    software_spec('ior', spack_spec='ior', compiler='gcc')
+    tags("synthetic-benchmarks", "IO")
 
-    required_package('ior')
+    define_compiler("gcc", spack_spec="gcc")
+    software_spec("openmpi", spack_spec="openmpi")
+    software_spec("ior", spack_spec="ior", compiler="gcc")
 
-    workload('multi-file', executable='ior')
+    required_package("ior")
 
-    workload('single-file', executable='ior')
+    workload("multi-file", executable="ior")
 
-    workload_variable('transfer-size', default='1m',
-                      description='Transfer Size',
-                      workloads=['multi-file', 'single-file'])
-    workload_variable('block-size', default='16m',
-                      description='Block Size',
-                      workloads=['multi-file', 'single-file'])
-    workload_variable('segment-count', default='16',
-                      description='Segment Count',
-                      workloads=['multi-file', 'single-file'])
+    workload("single-file", executable="ior")
 
-    workload_variable('iterations', default='1',
-                      description='Segment Count',
-                      workloads=['multi-file', 'single-file'])
+    workload_variable(
+        "transfer-size",
+        default="1m",
+        description="Transfer Size",
+        workloads=["multi-file", "single-file"],
+    )
+    workload_variable(
+        "block-size",
+        default="16m",
+        description="Block Size",
+        workloads=["multi-file", "single-file"],
+    )
+    workload_variable(
+        "segment-count",
+        default="16",
+        description="Segment Count",
+        workloads=["multi-file", "single-file"],
+    )
 
-    executable(name='ior', template='ior -t {transfer-size} -b {block-size} -s {segment-count} -i {iterations}', use_mpi=True)
-    executable(name='ior-shared', template='{ior} -F', use_mpi=True)
+    workload_variable(
+        "iterations",
+        default="1",
+        description="Segment Count",
+        workloads=["multi-file", "single-file"],
+    )
+
+    executable(
+        name="ior",
+        template="ior -t {transfer-size} -b {block-size} -s {segment-count} -i {iterations}",
+        use_mpi=True,
+    )
+    executable(name="ior-shared", template="{ior} -F", use_mpi=True)
 
     # FOMS
     # Match per iteration output in the format:
     # access    bw(MiB/s)  IOPS       Latency(s)  block(KiB) xfer(KiB)  open(s)    wr/rd(s)   close(s)   total(s)   iter
     # ------    ---------  ----       ----------  ---------- ---------  --------   --------   --------   --------   ----
     # write     560.70     2316.04    0.013670    16384      1024.00    0.002069   0.221067   0.693182   0.913139   0
-    metrics = ['bw', 'IOPS', 'latency', 'block', 'xfer', 'open', 'wrrd', 'close', 'total', 'iter']
-    units = ['MiB/s', 'count', 's', 'KiB', 'KiB', 's', 's', 's', 's', 'count']
+    metrics = [
+        "bw",
+        "IOPS",
+        "latency",
+        "block",
+        "xfer",
+        "open",
+        "wrrd",
+        "close",
+        "total",
+        "iter",
+    ]
+    units = ["MiB/s", "count", "s", "KiB", "KiB", "s", "s", "s", "s", "count"]
 
-    iter_regex = ''
+    iter_regex = ""
     for metric in metrics[0:3]:  # iter is non-float
-        iter_regex += r'\s+(?P<' + metric + r'>[0-9]+\.[0-9]+)'  # xfer => total
-    iter_regex += r'\s+(?P<' + metrics[3] + r'>[0-9]+)'  # handle block
+        iter_regex += (
+            r"\s+(?P<" + metric + r">[0-9]+\.[0-9]+)"
+        )  # xfer => total
+    iter_regex += r"\s+(?P<" + metrics[3] + r">[0-9]+)"  # handle block
 
     for metric in metrics[4:-1]:  # iter is non-float
-        iter_regex += r'\s+(?P<' + metric + r'>[0-9]+\.[0-9]+)'  # xfer => total
-    iter_regex += r'\s+(?P<' + metrics[-1] + r'>[0-9]+)\s*$'  # handle iter
+        iter_regex += (
+            r"\s+(?P<" + metric + r">[0-9]+\.[0-9]+)"
+        )  # xfer => total
+    iter_regex += r"\s+(?P<" + metrics[-1] + r">[0-9]+)\s*$"  # handle iter
 
-    access_regex = '(?P<access>(read|write))' + iter_regex
-    figure_of_merit_context('iter', regex=access_regex,
-                            output_format='iter {iter}')
+    access_regex = "(?P<access>(read|write))" + iter_regex
+    figure_of_merit_context(
+        "iter", regex=access_regex, output_format="iter {iter}"
+    )
 
-    log_str = Expander.expansion_str('log_file')
+    log_str = Expander.expansion_str("log_file")
 
     # Capture Per Iteration Data
     for metric, unit in zip(metrics, units):
-        fom_regex = r'\w+' + iter_regex
-        figure_of_merit(metric,
-                        log_file=log_str,
-                        fom_regex=fom_regex,
-                        group_name=metric,
-                        units=unit,
-                        contexts=['iter'])
+        fom_regex = r"\w+" + iter_regex
+        figure_of_merit(
+            metric,
+            log_file=log_str,
+            fom_regex=fom_regex,
+            group_name=metric,
+            units=unit,
+            contexts=["iter"],
+        )
 
     # Capture Summary Data in the format:
     # Operation   Max(MiB)   Min(MiB)  Mean(MiB)     StdDev   Max(OPs)   Min(OPs)  Mean(OPs)     StdDev    Mean(s) Stonewall(s) Stonewall(MiB) Test# #Tasks tPN reps fPP reord reordoff reordrand seed segcnt   blksiz    xsize aggs(MiB)   API RefNum
@@ -84,52 +119,63 @@ class Ior(SpackApplication):
     # Make a tuple of (name, unit, type) to make building the regex easier
     metrics = [
         # ('Operation', '', 'str'),
-        ('bw_Max', 'MiB', 'float'),
-        ('bw_Min', 'MiB', 'float'),
-        ('bw_Mean', 'MiB', 'float'),
-        ('bw_StdDev', '', 'float'),
-        ('ops_Max', 'OPs', 'float'),
-        ('ops_Min', 'OPs', 'float'),
-        ('ops_Mean', 'OPs', 'float'),
-        ('ops_StdDev', '', 'float'),
-        ('time_Mean', 's', 'float'),
-        ('time_Stonewall', 's', 'str'),  # Currently NA but may one day be a float?
-        ('bw_Stonewall', 'MiB', 'str'),  # Currently NA but may one day be a float?
-        ('Test_num', '', 'int'),
-        ('num_Tasks', '', 'int'),
-        ('tPN', '', 'int'),
-        ('reps', '', 'int'),
-        ('fPP', '', 'int'),
-        ('reord', '', 'int'),
-        ('reordoff', '', 'int'),
-        ('reordrand', '', 'int'),
-        ('seed', '', 'int'),
-        ('segcnt', '', 'int'),
-        ('blksiz', '', 'int'),
-        ('xsize', '', 'int'),
-        ('aggs', 'MiB', 'float'),
-        ('API', '', 'str'),
-        ('RefNum', '', 'int')
+        ("bw_Max", "MiB", "float"),
+        ("bw_Min", "MiB", "float"),
+        ("bw_Mean", "MiB", "float"),
+        ("bw_StdDev", "", "float"),
+        ("ops_Max", "OPs", "float"),
+        ("ops_Min", "OPs", "float"),
+        ("ops_Mean", "OPs", "float"),
+        ("ops_StdDev", "", "float"),
+        ("time_Mean", "s", "float"),
+        (
+            "time_Stonewall",
+            "s",
+            "str",
+        ),  # Currently NA but may one day be a float?
+        (
+            "bw_Stonewall",
+            "MiB",
+            "str",
+        ),  # Currently NA but may one day be a float?
+        ("Test_num", "", "int"),
+        ("num_Tasks", "", "int"),
+        ("tPN", "", "int"),
+        ("reps", "", "int"),
+        ("fPP", "", "int"),
+        ("reord", "", "int"),
+        ("reordoff", "", "int"),
+        ("reordrand", "", "int"),
+        ("seed", "", "int"),
+        ("segcnt", "", "int"),
+        ("blksiz", "", "int"),
+        ("xsize", "", "int"),
+        ("aggs", "MiB", "float"),
+        ("API", "", "str"),
+        ("RefNum", "", "int"),
     ]
 
-    summary_regex = '(?P<Operation>(read|write))'
+    summary_regex = "(?P<Operation>(read|write))"
     for name, unit, variant in metrics:
-        if 'str' in variant:
-            summary_regex += r'\s+(?P<' + name + r'>\w+)'
-        elif 'int' in variant:
-            summary_regex += r'\s+(?P<' + name + r'>[0-9]+)'
-        elif 'float' in variant:
-            summary_regex += r'\s+(?P<' + name + r'>[0-9]+\.[0-9]+)'
+        if "str" in variant:
+            summary_regex += r"\s+(?P<" + name + r">\w+)"
+        elif "int" in variant:
+            summary_regex += r"\s+(?P<" + name + r">[0-9]+)"
+        elif "float" in variant:
+            summary_regex += r"\s+(?P<" + name + r">[0-9]+\.[0-9]+)"
         else:
             tty.error("Incorrect metric for FOMs")
 
-    figure_of_merit_context('summary', regex=summary_regex,
-                            output_format='{Operation}')
+    figure_of_merit_context(
+        "summary", regex=summary_regex, output_format="{Operation}"
+    )
 
     for metric, unit, _ in metrics:
-        figure_of_merit(metric,
-                        log_file=log_str,
-                        fom_regex=summary_regex,
-                        group_name=metric,
-                        units=unit,
-                        contexts=['summary'])
+        figure_of_merit(
+            metric,
+            log_file=log_str,
+            fom_regex=summary_regex,
+            group_name=metric,
+            units=unit,
+            contexts=["summary"],
+        )

--- a/var/ramble/repos/builtin/applications/iperf2/application.py
+++ b/var/ramble/repos/builtin/applications/iperf2/application.py
@@ -12,77 +12,96 @@ from ramble.expander import Expander
 
 
 class Iperf2(SpackApplication):
-    '''Define the iperf2 application'''
-    name = 'iperf2'
+    """Define the iperf2 application"""
 
-    maintainers('rfbgo')
+    name = "iperf2"
 
-    define_compiler('gcc9', spack_spec='gcc@9.3.0')
+    maintainers("rfbgo")
 
-    software_spec('iperf2',
-                  spack_spec='iperf2@2.0.12',
-                  compiler='gcc9')
+    define_compiler("gcc9", spack_spec="gcc@9.3.0")
 
-    required_package('iperf2')
+    software_spec("iperf2", spack_spec="iperf2@2.0.12", compiler="gcc9")
+
+    required_package("iperf2")
 
     # Need to support these use cases:
     # iperf -s // set up server
     # iperf -t 600 -i 10 -c server_dns_or_internal_ip -P 16 // connect from another vm
-    workload('iperf2_server', executable='iperf2')
-    workload('iperf2_client', executable='iperf2')
-    workload('iperf2_custom', executable='iperf2')
+    workload("iperf2_server", executable="iperf2")
+    workload("iperf2_client", executable="iperf2")
+    workload("iperf2_custom", executable="iperf2")
 
-    workload_variable('input_flags',
-                      default='-s',
-                      description='Input flags to start iperf2 in server mode',
-                      workload='iperf2_server')
+    workload_variable(
+        "input_flags",
+        default="-s",
+        description="Input flags to start iperf2 in server mode",
+        workload="iperf2_server",
+    )
 
-    workload_variable('input_flags',
-                      default='-t {time} -i {interval} -c {host} -P {num_threads}',
-                      description='Input flags to start iperf2 in server mode',
-                      workload='iperf2_client')
+    workload_variable(
+        "input_flags",
+        default="-t {time} -i {interval} -c {host} -P {num_threads}",
+        description="Input flags to start iperf2 in server mode",
+        workload="iperf2_client",
+    )
 
-    workload_variable('input_flags',
-                      default='',
-                      description='Input flags in custom mode',
-                      workload='iperf2_custom')
+    workload_variable(
+        "input_flags",
+        default="",
+        description="Input flags in custom mode",
+        workload="iperf2_custom",
+    )
 
-    workload_variable('time',
-                      default='600',
-                      description='time in seconds to listen for new connections as well as to receive traffic (default not set)',
-                      workload='iperf2_client')
+    workload_variable(
+        "time",
+        default="600",
+        description="time in seconds to listen for new connections as well as to receive traffic (default not set)",
+        workload="iperf2_client",
+    )
 
-    workload_variable('interval',
-                      default='10',
-                      description='seconds between periodic bandwidth reports',
-                      workload='iperf2_client')
+    workload_variable(
+        "interval",
+        default="10",
+        description="seconds between periodic bandwidth reports",
+        workload="iperf2_client",
+    )
 
-    workload_variable('host',
-                      default='<host>',
-                      description='run in client mode, connecting to <host>',
-                      workload='iperf2_client')
+    workload_variable(
+        "host",
+        default="<host>",
+        description="run in client mode, connecting to <host>",
+        workload="iperf2_client",
+    )
 
-    workload_variable('num_threads',
-                      default='16',
-                      description='number of parallel client threads to run',
-                      workload='iperf2_client')
+    workload_variable(
+        "num_threads",
+        default="16",
+        description="number of parallel client threads to run",
+        workload="iperf2_client",
+    )
 
-    workload_variable('additional_flags',
-                      default='',
-                      description='Allow users to pass additional flags',
-                      workloads=['iperf2_client', 'iperf2_server', 'iperf2_custom'])
+    workload_variable(
+        "additional_flags",
+        default="",
+        description="Allow users to pass additional flags",
+        workloads=["iperf2_client", "iperf2_server", "iperf2_custom"],
+    )
 
-    executable('iperf2',
-               template='iperf {input_flags} {additional_flags}',
-               use_mpi=False)
+    executable(
+        "iperf2",
+        template="iperf {input_flags} {additional_flags}",
+        use_mpi=False,
+    )
 
     # TODO: add success_criteria(..
-    log_str = os.path.join(Expander.expansion_str('experiment_run_dir'),
-                           Expander.expansion_str('experiment_name') + '.out')
+    log_str = os.path.join(
+        Expander.expansion_str("experiment_run_dir"),
+        Expander.expansion_str("experiment_name") + ".out",
+    )
     figure_of_merit(
-        'Total BW',
+        "Total BW",
         log_file=log_str,
-        fom_regex=r'\[SUM\]\s.*sec\s.*GBytes\s(?P<bw>.*)\sGbits/sec.*',
-        group_name='bw',
-        units='Gbits/sec'
+        fom_regex=r"\[SUM\]\s.*sec\s.*GBytes\s(?P<bw>.*)\sGbits/sec.*",
+        group_name="bw",
+        units="Gbits/sec",
     )

--- a/var/ramble/repos/builtin/applications/lammps/application.py
+++ b/var/ramble/repos/builtin/applications/lammps/application.py
@@ -11,163 +11,314 @@ from ramble.appkit import *
 
 
 class Lammps(SpackApplication):
-    '''Define LAMMPS application'''
-    name = 'lammps'
+    """Define LAMMPS application"""
 
-    maintainers('douglasjacobsen')
+    name = "lammps"
 
-    tags('molecular-dynamics')
+    maintainers("douglasjacobsen")
 
-    define_compiler('gcc9', spack_spec='gcc@9.3.0')
+    tags("molecular-dynamics")
 
-    software_spec('impi2018', spack_spec='intel-mpi@2018.4.274')
+    define_compiler("gcc9", spack_spec="gcc@9.3.0")
 
-    software_spec('lammps',
-                  spack_spec='lammps@20220623.4 +opt+manybody+molecule+kspace+rigid+openmp+openmp-package+asphere+dpd-basic+dpd-meso+dpd-react+dpd-smooth',
-                  compiler='gcc9')
+    software_spec("impi2018", spack_spec="intel-mpi@2018.4.274")
 
-    required_package('lammps')
-
-    input_file('leonard-jones', url='https://www.lammps.org/inputs/in.lj.txt', expand=False,
-               sha256='874b4c63b6fcbb6ede76522df19087acf2f49b6bc96794cf0aa3218c66ff7e06',
-               description='Atomic fluid. 32k atoms. 100 timesteps. https://www.lammps.org/bench.html#lj')
-    input_file('eam', url='https://www.lammps.org/inputs/in.eam.txt', expand=False,
-               sha256='2fa09183c626c34570cc367384fe4c297ab153521adb3ea44ff7e265d451ad75',
-               description='Cu metallic solid with embedded atom method potential. 32k atoms. https://www.lammps.org/bench.html#eam')
-    input_file('polymer-chain-melt', url='https://www.lammps.org/inputs/in.chain.txt', expand=False,
-               sha256='97676f19d2d791c42415698c354a18b26a3cbe4006cd2161cf8924415d9f7c82',
-               description='Bead-spring polymer melt with 100-mer chains and FENE bonds. 32k atoms. 100 timesteps. https://www.lammps.org/bench.html#chain')
-    input_file('chute', url='https://www.lammps.org/inputs/in.chute.txt', expand=False,
-               sha256='91e1743cc39365b32757cfb3c76399f5ed8debad0b890cb36ee7bdf47d2dfd2d',
-               description='Chute flow of packed granular particles with frictional history potential. 32k atoms. 100 timeteps. https://www.lammps.org/bench.html#chute')
-    input_file('rhodo', url='https://www.lammps.org/inputs/in.rhodo.txt', expand=False,
-               sha256='4b6cc70db1b8fe269c48b8e06749f144f400e9a4054bf180ac9b1b9a5a5bb07f',
-               description='All-atom rhodopsin protein in solvated lipid bilayer with CHARMM force field, long-range Coulombics via PPPM (particle-particle particle mesh), SHAKE constraints. This model contains counter-ions and a reduced amount of water to make a 32K atom system. 32k atoms. 100 timesteps. https://www.lammps.org/bench.html#rhodo')
-
-    input_file('lammps-stage', url='https://github.com/lammps/lammps/archive/refs/tags/stable_23Jun2022_update3.tar.gz',
-               target_dir='{application_input_dir}/stable_23Jun2022_update3',
-               description='Stage of lammps source from 20220623.3 release',
-               sha256='8a276a01b50d37eecfe6eb36f420f354cde51936d20aca7944dea60d3c098c89')
-
-    executable('copy', template=['cp {input_path} {experiment_run_dir}/input.txt'],
-               use_mpi=False)
-    executable('set-size',
-               template=["sed -i -e 's/xx equal .*/xx equal {xx}/g' -i input.txt",
-                         "sed -i -e 's/yy equal .*/yy equal {yy}/g' -i input.txt",
-                         "sed -i -e 's/zz equal .*/zz equal {zz}/g' -i input.txt"],
-               use_mpi=False)
-    executable('set-timesteps',
-               template=["sed 's/run.*[0-9]+/run\t\t{timesteps}/g' -i input.txt"],
-               use_mpi=False)
-
-    exec_path = os.path.join('{lammps}', 'bin', 'lmp')
-    executable('execute', f'{exec_path}' + ' -i input.txt {lammps_flags}', use_mpi=True)
-
-    executable(
-        'set-data-path',
-        template=[r"sed 's|data\.|" + os.path.join("{lammps-stage}", "bench", "data.") + "|g' -i input.txt"],
-        use_mpi=False
+    software_spec(
+        "lammps",
+        spack_spec="lammps@20220623.4 +opt+manybody+molecule+kspace+rigid+openmp+openmp-package+asphere+dpd-basic+dpd-meso+dpd-react+dpd-smooth",
+        compiler="gcc9",
     )
 
-    workload('lj', executables=['copy', 'set-size', 'set-timesteps', 'execute'],
-             input='leonard-jones')
-    workload('eam', executables=['copy', 'set-size', 'set-timesteps', 'execute'],
-             input='eam')
-    workload('chain', executables=['copy', 'set-timesteps', 'set-data-path', 'execute'],
-             inputs=['polymer-chain-melt', 'lammps-stage'])
-    workload('chute', executables=['copy', 'set-timesteps', 'execute'],
-             input='chute')
-    workload('rhodo', executables=['copy', 'set-timesteps', 'set-data-path', 'execute'],
-             inputs=['rhodo', 'lammps-stage'])
+    required_package("lammps")
 
-    workload_variable('xx', default='20*$x',
-                      description='Number of atoms in the x direction',
-                      workloads=['lj', 'eam'])
-    workload_variable('yy', default='20*$y',
-                      description='Number of atoms in the y direction',
-                      workloads=['lj', 'eam'])
-    workload_variable('zz', default='20*$z',
-                      description='Number of atoms in the z direction',
-                      workloads=['lj', 'eam'])
-    workload_variable('timesteps', default='100',
-                      description='Number of timesteps',
-                      workloads=['lj', 'eam', 'chain', 'chute', 'rhodo'])
+    input_file(
+        "leonard-jones",
+        url="https://www.lammps.org/inputs/in.lj.txt",
+        expand=False,
+        sha256="874b4c63b6fcbb6ede76522df19087acf2f49b6bc96794cf0aa3218c66ff7e06",
+        description="Atomic fluid. 32k atoms. 100 timesteps. https://www.lammps.org/bench.html#lj",
+    )
+    input_file(
+        "eam",
+        url="https://www.lammps.org/inputs/in.eam.txt",
+        expand=False,
+        sha256="2fa09183c626c34570cc367384fe4c297ab153521adb3ea44ff7e265d451ad75",
+        description="Cu metallic solid with embedded atom method potential. 32k atoms. https://www.lammps.org/bench.html#eam",
+    )
+    input_file(
+        "polymer-chain-melt",
+        url="https://www.lammps.org/inputs/in.chain.txt",
+        expand=False,
+        sha256="97676f19d2d791c42415698c354a18b26a3cbe4006cd2161cf8924415d9f7c82",
+        description="Bead-spring polymer melt with 100-mer chains and FENE bonds. 32k atoms. 100 timesteps. https://www.lammps.org/bench.html#chain",
+    )
+    input_file(
+        "chute",
+        url="https://www.lammps.org/inputs/in.chute.txt",
+        expand=False,
+        sha256="91e1743cc39365b32757cfb3c76399f5ed8debad0b890cb36ee7bdf47d2dfd2d",
+        description="Chute flow of packed granular particles with frictional history potential. 32k atoms. 100 timeteps. https://www.lammps.org/bench.html#chute",
+    )
+    input_file(
+        "rhodo",
+        url="https://www.lammps.org/inputs/in.rhodo.txt",
+        expand=False,
+        sha256="4b6cc70db1b8fe269c48b8e06749f144f400e9a4054bf180ac9b1b9a5a5bb07f",
+        description="All-atom rhodopsin protein in solvated lipid bilayer with CHARMM force field, long-range Coulombics via PPPM (particle-particle particle mesh), SHAKE constraints. This model contains counter-ions and a reduced amount of water to make a 32K atom system. 32k atoms. 100 timesteps. https://www.lammps.org/bench.html#rhodo",
+    )
 
-    workload_variable('input_path', default='{workload_input_dir}/in.{workload_name}.txt',
-                      description='Path for the workload input file.',
-                      workloads=['lj', 'eam', 'chain', 'chute', 'rhodo'])
+    input_file(
+        "lammps-stage",
+        url="https://github.com/lammps/lammps/archive/refs/tags/stable_23Jun2022_update3.tar.gz",
+        target_dir="{application_input_dir}/stable_23Jun2022_update3",
+        description="Stage of lammps source from 20220623.3 release",
+        sha256="8a276a01b50d37eecfe6eb36f420f354cde51936d20aca7944dea60d3c098c89",
+    )
 
-    workload_variable('lammps_flags', default='',
-                      description='Additional execution flags for lammps',
-                      workloads=['lj', 'eam', 'chain', 'chute', 'rhodo'])
+    executable(
+        "copy",
+        template=["cp {input_path} {experiment_run_dir}/input.txt"],
+        use_mpi=False,
+    )
+    executable(
+        "set-size",
+        template=[
+            "sed -i -e 's/xx equal .*/xx equal {xx}/g' -i input.txt",
+            "sed -i -e 's/yy equal .*/yy equal {yy}/g' -i input.txt",
+            "sed -i -e 's/zz equal .*/zz equal {zz}/g' -i input.txt",
+        ],
+        use_mpi=False,
+    )
+    executable(
+        "set-timesteps",
+        template=["sed 's/run.*[0-9]+/run\t\t{timesteps}/g' -i input.txt"],
+        use_mpi=False,
+    )
+
+    exec_path = os.path.join("{lammps}", "bin", "lmp")
+    executable(
+        "execute",
+        f"{exec_path}" + " -i input.txt {lammps_flags}",
+        use_mpi=True,
+    )
+
+    executable(
+        "set-data-path",
+        template=[
+            r"sed 's|data\.|"
+            + os.path.join("{lammps-stage}", "bench", "data.")
+            + "|g' -i input.txt"
+        ],
+        use_mpi=False,
+    )
+
+    workload(
+        "lj",
+        executables=["copy", "set-size", "set-timesteps", "execute"],
+        input="leonard-jones",
+    )
+    workload(
+        "eam",
+        executables=["copy", "set-size", "set-timesteps", "execute"],
+        input="eam",
+    )
+    workload(
+        "chain",
+        executables=["copy", "set-timesteps", "set-data-path", "execute"],
+        inputs=["polymer-chain-melt", "lammps-stage"],
+    )
+    workload(
+        "chute",
+        executables=["copy", "set-timesteps", "execute"],
+        input="chute",
+    )
+    workload(
+        "rhodo",
+        executables=["copy", "set-timesteps", "set-data-path", "execute"],
+        inputs=["rhodo", "lammps-stage"],
+    )
+
+    workload_variable(
+        "xx",
+        default="20*$x",
+        description="Number of atoms in the x direction",
+        workloads=["lj", "eam"],
+    )
+    workload_variable(
+        "yy",
+        default="20*$y",
+        description="Number of atoms in the y direction",
+        workloads=["lj", "eam"],
+    )
+    workload_variable(
+        "zz",
+        default="20*$z",
+        description="Number of atoms in the z direction",
+        workloads=["lj", "eam"],
+    )
+    workload_variable(
+        "timesteps",
+        default="100",
+        description="Number of timesteps",
+        workloads=["lj", "eam", "chain", "chute", "rhodo"],
+    )
+
+    workload_variable(
+        "input_path",
+        default="{workload_input_dir}/in.{workload_name}.txt",
+        description="Path for the workload input file.",
+        workloads=["lj", "eam", "chain", "chute", "rhodo"],
+    )
+
+    workload_variable(
+        "lammps_flags",
+        default="",
+        description="Additional execution flags for lammps",
+        workloads=["lj", "eam", "chain", "chute", "rhodo"],
+    )
 
     intel_wl_names = [
-        'airebo',
-        'dpd',
-        'eam',
-        'lc',
-        'lj',
-        'rhodo',
-        'sw',
-        'tersoff',
-        'water',
+        "airebo",
+        "dpd",
+        "eam",
+        "lc",
+        "lj",
+        "rhodo",
+        "sw",
+        "tersoff",
+        "water",
     ]
 
     executable(
-        'change-root',
-        template=["sed 's|${root}|{lammps-stage}" + os.path.sep + "|g' -i input.txt"],
-        use_mpi=False
-    )
-    intel_test_path = os.path.join('{lammps-stage}', 'src', 'INTEL', 'TEST')
-    executable(
-        'copy-cube',
+        "change-root",
         template=[
-            'cp ' + os.path.join(intel_test_path, 'mW*.data') + ' {experiment_run_dir}' + os.path.sep + '.'
-            'cp ' + os.path.join(intel_test_path, 'mW.sw') + ' {experiment_run_dir}' + os.path.sep + '.'
+            "sed 's|${root}|{lammps-stage}" + os.path.sep + "|g' -i input.txt"
         ],
-        use_mpi=False
+        use_mpi=False,
+    )
+    intel_test_path = os.path.join("{lammps-stage}", "src", "INTEL", "TEST")
+    executable(
+        "copy-cube",
+        template=[
+            "cp "
+            + os.path.join(intel_test_path, "mW*.data")
+            + " {experiment_run_dir}"
+            + os.path.sep
+            + "."
+            "cp "
+            + os.path.join(intel_test_path, "mW.sw")
+            + " {experiment_run_dir}"
+            + os.path.sep
+            + "."
+        ],
+        use_mpi=False,
     )
 
     for wl_name in intel_wl_names:
-        workload_name = f'intel.{wl_name}'
-        if wl_name in ['water']:
-            workload(workload_name, executables=['copy', 'copy-cube', 'change-root', 'execute'], inputs=['lammps-stage'])
-        elif wl_name in ['rhodo', 'chain']:
-            workload(workload_name, executables=['copy', 'set-data-path', 'change-root', 'execute'], inputs=['lammps-stage'])
+        workload_name = f"intel.{wl_name}"
+        if wl_name in ["water"]:
+            workload(
+                workload_name,
+                executables=["copy", "copy-cube", "change-root", "execute"],
+                inputs=["lammps-stage"],
+            )
+        elif wl_name in ["rhodo", "chain"]:
+            workload(
+                workload_name,
+                executables=[
+                    "copy",
+                    "set-data-path",
+                    "change-root",
+                    "execute",
+                ],
+                inputs=["lammps-stage"],
+            )
         else:
-            workload(workload_name, executables=['copy', 'change-root', 'execute'], inputs=['lammps-stage'])
+            workload(
+                workload_name,
+                executables=["copy", "change-root", "execute"],
+                inputs=["lammps-stage"],
+            )
 
-        workload_variable('input_path', default=os.path.join(f'{intel_test_path}', f'in.{workload_name}'),
-                          description=f'Path to input file for {workload_name} workload',
-                          workloads=[workload_name])
+        workload_variable(
+            "input_path",
+            default=os.path.join(f"{intel_test_path}", f"in.{workload_name}"),
+            description=f"Path to input file for {workload_name} workload",
+            workloads=[workload_name],
+        )
 
-        workload_variable('lammps_flags', default='',
-                          description='Additional execution flags for lammps',
-                          workloads=[workload_name])
+        workload_variable(
+            "lammps_flags",
+            default="",
+            description="Additional execution flags for lammps",
+            workloads=[workload_name],
+        )
 
-    intel_test_path = os.path.join('{lammps-stage}', 'examples', 'reaxff', 'HNS')
-    executable('copy-contents',
-               template=[
-                   'cp {input_path}/* {experiment_run_dir}/.',
-                   'cp {input_file} input.txt'
-               ], use_mpi=False)
+    intel_test_path = os.path.join(
+        "{lammps-stage}", "examples", "reaxff", "HNS"
+    )
+    executable(
+        "copy-contents",
+        template=[
+            "cp {input_path}/* {experiment_run_dir}/.",
+            "cp {input_file} input.txt",
+        ],
+        use_mpi=False,
+    )
 
-    workload('hns-reaxff', executables=['copy-contents', 'set-timesteps', 'execute'],
-             inputs=['lammps-stage'])
+    workload(
+        "hns-reaxff",
+        executables=["copy-contents", "set-timesteps", "execute"],
+        inputs=["lammps-stage"],
+    )
 
-    workload_variable('input_file', default='in.reaxc.hns',
-                      description='hns-reaxff input file name',
-                      workloads=['hns-reaxff'])
-    workload_variable('input_path', default=os.path.join(f'{intel_test_path}'),
-                      description='Path to input directory for hns-reaxff workload',
-                      workloads=['hns-reaxff'])
-    workload_variable('lammps_flags', default='',
-                      description='Additional execution flags for lammps',
-                      workloads=['hns-reaxff'])
+    workload_variable(
+        "input_file",
+        default="in.reaxc.hns",
+        description="hns-reaxff input file name",
+        workloads=["hns-reaxff"],
+    )
+    workload_variable(
+        "input_path",
+        default=os.path.join(f"{intel_test_path}"),
+        description="Path to input directory for hns-reaxff workload",
+        workloads=["hns-reaxff"],
+    )
+    workload_variable(
+        "lammps_flags",
+        default="",
+        description="Additional execution flags for lammps",
+        workloads=["hns-reaxff"],
+    )
 
-    success_criteria('walltime', mode='string', match=r'\s*Total wall time', file='{log_file}')
+    success_criteria(
+        "walltime",
+        mode="string",
+        match=r"\s*Total wall time",
+        file="{log_file}",
+    )
 
-    figure_of_merit('Total wall time', fom_regex=r'Total wall time.*\s+(?P<walltime>[0-9:]+)', group_name='walltime', units='')
-    figure_of_merit('Nanoseconds per day', fom_regex=r'Performance.*\s+(?P<nspd>[0-9\.]+) (ns|tau)/day', group_name='nspd', units='ns/day')
-    figure_of_merit('Hours per nanosecond', fom_regex=r'Performance.*\s+(?P<hpns>[0-9\.]+) hours/ns', group_name='hpns', units='timesteps/s')
-    figure_of_merit('Timesteps per second', fom_regex=r'Performance.*\s+(?P<tsps>[0-9\.]+) timesteps/s', group_name='tsps', units='hours/ns')
+    figure_of_merit(
+        "Total wall time",
+        fom_regex=r"Total wall time.*\s+(?P<walltime>[0-9:]+)",
+        group_name="walltime",
+        units="",
+    )
+    figure_of_merit(
+        "Nanoseconds per day",
+        fom_regex=r"Performance.*\s+(?P<nspd>[0-9\.]+) (ns|tau)/day",
+        group_name="nspd",
+        units="ns/day",
+    )
+    figure_of_merit(
+        "Hours per nanosecond",
+        fom_regex=r"Performance.*\s+(?P<hpns>[0-9\.]+) hours/ns",
+        group_name="hpns",
+        units="timesteps/s",
+    )
+    figure_of_merit(
+        "Timesteps per second",
+        fom_regex=r"Performance.*\s+(?P<tsps>[0-9\.]+) timesteps/s",
+        group_name="tsps",
+        units="hours/ns",
+    )

--- a/var/ramble/repos/builtin/applications/lulesh/application.py
+++ b/var/ramble/repos/builtin/applications/lulesh/application.py
@@ -12,66 +12,101 @@ from ramble.expander import Expander
 
 
 class Lulesh(SpackApplication):
-    '''Define LULESH application'''
-    name = 'LULESH'
+    """Define LULESH application"""
 
-    maintainers('douglasjacobsen')
+    name = "LULESH"
 
-    tags('proxy-app', 'mini-app')
+    maintainers("douglasjacobsen")
 
-    define_compiler('gcc13', spack_spec='gcc@13.1.0')
+    tags("proxy-app", "mini-app")
 
-    software_spec('impi2018',
-                  spack_spec='intel-mpi@2018.4.274')
+    define_compiler("gcc13", spack_spec="gcc@13.1.0")
 
-    software_spec('lulesh',
-                  spack_spec='lulesh@2.0.3 +openmp',
-                  compiler='gcc13')
+    software_spec("impi2018", spack_spec="intel-mpi@2018.4.274")
 
-    required_package('lulesh')
+    software_spec(
+        "lulesh", spack_spec="lulesh@2.0.3 +openmp", compiler="gcc13"
+    )
 
-    executable('execute', 'lulesh2.0 {flags}', use_mpi=True)
+    required_package("lulesh")
 
-    workload('standard', executables=['execute'])
+    executable("execute", "lulesh2.0 {flags}", use_mpi=True)
 
-    workload_variable('size_flag', default='',
-                      description='Problem size in a single dimension. Real problem is size^3. Needs to be prefixed by -s',
-                      workloads=['standard'])
+    workload("standard", executables=["execute"])
 
-    workload_variable('iteration_flag', default='',
-                      description='Fixed number of iterations to perform. Needs to be prefixed by -i',
-                      workloads=['standard'])
+    workload_variable(
+        "size_flag",
+        default="",
+        description="Problem size in a single dimension. Real problem is size^3. Needs to be prefixed by -s",
+        workloads=["standard"],
+    )
 
-    workload_variable('flags', default='{size_flag} {iteration_flag}',
-                      description='Flags to pass in to LULESH',
-                      workloads=['standard'])
+    workload_variable(
+        "iteration_flag",
+        default="",
+        description="Fixed number of iterations to perform. Needs to be prefixed by -i",
+        workloads=["standard"],
+    )
 
-    log_str = os.path.join(Expander.expansion_str('experiment_run_dir'),
-                           Expander.expansion_str('experiment_name') + '.out')
+    workload_variable(
+        "flags",
+        default="{size_flag} {iteration_flag}",
+        description="Flags to pass in to LULESH",
+        workloads=["standard"],
+    )
 
-    figure_of_merit('Time', log_file=log_str,
-                    fom_regex=r'\s*Elapsed time\s+=\s+(?P<time>[0-9]+\.[0-9]+).*',
-                    group_name='time', units='s')
+    log_str = os.path.join(
+        Expander.expansion_str("experiment_run_dir"),
+        Expander.expansion_str("experiment_name") + ".out",
+    )
 
-    figure_of_merit('FOM', log_file=log_str,
-                    fom_regex=r'\s*FOM\s+=\s+(?P<fom>[0-9]+\.[0-9]+).*',
-                    group_name='fom', units='z/s')
+    figure_of_merit(
+        "Time",
+        log_file=log_str,
+        fom_regex=r"\s*Elapsed time\s+=\s+(?P<time>[0-9]+\.[0-9]+).*",
+        group_name="time",
+        units="s",
+    )
 
-    figure_of_merit('Size', log_file=log_str,
-                    fom_regex=r'\s*Problem size\s+=\s+(?P<size>[0-9]+)',
-                    group_name='size', units='')
+    figure_of_merit(
+        "FOM",
+        log_file=log_str,
+        fom_regex=r"\s*FOM\s+=\s+(?P<fom>[0-9]+\.[0-9]+).*",
+        group_name="fom",
+        units="z/s",
+    )
 
-    figure_of_merit('Grind Time', log_file=log_str,
-                    fom_regex=r'\s*Grind time \(us/z/c\)\s+=\s+(?P<grind>[0-9]+\.[0-9]+).*',
-                    group_name='grind', units='s/element')
+    figure_of_merit(
+        "Size",
+        log_file=log_str,
+        fom_regex=r"\s*Problem size\s+=\s+(?P<size>[0-9]+)",
+        group_name="size",
+        units="",
+    )
 
-    figure_of_merit('NumTasks', log_file=log_str,
-                    fom_regex=r'\s*MPI tasks\s+=\s+(?P<tasks>[0-9]+)',
-                    group_name='tasks', units='')
+    figure_of_merit(
+        "Grind Time",
+        log_file=log_str,
+        fom_regex=r"\s*Grind time \(us/z/c\)\s+=\s+(?P<grind>[0-9]+\.[0-9]+).*",
+        group_name="grind",
+        units="s/element",
+    )
 
-    figure_of_merit('Iterations', log_file=log_str,
-                    fom_regex=r'\s*Iteration count\s+=\s+(?P<iterations>[0-9]+)',
-                    group_name='iterations', units='')
+    figure_of_merit(
+        "NumTasks",
+        log_file=log_str,
+        fom_regex=r"\s*MPI tasks\s+=\s+(?P<tasks>[0-9]+)",
+        group_name="tasks",
+        units="",
+    )
+
+    figure_of_merit(
+        "Iterations",
+        log_file=log_str,
+        fom_regex=r"\s*Iteration count\s+=\s+(?P<iterations>[0-9]+)",
+        group_name="iterations",
+        units="",
+    )
 
     def _make_experiments(self, workspace, app_inst=None):
         """
@@ -83,10 +118,10 @@ class Lulesh(SpackApplication):
         We also need to recompute the number of nodes, or the value of
         processes per node here too.
         """
-        num_ranks = int(self.expander.expand_var_name('n_ranks'))
+        num_ranks = int(self.expander.expand_var_name("n_ranks"))
 
-        cube_root = int(num_ranks ** (1. / 3.))
+        cube_root = int(num_ranks ** (1.0 / 3.0))
 
-        self.variables['n_ranks'] = cube_root**3
+        self.variables["n_ranks"] = cube_root**3
 
         super()._make_experiments(workspace)

--- a/var/ramble/repos/builtin/applications/md-test/application.py
+++ b/var/ramble/repos/builtin/applications/md-test/application.py
@@ -11,54 +11,78 @@ from ramble.expander import Expander
 
 
 class MdTest(SpackApplication):
-    '''Define the MDTest parallel IO benchmark'''
-    name = 'md-test'
+    """Define the MDTest parallel IO benchmark"""
 
-    maintainers('rfbgo')
+    name = "md-test"
 
-    tags('synthetic-benchmarks', 'IO')
+    maintainers("rfbgo")
 
-    define_compiler('gcc', spack_spec='gcc')
-    software_spec('openmpi', spack_spec='openmpi')
+    tags("synthetic-benchmarks", "IO")
+
+    define_compiler("gcc", spack_spec="gcc")
+    software_spec("openmpi", spack_spec="openmpi")
 
     # The IOR spack package also includes MDTest, but we implement it as a
     # separate application in ramble
-    software_spec('ior', spack_spec='ior', compiler='gcc')
+    software_spec("ior", spack_spec="ior", compiler="gcc")
 
-    required_package('ior')
+    required_package("ior")
 
-    workload('multi-file', executable='ior')
+    workload("multi-file", executable="ior")
 
-    workload_variable('num-objects', default='1000',
-                      description='Number of files and dirs to create (per rank)',
-                      workloads=['multi-file'])
-    workload_variable('iterations', default='10',
-                      description='Number of iterations',
-                      workloads=['multi-file'])
-    workload_variable('additional-args', default='',
-                      description='Pass additional args, such as working directiroy (-d)',
-                      workloads=['multi-file'])
+    workload_variable(
+        "num-objects",
+        default="1000",
+        description="Number of files and dirs to create (per rank)",
+        workloads=["multi-file"],
+    )
+    workload_variable(
+        "iterations",
+        default="10",
+        description="Number of iterations",
+        workloads=["multi-file"],
+    )
+    workload_variable(
+        "additional-args",
+        default="",
+        description="Pass additional args, such as working directiroy (-d)",
+        workloads=["multi-file"],
+    )
 
-    executable(name='ior', template='mdtest -n {num-objects} -i {iterations} {additional-args}',
-               use_mpi=True)
+    executable(
+        name="ior",
+        template="mdtest -n {num-objects} -i {iterations} {additional-args}",
+        use_mpi=True,
+    )
 
-    operations = ['Directory creation', 'Directory stat', 'Directory removal', 'File creation',
-                  'File stat', 'File read', 'File removal', 'Tree creation', 'Tree removal']
+    operations = [
+        "Directory creation",
+        "Directory stat",
+        "Directory removal",
+        "File creation",
+        "File stat",
+        "File read",
+        "File removal",
+        "Tree creation",
+        "Tree removal",
+    ]
 
     unit = "ops/sec"
 
-    metrics = ['max', 'min', 'mean', 'stddev']
-    base_regex = ':'
+    metrics = ["max", "min", "mean", "stddev"]
+    base_regex = ":"
     for metric in metrics:
-        base_regex += r'\s+(?P<' + metric + r'>[0-9]+\.[0-9]+)'
+        base_regex += r"\s+(?P<" + metric + r">[0-9]+\.[0-9]+)"
 
-    log_str = Expander.expansion_str('log_file')
+    log_str = Expander.expansion_str("log_file")
 
     for op in operations:
-        fom_regex = r'\s*' + op + r'\s+' + base_regex
+        fom_regex = r"\s*" + op + r"\s+" + base_regex
         for metric in metrics:
-            figure_of_merit(f'{op}-{metric}',
-                            log_file=log_str,
-                            fom_regex=fom_regex,
-                            group_name=metric,
-                            units=unit)
+            figure_of_merit(
+                f"{op}-{metric}",
+                log_file=log_str,
+                fom_regex=fom_regex,
+                group_name=metric,
+                units=unit,
+            )

--- a/var/ramble/repos/builtin/applications/minixyce/application.py
+++ b/var/ramble/repos/builtin/applications/minixyce/application.py
@@ -12,157 +12,259 @@ from ramble.expander import Expander
 
 
 class Minixyce(SpackApplication):
-    '''Define miniXyce application'''
-    name = 'minixyce'
+    """Define miniXyce application"""
 
-    maintainers('rfbgo')
+    name = "minixyce"
 
-    tags('circuitdesign', 'miniapp', 'mini-app', 'minibenchmark', 'mini-benchmark')
+    maintainers("rfbgo")
 
-    define_compiler('gcc12', spack_spec="gcc@12.2.0")
+    tags(
+        "circuitdesign",
+        "miniapp",
+        "mini-app",
+        "minibenchmark",
+        "mini-benchmark",
+    )
 
-    software_spec('ompi415cxx', spack_spec='openmpi@4.1.5 +legacylaunchers +cxx',
-                  compiler='gcc12')
+    define_compiler("gcc12", spack_spec="gcc@12.2.0")
 
-    software_spec('minixyce', spack_spec='minixyce@1.0 +mpi',
-                  compiler='gcc12')
+    software_spec(
+        "ompi415cxx",
+        spack_spec="openmpi@4.1.5 +legacylaunchers +cxx",
+        compiler="gcc12",
+    )
 
-    required_package('minixyce')
+    software_spec("minixyce", spack_spec="minixyce@1.0 +mpi", compiler="gcc12")
 
-    executable('execute', 'miniXyce.x --circuit {workload_name}.net --pf params.txt', use_mpi=True)
+    required_package("minixyce")
 
-    executable('get_simple_network',
-               template=['cp {minixyce}/doc/tests/{workload_name}.net {experiment_run_dir}/{workload_name}.net'],
-               use_mpi=False)
+    executable(
+        "execute",
+        "miniXyce.x --circuit {workload_name}.net --pf params.txt",
+        use_mpi=True,
+    )
 
-    executable('generate_RC_ladder',
-               template=['perl {minixyce}/doc/tests/RC_ladder.pl {num_ladder_stages} > {experiment_run_dir}/{workload_name}.net; echo Running perl'],
-               use_mpi=False)
+    executable(
+        "get_simple_network",
+        template=[
+            "cp {minixyce}/doc/tests/{workload_name}.net {experiment_run_dir}/{workload_name}.net"
+        ],
+        use_mpi=False,
+    )
 
-    executable('generate_RLC_ladder',
-               template=['perl {minixyce}/doc/tests/RLC_ladder.pl {num_ladder_stages} > {experiment_run_dir}/{workload_name}.net; echo Running perl'],
-               use_mpi=False)
+    executable(
+        "generate_RC_ladder",
+        template=[
+            "perl {minixyce}/doc/tests/RC_ladder.pl {num_ladder_stages} > {experiment_run_dir}/{workload_name}.net; echo Running perl"
+        ],
+        use_mpi=False,
+    )
 
-    executable('generate_RC_ladder2',
-               template=['perl {minixyce}/doc/tests/RC_ladder2.pl {num_ladder_stages} > {experiment_run_dir}/{workload_name}.net; echo Running perl'],
-               use_mpi=False)
+    executable(
+        "generate_RLC_ladder",
+        template=[
+            "perl {minixyce}/doc/tests/RLC_ladder.pl {num_ladder_stages} > {experiment_run_dir}/{workload_name}.net; echo Running perl"
+        ],
+        use_mpi=False,
+    )
 
-    executable('generate_RLC_ladder2',
-               template=['perl {minixyce}/doc/tests/RLC_ladder2.pl {num_ladder_stages} > {experiment_run_dir}/{workload_name}.net; echo Running perl'],
-               use_mpi=False)
+    executable(
+        "generate_RC_ladder2",
+        template=[
+            "perl {minixyce}/doc/tests/RC_ladder2.pl {num_ladder_stages} > {experiment_run_dir}/{workload_name}.net; echo Running perl"
+        ],
+        use_mpi=False,
+    )
 
-    cir_workloads = ['cir1', 'cir2', 'cir3', 'cir4', 'cir5']
+    executable(
+        "generate_RLC_ladder2",
+        template=[
+            "perl {minixyce}/doc/tests/RLC_ladder2.pl {num_ladder_stages} > {experiment_run_dir}/{workload_name}.net; echo Running perl"
+        ],
+        use_mpi=False,
+    )
+
+    cir_workloads = ["cir1", "cir2", "cir3", "cir4", "cir5"]
     for cir_workload in cir_workloads:
-        workload(cir_workload, executables=['get_simple_network', 'execute'])
+        workload(cir_workload, executables=["get_simple_network", "execute"])
 
-    rc_workloads = ['RC_ladder', 'RLC_ladder', 'RC_ladder2', 'RLC_ladder2']
+    rc_workloads = ["RC_ladder", "RLC_ladder", "RC_ladder2", "RLC_ladder2"]
     for workload_name in rc_workloads:
-        workload(workload_name, executables=['generate_' + workload_name, 'execute'])
+        workload(
+            workload_name, executables=["generate_" + workload_name, "execute"]
+        )
 
     all_workloads = cir_workloads + rc_workloads
-    workload_variable('t_start', default='0', description='Start time', workloads=all_workloads)
-    workload_variable('t_step', default='1e-8', description='Time step', workloads=all_workloads)
-    workload_variable('t_stop', default='5e-5', description='Stop time', workloads=all_workloads)
-    workload_variable('tol', default='1e-6', description='Tolerance', workloads=all_workloads)
-    workload_variable('k', default='10', description='Tells GMRES how often to restart', workloads=all_workloads)
+    workload_variable(
+        "t_start",
+        default="0",
+        description="Start time",
+        workloads=all_workloads,
+    )
+    workload_variable(
+        "t_step",
+        default="1e-8",
+        description="Time step",
+        workloads=all_workloads,
+    )
+    workload_variable(
+        "t_stop",
+        default="5e-5",
+        description="Stop time",
+        workloads=all_workloads,
+    )
+    workload_variable(
+        "tol", default="1e-6", description="Tolerance", workloads=all_workloads
+    )
+    workload_variable(
+        "k",
+        default="10",
+        description="Tells GMRES how often to restart",
+        workloads=all_workloads,
+    )
 
-    workload_variable('num_ladder_stages', default='1024',
-                      description='Number of Ladder stages for RC|RLC ladder|ladder2 test generation',
-                      workloads=rc_workloads)
+    workload_variable(
+        "num_ladder_stages",
+        default="1024",
+        description="Number of Ladder stages for RC|RLC ladder|ladder2 test generation",
+        workloads=rc_workloads,
+    )
 
-    log_str = os.path.join(Expander.expansion_str('experiment_run_dir'),
-                           Expander.expansion_str('workload_name') + '_tran_results.prn')
-    out_file = os.path.join(Expander.expansion_str('experiment_run_dir'),
-                            Expander.expansion_str('experiment_name') + '.out')
-    processed_output = os.path.join(Expander.expansion_str('experiment_run_dir'),
-                                    'processed_output.txt')
+    log_str = os.path.join(
+        Expander.expansion_str("experiment_run_dir"),
+        Expander.expansion_str("workload_name") + "_tran_results.prn",
+    )
+    out_file = os.path.join(
+        Expander.expansion_str("experiment_run_dir"),
+        Expander.expansion_str("experiment_name") + ".out",
+    )
+    processed_output = os.path.join(
+        Expander.expansion_str("experiment_run_dir"), "processed_output.txt"
+    )
 
-    result_regex = r'.*\s+(?P<num_iters>[0-9]+)\s+(?P<num_restarts>[0-9]+)'
+    result_regex = r".*\s+(?P<num_iters>[0-9]+)\s+(?P<num_restarts>[0-9]+)"
 
-    floating_point_regex = r'\d+\.\d+'
-    scientific_number_regex = r'[\+\-]*\d+\.\d+[eE][\+\-]*\d+'
+    floating_point_regex = r"\d+\.\d+"
+    scientific_number_regex = r"[\+\-]*\d+\.\d+[eE][\+\-]*\d+"
 
-    success_regex = r'^\s*TIME.*num_GMRES_iters\s*num_GMRES_restarts'
-    success_criteria('valid', mode='string',
-                     match=success_regex,
-                     file=log_str)
+    success_regex = r"^\s*TIME.*num_GMRES_iters\s*num_GMRES_restarts"
+    success_criteria("valid", mode="string", match=success_regex, file=log_str)
 
-    figure_of_merit('Total Simulation Time', log_file=out_file,
-                    fom_regex=r'Total Simulation Time:\s+(?P<time>' + floating_point_regex + r')',
-                    group_name='time',
-                    units='s'
-                    )
-    figure_of_merit('I/O File Time', log_file=out_file,
-                    fom_regex=r'I/O File Time:\s+(?P<time>' + floating_point_regex + r')',
-                    group_name='time',
-                    units='s'
-                    )
+    figure_of_merit(
+        "Total Simulation Time",
+        log_file=out_file,
+        fom_regex=r"Total Simulation Time:\s+(?P<time>"
+        + floating_point_regex
+        + r")",
+        group_name="time",
+        units="s",
+    )
+    figure_of_merit(
+        "I/O File Time",
+        log_file=out_file,
+        fom_regex=r"I/O File Time:\s+(?P<time>" + floating_point_regex + r")",
+        group_name="time",
+        units="s",
+    )
 
     enable_deck_based_FOMs = False
     if enable_deck_based_FOMs:
-        figure_of_merit('Time_end', log_file=log_str,
-                        fom_regex=r'\s+(?P<time>' + scientific_number_regex + r')',
-                        group_name='time',
-                        units='s'
-                        )
+        figure_of_merit(
+            "Time_end",
+            log_file=log_str,
+            fom_regex=r"\s+(?P<time>" + scientific_number_regex + r")",
+            group_name="time",
+            units="s",
+        )
 
-        figure_of_merit('num_GMRES_iters', log_file=log_str,
-                        fom_regex=result_regex,
-                        group_name='num_iters',
-                        units=''
-                        )
+        figure_of_merit(
+            "num_GMRES_iters",
+            log_file=log_str,
+            fom_regex=result_regex,
+            group_name="num_iters",
+            units="",
+        )
 
-        figure_of_merit('num_GMRES_restarts', log_file=log_str,
-                        fom_regex=result_regex,
-                        group_name='num_restarts',
-                        units=''
-                        )
+        figure_of_merit(
+            "num_GMRES_restarts",
+            log_file=log_str,
+            fom_regex=result_regex,
+            group_name="num_restarts",
+            units="",
+        )
 
-        state_var_regex = r'\s*(?P<State_Variable>[0-9]+)*:*\s*(?P<name>[0-9A-Za-z]+)\s*=\s*(?P<value>' + scientific_number_regex + r')'
+        state_var_regex = (
+            r"\s*(?P<State_Variable>[0-9]+)*:*\s*(?P<name>[0-9A-Za-z]+)\s*=\s*(?P<value>"
+            + scientific_number_regex
+            + r")"
+        )
 
-        figure_of_merit('Name', log_file=processed_output,
-                        fom_regex=state_var_regex,
-                        group_name='name',
-                        units='', contexts=['state_variable']
-                        )
+        figure_of_merit(
+            "Name",
+            log_file=processed_output,
+            fom_regex=state_var_regex,
+            group_name="name",
+            units="",
+            contexts=["state_variable"],
+        )
 
-        figure_of_merit('Value', log_file=processed_output,
-                        fom_regex=state_var_regex,
-                        group_name='value',
-                        units='', contexts=['state_variable']
-                        )
+        figure_of_merit(
+            "Value",
+            log_file=processed_output,
+            fom_regex=state_var_regex,
+            group_name="value",
+            units="",
+            contexts=["state_variable"],
+        )
 
-        figure_of_merit_context('state_variable',
-                                regex=state_var_regex,
-                                output_format='{State_Variable}')
+        figure_of_merit_context(
+            "state_variable",
+            regex=state_var_regex,
+            output_format="{State_Variable}",
+        )
 
     def _make_experiments(self, workspace, app_inst=None):
         super()._make_experiments(workspace)
 
-        input_path = os.path.join(self.expander.expand_var_name('experiment_run_dir'), 'params.txt')
+        input_path = os.path.join(
+            self.expander.expand_var_name("experiment_run_dir"), "params.txt"
+        )
 
-        settings = ['t_start', 't_step', 't_stop', 'tol', 'k']
+        settings = ["t_start", "t_step", "t_stop", "tol", "k"]
 
-        with open(input_path, 'w+') as f:
+        with open(input_path, "w+") as f:
             for setting in settings:
-                f.write(setting + ' = ' + self.expander.expand_var_name(setting) + '\n')
+                f.write(
+                    setting
+                    + " = "
+                    + self.expander.expand_var_name(setting)
+                    + "\n"
+                )
 
     def _analyze_experiments(self, workspace, app_inst=None):
         import os
 
-        output_file = os.path.join(self.expander.expand_var_name('experiment_run_dir'),
-                                   self.expander.expand_var_name('workload_name') + '_tran_results.prn')
-        processed_output_path = os.path.join(self.expander.expand_var_name('experiment_run_dir'), 'processed_output.txt')
+        output_file = os.path.join(
+            self.expander.expand_var_name("experiment_run_dir"),
+            self.expander.expand_var_name("workload_name")
+            + "_tran_results.prn",
+        )
+        processed_output_path = os.path.join(
+            self.expander.expand_var_name("experiment_run_dir"),
+            "processed_output.txt",
+        )
 
         if os.path.isfile(output_file):
             names = []
-            with open(output_file, 'r') as f:
+            with open(output_file, "r") as f:
                 names = f.readline().split()
-                for line in (f.readlines()[-1:]):
+                for line in f.readlines()[-1:]:
                     values = line.split()
 
-            with open(processed_output_path, 'w+') as f:
-                for i, (name, value) in enumerate(zip(names[1:-2], values[1:-2])):
+            with open(processed_output_path, "w+") as f:
+                for i, (name, value) in enumerate(
+                    zip(names[1:-2], values[1:-2])
+                ):
                     f.write("{}: {} = {}\n".format((i + 1), name, value))
 
         super()._analyze_experiments(workspace)

--- a/var/ramble/repos/builtin/applications/namd/application.py
+++ b/var/ramble/repos/builtin/applications/namd/application.py
@@ -14,226 +14,274 @@ from ramble.keywords import keywords
 
 
 class Namd(SpackApplication):
-    '''Define NAMD application'''
-    name = 'namd'
+    """Define NAMD application"""
 
-    maintainers('douglasjacobsen')
+    name = "namd"
 
-    tags('molecular-dynamics', 'charm++', 'task-parallelism')
+    maintainers("douglasjacobsen")
 
-    define_compiler('gcc12', spack_spec='gcc@12.2.0')
+    tags("molecular-dynamics", "charm++", "task-parallelism")
 
-    software_spec('impi2021p8', spack_spec='intel-oneapi-mpi@2021.8.0')
+    define_compiler("gcc12", spack_spec="gcc@12.2.0")
 
-    software_spec('charmpp', spack_spec='charmpp backend=mpi build-target=charm++', compiler='gcc12')
+    software_spec("impi2021p8", spack_spec="intel-oneapi-mpi@2021.8.0")
 
-    software_spec('namd', spack_spec='namd@2.14 interface=tcl', compiler='gcc12')
+    software_spec(
+        "charmpp",
+        spack_spec="charmpp backend=mpi build-target=charm++",
+        compiler="gcc12",
+    )
 
-    required_package('namd')
+    software_spec(
+        "namd", spack_spec="namd@2.14 interface=tcl", compiler="gcc12"
+    )
 
-    input_file('stmv', url='https://www.ks.uiuc.edu/Research/namd/utilities/stmv.tar.gz',
-               sha256='2ef8beaa22046f2bf4ddc85bb8141391a27041302f101f5302f937d04104ccdd',
-               description='STMV (virus) benchmark (1,066,628 atoms, periodic, PME')
+    required_package("namd")
 
-    input_file('ApoA1', url='https://www.ks.uiuc.edu/Research/namd/utilities/apoa1.tar.gz',
-               sha256='fe30322cc94d93dff6c4e517d28584c48d0d0a1a7b23e2cd74cdb36d03863b22',
-               description='ApoA1 benchmark (92,224 atoms, periodic, PME)')
+    input_file(
+        "stmv",
+        url="https://www.ks.uiuc.edu/Research/namd/utilities/stmv.tar.gz",
+        sha256="2ef8beaa22046f2bf4ddc85bb8141391a27041302f101f5302f937d04104ccdd",
+        description="STMV (virus) benchmark (1,066,628 atoms, periodic, PME",
+    )
 
-    input_file('ATPase', url='https://www.ks.uiuc.edu/Research/namd/utilities/f1atpase.tar.gz',
-               sha256='ec34e31c69a7fc3c1649158bf7dbf20d20fe77520f73d05cbec4e9806b79148d',
-               description='ATPase benchmark (327,506 atoms, periodic, PME)')
+    input_file(
+        "ApoA1",
+        url="https://www.ks.uiuc.edu/Research/namd/utilities/apoa1.tar.gz",
+        sha256="fe30322cc94d93dff6c4e517d28584c48d0d0a1a7b23e2cd74cdb36d03863b22",
+        description="ApoA1 benchmark (92,224 atoms, periodic, PME)",
+    )
 
-    input_file('20STMV', url='https://www.ks.uiuc.edu/Research/namd/utilities/stmv_sc14.tar.gz',
-               sha256='e166ca309ae614417f1c2da3b0eed139c816666403d552955b04849f703ef719',
-               description='20STMV and 210STMV benchmarks from SC14 paper')
+    input_file(
+        "ATPase",
+        url="https://www.ks.uiuc.edu/Research/namd/utilities/f1atpase.tar.gz",
+        sha256="ec34e31c69a7fc3c1649158bf7dbf20d20fe77520f73d05cbec4e9806b79148d",
+        description="ATPase benchmark (327,506 atoms, periodic, PME)",
+    )
 
-    input_file('tiny', url='https://www.ks.uiuc.edu/Research/namd/utilities/tiny.tar.gz',
-               sha256='dabf5986456d504a5ba40d3660bb8b6e6bd5d714b413390a733a4f819c1512ec',
-               description='tiny benchmark (507 atoms, periodic, PME)')
+    input_file(
+        "20STMV",
+        url="https://www.ks.uiuc.edu/Research/namd/utilities/stmv_sc14.tar.gz",
+        sha256="e166ca309ae614417f1c2da3b0eed139c816666403d552955b04849f703ef719",
+        description="20STMV and 210STMV benchmarks from SC14 paper",
+    )
 
-    input_file('interactive_BPTI', url='https://www.ks.uiuc.edu/Research/namd/utilities/bpti_imd.tar.gz',
-               sha256='751ab94d13fc227a3313bc0a323597943fbf1f9a98d88c81086717399d61b8ec',
-               description='Interactive BPTI (882 atoms, small)')
+    input_file(
+        "tiny",
+        url="https://www.ks.uiuc.edu/Research/namd/utilities/tiny.tar.gz",
+        sha256="dabf5986456d504a5ba40d3660bb8b6e6bd5d714b413390a733a4f819c1512ec",
+        description="tiny benchmark (507 atoms, periodic, PME)",
+    )
 
-    input_file('ER-GRE', url='https://www.ks.uiuc.edu/Research/namd/utilities/er-gre.tar.gz',
-               sha256='8aaff093cddf5f28aec9ea65f9bce5853efa4f4346a64477efe0e0cde16740ce',
-               description='ER-GRE benchmark (36573 atoms, spherical)')
+    input_file(
+        "interactive_BPTI",
+        url="https://www.ks.uiuc.edu/Research/namd/utilities/bpti_imd.tar.gz",
+        sha256="751ab94d13fc227a3313bc0a323597943fbf1f9a98d88c81086717399d61b8ec",
+        description="Interactive BPTI (882 atoms, small)",
+    )
 
-    input_file('decalanin', url='https://www.ks.uiuc.edu/Research/namd/utilities/alanin.tar.gz',
-               sha256='92f8b6f1a55b548d450fe858cde9db901445964ed24639d5aa3667f3fc1ec52c',
-               description='decalanin (66 atoms, tiny, ancient)')
+    input_file(
+        "ER-GRE",
+        url="https://www.ks.uiuc.edu/Research/namd/utilities/er-gre.tar.gz",
+        sha256="8aaff093cddf5f28aec9ea65f9bce5853efa4f4346a64477efe0e0cde16740ce",
+        description="ER-GRE benchmark (36573 atoms, spherical)",
+    )
 
-    input_file('tcl-forces', url='https://www.ks.uiuc.edu/Research/namd/utilities/tclforces.tar.gz',
-               sha256='3daa557c51a41d4f2484aa3b4de7c1d96671da2baa159798ed0d90e638965eee',
-               description='Tcl forces (decalanin)')
+    input_file(
+        "decalanin",
+        url="https://www.ks.uiuc.edu/Research/namd/utilities/alanin.tar.gz",
+        sha256="92f8b6f1a55b548d450fe858cde9db901445964ed24639d5aa3667f3fc1ec52c",
+        description="decalanin (66 atoms, tiny, ancient)",
+    )
 
-    executable('copy_inputs', 'cp {input_path}/* {experiment_run_dir}/.', use_mpi=False)
-    executable('execute', 'namd2 {namd_flags} {input_file}', use_mpi=True)
+    input_file(
+        "tcl-forces",
+        url="https://www.ks.uiuc.edu/Research/namd/utilities/tclforces.tar.gz",
+        sha256="3daa557c51a41d4f2484aa3b4de7c1d96671da2baa159798ed0d90e638965eee",
+        description="Tcl forces (decalanin)",
+    )
+
+    executable(
+        "copy_inputs",
+        "cp {input_path}/* {experiment_run_dir}/.",
+        use_mpi=False,
+    )
+    executable("execute", "namd2 {namd_flags} {input_file}", use_mpi=True)
 
     # Configure standard benchmark workloads and variables
     # Assumes each benchmark workload has an input of the same name.
     benchmark_workloads = [
-        ('stmv', ['stmv.namd']),
-        ('ApoA1', ['apoa1.namd']),
-        ('ATPase', ['f1atpase.namd']),
-        ('20STMV', ['1stmv2fs.namd', '210stmv2fs.namd', 'compress_20stmv.namd']),
-        ('tiny', ['tiny.namd']),
-        ('interactive_BPTI', ['bpti.namd']),
-        ('ER-GRE', ['er-gre.namd']),
-        ('decalanin', ['alanin.namd']),
-        ('tcl-forces', ['tclforces.namd']),
+        ("stmv", ["stmv.namd"]),
+        ("ApoA1", ["apoa1.namd"]),
+        ("ATPase", ["f1atpase.namd"]),
+        (
+            "20STMV",
+            ["1stmv2fs.namd", "210stmv2fs.namd", "compress_20stmv.namd"],
+        ),
+        ("tiny", ["tiny.namd"]),
+        ("interactive_BPTI", ["bpti.namd"]),
+        ("ER-GRE", ["er-gre.namd"]),
+        ("decalanin", ["alanin.namd"]),
+        ("tcl-forces", ["tclforces.namd"]),
     ]
     for wl_def in benchmark_workloads:
-        workload(wl_def[0], executables=['copy_inputs', 'execute'],
-                 inputs=[wl_def[0]])
-
-        workload_variable(
-            'namd_flags',
-            default='+ppn {processes_per_node} +setcpuaffinity',
-            description='Flags for running NAMD',
-            workloads=[wl_def[0]]
+        workload(
+            wl_def[0],
+            executables=["copy_inputs", "execute"],
+            inputs=[wl_def[0]],
         )
 
         workload_variable(
-            'input_path',
+            "namd_flags",
+            default="+ppn {processes_per_node} +setcpuaffinity",
+            description="Flags for running NAMD",
+            workloads=[wl_def[0]],
+        )
+
+        workload_variable(
+            "input_path",
             default=Expander.expansion_str(wl_def[0]),
-            description=f'Path to the {wl_def[0]} inputs',
-            workloads=[wl_def[0]]
+            description=f"Path to the {wl_def[0]} inputs",
+            workloads=[wl_def[0]],
         )
 
         workload_variable(
-            'input_file',
+            "input_file",
             default=wl_def[1][0],
             values=wl_def[1],
-            description='Input file for namd',
-            workloads=[wl_def[0]]
+            description="Input file for namd",
+            workloads=[wl_def[0]],
         )
 
     log_file_str = Expander.expansion_str(keywords.log_file)
 
     success_criteria(
-        'Completion',
-        mode='string',
-        match=r'.*End of program.*',
-        file=log_file_str
+        "Completion",
+        mode="string",
+        match=r".*End of program.*",
+        file=log_file_str,
     )
 
     # Timing FOMs
-    timing_regex = r'TIMING:\s+(?P<itr>[0-9]+)\s+CPU:\s+(?P<cpu>[0-9]+\.[0-9]+),\s+(?P<cpu_per_step>[0-9]+\.[0-9]+)/step\s+' + \
-                   r'Wall:\s+(?P<wall>[0-9]+\.[0-9]+),\s+(?P<wall_per_step>[0-9]+\.[0-9]+)/step,\s+(?P<remaining>[0-9]+\.*[0-9]*)\s+' + \
-                   r'hours\s+remaining,\s+(?P<mem>[0-9]+\.[0-9]+)\s+MB.*'
+    timing_regex = (
+        r"TIMING:\s+(?P<itr>[0-9]+)\s+CPU:\s+(?P<cpu>[0-9]+\.[0-9]+),\s+(?P<cpu_per_step>[0-9]+\.[0-9]+)/step\s+"
+        + r"Wall:\s+(?P<wall>[0-9]+\.[0-9]+),\s+(?P<wall_per_step>[0-9]+\.[0-9]+)/step,\s+(?P<remaining>[0-9]+\.*[0-9]*)\s+"
+        + r"hours\s+remaining,\s+(?P<mem>[0-9]+\.[0-9]+)\s+MB.*"
+    )
     figure_of_merit_context(
-        'Perf iteration',
+        "Perf iteration",
         regex=timing_regex,
-        output_format='Timing Itertion: {itr}'
+        output_format="Timing Itertion: {itr}",
     )
 
     figure_of_merit(
-        'Timing iteration',
+        "Timing iteration",
         log_file=log_file_str,
         fom_regex=timing_regex,
-        group_name='itr',
-        units='',
-        contexts=['Perf iteration']
+        group_name="itr",
+        units="",
+        contexts=["Perf iteration"],
     )
 
     figure_of_merit(
-        'CPU time',
+        "CPU time",
         log_file=log_file_str,
         fom_regex=timing_regex,
-        group_name='cpu',
-        units='s',
-        contexts=['Perf iteration']
+        group_name="cpu",
+        units="s",
+        contexts=["Perf iteration"],
     )
 
     figure_of_merit(
-        'Avg. CPU time per time step',
+        "Avg. CPU time per time step",
         log_file=log_file_str,
         fom_regex=timing_regex,
-        group_name='cpu_per_step',
-        units='s/timestep',
-        contexts=['Perf iteration']
+        group_name="cpu_per_step",
+        units="s/timestep",
+        contexts=["Perf iteration"],
     )
 
     figure_of_merit(
-        'Wall time',
+        "Wall time",
         log_file=log_file_str,
         fom_regex=timing_regex,
-        group_name='wall',
-        units='s',
-        contexts=['Perf iteration']
+        group_name="wall",
+        units="s",
+        contexts=["Perf iteration"],
     )
 
     figure_of_merit(
-        'Avg. Wall time per time step',
+        "Avg. Wall time per time step",
         log_file=log_file_str,
         fom_regex=timing_regex,
-        group_name='wall_per_step',
-        units='s/timestep',
-        contexts=['Perf iteration']
+        group_name="wall_per_step",
+        units="s/timestep",
+        contexts=["Perf iteration"],
     )
 
     figure_of_merit(
-        'Wall time remaining',
+        "Wall time remaining",
         log_file=log_file_str,
         fom_regex=timing_regex,
-        group_name='remaining',
-        units='hours',
-        contexts=['Perf iteration']
+        group_name="remaining",
+        units="hours",
+        contexts=["Perf iteration"],
     )
 
     figure_of_merit(
-        'Memory used',
+        "Memory used",
         log_file=log_file_str,
         fom_regex=timing_regex,
-        group_name='mem',
-        units='MB',
-        contexts=['Perf iteration']
+        group_name="mem",
+        units="MB",
+        contexts=["Perf iteration"],
     )
 
     # Energy context
-    energy_regex = r'ENERGY:\s+(?P<itr>[0-9]+)'
+    energy_regex = r"ENERGY:\s+(?P<itr>[0-9]+)"
 
     # Name/group_name, units
     energy_foms = [
-        ('BOND', ''),
-        ('ANGLE', ''),
-        ('DIHED', ''),
-        ('IMPRP', ''),
-        ('ELECT', ''),
-        ('VWD', ''),
-        ('BOUNDARY', ''),
-        ('MISC', ''),
-        ('KINETIC', ''),
-        ('TOTAL', ''),
-        ('TEMP', ''),
-        ('POTENTIAL', ''),
-        ('TOTAL3', ''),
-        ('TEMPAVG', ''),
-        ('PRESSURE', ''),
-        ('GPRESSURE', ''),
-        ('VOLUME', ''),
-        ('PRESSAVG', ''),
-        ('GPRESSAVG', ''),
+        ("BOND", ""),
+        ("ANGLE", ""),
+        ("DIHED", ""),
+        ("IMPRP", ""),
+        ("ELECT", ""),
+        ("VWD", ""),
+        ("BOUNDARY", ""),
+        ("MISC", ""),
+        ("KINETIC", ""),
+        ("TOTAL", ""),
+        ("TEMP", ""),
+        ("POTENTIAL", ""),
+        ("TOTAL3", ""),
+        ("TEMPAVG", ""),
+        ("PRESSURE", ""),
+        ("GPRESSURE", ""),
+        ("VOLUME", ""),
+        ("PRESSAVG", ""),
+        ("GPRESSAVG", ""),
     ]
 
     # Build energy regex...
     for energy_fom in energy_foms:
-        energy_regex += r'\s+(?P<' + f'{energy_fom[0]}' + r'>-*[0-9]+\.*[0-9]*)'
+        energy_regex += (
+            r"\s+(?P<" + f"{energy_fom[0]}" + r">-*[0-9]+\.*[0-9]*)"
+        )
 
     figure_of_merit_context(
-        'Energy iteration',
+        "Energy iteration",
         regex=energy_regex,
-        output_format='Energy Iteration: {itr}'
+        output_format="Energy Iteration: {itr}",
     )
 
     figure_of_merit(
-        'Energy iteration',
+        "Energy iteration",
         log_file=log_file_str,
         fom_regex=timing_regex,
-        group_name='itr',
-        units='',
-        contexts=['Energy iteration']
+        group_name="itr",
+        units="",
+        contexts=["Energy iteration"],
     )
 
     for energy_fom in energy_foms:
@@ -243,81 +291,84 @@ class Namd(SpackApplication):
             fom_regex=energy_regex,
             group_name=energy_fom[0],
             units=energy_fom[1],
-            contexts=['Energy iteration']
+            contexts=["Energy iteration"],
         )
 
     # Benchmark foms
-    benchmark_regex = r'Info:\s+Benchmark\s+time:\s+(?P<cpus>[0-9]+)\s+CPUs\s+' + \
-                      r'(?P<wall_per_step>[0-9]+\.[0-9]+)\s+s/step\s+' + \
-                      r'(?P<days_per_ns>[0-9]+\.[0-9]+)\s+days/ns\s+' + \
-                      r'(?P<mem>[0-9]+\.[0-9]+)\s+MB\s+memory'
-
-    figure_of_merit(
-        'Number of CPUs',
-        log_file=log_file_str,
-        fom_regex=benchmark_regex,
-        group_name='cpus',
-        units=''
+    benchmark_regex = (
+        r"Info:\s+Benchmark\s+time:\s+(?P<cpus>[0-9]+)\s+CPUs\s+"
+        + r"(?P<wall_per_step>[0-9]+\.[0-9]+)\s+s/step\s+"
+        + r"(?P<days_per_ns>[0-9]+\.[0-9]+)\s+days/ns\s+"
+        + r"(?P<mem>[0-9]+\.[0-9]+)\s+MB\s+memory"
     )
 
     figure_of_merit(
-        'Benchmark wall time per step',
+        "Number of CPUs",
         log_file=log_file_str,
         fom_regex=benchmark_regex,
-        group_name='wall_per_step',
-        units='s'
+        group_name="cpus",
+        units="",
     )
 
     figure_of_merit(
-        'Benchmark days per nanosecond',
+        "Benchmark wall time per step",
         log_file=log_file_str,
         fom_regex=benchmark_regex,
-        group_name='days_per_ns',
-        units='days/ns'
+        group_name="wall_per_step",
+        units="s",
     )
 
     figure_of_merit(
-        'Benchmark memory used',
+        "Benchmark days per nanosecond",
         log_file=log_file_str,
         fom_regex=benchmark_regex,
-        group_name='mem',
-        units='MB'
+        group_name="days_per_ns",
+        units="days/ns",
+    )
+
+    figure_of_merit(
+        "Benchmark memory used",
+        log_file=log_file_str,
+        fom_regex=benchmark_regex,
+        group_name="mem",
+        units="MB",
     )
 
     # Global figures of merit
-    end_regex = r'\s*WallClock:\s+(?P<wall>[0-9]+\.[0-9]+)\s+CPUTime:\s+(?P<cpu>[0-9]+\.[0-9]+)\s+Memory:\s+(?P<mem>[0-9]+\.[0-9]+)\s+MB'
+    end_regex = r"\s*WallClock:\s+(?P<wall>[0-9]+\.[0-9]+)\s+CPUTime:\s+(?P<cpu>[0-9]+\.[0-9]+)\s+Memory:\s+(?P<mem>[0-9]+\.[0-9]+)\s+MB"
     figure_of_merit(
-        'Final wall time',
+        "Final wall time",
         log_file=log_file_str,
         fom_regex=end_regex,
-        group_name='wall',
-        units='s'
+        group_name="wall",
+        units="s",
     )
 
     figure_of_merit(
-        'Final CPU time',
+        "Final CPU time",
         log_file=log_file_str,
         fom_regex=end_regex,
-        group_name='cpu',
-        units='s'
+        group_name="cpu",
+        units="s",
     )
 
     figure_of_merit(
-        'Final Memory',
+        "Final Memory",
         log_file=log_file_str,
         fom_regex=end_regex,
-        group_name='mem',
-        units='MB'
+        group_name="mem",
+        units="MB",
     )
 
-    namd_nspd_stat_file = os.path.join(Expander.expansion_str('experiment_run_dir'),
-                                       'namd_nspd_stat.out')
+    namd_nspd_stat_file = os.path.join(
+        Expander.expansion_str("experiment_run_dir"), "namd_nspd_stat.out"
+    )
     figure_of_merit(
-        'Nanoseconds per day',
+        "Nanoseconds per day",
         log_file=namd_nspd_stat_file,
-        fom_regex=r'(?P<ns_per_day>[0-9]+\.*[0-9]*) ns/day',
-        group_name='ns_per_day',
-        units='ns/day'
+        fom_regex=r"(?P<ns_per_day>[0-9]+\.*[0-9]*) ns/day",
+        group_name="ns_per_day",
+        units="ns/day",
     )
 
     def _analyze_experiments(self, workspace, app_inst=None):
@@ -329,20 +380,21 @@ class Namd(SpackApplication):
         dpns = None
 
         if os.path.isfile(log_path):
-            with open(log_path, 'r') as f:
+            with open(log_path, "r") as f:
                 for line in f.readlines():
                     match = ns_regex.match(line)
                     if match:
-                        dpns = float(match.group('days_per_ns'))
+                        dpns = float(match.group("days_per_ns"))
 
         if dpns:
             nspd = 1.0 / dpns
             nspd_file_path = os.path.join(
                 self.expander.expand_var(
                     self.expander.expansion_str(keywords.experiment_run_dir)
-                ), 'namd_nspd_stat.out'
+                ),
+                "namd_nspd_stat.out",
             )
-            with open(nspd_file_path, 'w+') as f:
-                f.write(f'{nspd} ns/day\n')
+            with open(nspd_file_path, "w+") as f:
+                f.write(f"{nspd} ns/day\n")
 
         super()._analyze_experiments(workspace)

--- a/var/ramble/repos/builtin/applications/nvbandwidth/application.py
+++ b/var/ramble/repos/builtin/applications/nvbandwidth/application.py
@@ -10,26 +10,32 @@ from ramble.appkit import *
 
 
 class Nvbandwidth(SpackApplication):
-    '''Define the nvbandwidth benchmark'''
-    name = 'nvbandwidth'
+    """Define the nvbandwidth benchmark"""
 
-    maintainers('rfbgo')
+    name = "nvbandwidth"
 
-    tags('synthetic-benchmarks')
+    maintainers("rfbgo")
 
-    software_spec('nvbandwidth', spack_spec='nvbandwidth')
+    tags("synthetic-benchmarks")
 
-    required_package('nvbandwidth')
+    software_spec("nvbandwidth", spack_spec="nvbandwidth")
 
-    workload('all_benchmarks', executable='nvbandwidth')
+    required_package("nvbandwidth")
 
-    workload_variable('transfer-size', default='1m',
-                      description='Transfer Size',
-                      workloads=['all_benchmarks'])
+    workload("all_benchmarks", executable="nvbandwidth")
 
-    executable(name='nvbandwidth', template='nvbandwidth', use_mpi=False)
+    workload_variable(
+        "transfer-size",
+        default="1m",
+        description="Transfer Size",
+        workloads=["all_benchmarks"],
+    )
 
-    figure_of_merit('SUM {metric}',
-                    fom_regex=r'SUM\s+(?P<metric>\w+)\s+(?P<value>\d+\.\d+)',
-                    group_name='value',
-                    units='GB/s')
+    executable(name="nvbandwidth", template="nvbandwidth", use_mpi=False)
+
+    figure_of_merit(
+        "SUM {metric}",
+        fom_regex=r"SUM\s+(?P<metric>\w+)\s+(?P<value>\d+\.\d+)",
+        group_name="value",
+        units="GB/s",
+    )

--- a/var/ramble/repos/builtin/applications/openfoam/application.py
+++ b/var/ramble/repos/builtin/applications/openfoam/application.py
@@ -12,215 +12,383 @@ from ramble.expander import Expander
 
 
 class Openfoam(SpackApplication):
-    '''Define the Openfoam application'''
-    name = 'openfoam'
+    """Define the Openfoam application"""
 
-    maintainers('douglasjacobsen')
+    name = "openfoam"
 
-    tags('cfd', 'fluid', 'dynamics')
+    maintainers("douglasjacobsen")
 
-    define_compiler('gcc9', spack_spec='gcc@9.3.0')
+    tags("cfd", "fluid", "dynamics")
 
-    software_spec('ompi412',
-                  spack_spec='openmpi@4.1.2 +legacylaunchers +cxx',
-                  compiler='gcc9')
+    define_compiler("gcc9", spack_spec="gcc@9.3.0")
 
-    software_spec('flex',
-                  spack_spec='flex@2.6.4',
-                  compiler='gcc9')
-    software_spec('openfoam',
-                  spack_spec='openfoam-org@7',
-                  compiler='gcc9')
+    software_spec(
+        "ompi412",
+        spack_spec="openmpi@4.1.2 +legacylaunchers +cxx",
+        compiler="gcc9",
+    )
 
-    required_package('openfoam-org')
+    software_spec("flex", spack_spec="flex@2.6.4", compiler="gcc9")
+    software_spec("openfoam", spack_spec="openfoam-org@7", compiler="gcc9")
 
-    workload('motorbike', executables=['get_inputs', 'configure_mesh', 'surfaceFeatures',
-                                       'blockMesh', 'decomposePar1', 'snappyHexMesh',
-                                       'reconstructParMesh', 'renumberMesh', 'configure_simplefoam',
-                                       'decomposePar2', 'patchSummary', 'checkMesh', 'potentialFoam',
-                                       'simpleFoam'])
+    required_package("openfoam-org")
 
-    workload('hpc_motorbike', executables=['build_mesh', 'allRun'],
-             input='hpc_motorbike')
+    workload(
+        "motorbike",
+        executables=[
+            "get_inputs",
+            "configure_mesh",
+            "surfaceFeatures",
+            "blockMesh",
+            "decomposePar1",
+            "snappyHexMesh",
+            "reconstructParMesh",
+            "renumberMesh",
+            "configure_simplefoam",
+            "decomposePar2",
+            "patchSummary",
+            "checkMesh",
+            "potentialFoam",
+            "simpleFoam",
+        ],
+    )
 
-    workload_variable('input_path', default='$FOAM_TUTORIALS/incompressible/simpleFoam/motorBike',
-                      description='Path to the tutorial input',
-                      workload='motorbike')
-    workload_variable('geometry_path', default='$FOAM_TUTORIALS/resources/geometry/motorBike.obj.gz',
-                      description='Path to the geometry resource',
-                      workload='motorbike')
-    workload_variable('decomposition_path', default='system/decomposeParDict*',
-                      description='Path to decomposition files',
-                      workloads=['hpc_motorbike', 'motorbike'])
-    workload_variable('control_path', default='system/controlDict',
-                      description='Path to control file',
-                      workloads=['hpc_motorbike', 'motorbike'])
-    workload_variable('block_mesh_path', default='system/blockMeshDict',
-                      description='Path to block mesh file',
-                      workloads=['hpc_motorbike', 'motorbike'])
-    workload_variable('hex_mesh_path', default='system/snappyHexMeshDict',
-                      description='Path to hexh mesh file',
-                      workloads=['hpc_motorbike', 'motorbike'])
+    workload(
+        "hpc_motorbike",
+        executables=["build_mesh", "allRun"],
+        input="hpc_motorbike",
+    )
 
-    workload_variable('end_time', default='250',
-                      description='End time for simulation',
-                      workload='motorbike')
-    workload_variable('write_interval', default='500',
-                      description='Interval to write output files',
-                      workload='motorbike')
-    workload_variable('start_from', default='startTime',
-                      description='How to start a new simulation',
-                      workload='motorbike')
-    workload_variable('mesh_size', default='(20 8 8)',
-                      description='Mesh size for simulation',
-                      workload='motorbike')
-    workload_variable('mesh_size', default='(50 20 20)',
-                      description='Mesh size for simulation',
-                      workload='hpc_motorbike')
-    workload_variable('max_local_cells', default='100000',
-                      description='Max local cells for simulation',
-                      workload='motorbike')
-    workload_variable('max_local_cells', default='10000000',
-                      description='Max local cells for simulation',
-                      workload='hpc_motorbike')
-    workload_variable('max_global_cells', default='50000000',
-                      description='Max global cells for simulation',
-                      workload='motorbike')
-    workload_variable('max_global_cells', default='200000000',
-                      description='Max global cells for simulation',
-                      workload='hpc_motorbike')
+    workload_variable(
+        "input_path",
+        default="$FOAM_TUTORIALS/incompressible/simpleFoam/motorBike",
+        description="Path to the tutorial input",
+        workload="motorbike",
+    )
+    workload_variable(
+        "geometry_path",
+        default="$FOAM_TUTORIALS/resources/geometry/motorBike.obj.gz",
+        description="Path to the geometry resource",
+        workload="motorbike",
+    )
+    workload_variable(
+        "decomposition_path",
+        default="system/decomposeParDict*",
+        description="Path to decomposition files",
+        workloads=["hpc_motorbike", "motorbike"],
+    )
+    workload_variable(
+        "control_path",
+        default="system/controlDict",
+        description="Path to control file",
+        workloads=["hpc_motorbike", "motorbike"],
+    )
+    workload_variable(
+        "block_mesh_path",
+        default="system/blockMeshDict",
+        description="Path to block mesh file",
+        workloads=["hpc_motorbike", "motorbike"],
+    )
+    workload_variable(
+        "hex_mesh_path",
+        default="system/snappyHexMeshDict",
+        description="Path to hexh mesh file",
+        workloads=["hpc_motorbike", "motorbike"],
+    )
 
-    workload_variable('n_ranks_hex', default='16',
-                      description='Number of ranks to use for snappyHexMesh',
-                      workloads=['motorbike'])
-    workload_variable('n_ranks_hex', default='{n_rank}',
-                      description='Number of ranks to use for snappyHexMesh',
-                      workloads=['hpc_motorbike'])
-    workload_variable('hex_flags', default='-overwrite',
-                      description='Flags for snappyHexMesh',
-                      workloads=['hpc_motorbike', 'motorbike'])
-    workload_variable('potential_flags', default='-parallel',
-                      description='Flags for potentialFoam',
-                      workloads=['hpc_motorbike', 'motorbike'])
-    workload_variable('simple_flags', default='-parallel',
-                      description='Flags for simpleFoam',
-                      workloads=['hpc_motorbike', 'motorbike'])
+    workload_variable(
+        "end_time",
+        default="250",
+        description="End time for simulation",
+        workload="motorbike",
+    )
+    workload_variable(
+        "write_interval",
+        default="500",
+        description="Interval to write output files",
+        workload="motorbike",
+    )
+    workload_variable(
+        "start_from",
+        default="startTime",
+        description="How to start a new simulation",
+        workload="motorbike",
+    )
+    workload_variable(
+        "mesh_size",
+        default="(20 8 8)",
+        description="Mesh size for simulation",
+        workload="motorbike",
+    )
+    workload_variable(
+        "mesh_size",
+        default="(50 20 20)",
+        description="Mesh size for simulation",
+        workload="hpc_motorbike",
+    )
+    workload_variable(
+        "max_local_cells",
+        default="100000",
+        description="Max local cells for simulation",
+        workload="motorbike",
+    )
+    workload_variable(
+        "max_local_cells",
+        default="10000000",
+        description="Max local cells for simulation",
+        workload="hpc_motorbike",
+    )
+    workload_variable(
+        "max_global_cells",
+        default="50000000",
+        description="Max global cells for simulation",
+        workload="motorbike",
+    )
+    workload_variable(
+        "max_global_cells",
+        default="200000000",
+        description="Max global cells for simulation",
+        workload="hpc_motorbike",
+    )
 
-    workload_variable('size', default='Large',
-                      description='Size of HPC motorbike workload. Can be Large, Medium, or Small.',
-                      workload='hpc_motorbike')
-    workload_variable('input_version', default='v1912',
-                      description='Version of Openfoam the input was made for. Options are v8 and v1912.',
-                      workload='hpc_motorbike')
-    workload_variable('input_path', default='{hpc_motorbike}/HPC_motorbike/{size}/{input_version}',
-                      description='Path to the HPC_motorbike input',
-                      workload='hpc_motorbike')
+    workload_variable(
+        "n_ranks_hex",
+        default="16",
+        description="Number of ranks to use for snappyHexMesh",
+        workloads=["motorbike"],
+    )
+    workload_variable(
+        "n_ranks_hex",
+        default="{n_rank}",
+        description="Number of ranks to use for snappyHexMesh",
+        workloads=["hpc_motorbike"],
+    )
+    workload_variable(
+        "hex_flags",
+        default="-overwrite",
+        description="Flags for snappyHexMesh",
+        workloads=["hpc_motorbike", "motorbike"],
+    )
+    workload_variable(
+        "potential_flags",
+        default="-parallel",
+        description="Flags for potentialFoam",
+        workloads=["hpc_motorbike", "motorbike"],
+    )
+    workload_variable(
+        "simple_flags",
+        default="-parallel",
+        description="Flags for simpleFoam",
+        workloads=["hpc_motorbike", "motorbike"],
+    )
 
-    input_file('hpc_motorbike',
-               url='https://develop.openfoam.com/committees/hpc/-/archive/develop/hpc-develop.tar.gz',
-               sha256='b285a18332fd718dbdc6b6c90dd7f134c9745cb7eb479d93b394160bbef97390',
-               description='HPC Benchmarking version of the Motorbike input')
+    workload_variable(
+        "size",
+        default="Large",
+        description="Size of HPC motorbike workload. Can be Large, Medium, or Small.",
+        workload="hpc_motorbike",
+    )
+    workload_variable(
+        "input_version",
+        default="v1912",
+        description="Version of Openfoam the input was made for. Options are v8 and v1912.",
+        workload="hpc_motorbike",
+    )
+    workload_variable(
+        "input_path",
+        default="{hpc_motorbike}/HPC_motorbike/{size}/{input_version}",
+        description="Path to the HPC_motorbike input",
+        workload="hpc_motorbike",
+    )
 
-    executable('get_inputs', template=['cp -R {input_path}/* {experiment_run_dir}/.',
-                                       'mkdir -p constant/triSurface',
-                                       'mkdir -p constant/geometry',
-                                       'cp {geometry_path} constant/triSurface/.',
-                                       'cp {geometry_path} constant/geometry/.'],
-               use_mpi=False)
+    input_file(
+        "hpc_motorbike",
+        url="https://develop.openfoam.com/committees/hpc/-/archive/develop/hpc-develop.tar.gz",
+        sha256="b285a18332fd718dbdc6b6c90dd7f134c9745cb7eb479d93b394160bbef97390",
+        description="HPC Benchmarking version of the Motorbike input",
+    )
 
-    executable('build_mesh', template=['cp -R {input_path}/* {experiment_run_dir}/.',
-                                       r'sed "/^numberOfSubdomains/ c\\numberOfSubdomains {n_ranks};" -i {decomposition_path}',
-                                       'chmod a+x All*',
-                                       'mv Allmesh* Allmesh',
-                                       './Allmesh'],
-               use_mpi=False)
+    executable(
+        "get_inputs",
+        template=[
+            "cp -R {input_path}/* {experiment_run_dir}/.",
+            "mkdir -p constant/triSurface",
+            "mkdir -p constant/geometry",
+            "cp {geometry_path} constant/triSurface/.",
+            "cp {geometry_path} constant/geometry/.",
+        ],
+        use_mpi=False,
+    )
 
-    executable('configure_mesh', template=['. $WM_PROJECT_DIR/bin/tools/RunFunctions',
-                                           'rm log.*',
-                                           'foamDictionary -entry "numberOfSubdomains" -set "{n_ranks_hex}" {decomposition_path}',
-                                           'foamDictionary -entry "method" -set "hierarchical" {decomposition_path}',
-                                           'foamDictionary -entry "hierarchicalCoeffs.n" -set "(4 2 2)" {decomposition_path}',
-                                           'foamDictionary -entry "castellatedMeshControls.maxLocalCells" -set "{max_local_cells}" {hex_mesh_path}',
-                                           'foamDictionary -entry "castellatedMeshControls.maxGlobalCells" -set "{max_global_cells}" {hex_mesh_path}',
-                                           'sed "s/(20 8 8)/{mesh_size}/" -i {block_mesh_path}',
-                                           'ln -s 0 0.orig'],
-               use_mpi=False)
+    executable(
+        "build_mesh",
+        template=[
+            "cp -R {input_path}/* {experiment_run_dir}/.",
+            r'sed "/^numberOfSubdomains/ c\\numberOfSubdomains {n_ranks};" -i {decomposition_path}',
+            "chmod a+x All*",
+            "mv Allmesh* Allmesh",
+            "./Allmesh",
+        ],
+        use_mpi=False,
+    )
 
-    executable('configure_simplefoam', template=['. $WM_PROJECT_DIR/bin/tools/RunFunctions',
-                                                 'foamDictionary -entry "numberOfSubdomains" -set "{n_ranks}" {decomposition_path}',
-                                                 'foamDictionary -entry "endTime" -set "{end_time}" {control_path}',
-                                                 'foamDictionary -entry "writeInterval" -set "{write_interval}" {control_path}',
-                                                 'foamDictionary -entry "startFrom" -set "{start_from}" {control_path}',
-                                                 'foamDictionary -entry "hierarchicalCoeffs.n" -set "(3 2 1)" {decomposition_path}',
-                                                 'foamDictionary -entry "method" -set "scotch" {decomposition_path}',
-                                                 'foamDictionary system/fvSolution -entry relaxationFactors.equations.U -set "0.7"',
-                                                 'foamDictionary system/fvSolution -entry relaxationFactors.fields -add "{}"',
-                                                 'foamDictionary system/fvSolution -entry relaxationFactors.fields.p -set "0.3"',
-                                                 'foamDictionary system/fvSolution -entry solvers.p.nPreSweeps -set "0"',
-                                                 'foamDictionary system/fvSolution -entry solvers.p.nPostSweeps -set "2"',
-                                                 'foamDictionary system/fvSolution -entry solvers.p.cacheAgglomeration -set "on"',
-                                                 'foamDictionary system/fvSolution -entry solvers.p.agglomerator -set "faceAreaPair"',
-                                                 'foamDictionary system/fvSolution -entry solvers.p.nCellsInCoarsestLevel -set "10"',
-                                                 'foamDictionary system/fvSolution -entry solvers.p.mergeLevels -set "1"',
-                                                 'foamDictionary system/fvSolution -entry SIMPLE.consistent -set "yes"'],
-               use_mpi=False)
+    executable(
+        "configure_mesh",
+        template=[
+            ". $WM_PROJECT_DIR/bin/tools/RunFunctions",
+            "rm log.*",
+            'foamDictionary -entry "numberOfSubdomains" -set "{n_ranks_hex}" {decomposition_path}',
+            'foamDictionary -entry "method" -set "hierarchical" {decomposition_path}',
+            'foamDictionary -entry "hierarchicalCoeffs.n" -set "(4 2 2)" {decomposition_path}',
+            'foamDictionary -entry "castellatedMeshControls.maxLocalCells" -set "{max_local_cells}" {hex_mesh_path}',
+            'foamDictionary -entry "castellatedMeshControls.maxGlobalCells" -set "{max_global_cells}" {hex_mesh_path}',
+            'sed "s/(20 8 8)/{mesh_size}/" -i {block_mesh_path}',
+            "ln -s 0 0.orig",
+        ],
+        use_mpi=False,
+    )
 
-    executable('surfaceFeatures', 'runApplication surfaceFeatures',
-               use_mpi=False)
+    executable(
+        "configure_simplefoam",
+        template=[
+            ". $WM_PROJECT_DIR/bin/tools/RunFunctions",
+            'foamDictionary -entry "numberOfSubdomains" -set "{n_ranks}" {decomposition_path}',
+            'foamDictionary -entry "endTime" -set "{end_time}" {control_path}',
+            'foamDictionary -entry "writeInterval" -set "{write_interval}" {control_path}',
+            'foamDictionary -entry "startFrom" -set "{start_from}" {control_path}',
+            'foamDictionary -entry "hierarchicalCoeffs.n" -set "(3 2 1)" {decomposition_path}',
+            'foamDictionary -entry "method" -set "scotch" {decomposition_path}',
+            'foamDictionary system/fvSolution -entry relaxationFactors.equations.U -set "0.7"',
+            'foamDictionary system/fvSolution -entry relaxationFactors.fields -add "{}"',
+            'foamDictionary system/fvSolution -entry relaxationFactors.fields.p -set "0.3"',
+            'foamDictionary system/fvSolution -entry solvers.p.nPreSweeps -set "0"',
+            'foamDictionary system/fvSolution -entry solvers.p.nPostSweeps -set "2"',
+            'foamDictionary system/fvSolution -entry solvers.p.cacheAgglomeration -set "on"',
+            'foamDictionary system/fvSolution -entry solvers.p.agglomerator -set "faceAreaPair"',
+            'foamDictionary system/fvSolution -entry solvers.p.nCellsInCoarsestLevel -set "10"',
+            'foamDictionary system/fvSolution -entry solvers.p.mergeLevels -set "1"',
+            'foamDictionary system/fvSolution -entry SIMPLE.consistent -set "yes"',
+        ],
+        use_mpi=False,
+    )
 
-    executable('blockMesh', 'runApplication blockMesh',
-               use_mpi=False)
+    executable(
+        "surfaceFeatures", "runApplication surfaceFeatures", use_mpi=False
+    )
 
-    executable('decomposePar1', template=['rm log.decomposePar', 'runApplication decomposePar'],
-               use_mpi=False)
+    executable("blockMesh", "runApplication blockMesh", use_mpi=False)
 
-    executable('decomposePar2', template=['rm log.decomposePar', 'runApplication decomposePar'],
-               use_mpi=False)
+    executable(
+        "decomposePar1",
+        template=["rm log.decomposePar", "runApplication decomposePar"],
+        use_mpi=False,
+    )
 
-    executable('snappyHexMesh', 'runParallel snappyHexMesh {hex_flags}', use_mpi=False)
-    executable('patchSummary', 'patchSummary', use_mpi=True,
-               redirect='{experiment_run_dir}/log.patchSummary')
-    executable('checkMesh', 'checkMesh', use_mpi=True,
-               redirect='{experiment_run_dir}/log.checkMesh')
-    executable('potentialFoam', 'potentialFoam {potential_flags}', use_mpi=True,
-               redirect='{experiment_run_dir}/log.potentialFoam')
-    executable('simpleFoam', 'simpleFoam {simple_flags}', use_mpi=True,
-               redirect='{experiment_run_dir}/log.simpleFoam')
+    executable(
+        "decomposePar2",
+        template=["rm log.decomposePar", "runApplication decomposePar"],
+        use_mpi=False,
+    )
 
-    executable('reconstructParMesh', 'reconstructParMesh -constant', use_mpi=False,
-               redirect='{experiment_run_dir}/log.reconstructParMesh')
+    executable(
+        "snappyHexMesh", "runParallel snappyHexMesh {hex_flags}", use_mpi=False
+    )
+    executable(
+        "patchSummary",
+        "patchSummary",
+        use_mpi=True,
+        redirect="{experiment_run_dir}/log.patchSummary",
+    )
+    executable(
+        "checkMesh",
+        "checkMesh",
+        use_mpi=True,
+        redirect="{experiment_run_dir}/log.checkMesh",
+    )
+    executable(
+        "potentialFoam",
+        "potentialFoam {potential_flags}",
+        use_mpi=True,
+        redirect="{experiment_run_dir}/log.potentialFoam",
+    )
+    executable(
+        "simpleFoam",
+        "simpleFoam {simple_flags}",
+        use_mpi=True,
+        redirect="{experiment_run_dir}/log.simpleFoam",
+    )
 
-    executable('renumberMesh', template=['rm -rf processor*',
-                                         'renumberMesh -constant -overwrite'],
-               use_mpi=False,
-               redirect='{experiment_run_dir}/log.renumberMesh')
+    executable(
+        "reconstructParMesh",
+        "reconstructParMesh -constant",
+        use_mpi=False,
+        redirect="{experiment_run_dir}/log.reconstructParMesh",
+    )
 
-    executable('allRun', template=[r'sed "s/writephi/writePhi/g" -i Allrun',
-                                   r'sed "s/rm.*log./#/g" -i Allclean',
-                                   r'chmod a+x Allrun',
-                                   './Allrun'],
-               use_mpi=False)
+    executable(
+        "renumberMesh",
+        template=["rm -rf processor*", "renumberMesh -constant -overwrite"],
+        use_mpi=False,
+        redirect="{experiment_run_dir}/log.renumberMesh",
+    )
 
-    log_prefix = os.path.join(Expander.expansion_str('experiment_run_dir'), 'log.')
+    executable(
+        "allRun",
+        template=[
+            r'sed "s/writephi/writePhi/g" -i Allrun',
+            r'sed "s/rm.*log./#/g" -i Allclean',
+            r"chmod a+x Allrun",
+            "./Allrun",
+        ],
+        use_mpi=False,
+    )
 
-    figure_of_merit('Number of cells', log_file=(log_prefix + 'snappyHexMesh'),
-                    fom_regex=r'Layer mesh\s+:\s+cells:(?P<ncells>[0-9]+)\s+.*',
-                    group_name='ncells', units='')
+    log_prefix = os.path.join(
+        Expander.expansion_str("experiment_run_dir"), "log."
+    )
 
-    figure_of_merit('snappyHexMesh Time ({n_ranks_hex} ranks)', log_file=(log_prefix + 'snappyHexMesh'),
-                    fom_regex=r'Finished meshing in = (?P<mesh_time>[0-9]+\.?[0-9]*).*',
-                    group_name='mesh_time', units='s')
+    figure_of_merit(
+        "Number of cells",
+        log_file=(log_prefix + "snappyHexMesh"),
+        fom_regex=r"Layer mesh\s+:\s+cells:(?P<ncells>[0-9]+)\s+.*",
+        group_name="ncells",
+        units="",
+    )
 
-    figure_of_merit('simpleFoam Time ({n_ranks} ranks)', log_file=(log_prefix + 'simpleFoam'),
-                    fom_regex=r'\s*ExecutionTime = (?P<foam_time>[0-9]+\.?[0-9]*).*',
-                    group_name='foam_time', units='s')
+    figure_of_merit(
+        "snappyHexMesh Time ({n_ranks_hex} ranks)",
+        log_file=(log_prefix + "snappyHexMesh"),
+        fom_regex=r"Finished meshing in = (?P<mesh_time>[0-9]+\.?[0-9]*).*",
+        group_name="mesh_time",
+        units="s",
+    )
 
-    figure_of_merit('potentialFoam Time ({n_ranks} ranks)', log_file=(log_prefix + 'potentialFoam'),
-                    fom_regex=r'\s*ExecutionTime = (?P<foam_time>[0-9]+\.?[0-9]*).*',
-                    group_name='foam_time', units='s')
+    figure_of_merit(
+        "simpleFoam Time ({n_ranks} ranks)",
+        log_file=(log_prefix + "simpleFoam"),
+        fom_regex=r"\s*ExecutionTime = (?P<foam_time>[0-9]+\.?[0-9]*).*",
+        group_name="foam_time",
+        units="s",
+    )
 
-    success_criteria('snappyHexMesh_completed', mode='string', match='Finalising parallel run',
-                     file='{experiment_run_dir}/log.snappyHexMesh')
+    figure_of_merit(
+        "potentialFoam Time ({n_ranks} ranks)",
+        log_file=(log_prefix + "potentialFoam"),
+        fom_regex=r"\s*ExecutionTime = (?P<foam_time>[0-9]+\.?[0-9]*).*",
+        group_name="foam_time",
+        units="s",
+    )
 
-    success_criteria('simpleFoam_completed', mode='string', match='Finalising parallel run',
-                     file='{experiment_run_dir}/log.simpleFoam')
+    success_criteria(
+        "snappyHexMesh_completed",
+        mode="string",
+        match="Finalising parallel run",
+        file="{experiment_run_dir}/log.snappyHexMesh",
+    )
+
+    success_criteria(
+        "simpleFoam_completed",
+        mode="string",
+        match="Finalising parallel run",
+        file="{experiment_run_dir}/log.simpleFoam",
+    )

--- a/var/ramble/repos/builtin/applications/osu-micro-benchmarks/application.py
+++ b/var/ramble/repos/builtin/applications/osu-micro-benchmarks/application.py
@@ -16,153 +16,208 @@ from enum import Enum
 
 
 class OsuMicroBenchmarks(SpackApplication):
-    '''Define an OSU micro benchmarks application'''
-    name = 'osu-micro-benchmarks'
+    """Define an OSU micro benchmarks application"""
 
-    maintainers('rfbgo', 'douglasjacobsen')
+    name = "osu-micro-benchmarks"
 
-    tags('synthetic-benchmarks')
+    maintainers("rfbgo", "douglasjacobsen")
 
-    define_compiler('gcc', spack_spec='gcc')
-    software_spec('openmpi', spack_spec='openmpi')
-    software_spec('osu-micro-benchmarks', spack_spec='osu-micro-benchmarks',
-                  compiler='gcc')
+    tags("synthetic-benchmarks")
 
-    required_package('osu-micro-benchmarks')
+    define_compiler("gcc", spack_spec="gcc")
+    software_spec("openmpi", spack_spec="openmpi")
+    software_spec(
+        "osu-micro-benchmarks",
+        spack_spec="osu-micro-benchmarks",
+        compiler="gcc",
+    )
+
+    required_package("osu-micro-benchmarks")
 
     all_workloads = [
-        'osu_bibw',
-        'osu_bw',
-        'osu_latency',
-        'osu_latency_mp',
-        'osu_latency_mt',
-        'osu_mbw_mr',
-        'osu_multi_lat',
-        'osu_allgather',
-        'osu_allreduce_persistent',
-        'osu_alltoallw',
-        'osu_bcast_persistent',
-        'osu_iallgather',
-        'osu_ialltoallw',
-        'osu_ineighbor_allgather',
-        'osu_ireduce',
-        'osu_neighbor_allgatherv',
-        'osu_reduce_persistent',
-        'osu_scatterv',
-        'osu_allgather_persistent',
-        'osu_alltoall',
-        'osu_alltoallw_persistent',
-        'osu_gather',
-        'osu_iallgatherv',
-        'osu_ibarrier',
-        'osu_ineighbor_allgatherv',
-        'osu_ireduce_scatter',
-        'osu_neighbor_alltoall',
-        'osu_reduce_scatter',
-        'osu_scatterv_persistent',
-        'osu_allgatherv',
-        'osu_alltoall_persistent',
-        'osu_barrier',
-        'osu_gather_persistent',
-        'osu_iallreduce',
-        'osu_ibcast',
-        'osu_ineighbor_alltoall',
-        'osu_iscatter',
-        'osu_neighbor_alltoallv',
-        'osu_reduce_scatter_persistent',
-        'osu_allgatherv_persistent',
-        'osu_alltoallv',
-        'osu_barrier_persistent',
-        'osu_gatherv',
-        'osu_ialltoall',
-        'osu_igather',
-        'osu_ineighbor_alltoallv',
-        'osu_iscatterv',
-        'osu_neighbor_alltoallw',
-        'osu_scatter',
-        'osu_allreduce',
-        'osu_alltoallv_persistent',
-        'osu_bcast',
-        'osu_gatherv_persistent',
-        'osu_ialltoallv',
-        'osu_igatherv',
-        'osu_ineighbor_alltoallw',
-        'osu_neighbor_allgather',
-        'osu_reduce',
-        'osu_scatter_persistent',
-        'osu_acc_latency',
-        'osu_cas_latency',
-        'osu_fop_latency',
-        'osu_get_acc_latency',
-        'osu_get_bw',
-        'osu_get_latency',
-        'osu_put_bibw',
-        'osu_put_bw',
-        'osu_put_latency',
-        'osu_hello',
-        'osu_init',
+        "osu_bibw",
+        "osu_bw",
+        "osu_latency",
+        "osu_latency_mp",
+        "osu_latency_mt",
+        "osu_mbw_mr",
+        "osu_multi_lat",
+        "osu_allgather",
+        "osu_allreduce_persistent",
+        "osu_alltoallw",
+        "osu_bcast_persistent",
+        "osu_iallgather",
+        "osu_ialltoallw",
+        "osu_ineighbor_allgather",
+        "osu_ireduce",
+        "osu_neighbor_allgatherv",
+        "osu_reduce_persistent",
+        "osu_scatterv",
+        "osu_allgather_persistent",
+        "osu_alltoall",
+        "osu_alltoallw_persistent",
+        "osu_gather",
+        "osu_iallgatherv",
+        "osu_ibarrier",
+        "osu_ineighbor_allgatherv",
+        "osu_ireduce_scatter",
+        "osu_neighbor_alltoall",
+        "osu_reduce_scatter",
+        "osu_scatterv_persistent",
+        "osu_allgatherv",
+        "osu_alltoall_persistent",
+        "osu_barrier",
+        "osu_gather_persistent",
+        "osu_iallreduce",
+        "osu_ibcast",
+        "osu_ineighbor_alltoall",
+        "osu_iscatter",
+        "osu_neighbor_alltoallv",
+        "osu_reduce_scatter_persistent",
+        "osu_allgatherv_persistent",
+        "osu_alltoallv",
+        "osu_barrier_persistent",
+        "osu_gatherv",
+        "osu_ialltoall",
+        "osu_igather",
+        "osu_ineighbor_alltoallv",
+        "osu_iscatterv",
+        "osu_neighbor_alltoallw",
+        "osu_scatter",
+        "osu_allreduce",
+        "osu_alltoallv_persistent",
+        "osu_bcast",
+        "osu_gatherv_persistent",
+        "osu_ialltoallv",
+        "osu_igatherv",
+        "osu_ineighbor_alltoallw",
+        "osu_neighbor_allgather",
+        "osu_reduce",
+        "osu_scatter_persistent",
+        "osu_acc_latency",
+        "osu_cas_latency",
+        "osu_fop_latency",
+        "osu_get_acc_latency",
+        "osu_get_bw",
+        "osu_get_latency",
+        "osu_put_bibw",
+        "osu_put_bw",
+        "osu_put_latency",
+        "osu_hello",
+        "osu_init",
     ]
 
-    size_time_regex = r'(?P<msg_size>[0-9.]+)+\s+(?P<fom>[0-9.]+)'
-    figure_of_merit_context('msg_size',
-                            regex=size_time_regex,
-                            output_format='Message Size: {msg_size}')
+    size_time_regex = r"(?P<msg_size>[0-9.]+)+\s+(?P<fom>[0-9.]+)"
+    figure_of_merit_context(
+        "msg_size",
+        regex=size_time_regex,
+        output_format="Message Size: {msg_size}",
+    )
 
-    log_str = Expander.expansion_str('log_file')
+    log_str = Expander.expansion_str("log_file")
     for benchmark in all_workloads:
-        executable(name=f'execute-{benchmark}', template=f'{benchmark} ' + '{additional_args}', use_mpi=True)
-        workload(benchmark, executable=f'execute-{benchmark}')
+        executable(
+            name=f"execute-{benchmark}",
+            template=f"{benchmark} " + "{additional_args}",
+            use_mpi=True,
+        )
+        workload(benchmark, executable=f"execute-{benchmark}")
 
-    workload_variable('additional_args', default='',
-                      description='Additional arguments for benchmark',
-                      workloads=all_workloads)
+    workload_variable(
+        "additional_args",
+        default="",
+        description="Additional arguments for benchmark",
+        workloads=all_workloads,
+    )
 
-    data_type_regex = r'# Datatype: (?P<type>\S+)\.'
-    figure_of_merit('OMB Datatype', fom_regex=data_type_regex, group_name='type', units='')
+    data_type_regex = r"# Datatype: (?P<type>\S+)\."
+    figure_of_merit(
+        "OMB Datatype", fom_regex=data_type_regex, group_name="type", units=""
+    )
 
-    hello_regex = r'This is a test with (?P<nprocs>[0-9]+) processes'
-    figure_of_merit('osu_hello_nprocs', fom_regex=hello_regex, group_name='nprocs', units='')
+    hello_regex = r"This is a test with (?P<nprocs>[0-9]+) processes"
+    figure_of_merit(
+        "osu_hello_nprocs",
+        fom_regex=hello_regex,
+        group_name="nprocs",
+        units="",
+    )
 
-    init_regex = r'nprocs: (?P<nprocs>[0-9]+), min: (?P<min>[0-9\.]+) ms, max: (?P<max>[0-9\.]+) ms, avg: (?P<avg>[0-9\.]+) ms'
-    figure_of_merit('osu_init_nprocs', fom_regex=init_regex, group_name='nprocs', units='')
-    figure_of_merit('osu_init_min', fom_regex=init_regex, group_name='min', units='ms')
-    figure_of_merit('osu_init_max', fom_regex=init_regex, group_name='max', units='ms')
-    figure_of_merit('osu_init_avg', fom_regex=init_regex, group_name='avg', units='ms')
+    init_regex = r"nprocs: (?P<nprocs>[0-9]+), min: (?P<min>[0-9\.]+) ms, max: (?P<max>[0-9\.]+) ms, avg: (?P<avg>[0-9\.]+) ms"
+    figure_of_merit(
+        "osu_init_nprocs", fom_regex=init_regex, group_name="nprocs", units=""
+    )
+    figure_of_merit(
+        "osu_init_min", fom_regex=init_regex, group_name="min", units="ms"
+    )
+    figure_of_merit(
+        "osu_init_max", fom_regex=init_regex, group_name="max", units="ms"
+    )
+    figure_of_merit(
+        "osu_init_avg", fom_regex=init_regex, group_name="avg", units="ms"
+    )
 
-    fom_types = Enum('fom_types', ['single_lat', 'single_tail_lat',
-                                   'avg_lat', 'avg_tail_lat', 'multi_lat', 'multi_tail_lat',
-                                   'single_bw', 'single_tail_bw', 'multi_bw', 'multi_tail_bw',
-                                   'single_avg_lat', 'single_avg_tail_lat'])
+    fom_types = Enum(
+        "fom_types",
+        [
+            "single_lat",
+            "single_tail_lat",
+            "avg_lat",
+            "avg_tail_lat",
+            "multi_lat",
+            "multi_tail_lat",
+            "single_bw",
+            "single_tail_bw",
+            "multi_bw",
+            "multi_tail_bw",
+            "single_avg_lat",
+            "single_avg_tail_lat",
+        ],
+    )
 
     fom_regex_headers = {
-        fom_types.single_lat: re.compile(r'#\s+Size\s+Latency \(us\)\s*$'),
-        fom_types.single_tail_lat: re.compile(r'# Size\s+Latency \(us\)\s+P50 Tail Lat\(us\)\s+P90 Tail Lat\(us\)\s+P99 Tail Lat\(us\)$'),
-        fom_types.avg_lat: re.compile(r'#\s+Size\s+Avg Latency\(us\)\s*$'),
-        fom_types.avg_tail_lat: re.compile(r'# Size\s+Avg Latency\(us\)\s+P50 Tail Lat\(us\)\s+P90 Tail Lat\(us\)\s+P99 Tail Lat\(us\)$'),
-        fom_types.multi_lat: re.compile(r'#\s+Size\s+Overall\(us\)\s+Compute\(us\)\s+Pure Comm\.\(us\)\s+Overlap\(%\)\s*$'),
-        fom_types.multi_tail_lat: re.compile(r'# Size\s+Overall\(us\)\s+Compute\(us\)\s+Pure Comm\.\(us\)\s+Overlap\(%\)  P50 Tail Lat\(us\)  P90 Tail Lat\(us\)  P99 Tail Lat\(us\)\s*$'),
-        fom_types.single_bw: re.compile(r'# Size\s+Bandwidth \(MB/s\)\s*$'),
-        fom_types.single_tail_bw: re.compile(r'# Size\s+Bandwidth \(MB/s\) P50 Tail BW\(MB/s\) P90 Tail BW\(MB/s\) P99 Tail BW\(MB/s\)\s*$'),
-        fom_types.multi_bw: re.compile(r'# Size\s+MB/s\s+Messages/s\s*$'),
-        fom_types.multi_tail_bw: re.compile(r'# Size\s+MB/s\s+Messages/s P50 Tail BW\(MB/s\) P90 Tail BW\(MB/s\) P99 Tail BW\(MB/s\)\s*$'),
-        fom_types.single_avg_lat: re.compile(r'# Avg Latency\(us\)\s*$'),
-        fom_types.single_avg_tail_lat: re.compile(r'# Avg Latency\(us\)\s+P50 Tail Lat\(us\)\s+P90 Tail Lat\(us\)\s+P99 Tail Lat\(us\)\s*$')
+        fom_types.single_lat: re.compile(r"#\s+Size\s+Latency \(us\)\s*$"),
+        fom_types.single_tail_lat: re.compile(
+            r"# Size\s+Latency \(us\)\s+P50 Tail Lat\(us\)\s+P90 Tail Lat\(us\)\s+P99 Tail Lat\(us\)$"
+        ),
+        fom_types.avg_lat: re.compile(r"#\s+Size\s+Avg Latency\(us\)\s*$"),
+        fom_types.avg_tail_lat: re.compile(
+            r"# Size\s+Avg Latency\(us\)\s+P50 Tail Lat\(us\)\s+P90 Tail Lat\(us\)\s+P99 Tail Lat\(us\)$"
+        ),
+        fom_types.multi_lat: re.compile(
+            r"#\s+Size\s+Overall\(us\)\s+Compute\(us\)\s+Pure Comm\.\(us\)\s+Overlap\(%\)\s*$"
+        ),
+        fom_types.multi_tail_lat: re.compile(
+            r"# Size\s+Overall\(us\)\s+Compute\(us\)\s+Pure Comm\.\(us\)\s+Overlap\(%\)  P50 Tail Lat\(us\)  P90 Tail Lat\(us\)  P99 Tail Lat\(us\)\s*$"
+        ),
+        fom_types.single_bw: re.compile(r"# Size\s+Bandwidth \(MB/s\)\s*$"),
+        fom_types.single_tail_bw: re.compile(
+            r"# Size\s+Bandwidth \(MB/s\) P50 Tail BW\(MB/s\) P90 Tail BW\(MB/s\) P99 Tail BW\(MB/s\)\s*$"
+        ),
+        fom_types.multi_bw: re.compile(r"# Size\s+MB/s\s+Messages/s\s*$"),
+        fom_types.multi_tail_bw: re.compile(
+            r"# Size\s+MB/s\s+Messages/s P50 Tail BW\(MB/s\) P90 Tail BW\(MB/s\) P99 Tail BW\(MB/s\)\s*$"
+        ),
+        fom_types.single_avg_lat: re.compile(r"# Avg Latency\(us\)\s*$"),
+        fom_types.single_avg_tail_lat: re.compile(
+            r"# Avg Latency\(us\)\s+P50 Tail Lat\(us\)\s+P90 Tail Lat\(us\)\s+P99 Tail Lat\(us\)\s*$"
+        ),
     }
 
     group_mapping = {
-        'avg_lat': {'name': 'Latency', 'units': 'us'},
-        'p50_lat': {'name': 'P50 Tail Latency', 'units': 'us'},
-        'p90_lat': {'name': 'P90 Tail Latency', 'units': 'us'},
-        'p99_lat': {'name': 'P99 Tail Latency', 'units': 'us'},
-        'avg_bw': {'name': 'Bandwidth', 'units': 'MB/s'},
-        'p50_bw': {'name': 'P50 Tail Bandwidth', 'units': 'MB/s'},
-        'p90_bw': {'name': 'P90 Tail Bandwidth', 'units': 'MB/s'},
-        'p99_bw': {'name': 'P99 Tail Bandwidth', 'units': 'MB/s'},
-        'overall_lat': {'name': 'Overall', 'units': 'us'},
-        'comp_lat': {'name': 'Computation', 'units': 'us'},
-        'comm_lat': {'name': 'Communication', 'units': 'us'},
-        'overlap': {'name': 'Overlap', 'units': '%'},
-        'msg_rate': {'name': 'Message Rate', 'units': 'Messages/s'},
+        "avg_lat": {"name": "Latency", "units": "us"},
+        "p50_lat": {"name": "P50 Tail Latency", "units": "us"},
+        "p90_lat": {"name": "P90 Tail Latency", "units": "us"},
+        "p99_lat": {"name": "P99 Tail Latency", "units": "us"},
+        "avg_bw": {"name": "Bandwidth", "units": "MB/s"},
+        "p50_bw": {"name": "P50 Tail Bandwidth", "units": "MB/s"},
+        "p90_bw": {"name": "P90 Tail Bandwidth", "units": "MB/s"},
+        "p99_bw": {"name": "P99 Tail Bandwidth", "units": "MB/s"},
+        "overall_lat": {"name": "Overall", "units": "us"},
+        "comp_lat": {"name": "Computation", "units": "us"},
+        "comm_lat": {"name": "Communication", "units": "us"},
+        "overlap": {"name": "Overlap", "units": "%"},
+        "msg_rate": {"name": "Message Rate", "units": "Messages/s"},
     }
 
     def _add_foms(self, regex: str):
@@ -179,20 +234,24 @@ class OsuMicroBenchmarks(SpackApplication):
 
         for grp_name, _ in compiled.groupindex.items():
             if grp_name in self.group_mapping:
-                self.figure_of_merit(self.group_mapping[grp_name]['name'],
-                                     fom_regex=regex,
-                                     group_name=grp_name,
-                                     units=self.group_mapping[grp_name]['units'],
-                                     contexts=['msg_size'])
+                self.figure_of_merit(
+                    self.group_mapping[grp_name]["name"],
+                    fom_regex=regex,
+                    group_name=grp_name,
+                    units=self.group_mapping[grp_name]["units"],
+                    contexts=["msg_size"],
+                )
 
     def _prepare_analysis(self, workspace, app_inst=None):
-        test_ver_regex = r'# OSU.*Test (?P<ver>v[0-9\.]+)'
-        self.figure_of_merit('OMB Version', fom_regex=test_ver_regex, group_name='ver', units='')
+        test_ver_regex = r"# OSU.*Test (?P<ver>v[0-9\.]+)"
+        self.figure_of_merit(
+            "OMB Version", fom_regex=test_ver_regex, group_name="ver", units=""
+        )
 
         fom_type = None
-        log_file = self.expander.expand_var_name('log_file')
+        log_file = self.expander.expand_var_name("log_file")
         if os.path.isfile(log_file):
-            with open(log_file, 'r') as f:
+            with open(log_file, "r") as f:
                 for line in f.readlines():
                     for test_fom_type in self.fom_types:
                         if self.fom_regex_headers[test_fom_type].match(line):
@@ -203,25 +262,25 @@ class OsuMicroBenchmarks(SpackApplication):
 
         fom_regex = None
         if fom_type == self.fom_types.single_lat:
-            fom_regex = r'\s*(?P<msg_size>[0-9]+)+\s+(?P<avg_lat>[0-9\.]+)\s*$'
+            fom_regex = r"\s*(?P<msg_size>[0-9]+)+\s+(?P<avg_lat>[0-9\.]+)\s*$"
             self._add_foms(fom_regex)
         elif fom_type == self.fom_types.single_tail_lat:
-            fom_regex = r'\s*(?P<msg_size>[0-9]+)\s+(?P<avg_lat>[0-9\.]+)\s+(?P<p50_lat>[0-9\.]+)\s+(?P<p90_lat>[0-9\.]+)\s+(?P<p99_lat>[0-9\.]+)\s*$'
+            fom_regex = r"\s*(?P<msg_size>[0-9]+)\s+(?P<avg_lat>[0-9\.]+)\s+(?P<p50_lat>[0-9\.]+)\s+(?P<p90_lat>[0-9\.]+)\s+(?P<p99_lat>[0-9\.]+)\s*$"
         elif fom_type == self.fom_types.avg_lat:
-            fom_regex = r'\s*(?P<msg_size>[0-9]+)+\s+(?P<avg_lat>[0-9\.]+)\s*$'
+            fom_regex = r"\s*(?P<msg_size>[0-9]+)+\s+(?P<avg_lat>[0-9\.]+)\s*$"
         elif fom_type == self.fom_types.avg_tail_lat:
-            fom_regex = r'\s*(?P<msg_size>[0-9]+)\s+(?P<avg_lat>[0-9\.]+)\s+(?P<p50_lat>[0-9\.]+)\s+(?P<p90_lat>[0-9\.]+)\s+(?P<p99_lat>[0-9\.]+)\s*$'
+            fom_regex = r"\s*(?P<msg_size>[0-9]+)\s+(?P<avg_lat>[0-9\.]+)\s+(?P<p50_lat>[0-9\.]+)\s+(?P<p90_lat>[0-9\.]+)\s+(?P<p99_lat>[0-9\.]+)\s*$"
         elif fom_type == self.fom_types.single_bw:
-            fom_regex = r'\s*(?P<msg_size>[0-9]+)\s+(?P<avg_bw>[0-9\.]+)\s*$'
+            fom_regex = r"\s*(?P<msg_size>[0-9]+)\s+(?P<avg_bw>[0-9\.]+)\s*$"
         elif fom_type == self.fom_types.single_tail_bw:
-            fom_regex = r'\s*(?P<msg_size>[0-9]+)\s+(?P<avg_bw>[0-9\.]+)\s+(?P<p50_bw>[0-9\.]+)\s+(?P<p90_bw>[0-9\.]+)\s+(?P<p99_bw>[0-9\.]+)\s*$'
+            fom_regex = r"\s*(?P<msg_size>[0-9]+)\s+(?P<avg_bw>[0-9\.]+)\s+(?P<p50_bw>[0-9\.]+)\s+(?P<p90_bw>[0-9\.]+)\s+(?P<p99_bw>[0-9\.]+)\s*$"
         elif fom_type == self.fom_types.multi_bw:
-            fom_regex = r'\s*(?P<msg_size>[0-9]+)\s+(?P<avg_bw>[0-9\.]+)\s+(?P<msg_rate>[0-9\.]+)\s*$'
+            fom_regex = r"\s*(?P<msg_size>[0-9]+)\s+(?P<avg_bw>[0-9\.]+)\s+(?P<msg_rate>[0-9\.]+)\s*$"
         elif fom_type == self.fom_types.multi_tail_bw:
-            fom_regex = r'\s*(?P<msg_size>[0-9]+)\s+(?P<avg_bw>[0-9\.]+)\s+(?P<msg_rate>[0-9\.]+)\s+(?P<p50_bw>[0-9\.]+)\s+(?P<p90_bw>[0-9\.]+)\s+(?P<p99_bw>[0-9\.]+)\s*$'
+            fom_regex = r"\s*(?P<msg_size>[0-9]+)\s+(?P<avg_bw>[0-9\.]+)\s+(?P<msg_rate>[0-9\.]+)\s+(?P<p50_bw>[0-9\.]+)\s+(?P<p90_bw>[0-9\.]+)\s+(?P<p99_bw>[0-9\.]+)\s*$"
         elif fom_type == self.fom_types.single_avg_lat:
-            fom_regex = r'\s*(?P<avg_lat>[0-9\.]+)\s*$'
+            fom_regex = r"\s*(?P<avg_lat>[0-9\.]+)\s*$"
         elif fom_type == self.fom_types.single_avg_tail_lat:
-            fom_regex = r'\s*(?P<avg_lat>[0-9\.]+)\s+(?P<p50_lat>[0-9\.]+)\s+(?P<p90_lat>[0-9\.]+)\s+(?P<p99_lat>[0-9\.]+)\s*$'
+            fom_regex = r"\s*(?P<avg_lat>[0-9\.]+)\s+(?P<p50_lat>[0-9\.]+)\s+(?P<p90_lat>[0-9\.]+)\s+(?P<p99_lat>[0-9\.]+)\s*$"
 
         self._add_foms(fom_regex)

--- a/var/ramble/repos/builtin/applications/quantum-espresso/application.py
+++ b/var/ramble/repos/builtin/applications/quantum-espresso/application.py
@@ -12,129 +12,230 @@ from ramble.expander import Expander
 
 
 class QuantumEspresso(SpackApplication):
-    '''Define Quantum-Espresso application.'''
-    name = 'quantum-espresso'
+    """Define Quantum-Espresso application."""
 
-    maintainers('douglasjacobsen')
+    name = "quantum-espresso"
 
-    tags('electronic-structure', 'materials', 'dft', 'density-functional-theory', 'plane-waves', 'pseudopotentials')
+    maintainers("douglasjacobsen")
 
-    define_compiler('gcc13', spack_spec='gcc@13.1.0')
+    tags(
+        "electronic-structure",
+        "materials",
+        "dft",
+        "density-functional-theory",
+        "plane-waves",
+        "pseudopotentials",
+    )
 
-    software_spec('impi2021p8', spack_spec='intel-oneapi-mpi@2021.8.0')
-    software_spec('quantum-espresso', spack_spec='quantum-espresso@7.1', compiler='gcc13')
+    define_compiler("gcc13", spack_spec="gcc@13.1.0")
 
-    required_package('quantum-espresso')
+    software_spec("impi2021p8", spack_spec="intel-oneapi-mpi@2021.8.0")
+    software_spec(
+        "quantum-espresso", spack_spec="quantum-espresso@7.1", compiler="gcc13"
+    )
 
-    input_file('AUSURF112', url='https://github.com/QEF/benchmarks/releases/download/bench0.0/AUSURF112.tgz',
-               sha256='2b71c27801f8abbde05f48297b56b3194be0f83be50c50433f44bb886cac5117',
-               description='Input file for AUSURF112 benchmark')
+    required_package("quantum-espresso")
 
-    input_file('CNT10POR8', url='https://github.com/QEF/benchmarks/releases/download/bench0.0/CNT10POR8.tgz',
-               sha256='65e36acd332c1511cfa9cbdab0170a867b3144c98103c5bff3c5621ef795c00a',
-               description='Input file for CNT10POR8 benchmark')
+    input_file(
+        "AUSURF112",
+        url="https://github.com/QEF/benchmarks/releases/download/bench0.0/AUSURF112.tgz",
+        sha256="2b71c27801f8abbde05f48297b56b3194be0f83be50c50433f44bb886cac5117",
+        description="Input file for AUSURF112 benchmark",
+    )
 
-    input_file('GRIR443', url='https://github.com/QEF/benchmarks/releases/download/bench0.0/GRIR443.tgz',
-               sha256='18016da632cde8624faeb07f3de04151a02f3b885aa4cbc111d6b912215403f8',
-               description='Input file for GRIR443 benchmark')
+    input_file(
+        "CNT10POR8",
+        url="https://github.com/QEF/benchmarks/releases/download/bench0.0/CNT10POR8.tgz",
+        sha256="65e36acd332c1511cfa9cbdab0170a867b3144c98103c5bff3c5621ef795c00a",
+        description="Input file for CNT10POR8 benchmark",
+    )
 
-    input_file('GRIR686', url='https://github.com/QEF/benchmarks/releases/download/bench0.0/GRIR686.tgz',
-               sha256='4ade7691f88dd322b41abecbc08cc55437f9d376142e62b615317598abe498d7',
-               description='Input file for GRIR686 benchmark')
+    input_file(
+        "GRIR443",
+        url="https://github.com/QEF/benchmarks/releases/download/bench0.0/GRIR443.tgz",
+        sha256="18016da632cde8624faeb07f3de04151a02f3b885aa4cbc111d6b912215403f8",
+        description="Input file for GRIR443 benchmark",
+    )
 
-    input_file('PSIWAT', url='https://github.com/QEF/benchmarks/releases/download/bench0.0/PSIWAT.tgz',
-               sha256='698fbdac9f307b9ebc77e70e52574d67adb0f21bfd6874559d633471664b77d6',
-               description='Input file for PSIWAT benchmark')
+    input_file(
+        "GRIR686",
+        url="https://github.com/QEF/benchmarks/releases/download/bench0.0/GRIR686.tgz",
+        sha256="4ade7691f88dd322b41abecbc08cc55437f9d376142e62b615317598abe498d7",
+        description="Input file for GRIR686 benchmark",
+    )
 
-    input_file('WATER_EXX', url='https://raw.githubusercontent.com/QEF/benchmarks/master/other-inputs/water/pw.in',
-               sha256='20a20b2f9370103cc62b97367b36d95017a4e9330b693fefe8742c345e963bbc',
-               expand=False,
-               description='Input file for WATER_EXX benchmark')
+    input_file(
+        "PSIWAT",
+        url="https://github.com/QEF/benchmarks/releases/download/bench0.0/PSIWAT.tgz",
+        sha256="698fbdac9f307b9ebc77e70e52574d67adb0f21bfd6874559d633471664b77d6",
+        description="Input file for PSIWAT benchmark",
+    )
 
-    input_file('WATER_EXX_H', url='https://raw.githubusercontent.com/QEF/benchmarks/master/other-inputs/water/pseudo/H.pbe-mt_fhi.UPF',
-               sha256='124e26c52bc3ccaa24012895ad5f4902e1f646546a3477be7e7e6080a2f6b3af',
-               expand=False,
-               description='H Pseudopotential for WATER_EXX benchmark')
+    input_file(
+        "WATER_EXX",
+        url="https://raw.githubusercontent.com/QEF/benchmarks/master/other-inputs/water/pw.in",
+        sha256="20a20b2f9370103cc62b97367b36d95017a4e9330b693fefe8742c345e963bbc",
+        expand=False,
+        description="Input file for WATER_EXX benchmark",
+    )
 
-    input_file('WATER_EXX_O', url='https://raw.githubusercontent.com/QEF/benchmarks/master/other-inputs/water/pseudo/O.pbe-mt_fhi.UPF',
-               sha256='436751b1fe7bb83e647fb1a9d754d2d9c1057e7df6243811fc8ca266f5f74fc8',
-               expand=False,
-               description='O Pseudopotential for WATER_EXX benchmark')
+    input_file(
+        "WATER_EXX_H",
+        url="https://raw.githubusercontent.com/QEF/benchmarks/master/other-inputs/water/pseudo/H.pbe-mt_fhi.UPF",
+        sha256="124e26c52bc3ccaa24012895ad5f4902e1f646546a3477be7e7e6080a2f6b3af",
+        expand=False,
+        description="H Pseudopotential for WATER_EXX benchmark",
+    )
 
-    executable('copy_inputs', 'cp ' + os.path.join(Expander.expansion_str('input_path'), '*') + ' '
-               + os.path.join(Expander.expansion_str('experiment_run_dir'), '.'),
-               use_mpi=False)
-    executable('copy_potential1',
-               template=[
-                   'mkdir -p {experiment_run_dir}/pseudo',
-                   'cp {potential1} {experiment_run_dir}/pseudo/.'
-               ],
-               use_mpi=False)
-    executable('copy_potential2',
-               template=[
-                   'mkdir -p {experiment_run_dir}/pseudo',
-                   'cp {potential2} {experiment_run_dir}/pseudo/.'
-               ],
-               use_mpi=False)
+    input_file(
+        "WATER_EXX_O",
+        url="https://raw.githubusercontent.com/QEF/benchmarks/master/other-inputs/water/pseudo/O.pbe-mt_fhi.UPF",
+        sha256="436751b1fe7bb83e647fb1a9d754d2d9c1057e7df6243811fc8ca266f5f74fc8",
+        expand=False,
+        description="O Pseudopotential for WATER_EXX benchmark",
+    )
 
-    executable('execute', 'pw.x {flags} < {input_file}', use_mpi=True)
+    executable(
+        "copy_inputs",
+        "cp "
+        + os.path.join(Expander.expansion_str("input_path"), "*")
+        + " "
+        + os.path.join(Expander.expansion_str("experiment_run_dir"), "."),
+        use_mpi=False,
+    )
+    executable(
+        "copy_potential1",
+        template=[
+            "mkdir -p {experiment_run_dir}/pseudo",
+            "cp {potential1} {experiment_run_dir}/pseudo/.",
+        ],
+        use_mpi=False,
+    )
+    executable(
+        "copy_potential2",
+        template=[
+            "mkdir -p {experiment_run_dir}/pseudo",
+            "cp {potential2} {experiment_run_dir}/pseudo/.",
+        ],
+        use_mpi=False,
+    )
 
-    workload_names = ['AUSURF112', 'CNT10POR8', 'GRIR443', 'GRIR686', 'PSIWAT']
-    input_files = ['ausurf.in', 'pw.in', 'grir443.in', 'grir686.in', 'psiwat.in']
+    executable("execute", "pw.x {flags} < {input_file}", use_mpi=True)
+
+    workload_names = ["AUSURF112", "CNT10POR8", "GRIR443", "GRIR686", "PSIWAT"]
+    input_files = [
+        "ausurf.in",
+        "pw.in",
+        "grir443.in",
+        "grir686.in",
+        "psiwat.in",
+    ]
     for wl_name, input_file in zip(workload_names, input_files):
-        workload(wl_name, executables=['copy_inputs', 'execute'], inputs=[wl_name])
-        workload_variable('input_path', default=Expander.expansion_str(wl_name),
-                          description='Path to inputs for ' + wl_name + ' workload',
-                          workloads=[wl_name])
-        workload_variable('input_file', default=input_file,
-                          description='Name of input file for ' + wl_name + ' workload',
-                          workloads=[wl_name])
-        workload_variable('flags', default='',
-                          description='Flags for Quantum Espresso',
-                          workloads=[wl_name])
+        workload(
+            wl_name, executables=["copy_inputs", "execute"], inputs=[wl_name]
+        )
+        workload_variable(
+            "input_path",
+            default=Expander.expansion_str(wl_name),
+            description="Path to inputs for " + wl_name + " workload",
+            workloads=[wl_name],
+        )
+        workload_variable(
+            "input_file",
+            default=input_file,
+            description="Name of input file for " + wl_name + " workload",
+            workloads=[wl_name],
+        )
+        workload_variable(
+            "flags",
+            default="",
+            description="Flags for Quantum Espresso",
+            workloads=[wl_name],
+        )
 
-    workload('WATER_EXX', executables=['copy_potential1', 'copy_potential2', 'execute'],
-             inputs=['WATER_EXX', 'WATER_EXX_H', 'WATER_EXX_O'])
-    workload_variable('input_file', default=Expander.expansion_str('WATER_EXX'),
-                      description='Path to WATER_EXX input',
-                      workloads=['WATER_EXX'])
-    workload_variable('potential1', default=Expander.expansion_str('WATER_EXX_H'),
-                      description='Path to WATER_EXX H potential file',
-                      workloads=['WATER_EXX'])
-    workload_variable('potential2', default=Expander.expansion_str('WATER_EXX_O'),
-                      description='Path to WATER_EXX O potential file',
-                      workloads=['WATER_EXX'])
+    workload(
+        "WATER_EXX",
+        executables=["copy_potential1", "copy_potential2", "execute"],
+        inputs=["WATER_EXX", "WATER_EXX_H", "WATER_EXX_O"],
+    )
+    workload_variable(
+        "input_file",
+        default=Expander.expansion_str("WATER_EXX"),
+        description="Path to WATER_EXX input",
+        workloads=["WATER_EXX"],
+    )
+    workload_variable(
+        "potential1",
+        default=Expander.expansion_str("WATER_EXX_H"),
+        description="Path to WATER_EXX H potential file",
+        workloads=["WATER_EXX"],
+    )
+    workload_variable(
+        "potential2",
+        default=Expander.expansion_str("WATER_EXX_O"),
+        description="Path to WATER_EXX O potential file",
+        workloads=["WATER_EXX"],
+    )
 
-    workload_variable('flags', default='',
-                      description='Flags for Quantum Espresso',
-                      workloads=['WATER_EXX'])
+    workload_variable(
+        "flags",
+        default="",
+        description="Flags for Quantum Espresso",
+        workloads=["WATER_EXX"],
+    )
 
-    log_str = Expander.expansion_str('log_file')
-    figure_of_merit('Total CPU time',
-                    fom_regex=r'\s*total cpu time spent up to now is\s+(?P<time>[0-9]+\.[0-9]+).*',
-                    group_name='time', log_file=log_str, units='s')
+    log_str = Expander.expansion_str("log_file")
+    figure_of_merit(
+        "Total CPU time",
+        fom_regex=r"\s*total cpu time spent up to now is\s+(?P<time>[0-9]+\.[0-9]+).*",
+        group_name="time",
+        log_file=log_str,
+        units="s",
+    )
 
-    figure_of_merit('Estimated SCF accuracy',
-                    fom_regex=r'\s*estimated scf accuracy\s+<\s+(?P<energy>[0-9]+\.[0-9]+).*',
-                    group_name='energy', log_file=log_str, units='Ry')
+    figure_of_merit(
+        "Estimated SCF accuracy",
+        fom_regex=r"\s*estimated scf accuracy\s+<\s+(?P<energy>[0-9]+\.[0-9]+).*",
+        group_name="energy",
+        log_file=log_str,
+        units="Ry",
+    )
 
-    profile_regex = r'\s+(?P<section>[\w:]+)\s+:\s+(?P<cpu>[0-9]+\.[0-9]+)s CPU\s+' + \
-                    r'(?P<wall>[0-9]+\.[0-9]+)s WALL \(\s+(?P<calls>[0-9]+) calls\).*'
-    figure_of_merit_context('Profile section', regex=profile_regex,
-                            output_format='{section}')
+    profile_regex = (
+        r"\s+(?P<section>[\w:]+)\s+:\s+(?P<cpu>[0-9]+\.[0-9]+)s CPU\s+"
+        + r"(?P<wall>[0-9]+\.[0-9]+)s WALL \(\s+(?P<calls>[0-9]+) calls\).*"
+    )
+    figure_of_merit_context(
+        "Profile section", regex=profile_regex, output_format="{section}"
+    )
 
-    figure_of_merit('Section CPU Time', fom_regex=profile_regex,
-                    group_name='cpu', log_file=log_str, units='s',
-                    contexts=['Profile section'])
+    figure_of_merit(
+        "Section CPU Time",
+        fom_regex=profile_regex,
+        group_name="cpu",
+        log_file=log_str,
+        units="s",
+        contexts=["Profile section"],
+    )
 
-    figure_of_merit('Section Wall Time', fom_regex=profile_regex,
-                    group_name='wall', log_file=log_str, units='s',
-                    contexts=['Profile section'])
+    figure_of_merit(
+        "Section Wall Time",
+        fom_regex=profile_regex,
+        group_name="wall",
+        log_file=log_str,
+        units="s",
+        contexts=["Profile section"],
+    )
 
-    figure_of_merit('Section Number of Calls', fom_regex=profile_regex,
-                    group_name='calls', log_file=log_str, units='',
-                    contexts=['Profile section'])
+    figure_of_merit(
+        "Section Number of Calls",
+        fom_regex=profile_regex,
+        group_name="calls",
+        log_file=log_str,
+        units="",
+        contexts=["Profile section"],
+    )
 
-    success_criteria('job_done', mode='string',
-                     match=r'.*JOB DONE\..*',
-                     file=log_str)
+    success_criteria(
+        "job_done", mode="string", match=r".*JOB DONE\..*", file=log_str
+    )

--- a/var/ramble/repos/builtin/applications/sleep/application.py
+++ b/var/ramble/repos/builtin/applications/sleep/application.py
@@ -14,55 +14,89 @@ from ramble.expander import Expander
 class Sleep(ExecutableApplication):
     """This is an example application that will simply run sleep for a
     controlled random amount of time"""
+
     name = "sleep"
 
     tags("test-app")
 
-    maintainers('douglasjacobsen')
+    maintainers("douglasjacobsen")
 
-    time_file = os.path.join(Expander.expansion_str('experiment_run_dir'),
-                             'time_output')
-    executable('define_sleep_time', 'export SLEEP_TIME={sleep_seconds}', output_capture='', redirect='')
-    executable('sleep', '/usr/bin/time sleep $SLEEP_TIME', output_capture='&>>')
-    executable('echo', 'echo "Sleep for $SLEEP_TIME seconds"')
+    time_file = os.path.join(
+        Expander.expansion_str("experiment_run_dir"), "time_output"
+    )
+    executable(
+        "define_sleep_time",
+        "export SLEEP_TIME={sleep_seconds}",
+        output_capture="",
+        redirect="",
+    )
+    executable(
+        "sleep", "/usr/bin/time sleep $SLEEP_TIME", output_capture="&>>"
+    )
+    executable("echo", 'echo "Sleep for $SLEEP_TIME seconds"')
 
-    workload('sleep', executables=['define_sleep_time', 'echo', 'sleep'])
-    workload('rand_sleep', executables=['define_sleep_time', 'echo', 'sleep'])
+    workload("sleep", executables=["define_sleep_time", "echo", "sleep"])
+    workload("rand_sleep", executables=["define_sleep_time", "echo", "sleep"])
 
-    workload_variable('sleep_seconds', default='3',
-                      description='Number of seconds to sleep for',
-                      workloads=['sleep'])
+    workload_variable(
+        "sleep_seconds",
+        default="3",
+        description="Number of seconds to sleep for",
+        workloads=["sleep"],
+    )
 
-    workload_variable('rand_min', default='1',
-                      description='Minimum of the random range',
-                      workloads=['rand_sleep'])
+    workload_variable(
+        "rand_min",
+        default="1",
+        description="Minimum of the random range",
+        workloads=["rand_sleep"],
+    )
 
-    workload_variable('rand_max', default='5',
-                      description='Maximum of the random range',
-                      workloads=['rand_sleep'])
+    workload_variable(
+        "rand_max",
+        default="5",
+        description="Maximum of the random range",
+        workloads=["rand_sleep"],
+    )
 
-    workload_variable('sleep_seconds', default='{randint({rand_min}, {rand_max})}',
-                      description='Number of seconds to sleep for',
-                      workloads=['rand_sleep'])
+    workload_variable(
+        "sleep_seconds",
+        default="{randint({rand_min}, {rand_max})}",
+        description="Number of seconds to sleep for",
+        workloads=["rand_sleep"],
+    )
 
-    echo_regex = r'.*Sleep for (?P<time>[0-9]+) seconds.*'
-    figure_of_merit('Sleep time', fom_regex=echo_regex,
-                    group_name='time', units='s')
+    echo_regex = r".*Sleep for (?P<time>[0-9]+) seconds.*"
+    figure_of_merit(
+        "Sleep time", fom_regex=echo_regex, group_name="time", units="s"
+    )
 
-    figure_of_merit('User time',
-                    fom_regex=r'(?P<user_time>[0-9]+\.[0-9]+)user.*',
-                    group_name='user_time', units='s')
+    figure_of_merit(
+        "User time",
+        fom_regex=r"(?P<user_time>[0-9]+\.[0-9]+)user.*",
+        group_name="user_time",
+        units="s",
+    )
 
-    figure_of_merit('Elapsed minutes',
-                    fom_regex=r'.*(?P<mins>[0-9]+):(?P<secs>[0-9]+)\.(?P<millisecs>[0-9]+)elapsed.*',
-                    group_name='mins', units='minutes')
+    figure_of_merit(
+        "Elapsed minutes",
+        fom_regex=r".*(?P<mins>[0-9]+):(?P<secs>[0-9]+)\.(?P<millisecs>[0-9]+)elapsed.*",
+        group_name="mins",
+        units="minutes",
+    )
 
-    figure_of_merit('Elapsed seconds',
-                    fom_regex=r'.*(?P<mins>[0-9]+):(?P<secs>[0-9]+)\.(?P<millisecs>[0-9]+)elapsed.*',
-                    group_name='secs', units='s')
+    figure_of_merit(
+        "Elapsed seconds",
+        fom_regex=r".*(?P<mins>[0-9]+):(?P<secs>[0-9]+)\.(?P<millisecs>[0-9]+)elapsed.*",
+        group_name="secs",
+        units="s",
+    )
 
-    figure_of_merit('Elapsed milliseconds',
-                    fom_regex=r'.*(?P<mins>[0-9]+):(?P<secs>[0-9]+)\.(?P<millisecs>[0-9]+)elapsed.*',
-                    group_name='millisecs', units='ms')
+    figure_of_merit(
+        "Elapsed milliseconds",
+        fom_regex=r".*(?P<mins>[0-9]+):(?P<secs>[0-9]+)\.(?P<millisecs>[0-9]+)elapsed.*",
+        group_name="millisecs",
+        units="ms",
+    )
 
-    success_criteria('printed_sleep_time', mode='string', match=echo_regex)
+    success_criteria("printed_sleep_time", mode="string", match=echo_regex)

--- a/var/ramble/repos/builtin/applications/spack-stack/application.py
+++ b/var/ramble/repos/builtin/applications/spack-stack/application.py
@@ -11,7 +11,7 @@ import spack.util.executable
 
 
 class SpackStack(SpackApplication):
-    '''Application definition for creating a spack software stack
+    """Application definition for creating a spack software stack
 
     This application definition is used solely to create spack software stacks.
 
@@ -23,81 +23,119 @@ class SpackStack(SpackApplication):
     accelerate package installation.
 
     The experiments are considered successful if the installation completed.
-    '''
-    name = 'spack-stack'
+    """
 
-    maintainers('douglasjacobsen')
+    name = "spack-stack"
 
-    tags('software', 'configuration')
+    maintainers("douglasjacobsen")
 
-    executable('configure', template=['spack config add "config:install_tree:padded_length:{padded_length}"'],
-               use_mpi=False)
+    tags("software", "configuration")
 
-    executable('install', 'spack install {install_flags}', use_mpi=True)
+    executable(
+        "configure",
+        template=[
+            'spack config add "config:install_tree:padded_length:{padded_length}"'
+        ],
+        use_mpi=False,
+    )
 
-    workload('create', executables=['builtin::remove_env_files',
-                                    'builtin::spack_source',
-                                    'builtin::spack_activate',
-                                    'configure',
-                                    'install',
-                                    'builtin::spack_deactivate'])
+    executable("install", "spack install {install_flags}", use_mpi=True)
 
-    executable('uninstall', 'spack uninstall {uninstall_flags}', use_mpi=True)
+    workload(
+        "create",
+        executables=[
+            "builtin::remove_env_files",
+            "builtin::spack_source",
+            "builtin::spack_activate",
+            "configure",
+            "install",
+            "builtin::spack_deactivate",
+        ],
+    )
 
-    workload('remove', executables=['builtin::spack_source',
-                                    'builtin::spack_activate',
-                                    'uninstall',
-                                    'builtin::spack_deactivate'])
+    executable("uninstall", "spack uninstall {uninstall_flags}", use_mpi=True)
 
-    workload_variable('install_flags', default='',
-                      description='Flags to use for `spack install`',
-                      workloads=['create'])
+    workload(
+        "remove",
+        executables=[
+            "builtin::spack_source",
+            "builtin::spack_activate",
+            "uninstall",
+            "builtin::spack_deactivate",
+        ],
+    )
 
-    workload_variable('padded_length', default='512',
-                      description='Length to pad install prefixes with',
-                      workloads=['create'])
+    workload_variable(
+        "install_flags",
+        default="",
+        description="Flags to use for `spack install`",
+        workloads=["create"],
+    )
 
-    workload_variable('uninstall_flags', default='--all -y',
-                      description='Flags to use for `spack uninstall`',
-                      workloads=['remove'])
+    workload_variable(
+        "padded_length",
+        default="512",
+        description="Length to pad install prefixes with",
+        workloads=["create"],
+    )
 
-    success_criteria('view-updated', mode='string', match=r'.*==> Updating view at.*')
+    workload_variable(
+        "uninstall_flags",
+        default="--all -y",
+        description="Flags to use for `spack uninstall`",
+        workloads=["remove"],
+    )
 
-    pkg_regex = r'\s*==\> (?P<name>.*) Successfully installed (?P<spec>.*)'
+    success_criteria(
+        "view-updated", mode="string", match=r".*==> Updating view at.*"
+    )
 
-    figure_of_merit('Previously installed packages',
-                    fom_regex=r'\s*==\> (?P<quant>.*) of the packages are already installed',
-                    group_name='quant', units='')
+    pkg_regex = r"\s*==\> (?P<name>.*) Successfully installed (?P<spec>.*)"
 
-    figure_of_merit('{pkg_name} installed',
-                    fom_regex=r'\s*==\> (?P<pkg_name>.*): Successfully installed (?P<spec>.*)',
-                    group_name='spec', units='')
+    figure_of_merit(
+        "Previously installed packages",
+        fom_regex=r"\s*==\> (?P<quant>.*) of the packages are already installed",
+        group_name="quant",
+        units="",
+    )
 
-    figure_of_merit_context('Package', regex=pkg_regex,
-                            output_format='({name}, {spec})')
+    figure_of_merit(
+        "{pkg_name} installed",
+        fom_regex=r"\s*==\> (?P<pkg_name>.*): Successfully installed (?P<spec>.*)",
+        group_name="spec",
+        units="",
+    )
 
-    fom_parts = ['Autoreconf',
-                 'Bootstrap',
-                 'Build',
-                 'Cmake',
-                 'Configure',
-                 'Edit',
-                 'Install',
-                 'Post-install',
-                 'Stage',
-                 'Total']
+    figure_of_merit_context(
+        "Package", regex=pkg_regex, output_format="({name}, {spec})"
+    )
+
+    fom_parts = [
+        "Autoreconf",
+        "Bootstrap",
+        "Build",
+        "Cmake",
+        "Configure",
+        "Edit",
+        "Install",
+        "Post-install",
+        "Stage",
+        "Total",
+    ]
     for i, fom_part in enumerate(fom_parts):
-        full_regex = r'.*\s*' + fom_part + r':\s+(?P<fom>[0-9\.]+)s.*'
-        figure_of_merit(fom_part, fom_regex=full_regex, group_name='fom', units='s',
-                        contexts=['Package'])
+        full_regex = r".*\s*" + fom_part + r":\s+(?P<fom>[0-9\.]+)s.*"
+        figure_of_merit(
+            fom_part,
+            fom_regex=full_regex,
+            group_name="fom",
+            units="s",
+            contexts=["Package"],
+        )
 
-    register_builtin('remove_env_files', required=False)
+    register_builtin("remove_env_files", required=False)
 
     def remove_env_files(self):
-        cmds = [
-            'rm -f {env_path}/spack.lock',
-            'rm -rf {env_path}/.spack-env'
-        ]
+        cmds = ["rm -f {env_path}/spack.lock", "rm -rf {env_path}/.spack-env"]
         return cmds
 
     def _software_install(self, workspace, app_inst=None):
@@ -109,14 +147,15 @@ class SpackStack(SpackApplication):
 
     def evaluate_success(self):
         import spack.util.spack_yaml as syaml
-        spack_file = self.expander.expand_var('{env_path}/spack.yaml')
+
+        spack_file = self.expander.expand_var("{env_path}/spack.yaml")
         spec_list = []
-        with open(spack_file, 'r') as f:
+        with open(spack_file, "r") as f:
             spack_data = syaml.load_config(f)
 
-        tty.debug(f'Spack data: {spack_data}')
+        tty.debug(f"Spack data: {spack_data}")
 
-        for spec in spack_data['spack']['specs']:
+        for spec in spack_data["spack"]["specs"]:
             spec_list.append(spec)
 
         self.spack_runner.set_env(self.expander.env_path)
@@ -125,7 +164,7 @@ class SpackStack(SpackApplication):
         # Spack find errors if a spec is provided that is not installed.
         for spec in spec_list:
             try:
-                self.spack_runner.spack('find', spec, output=str)
+                self.spack_runner.spack("find", spec, output=str)
             except spack.util.executable.ProcessError:
                 return False
         return True

--- a/var/ramble/repos/builtin/applications/streamc/application.py
+++ b/var/ramble/repos/builtin/applications/streamc/application.py
@@ -12,92 +12,135 @@ from ramble.expander import Expander
 
 
 class Streamc(SpackApplication):
-    '''Define STREAMC application'''
-    name = 'streamc'
+    """Define STREAMC application"""
 
-    maintainers('rfbgo')
+    name = "streamc"
 
-    tags('memorybenchmark', 'microbenchmark', 'memory-benchmark', 'micro-benchmark')
+    maintainers("rfbgo")
 
-    define_compiler('gcc12', spack_spec='gcc@12.2.0')
+    tags(
+        "memorybenchmark",
+        "microbenchmark",
+        "memory-benchmark",
+        "micro-benchmark",
+    )
 
-    software_spec('streamc',
-                  spack_spec='stream@5.10 +openmp cflags="-O3 -DSTREAM_ARRAY_SIZE=80000000 -DNTIMES=20"',
-                  compiler='gcc12')
+    define_compiler("gcc12", spack_spec="gcc@12.2.0")
 
-    required_package('stream')
+    software_spec(
+        "streamc",
+        spack_spec='stream@5.10 +openmp cflags="-O3 -DSTREAM_ARRAY_SIZE=80000000 -DNTIMES=20"',
+        compiler="gcc12",
+    )
 
-    executable('execute_c', 'stream_c.exe')
+    required_package("stream")
 
-    workload('streamc', executable='execute_c')
+    executable("execute_c", "stream_c.exe")
 
-    log_file = os.path.join(Expander.expansion_str('experiment_run_dir'),
-                            Expander.expansion_str('experiment_name') + '.out')
+    workload("streamc", executable="execute_c")
 
-    success_criteria('valid', mode='string',
-                     match=r'Solution Validates: avg error less than 1.000000e-13 on all three arrays',
-                     file=log_file)
+    log_file = os.path.join(
+        Expander.expansion_str("experiment_run_dir"),
+        Expander.expansion_str("experiment_name") + ".out",
+    )
 
-    figure_of_merit("Array size",
-                    log_file=log_file,
-                    fom_regex=r'Array size\s+\=\s+(?P<array_size>[0-9]+)',
-                    group_name='array_size',
-                    units='elements')
+    success_criteria(
+        "valid",
+        mode="string",
+        match=r"Solution Validates: avg error less than 1.000000e-13 on all three arrays",
+        file=log_file,
+    )
 
-    figure_of_merit("Array memory",
-                    log_file=log_file,
-                    fom_regex=r'Memory per array\s+\=\s+(?P<array_mem>[0-9]+)\.*[0-9]*',
-                    group_name='array_mem',
-                    units='MiB')
+    figure_of_merit(
+        "Array size",
+        log_file=log_file,
+        fom_regex=r"Array size\s+\=\s+(?P<array_size>[0-9]+)",
+        group_name="array_size",
+        units="elements",
+    )
 
-    figure_of_merit("Total memory",
-                    log_file=log_file,
-                    fom_regex=r'Total memory required\s+\=\s+(?P<total_mem>[0-9]+\.*[0-9]*)',
-                    group_name='total_mem',
-                    units='MiB')
+    figure_of_merit(
+        "Array memory",
+        log_file=log_file,
+        fom_regex=r"Memory per array\s+\=\s+(?P<array_mem>[0-9]+)\.*[0-9]*",
+        group_name="array_mem",
+        units="MiB",
+    )
 
-    figure_of_merit("Number of iterations per thread",
-                    log_file=log_file,
-                    fom_regex=r'Each kernel will be executed\s+(?P<n_times>[0-9]+)',
-                    group_name='n_times',
-                    units='')
+    figure_of_merit(
+        "Total memory",
+        log_file=log_file,
+        fom_regex=r"Total memory required\s+\=\s+(?P<total_mem>[0-9]+\.*[0-9]*)",
+        group_name="total_mem",
+        units="MiB",
+    )
 
-    figure_of_merit("Number of threads",
-                    log_file=log_file,
-                    fom_regex=r'Number of Threads counted\s+\=\s+(?P<n_threads>[0-9]+\.*[0-9]*)',
-                    group_name='n_threads',
-                    units='')
+    figure_of_merit(
+        "Number of iterations per thread",
+        log_file=log_file,
+        fom_regex=r"Each kernel will be executed\s+(?P<n_times>[0-9]+)",
+        group_name="n_times",
+        units="",
+    )
 
-    for opName in ['Copy', 'Scale', 'Add', 'Triad']:
+    figure_of_merit(
+        "Number of threads",
+        log_file=log_file,
+        fom_regex=r"Number of Threads counted\s+\=\s+(?P<n_threads>[0-9]+\.*[0-9]*)",
+        group_name="n_threads",
+        units="",
+    )
+
+    for opName in ["Copy", "Scale", "Add", "Triad"]:
 
         opname = opName.lower()
 
-        opregex = (r'^' + opName + r':' +
-                   r'\s+(?P<' + opname + r'_top_rate>[0-9]+\.[0-9]*)' +
-                   r'\s+(?P<' + opname + r'_avg_time>[0-9]+\.[0-9]*)' +
-                   r'\s+(?P<' + opname + r'_min_time>[0-9]+\.[0-9]*)' +
-                   r'\s+(?P<' + opname + r'_max_time>[0-9]+\.[0-9]*)')
+        opregex = (
+            r"^"
+            + opName
+            + r":"
+            + r"\s+(?P<"
+            + opname
+            + r"_top_rate>[0-9]+\.[0-9]*)"
+            + r"\s+(?P<"
+            + opname
+            + r"_avg_time>[0-9]+\.[0-9]*)"
+            + r"\s+(?P<"
+            + opname
+            + r"_min_time>[0-9]+\.[0-9]*)"
+            + r"\s+(?P<"
+            + opname
+            + r"_max_time>[0-9]+\.[0-9]*)"
+        )
 
-        figure_of_merit(opName + ' top rate',
-                        log_file=log_file,
-                        fom_regex=opregex,
-                        group_name=(opname + '_top_rate'),
-                        units='MB/s')
+        figure_of_merit(
+            opName + " top rate",
+            log_file=log_file,
+            fom_regex=opregex,
+            group_name=(opname + "_top_rate"),
+            units="MB/s",
+        )
 
-        figure_of_merit(opName + ' average time',
-                        log_file=log_file,
-                        fom_regex=opregex,
-                        group_name=(opname + '_avg_time'),
-                        units='s')
+        figure_of_merit(
+            opName + " average time",
+            log_file=log_file,
+            fom_regex=opregex,
+            group_name=(opname + "_avg_time"),
+            units="s",
+        )
 
-        figure_of_merit(opName + ' min time',
-                        log_file=log_file,
-                        fom_regex=opregex,
-                        group_name=(opname + '_min_time'),
-                        units='s')
+        figure_of_merit(
+            opName + " min time",
+            log_file=log_file,
+            fom_regex=opregex,
+            group_name=(opname + "_min_time"),
+            units="s",
+        )
 
-        figure_of_merit(opName + ' max time',
-                        log_file=log_file,
-                        fom_regex=opregex,
-                        group_name=(opname + '_max_time'),
-                        units='s')
+        figure_of_merit(
+            opName + " max time",
+            log_file=log_file,
+            fom_regex=opregex,
+            group_name=(opname + "_max_time"),
+            units="s",
+        )

--- a/var/ramble/repos/builtin/applications/ufs-weather-model/application.py
+++ b/var/ramble/repos/builtin/applications/ufs-weather-model/application.py
@@ -12,115 +12,209 @@ from ramble.expander import Expander
 
 
 class UfsWeatherModel(SpackApplication):
-    '''Define FV3 application via ufs-weather-model'''
-    name = 'ufs-weather-model'
+    """Define FV3 application via ufs-weather-model"""
 
-    maintainers('rfbgo')
+    name = "ufs-weather-model"
 
-    tags('nwp', 'weather')
+    maintainers("rfbgo")
 
-    define_compiler('gcc9', spack_spec='gcc@9.3.0')
+    tags("nwp", "weather")
 
-    software_spec('ompi415', spack_spec="openmpi@4.1.5", compiler='gcc9')
+    define_compiler("gcc9", spack_spec="gcc@9.3.0")
 
-    software_spec('python39', spack_spec="python@3.9.15", compiler='gcc9')
-    software_spec('esmf', spack_spec="esmf@8.0.1", compiler='gcc9')
+    software_spec("ompi415", spack_spec="openmpi@4.1.5", compiler="gcc9")
 
-    software_spec('ufs-weather-model',
-                  spack_spec='ufs-weather-model@2.0.0 +avx2 +openmp', compiler='gcc9')
+    software_spec("python39", spack_spec="python@3.9.15", compiler="gcc9")
+    software_spec("esmf", spack_spec="esmf@8.0.1", compiler="gcc9")
 
-    required_package('ufs-weather-model')
+    software_spec(
+        "ufs-weather-model",
+        spack_spec="ufs-weather-model@2.0.0 +avx2 +openmp",
+        compiler="gcc9",
+    )
 
-    input_file('simple_test_case', url='https://ftp.emc.ncep.noaa.gov/EIB/UFS/simple-test-case.tar.gz',
-               sha256='c713ecb208abcff9a7ec74d7991915d842f85a53b5771afa6b9c57c27651aaeb',
-               description='Simple test case for ufs-weather-model')
+    required_package("ufs-weather-model")
 
-    executable('execute', 'ufs_weather_model', use_mpi=True)
+    input_file(
+        "simple_test_case",
+        url="https://ftp.emc.ncep.noaa.gov/EIB/UFS/simple-test-case.tar.gz",
+        sha256="c713ecb208abcff9a7ec74d7991915d842f85a53b5771afa6b9c57c27651aaeb",
+        description="Simple test case for ufs-weather-model",
+    )
 
-    executable('copy_input',
-               template=['cp -pR {input_path}/* {experiment_run_dir}'], use_mpi=False)
+    executable("execute", "ufs_weather_model", use_mpi=True)
 
-    workload('simple_test_case', executables=['copy_input', 'execute'], input='simple_test_case')
+    executable(
+        "copy_input",
+        template=["cp -pR {input_path}/* {experiment_run_dir}"],
+        use_mpi=False,
+    )
 
-    workload_variable('input_path', default='{simple_test_case}',
-                      description='extracted simple-test-case tarfile path',
-                      workloads=['simple_test_case'])
+    workload(
+        "simple_test_case",
+        executables=["copy_input", "execute"],
+        input="simple_test_case",
+    )
 
-    log_str = os.path.join(Expander.expansion_str('experiment_run_dir'),
-                           Expander.expansion_str('experiment_name') + '.out')
+    workload_variable(
+        "input_path",
+        default="{simple_test_case}",
+        description="extracted simple-test-case tarfile path",
+        workloads=["simple_test_case"],
+    )
 
-    figure_of_merit('Total wall clock time',
-                    fom_regex=(r'^\s*The total amount of wall time\s+=\s+'
-                               r'(?P<walltime>[0-9]+\.[0-9]+).*'),
-                    group_name='walltime', log_file=log_str, units='s')
+    log_str = os.path.join(
+        Expander.expansion_str("experiment_run_dir"),
+        Expander.expansion_str("experiment_name") + ".out",
+    )
 
-    figure_of_merit('Total user mode time',
-                    fom_regex=(r'^\s*The total amount of time in user mode\s+=\s+'
-                               r'(?P<usertime>[0-9]+\.[0-9]+).*'),
-                    group_name='usertime', log_file=log_str, units='s')
+    figure_of_merit(
+        "Total wall clock time",
+        fom_regex=(
+            r"^\s*The total amount of wall time\s+=\s+"
+            r"(?P<walltime>[0-9]+\.[0-9]+).*"
+        ),
+        group_name="walltime",
+        log_file=log_str,
+        units="s",
+    )
 
-    figure_of_merit('Total sys mode time',
-                    fom_regex=(r'^\s*The total amount of time in sys mode\s+=\s+'
-                               r'(?P<systime>[0-9]+\.[0-9]+).*'),
-                    group_name='systime', log_file=log_str, units='s')
+    figure_of_merit(
+        "Total user mode time",
+        fom_regex=(
+            r"^\s*The total amount of time in user mode\s+=\s+"
+            r"(?P<usertime>[0-9]+\.[0-9]+).*"
+        ),
+        group_name="usertime",
+        log_file=log_str,
+        units="s",
+    )
 
-    figure_of_merit('Maximum resident set size',
-                    fom_regex=(r'^\s*The maximum resident set size.*\s+=\s+'
-                               r'(?P<res_set_size>[0-9]+).*'),
-                    group_name='res_set_size', log_file=log_str, units='KB')
+    figure_of_merit(
+        "Total sys mode time",
+        fom_regex=(
+            r"^\s*The total amount of time in sys mode\s+=\s+"
+            r"(?P<systime>[0-9]+\.[0-9]+).*"
+        ),
+        group_name="systime",
+        log_file=log_str,
+        units="s",
+    )
 
-    figure_of_merit('Mean specific humidity above 75mb',
-                    fom_regex=(r'^\s*Mean specific humidity.*=\s+'
-                               r'(?P<mean_sp_hum>[0-9]+\.[0-9]+).*'),
-                    group_name='mean_sp_hum', log_file=log_str, units='mg/kg')
+    figure_of_merit(
+        "Maximum resident set size",
+        fom_regex=(
+            r"^\s*The maximum resident set size.*\s+=\s+"
+            r"(?P<res_set_size>[0-9]+).*"
+        ),
+        group_name="res_set_size",
+        log_file=log_str,
+        units="KB",
+    )
 
-    figure_of_merit('Total surface pressure',
-                    fom_regex=(r'^\s*Total surface pressure.*=\s+'
-                               r'(?P<tot_surf_press>[0-9]+\.[0-9]+).*'),
-                    group_name='tot_surf_press', log_file=log_str, units='mb')
+    figure_of_merit(
+        "Mean specific humidity above 75mb",
+        fom_regex=(
+            r"^\s*Mean specific humidity.*=\s+"
+            r"(?P<mean_sp_hum>[0-9]+\.[0-9]+).*"
+        ),
+        group_name="mean_sp_hum",
+        log_file=log_str,
+        units="mg/kg",
+    )
 
-    figure_of_merit('mean dry surface pressure',
-                    fom_regex=(r'^\s*mean dry surface pressure.*=\s+'
-                               r'(?P<mean_dry_surf_press>'
-                               r'[\+\-]*[0-9]*\.*[0-9]+E*[\+\-]*[0-9]*'
-                               r').*'),
-                    group_name='mean_dry_surf_press', log_file=log_str, units='mb')
+    figure_of_merit(
+        "Total surface pressure",
+        fom_regex=(
+            r"^\s*Total surface pressure.*=\s+"
+            r"(?P<tot_surf_press>[0-9]+\.[0-9]+).*"
+        ),
+        group_name="tot_surf_press",
+        log_file=log_str,
+        units="mb",
+    )
 
-    figure_of_merit('Total water vapor',
-                    fom_regex=(r'^\s*Total Water Vapor.*=\s+'
-                               r'(?P<tot_h2o_vapor>'
-                               r'[\+\-]*[0-9]*\.*[0-9]+E*[\+\-]*[0-9]*'
-                               r').*'),
-                    group_name='tot_h2o_vapor', log_file=log_str, units='kg/m**2')
+    figure_of_merit(
+        "mean dry surface pressure",
+        fom_regex=(
+            r"^\s*mean dry surface pressure.*=\s+"
+            r"(?P<mean_dry_surf_press>"
+            r"[\+\-]*[0-9]*\.*[0-9]+E*[\+\-]*[0-9]*"
+            r").*"
+        ),
+        group_name="mean_dry_surf_press",
+        log_file=log_str,
+        units="mb",
+    )
 
-    figure_of_merit('Total cloud water',
-                    fom_regex=(r'^\s*Total cloud water.*=\s+'
-                               r'(?P<tot_cloud_h2o>'
-                               r'[\+\-]*[0-9]*\.*[0-9]+E*[\+\-]*[0-9]*'
-                               r').*'),
-                    group_name='tot_cloud_h2o', log_file=log_str, units='kg/m**2')
+    figure_of_merit(
+        "Total water vapor",
+        fom_regex=(
+            r"^\s*Total Water Vapor.*=\s+"
+            r"(?P<tot_h2o_vapor>"
+            r"[\+\-]*[0-9]*\.*[0-9]+E*[\+\-]*[0-9]*"
+            r").*"
+        ),
+        group_name="tot_h2o_vapor",
+        log_file=log_str,
+        units="kg/m**2",
+    )
 
-    figure_of_merit('Total rain water',
-                    fom_regex=(r'^\s*Total rain water.*=\s+'
-                               r'(?P<tot_rain_h2o>'
-                               r'[\+\-]*[0-9]*\.*[0-9]+E*[\+\-]*[0-9]*'
-                               r').*'),
-                    group_name='tot_rain_h2o', log_file=log_str, units='kg/m**2')
+    figure_of_merit(
+        "Total cloud water",
+        fom_regex=(
+            r"^\s*Total cloud water.*=\s+"
+            r"(?P<tot_cloud_h2o>"
+            r"[\+\-]*[0-9]*\.*[0-9]+E*[\+\-]*[0-9]*"
+            r").*"
+        ),
+        group_name="tot_cloud_h2o",
+        log_file=log_str,
+        units="kg/m**2",
+    )
 
-    figure_of_merit('Total snow',
-                    fom_regex=(r'^\s*Total snow.*=\s+'
-                               r'(?P<tot_snow>'
-                               r'[\+\-]*[0-9]*\.*[0-9]+E*[\+\-]*[0-9]*'
-                               r').*'),
-                    group_name='tot_snow', log_file=log_str, units='kg/m**2')
+    figure_of_merit(
+        "Total rain water",
+        fom_regex=(
+            r"^\s*Total rain water.*=\s+"
+            r"(?P<tot_rain_h2o>"
+            r"[\+\-]*[0-9]*\.*[0-9]+E*[\+\-]*[0-9]*"
+            r").*"
+        ),
+        group_name="tot_rain_h2o",
+        log_file=log_str,
+        units="kg/m**2",
+    )
 
-    figure_of_merit('Total graupel',
-                    fom_regex=(r'^\s*Total graupel.*=\s+'
-                               r'(?P<tot_graupel>'
-                               r'[\+\-]*[0-9]*\.*[0-9]+E*[\+\-]*[0-9]*'
-                               r').*'),
-                    group_name='tot_graupel', log_file=log_str, units='kg/m**2')
+    figure_of_merit(
+        "Total snow",
+        fom_regex=(
+            r"^\s*Total snow.*=\s+"
+            r"(?P<tot_snow>"
+            r"[\+\-]*[0-9]*\.*[0-9]+E*[\+\-]*[0-9]*"
+            r").*"
+        ),
+        group_name="tot_snow",
+        log_file=log_str,
+        units="kg/m**2",
+    )
 
-    success_criteria('program_ended', mode='string',
-                     match=r'^\s+PROGRAM.*HAS ENDED\..*',
-                     file=log_str)
+    figure_of_merit(
+        "Total graupel",
+        fom_regex=(
+            r"^\s*Total graupel.*=\s+"
+            r"(?P<tot_graupel>"
+            r"[\+\-]*[0-9]*\.*[0-9]+E*[\+\-]*[0-9]*"
+            r").*"
+        ),
+        group_name="tot_graupel",
+        log_file=log_str,
+        units="kg/m**2",
+    )
+
+    success_criteria(
+        "program_ended",
+        mode="string",
+        match=r"^\s+PROGRAM.*HAS ENDED\..*",
+        file=log_str,
+    )

--- a/var/ramble/repos/builtin/applications/wrfv3/application.py
+++ b/var/ramble/repos/builtin/applications/wrfv3/application.py
@@ -12,105 +12,173 @@ from ramble.expander import Expander
 
 
 class Wrfv3(SpackApplication):
-    '''Define Wrf version 3 application'''
-    name = 'wrfv3'
+    """Define Wrf version 3 application"""
 
-    maintainers('douglasjacobsen')
+    name = "wrfv3"
 
-    tags('nwp', 'weather')
+    maintainers("douglasjacobsen")
 
-    define_compiler('gcc8', spack_spec='gcc@8.2.0')
+    tags("nwp", "weather")
 
-    software_spec('impi2018', spack_spec='intel-mpi@2018.4.274')
+    define_compiler("gcc8", spack_spec="gcc@8.2.0")
 
-    software_spec('wrfv3',
-                  spack_spec='wrf@3.9.1.1 build_type=dm+sm compile_type=em_real nesting=basic ~pnetcdf',
-                  compiler='gcc8')
+    software_spec("impi2018", spack_spec="intel-mpi@2018.4.274")
 
-    required_package('wrf')
+    software_spec(
+        "wrfv3",
+        spack_spec="wrf@3.9.1.1 build_type=dm+sm compile_type=em_real nesting=basic ~pnetcdf",
+        compiler="gcc8",
+    )
 
-    input_file('CONUS_2p5km', url='https://www2.mmm.ucar.edu/wrf/bench/conus2.5km_v3911/bench_2.5km.tar.bz2',
-               sha256='1919a0e0499057c1a570619d069817022bae95b17cf1a52bdaa174f8e8d11508',
-               description='2.5 km resolution mesh of the continental United States.')
+    required_package("wrf")
 
-    input_file('CONUS_12km', url='https://www2.mmm.ucar.edu/wrf/bench/conus12km_v3911/bench_12km.tar.bz2',
-               sha256='0c5ecfc85f2a982f0fa0191371401c1474cf562a7cf97192acd3c9b91ebcc48d',
-               description='12 km resolution mesh of the continental United States.')
+    input_file(
+        "CONUS_2p5km",
+        url="https://www2.mmm.ucar.edu/wrf/bench/conus2.5km_v3911/bench_2.5km.tar.bz2",
+        sha256="1919a0e0499057c1a570619d069817022bae95b17cf1a52bdaa174f8e8d11508",
+        description="2.5 km resolution mesh of the continental United States.",
+    )
 
-    executable('cleanup', 'rm -f rsl.* wrfout*', use_mpi=False, output_capture=OUTPUT_CAPTURE.ALL)
-    executable('copy', template=['cp -R {input_path}/* {experiment_run_dir}/.',
-                                 'ln -s {wrf}/run/* {experiment_run_dir}/.'],
-               use_mpi=False, output_capture=OUTPUT_CAPTURE.ALL)
-    executable('execute', 'wrf.exe', use_mpi=True)
+    input_file(
+        "CONUS_12km",
+        url="https://www2.mmm.ucar.edu/wrf/bench/conus12km_v3911/bench_12km.tar.bz2",
+        sha256="0c5ecfc85f2a982f0fa0191371401c1474cf562a7cf97192acd3c9b91ebcc48d",
+        description="12 km resolution mesh of the continental United States.",
+    )
 
-    workload('CONUS_2p5km', executables=['cleanup', 'copy', 'execute'],
-             input='CONUS_2p5km')
+    executable(
+        "cleanup",
+        "rm -f rsl.* wrfout*",
+        use_mpi=False,
+        output_capture=OUTPUT_CAPTURE.ALL,
+    )
+    executable(
+        "copy",
+        template=[
+            "cp -R {input_path}/* {experiment_run_dir}/.",
+            "ln -s {wrf}/run/* {experiment_run_dir}/.",
+        ],
+        use_mpi=False,
+        output_capture=OUTPUT_CAPTURE.ALL,
+    )
+    executable("execute", "wrf.exe", use_mpi=True)
 
-    workload('CONUS_12km', executables=['cleanup', 'copy', 'execute'],
-             input='CONUS_12km')
+    workload(
+        "CONUS_2p5km",
+        executables=["cleanup", "copy", "execute"],
+        input="CONUS_2p5km",
+    )
 
-    workload_variable('input_path', default='{CONUS_12km}',
-                      description='Path for CONUS 12km inputs.',
-                      workloads=['CONUS_12km'])
+    workload(
+        "CONUS_12km",
+        executables=["cleanup", "copy", "execute"],
+        input="CONUS_12km",
+    )
 
-    workload_variable('input_path', default='{CONUS_2p5km}',
-                      description='Path for CONUS 2.5km inputs.',
-                      workloads=['CONUS_2p5km'])
+    workload_variable(
+        "input_path",
+        default="{CONUS_12km}",
+        description="Path for CONUS 12km inputs.",
+        workloads=["CONUS_12km"],
+    )
 
-    log_str = os.path.join(Expander.expansion_str('experiment_run_dir'),
-                           'stats.out')
+    workload_variable(
+        "input_path",
+        default="{CONUS_2p5km}",
+        description="Path for CONUS 2.5km inputs.",
+        workloads=["CONUS_2p5km"],
+    )
 
-    figure_of_merit('Average Timestep Time', log_file=log_str,
-                    fom_regex=r'Average time:\s+(?P<avg_time>[0-9]+\.[0-9]*).*',
-                    group_name='avg_time', units='s')
+    log_str = os.path.join(
+        Expander.expansion_str("experiment_run_dir"), "stats.out"
+    )
 
-    figure_of_merit('Cumulative Timestep Time', log_file=log_str,
-                    fom_regex=r'Cumulative time:\s+(?P<total_time>[0-9]+\.[0-9]*).*',
-                    group_name='total_time', units='s')
+    figure_of_merit(
+        "Average Timestep Time",
+        log_file=log_str,
+        fom_regex=r"Average time:\s+(?P<avg_time>[0-9]+\.[0-9]*).*",
+        group_name="avg_time",
+        units="s",
+    )
 
-    figure_of_merit('Minimum Timestep Time', log_file=log_str,
-                    fom_regex=r'Min time:\s+(?P<min_time>[0-9]+\.[0-9]*).*',
-                    group_name='min_time', units='s')
+    figure_of_merit(
+        "Cumulative Timestep Time",
+        log_file=log_str,
+        fom_regex=r"Cumulative time:\s+(?P<total_time>[0-9]+\.[0-9]*).*",
+        group_name="total_time",
+        units="s",
+    )
 
-    figure_of_merit('Maximum Timestep Time', log_file=log_str,
-                    fom_regex=r'Max time:\s+(?P<max_time>[0-9]+\.[0-9]*).*',
-                    group_name='max_time', units='s')
+    figure_of_merit(
+        "Minimum Timestep Time",
+        log_file=log_str,
+        fom_regex=r"Min time:\s+(?P<min_time>[0-9]+\.[0-9]*).*",
+        group_name="min_time",
+        units="s",
+    )
 
-    figure_of_merit('Number of timesteps', log_file=log_str,
-                    fom_regex=r'Number of times:\s+(?P<count>[0-9]+)',
-                    group_name='count', units='')
+    figure_of_merit(
+        "Maximum Timestep Time",
+        log_file=log_str,
+        fom_regex=r"Max time:\s+(?P<max_time>[0-9]+\.[0-9]*).*",
+        group_name="max_time",
+        units="s",
+    )
 
-    figure_of_merit('Avg. Max Ratio Time', log_file=log_str,
-                    fom_regex=r'Avg time / Max time:\s+(?P<avg_max_ratio>[0-9]+\.[0-9]*).*',
-                    group_name='avg_max_ratio', units='')
+    figure_of_merit(
+        "Number of timesteps",
+        log_file=log_str,
+        fom_regex=r"Number of times:\s+(?P<count>[0-9]+)",
+        group_name="count",
+        units="",
+    )
 
-    success_criteria('Complete', mode='string', match=r'.*wrf: SUCCESS COMPLETE WRF.*',
-                     file='{experiment_run_dir}/rsl.out.0000')
+    figure_of_merit(
+        "Avg. Max Ratio Time",
+        log_file=log_str,
+        fom_regex=r"Avg time / Max time:\s+(?P<avg_max_ratio>[0-9]+\.[0-9]*).*",
+        group_name="avg_max_ratio",
+        units="",
+    )
 
-    archive_pattern('{experiment_run_dir}/rsl.out.*')
-    archive_pattern('{experiment_run_dir}/rsl.error.*')
+    success_criteria(
+        "Complete",
+        mode="string",
+        match=r".*wrf: SUCCESS COMPLETE WRF.*",
+        file="{experiment_run_dir}/rsl.out.0000",
+    )
+
+    archive_pattern("{experiment_run_dir}/rsl.out.*")
+    archive_pattern("{experiment_run_dir}/rsl.error.*")
 
     def _analyze_experiments(self, workspace, app_inst=None):
         import glob
         import re
+
         # Generate stats file
 
-        file_list = glob.glob(os.path.join(self.expander.expand_var_name('experiment_run_dir'),
-                                           'rsl.out.*'))
+        file_list = glob.glob(
+            os.path.join(
+                self.expander.expand_var_name("experiment_run_dir"),
+                "rsl.out.*",
+            )
+        )
 
         if file_list:
-            timing_regex = re.compile(r'Timing for main.*:\s+(?P<main_time>[0-9]+\.[0-9]*).*')
+            timing_regex = re.compile(
+                r"Timing for main.*:\s+(?P<main_time>[0-9]+\.[0-9]*).*"
+            )
             avg_time = 0.0
-            min_time = float('inf')
-            max_time = float('-inf')
+            min_time = float("inf")
+            max_time = float("-inf")
             sum_time = 0.0
             count = 0
             for out_file in file_list:
-                with open(out_file, 'r') as f:
+                with open(out_file, "r") as f:
                     for line in f.readlines():
                         m = timing_regex.match(line)
                         if m:
-                            time = float(m.group('main_time'))
+                            time = float(m.group("main_time"))
                             count += 1
                             sum_time += time
                             min_time = min(min_time, time)
@@ -118,14 +186,19 @@ class Wrfv3(SpackApplication):
 
             avg_time = sum_time / max(count, 1)
 
-            stats_path = os.path.join(self.expander.expand_var_name('experiment_run_dir'),
-                                      'stats.out')
-            with open(stats_path, 'w+') as f:
-                f.write('Average time: %s s\n' % (avg_time))
-                f.write('Cumulative time: %s s\n' % (sum_time))
-                f.write('Min time: %s s\n' % (min_time))
-                f.write('Max time: %s s\n' % (max_time))
-                f.write('Avg time / Max time: %s s\n' % (avg_time / max(max_time, float(1.0))))
-                f.write('Number of times: %s\n' % (count))
+            stats_path = os.path.join(
+                self.expander.expand_var_name("experiment_run_dir"),
+                "stats.out",
+            )
+            with open(stats_path, "w+") as f:
+                f.write("Average time: %s s\n" % (avg_time))
+                f.write("Cumulative time: %s s\n" % (sum_time))
+                f.write("Min time: %s s\n" % (min_time))
+                f.write("Max time: %s s\n" % (max_time))
+                f.write(
+                    "Avg time / Max time: %s s\n"
+                    % (avg_time / max(max_time, float(1.0)))
+                )
+                f.write("Number of times: %s\n" % (count))
 
         super()._analyze_experiments(workspace)

--- a/var/ramble/repos/builtin/applications/wrfv4/application.py
+++ b/var/ramble/repos/builtin/applications/wrfv4/application.py
@@ -12,111 +12,184 @@ from ramble.expander import Expander
 
 
 class Wrfv4(SpackApplication):
-    '''Define Wrf version 4 application'''
-    name = 'wrfv4'
+    """Define Wrf version 4 application"""
 
-    maintainers('douglasjacobsen')
+    name = "wrfv4"
 
-    tags('nwp', 'weather')
+    maintainers("douglasjacobsen")
 
-    define_compiler('gcc9', spack_spec='gcc@9.3.0')
+    tags("nwp", "weather")
 
-    software_spec('intel-mpi', spack_spec="intel-mpi@2018.4.274",
-                  compiler='gcc9')
+    define_compiler("gcc9", spack_spec="gcc@9.3.0")
 
-    software_spec('wrfv4',
-                  spack_spec="wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf",
-                  compiler='gcc9')
+    software_spec(
+        "intel-mpi", spack_spec="intel-mpi@2018.4.274", compiler="gcc9"
+    )
 
-    required_package('wrf')
+    software_spec(
+        "wrfv4",
+        spack_spec="wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf",
+        compiler="gcc9",
+    )
 
-    input_file('CONUS_2p5km', url='https://www2.mmm.ucar.edu/wrf/users/benchmark/v422/v42_bench_conus2.5km.tar.gz',
-               sha256='dcae9965d1873c1c1e34e21ad653179783302b9a13528ac10fab092b998578f6',
-               description='2.5 km resolution mesh of the continental United States.')
+    required_package("wrf")
 
-    input_file('CONUS_12km', url='https://www2.mmm.ucar.edu/wrf/users/benchmark/v422/v42_bench_conus12km.tar.gz',
-               sha256='6a0e87e3401efddc50539e71e5437fd7a5af9228b64cd4837e739737c3706fc3',
-               description='12 km resolution mesh of the continental United States.')
+    input_file(
+        "CONUS_2p5km",
+        url="https://www2.mmm.ucar.edu/wrf/users/benchmark/v422/v42_bench_conus2.5km.tar.gz",
+        sha256="dcae9965d1873c1c1e34e21ad653179783302b9a13528ac10fab092b998578f6",
+        description="2.5 km resolution mesh of the continental United States.",
+    )
 
-    executable('cleanup', 'rm -f rsl.* wrfout*', use_mpi=False, output_capture=OUTPUT_CAPTURE.ALL)
-    executable('copy', template=['cp -R {input_path}/* {experiment_run_dir}/.',
-                                 'ln -s {wrf}/run/* {experiment_run_dir}/.'],
-               use_mpi=False, output_capture=OUTPUT_CAPTURE.ALL)
-    executable('fix_12km',
-               template=[
-                   "sed -i -e 's/ start_hour.*/ start_hour                          = 23,/g' namelist.input",
-                   "sed -i -e 's/ restart .*/ restart                             = .true.,/g' namelist.input"
-               ], use_mpi=False, output_capture=OUTPUT_CAPTURE.ALL)
-    executable('execute', 'wrf.exe', use_mpi=True)
+    input_file(
+        "CONUS_12km",
+        url="https://www2.mmm.ucar.edu/wrf/users/benchmark/v422/v42_bench_conus12km.tar.gz",
+        sha256="6a0e87e3401efddc50539e71e5437fd7a5af9228b64cd4837e739737c3706fc3",
+        description="12 km resolution mesh of the continental United States.",
+    )
 
-    workload('CONUS_2p5km', executables=['cleanup', 'copy', 'execute'],
-             input='CONUS_2p5km')
+    executable(
+        "cleanup",
+        "rm -f rsl.* wrfout*",
+        use_mpi=False,
+        output_capture=OUTPUT_CAPTURE.ALL,
+    )
+    executable(
+        "copy",
+        template=[
+            "cp -R {input_path}/* {experiment_run_dir}/.",
+            "ln -s {wrf}/run/* {experiment_run_dir}/.",
+        ],
+        use_mpi=False,
+        output_capture=OUTPUT_CAPTURE.ALL,
+    )
+    executable(
+        "fix_12km",
+        template=[
+            "sed -i -e 's/ start_hour.*/ start_hour                          = 23,/g' namelist.input",
+            "sed -i -e 's/ restart .*/ restart                             = .true.,/g' namelist.input",
+        ],
+        use_mpi=False,
+        output_capture=OUTPUT_CAPTURE.ALL,
+    )
+    executable("execute", "wrf.exe", use_mpi=True)
 
-    workload('CONUS_12km', executables=['cleanup', 'copy', 'fix_12km', 'execute'],
-             input='CONUS_12km')
+    workload(
+        "CONUS_2p5km",
+        executables=["cleanup", "copy", "execute"],
+        input="CONUS_2p5km",
+    )
 
-    workload_variable('input_path', default='{CONUS_12km}',
-                      description='Path for CONUS 12km inputs.',
-                      workloads=['CONUS_12km'])
+    workload(
+        "CONUS_12km",
+        executables=["cleanup", "copy", "fix_12km", "execute"],
+        input="CONUS_12km",
+    )
 
-    workload_variable('input_path', default='{CONUS_2p5km}',
-                      description='Path for CONUS 2.5km inputs.',
-                      workloads=['CONUS_2p5km'])
+    workload_variable(
+        "input_path",
+        default="{CONUS_12km}",
+        description="Path for CONUS 12km inputs.",
+        workloads=["CONUS_12km"],
+    )
 
-    log_str = os.path.join(Expander.expansion_str('experiment_run_dir'),
-                           'stats.out')
+    workload_variable(
+        "input_path",
+        default="{CONUS_2p5km}",
+        description="Path for CONUS 2.5km inputs.",
+        workloads=["CONUS_2p5km"],
+    )
 
-    figure_of_merit('Average Timestep Time', log_file=log_str,
-                    fom_regex=r'Average time:\s+(?P<avg_time>[0-9]+\.[0-9]*).*',
-                    group_name='avg_time', units='s')
+    log_str = os.path.join(
+        Expander.expansion_str("experiment_run_dir"), "stats.out"
+    )
 
-    figure_of_merit('Cumulative Timestep Time', log_file=log_str,
-                    fom_regex=r'Cumulative time:\s+(?P<total_time>[0-9]+\.[0-9]*).*',
-                    group_name='total_time', units='s')
+    figure_of_merit(
+        "Average Timestep Time",
+        log_file=log_str,
+        fom_regex=r"Average time:\s+(?P<avg_time>[0-9]+\.[0-9]*).*",
+        group_name="avg_time",
+        units="s",
+    )
 
-    figure_of_merit('Minimum Timestep Time', log_file=log_str,
-                    fom_regex=r'Min time:\s+(?P<min_time>[0-9]+\.[0-9]*).*',
-                    group_name='min_time', units='s')
+    figure_of_merit(
+        "Cumulative Timestep Time",
+        log_file=log_str,
+        fom_regex=r"Cumulative time:\s+(?P<total_time>[0-9]+\.[0-9]*).*",
+        group_name="total_time",
+        units="s",
+    )
 
-    figure_of_merit('Maximum Timestep Time', log_file=log_str,
-                    fom_regex=r'Max time:\s+(?P<max_time>[0-9]+\.[0-9]*).*',
-                    group_name='max_time', units='s')
+    figure_of_merit(
+        "Minimum Timestep Time",
+        log_file=log_str,
+        fom_regex=r"Min time:\s+(?P<min_time>[0-9]+\.[0-9]*).*",
+        group_name="min_time",
+        units="s",
+    )
 
-    figure_of_merit('Number of timesteps', log_file=log_str,
-                    fom_regex=r'Number of times:\s+(?P<count>[0-9]+)',
-                    group_name='count', units='')
+    figure_of_merit(
+        "Maximum Timestep Time",
+        log_file=log_str,
+        fom_regex=r"Max time:\s+(?P<max_time>[0-9]+\.[0-9]*).*",
+        group_name="max_time",
+        units="s",
+    )
 
-    figure_of_merit('Avg. Max Ratio Time', log_file=log_str,
-                    fom_regex=r'Avg time / Max time:\s+(?P<avg_max_ratio>[0-9]+\.[0-9]*).*',
-                    group_name='avg_max_ratio', units='')
+    figure_of_merit(
+        "Number of timesteps",
+        log_file=log_str,
+        fom_regex=r"Number of times:\s+(?P<count>[0-9]+)",
+        group_name="count",
+        units="",
+    )
 
-    success_criteria('Complete', mode='string', match=r'.*wrf: SUCCESS COMPLETE WRF.*',
-                     file='{experiment_run_dir}/rsl.out.0000')
+    figure_of_merit(
+        "Avg. Max Ratio Time",
+        log_file=log_str,
+        fom_regex=r"Avg time / Max time:\s+(?P<avg_max_ratio>[0-9]+\.[0-9]*).*",
+        group_name="avg_max_ratio",
+        units="",
+    )
 
-    archive_pattern('{experiment_run_dir}/rsl.out.*')
-    archive_pattern('{experiment_run_dir}/rsl.error.*')
+    success_criteria(
+        "Complete",
+        mode="string",
+        match=r".*wrf: SUCCESS COMPLETE WRF.*",
+        file="{experiment_run_dir}/rsl.out.0000",
+    )
+
+    archive_pattern("{experiment_run_dir}/rsl.out.*")
+    archive_pattern("{experiment_run_dir}/rsl.error.*")
 
     def _analyze_experiments(self, workspace, app_inst=None):
         import glob
         import re
+
         # Generate stats file
 
-        file_list = glob.glob(os.path.join(self.expander.expand_var_name('experiment_run_dir'),
-                                           'rsl.out.*'))
+        file_list = glob.glob(
+            os.path.join(
+                self.expander.expand_var_name("experiment_run_dir"),
+                "rsl.out.*",
+            )
+        )
 
         if file_list:
-            timing_regex = re.compile(r'Timing for main.*:\s+(?P<main_time>[0-9]+\.[0-9]*).*')
+            timing_regex = re.compile(
+                r"Timing for main.*:\s+(?P<main_time>[0-9]+\.[0-9]*).*"
+            )
             avg_time = 0.0
-            min_time = float('inf')
-            max_time = float('-inf')
+            min_time = float("inf")
+            max_time = float("-inf")
             sum_time = 0.0
             count = 0
             for out_file in file_list:
-                with open(out_file, 'r') as f:
+                with open(out_file, "r") as f:
                     for line in f.readlines():
                         m = timing_regex.match(line)
                         if m:
-                            time = float(m.group('main_time'))
+                            time = float(m.group("main_time"))
                             count += 1
                             sum_time += time
                             min_time = min(min_time, time)
@@ -124,14 +197,19 @@ class Wrfv4(SpackApplication):
 
             avg_time = sum_time / max(count, 1)
 
-            stats_path = os.path.join(self.expander.expand_var_name('experiment_run_dir'),
-                                      'stats.out')
-            with open(stats_path, 'w+') as f:
-                f.write('Average time: %s s\n' % (avg_time))
-                f.write('Cumulative time: %s s\n' % (sum_time))
-                f.write('Min time: %s s\n' % (min_time))
-                f.write('Max time: %s s\n' % (max_time))
-                f.write('Avg time / Max time: %s s\n' % (avg_time / max(max_time, float(1.0))))
-                f.write('Number of times: %s\n' % (count))
+            stats_path = os.path.join(
+                self.expander.expand_var_name("experiment_run_dir"),
+                "stats.out",
+            )
+            with open(stats_path, "w+") as f:
+                f.write("Average time: %s s\n" % (avg_time))
+                f.write("Cumulative time: %s s\n" % (sum_time))
+                f.write("Min time: %s s\n" % (min_time))
+                f.write("Max time: %s s\n" % (max_time))
+                f.write(
+                    "Avg time / Max time: %s s\n"
+                    % (avg_time / max(max_time, float(1.0)))
+                )
+                f.write("Number of times: %s\n" % (count))
 
         super()._analyze_experiments(workspace)

--- a/var/ramble/repos/builtin/modifiers/execution-date/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/execution-date/modifier.py
@@ -1,4 +1,3 @@
-
 # Copyright 2022-2024 The Ramble Authors
 #
 # Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
@@ -11,21 +10,27 @@ from ramble.modkit import *
 
 
 class ExecutionDate(BasicModifier):
-    """Define a modifier to print the date
-    """
+    """Define a modifier to print the date"""
+
     name = "execution-date"
 
-    maintainers('rfbgo')
+    maintainers("rfbgo")
 
-    mode('standard', description='Standard execution mode')
+    mode("standard", description="Standard execution mode")
 
-    executable_modifier('get_startend_date')
+    executable_modifier("get_startend_date")
 
-    modifier_variable('date_format', default="", description="Date args to format output", mode='standard')
+    modifier_variable(
+        "date_format",
+        default="",
+        description="Date args to format output",
+        mode="standard",
+    )
 
     def get_startend_date(self, executable_name, executable, app_inst=None):
         from ramble.util.executable import CommandExecutable
-        if hasattr(self, '_already_applied'):
+
+        if hasattr(self, "_already_applied"):
             return [], []
 
         self._already_applied = True
@@ -34,21 +39,33 @@ class ExecutionDate(BasicModifier):
         post_cmds = []
 
         pre_cmds.append(
-            CommandExecutable('start-date',
-                              template=[self.expander.expand_var('date {date_format}')],
-                              redirect='{experiment_run_dir}/start_date'
-                              )
+            CommandExecutable(
+                "start-date",
+                template=[self.expander.expand_var("date {date_format}")],
+                redirect="{experiment_run_dir}/start_date",
+            )
         )
         post_cmds.append(
-            CommandExecutable('end-date',
-                              template=[self.expander.expand_var('date {date_format}')],
-                              redirect='{experiment_run_dir}/end_date'
-                              )
+            CommandExecutable(
+                "end-date",
+                template=[self.expander.expand_var("date {date_format}")],
+                redirect="{experiment_run_dir}/end_date",
+            )
         )
         return pre_cmds, post_cmds
 
-    figure_of_merit('Start Date', fom_regex=r'(?P<date>.*)', log_file='{experiment_run_dir}/start_date',
-                    group_name='date', units='')
+    figure_of_merit(
+        "Start Date",
+        fom_regex=r"(?P<date>.*)",
+        log_file="{experiment_run_dir}/start_date",
+        group_name="date",
+        units="",
+    )
 
-    figure_of_merit('End Date', fom_regex=r'(?P<date>.*)', log_file='{experiment_run_dir}/end_date',
-                    group_name='date', units='')
+    figure_of_merit(
+        "End Date",
+        fom_regex=r"(?P<date>.*)",
+        log_file="{experiment_run_dir}/end_date",
+        group_name="date",
+        units="",
+    )

--- a/var/ramble/repos/builtin/modifiers/gcp-metadata/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/gcp-metadata/modifier.py
@@ -18,17 +18,18 @@ class GcpMetadata(BasicModifier):
 
     name = "GcpMetadata"
 
-    tags('gcp-metadata')
-    maintainers('rfbgo')
+    tags("gcp-metadata")
+    maintainers("rfbgo")
 
-    mode('standard', description='Standard execution mode')
-    default_mode('standard')
+    mode("standard", description="Standard execution mode")
+    default_mode("standard")
 
-    executable_modifier('gcp_metadata_exec')
+    executable_modifier("gcp_metadata_exec")
 
     def gcp_metadata_exec(self, executable_name, executable, app_inst=None):
         from ramble.util.executable import CommandExecutable
-        if hasattr(self, '_already_applied'):
+
+        if hasattr(self, "_already_applied"):
             return [], []
 
         self._already_applied = True
@@ -38,44 +39,73 @@ class GcpMetadata(BasicModifier):
 
         payloads = [
             # end point, use_mpi
-            ('machine-type', False),
-            ('image', False),
-            ('hostname', False),
-            ('id', True),  # True since we want the gid of every node
+            ("machine-type", False),
+            ("image", False),
+            ("hostname", False),
+            ("id", True),  # True since we want the gid of every node
         ]
 
         for end_point, use_mpi in payloads:
             pre_cmds.append(
-                CommandExecutable('machine-type',
-                                  template=[
-                                      f'curl -s -w "\\n" "http://metadata.google.internal/computeMetadata/v1/instance/{end_point}" -H "Metadata-Flavor: Google"'
-                                  ],
-                                  mpi=use_mpi,
-                                  redirect=f'{{experiment_run_dir}}/gcp-metadata.{end_point}.log',
-                                  output_capture='>'
-                                  )
+                CommandExecutable(
+                    "machine-type",
+                    template=[
+                        f'curl -s -w "\\n" "http://metadata.google.internal/computeMetadata/v1/instance/{end_point}" -H "Metadata-Flavor: Google"'
+                    ],
+                    mpi=use_mpi,
+                    redirect=f"{{experiment_run_dir}}/gcp-metadata.{end_point}.log",
+                    output_capture=">",
+                )
             )
 
         return pre_cmds, post_cmds
 
     def _prepare_analysis(self, workspace):
         import os.path
+
         ids = set()
-        file_name = self.expander.expand_var('{experiment_run_dir}/gcp-metadata.id.log')
+        file_name = self.expander.expand_var(
+            "{experiment_run_dir}/gcp-metadata.id.log"
+        )
 
         if os.path.isfile(file_name):
-            with open(file_name, 'r') as f:
+            with open(file_name, "r") as f:
                 for cur_id in f.readlines():
                     ids.add(cur_id.strip())
 
-            with open(self.expander.expand_var('{experiment_run_dir}/gcp-metadata.id_list.log'), 'w+') as f:
+            with open(
+                self.expander.expand_var(
+                    "{experiment_run_dir}/gcp-metadata.id_list.log"
+                ),
+                "w+",
+            ) as f:
                 f.write(", ".join(sorted(ids)))
 
-    figure_of_merit('machine-type', fom_regex=r'.*machineTypes/(?P<machine>.*)', group_name='machine', log_file='{experiment_run_dir}/gcp-metadata.machine-type.log')
-    figure_of_merit('image', fom_regex=r'(?P<image>.*global/images.*)', group_name='image', log_file='{experiment_run_dir}/gcp-metadata.image.log')
+    figure_of_merit(
+        "machine-type",
+        fom_regex=r".*machineTypes/(?P<machine>.*)",
+        group_name="machine",
+        log_file="{experiment_run_dir}/gcp-metadata.machine-type.log",
+    )
+    figure_of_merit(
+        "image",
+        fom_regex=r"(?P<image>.*global/images.*)",
+        group_name="image",
+        log_file="{experiment_run_dir}/gcp-metadata.image.log",
+    )
 
     # This is intentionally left singular, to get the hostname of the "parent" or "root" process
-    figure_of_merit('ghostname', fom_regex=r'(?P<ghostname>.*internal)', group_name='ghostname', log_file='{experiment_run_dir}/gcp-metadata.hostname.log')
+    figure_of_merit(
+        "ghostname",
+        fom_regex=r"(?P<ghostname>.*internal)",
+        group_name="ghostname",
+        log_file="{experiment_run_dir}/gcp-metadata.hostname.log",
+    )
 
     # This returns a list of all known gids in the job
-    figure_of_merit('gids', fom_regex=r'(?P<gid>.*)', group_name='gid', log_file='{experiment_run_dir}/gcp-metadata.id_list.log')
+    figure_of_merit(
+        "gids",
+        fom_regex=r"(?P<gid>.*)",
+        group_name="gid",
+        log_file="{experiment_run_dir}/gcp-metadata.id_list.log",
+    )

--- a/var/ramble/repos/builtin/modifiers/install-ramble/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/install-ramble/modifier.py
@@ -11,26 +11,43 @@ from ramble.modkit import *
 
 class InstallRamble(BasicModifier):
     """Modifier to define commands to install ramble"""
+
     name = "install-ramble"
 
-    tags('tool-installation')
+    tags("tool-installation")
 
-    maintainers('douglasjacobsen')
+    maintainers("douglasjacobsen")
 
-    mode('standard', description='Standard execution mode for ramble')
-    default_mode('standard')
+    mode("standard", description="Standard execution mode for ramble")
+    default_mode("standard")
 
-    modifier_variable('ramble_url', default='https://github.com/GoogleCloudPlatform/ramble',
-                      description='URL to clone ramble from', mode='standard')
+    modifier_variable(
+        "ramble_url",
+        default="https://github.com/GoogleCloudPlatform/ramble",
+        description="URL to clone ramble from",
+        mode="standard",
+    )
 
-    modifier_variable('ramble_ref', default='develop',
-                      description='Ref to checkout for ramble', mode='standard')
+    modifier_variable(
+        "ramble_ref",
+        default="develop",
+        description="Ref to checkout for ramble",
+        mode="standard",
+    )
 
-    modifier_variable('ramble_install_dir', default='${HOME}/.ramble/ramble',
-                      description='Directory to install ramble into', mode='standard')
+    modifier_variable(
+        "ramble_install_dir",
+        default="${HOME}/.ramble/ramble",
+        description="Directory to install ramble into",
+        mode="standard",
+    )
 
-    modifier_variable('ramble_venv_path', default='${HOME}/.ramble/ramble-venv',
-                      description='Virtual environment path for ramble', mode='standard')
+    modifier_variable(
+        "ramble_venv_path",
+        default="${HOME}/.ramble/ramble-venv",
+        description="Virtual environment path for ramble",
+        mode="standard",
+    )
 
     create_ramble_venv = """
 if [ ! -d {ramble_venv_path} ]; then
@@ -60,25 +77,38 @@ git checkout FETCH_HEAD
 cd -
 fi
 """
-    modifier_variable('install_ramble_full', default=install_ramble_full + create_ramble_venv, description='Install script for full ramble history',
-                      mode='standard')
+    modifier_variable(
+        "install_ramble_full",
+        default=install_ramble_full + create_ramble_venv,
+        description="Install script for full ramble history",
+        mode="standard",
+    )
 
-    modifier_variable('install_ramble_shallow', default=install_ramble_shallow + create_ramble_venv, description='Install script for shallow ramble history',
-                      mode='standard')
+    modifier_variable(
+        "install_ramble_shallow",
+        default=install_ramble_shallow + create_ramble_venv,
+        description="Install script for shallow ramble history",
+        mode="standard",
+    )
 
-    executable_modifier('source_installed_ramble')
+    executable_modifier("source_installed_ramble")
 
-    def source_installed_ramble(self, executable_name, executable, app_inst=None):
+    def source_installed_ramble(
+        self, executable_name, executable, app_inst=None
+    ):
         from ramble.util.executable import CommandExecutable
 
         pre_exec = []
         post_exec = []
 
-        if not hasattr(self, '_already_applied'):
+        if not hasattr(self, "_already_applied"):
             pre_exec.append(
-                CommandExecutable('source-installed-ramble',
-                                  template=['. {ramble_install_dir}/share/ramble/setup-env.sh']
-                                  )
+                CommandExecutable(
+                    "source-installed-ramble",
+                    template=[
+                        ". {ramble_install_dir}/share/ramble/setup-env.sh"
+                    ],
+                )
             )
 
             self._already_applied = True

--- a/var/ramble/repos/builtin/modifiers/install-spack/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/install-spack/modifier.py
@@ -11,23 +11,36 @@ from ramble.modkit import *
 
 class InstallSpack(BasicModifier):
     """Modifier to define commands to install spack"""
+
     name = "install-spack"
 
-    tags('tool-installation')
+    tags("tool-installation")
 
-    maintainers('douglasjacobsen')
+    maintainers("douglasjacobsen")
 
-    mode('standard', description='Standard execution mode for spack')
-    default_mode('standard')
+    mode("standard", description="Standard execution mode for spack")
+    default_mode("standard")
 
-    modifier_variable('spack_url', default='https://github.com/spack/spack',
-                      description='URL to clone spack from', mode='standard')
+    modifier_variable(
+        "spack_url",
+        default="https://github.com/spack/spack",
+        description="URL to clone spack from",
+        mode="standard",
+    )
 
-    modifier_variable('spack_ref', default='develop',
-                      description='Ref to checkout for spack', mode='standard')
+    modifier_variable(
+        "spack_ref",
+        default="develop",
+        description="Ref to checkout for spack",
+        mode="standard",
+    )
 
-    modifier_variable('spack_install_dir', default='${HOME}/.ramble/spack',
-                      description='Directory to install spack into', mode='standard')
+    modifier_variable(
+        "spack_install_dir",
+        default="${HOME}/.ramble/spack",
+        description="Directory to install spack into",
+        mode="standard",
+    )
 
     install_spack_full = """
 if [ ! -d {spack_install_dir} ]; then
@@ -48,25 +61,38 @@ git checkout FETCH_HEAD
 cd -
 fi
 """
-    modifier_variable('install_spack_full', default=install_spack_full, description='Install script for full spack history',
-                      mode='standard')
+    modifier_variable(
+        "install_spack_full",
+        default=install_spack_full,
+        description="Install script for full spack history",
+        mode="standard",
+    )
 
-    modifier_variable('install_spack_shallow', default=install_spack_shallow, description='Install script for shallow spack history',
-                      mode='standard')
+    modifier_variable(
+        "install_spack_shallow",
+        default=install_spack_shallow,
+        description="Install script for shallow spack history",
+        mode="standard",
+    )
 
-    executable_modifier('source_installed_spack')
+    executable_modifier("source_installed_spack")
 
-    def source_installed_spack(self, executable_name, executable, app_inst=None):
+    def source_installed_spack(
+        self, executable_name, executable, app_inst=None
+    ):
         from ramble.util.executable import CommandExecutable
 
         pre_exec = []
         post_exec = []
 
-        if not hasattr(self, '_already_applied'):
+        if not hasattr(self, "_already_applied"):
             pre_exec.append(
-                CommandExecutable('source-installed-spack',
-                                  template=['. {spack_install_dir}/share/spack/setup-env.sh']
-                                  )
+                CommandExecutable(
+                    "source-installed-spack",
+                    template=[
+                        ". {spack_install_dir}/share/spack/setup-env.sh"
+                    ],
+                )
             )
 
             self._already_applied = True

--- a/var/ramble/repos/builtin/modifiers/intel-aps/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/intel-aps/modifier.py
@@ -16,27 +16,36 @@ class IntelAps(SpackModifier):
     gives a quick view into the high level performance characteristics of an
     experiment. This modifier allows for easy application of APS to experiments.
     """
+
     name = "intel-aps"
 
-    tags('profiler', 'performance-analysis')
+    tags("profiler", "performance-analysis")
 
-    maintainers('douglasjacobsen')
+    maintainers("douglasjacobsen")
 
-    mode('mpi', description='Mode for collecting mpi statistics')
-    default_mode('mpi')
+    mode("mpi", description="Mode for collecting mpi statistics")
+    default_mode("mpi")
 
-    variable_modification('aps_log_dir', 'aps_{executable_name}_results_dir',
-                          method='set', modes=['mpi'])
-    variable_modification('aps_flags', '-c mpi -r {aps_log_dir}', method='set', modes=['mpi'])
-    variable_modification('mpi_command', 'aps {aps_flags}', method='append', modes=['mpi'])
+    variable_modification(
+        "aps_log_dir",
+        "aps_{executable_name}_results_dir",
+        method="set",
+        modes=["mpi"],
+    )
+    variable_modification(
+        "aps_flags", "-c mpi -r {aps_log_dir}", method="set", modes=["mpi"]
+    )
+    variable_modification(
+        "mpi_command", "aps {aps_flags}", method="append", modes=["mpi"]
+    )
 
-    archive_pattern('aps_*_results_dir/*')
+    archive_pattern("aps_*_results_dir/*")
 
-    software_spec('intel-oneapi-vtune', spack_spec='intel-oneapi-vtune')
+    software_spec("intel-oneapi-vtune", spack_spec="intel-oneapi-vtune")
 
-    required_package('intel-oneapi-vtune')
+    required_package("intel-oneapi-vtune")
 
-    executable_modifier('aps_summary')
+    executable_modifier("aps_summary")
 
     def aps_summary(self, executable_name, executable, app_inst=None):
         from ramble.util.executable import CommandExecutable
@@ -45,64 +54,135 @@ class IntelAps(SpackModifier):
         post_exec = []
         if executable.mpi:
             pre_exec.append(
-                CommandExecutable(f'load-aps-{executable_name}',
-                                  template=['spack load intel-oneapi-vtune'])
+                CommandExecutable(
+                    f"load-aps-{executable_name}",
+                    template=["spack load intel-oneapi-vtune"],
+                )
             )
             post_exec.append(
-                CommandExecutable(f'unload-aps-{executable_name}',
-                                  template=['spack unload intel-oneapi-vtune'])
+                CommandExecutable(
+                    f"unload-aps-{executable_name}",
+                    template=["spack unload intel-oneapi-vtune"],
+                )
             )
             post_exec.append(
-                CommandExecutable(f'gen-aps-{executable_name}',
-                                  template=['echo "APS Results for executable {executable_name}"',
-                                            'aps-report -s -D {aps_log_dir}'],
-                                  mpi=False,
-                                  redirect='{log_file}'
-                                  )
+                CommandExecutable(
+                    f"gen-aps-{executable_name}",
+                    template=[
+                        'echo "APS Results for executable {executable_name}"',
+                        "aps-report -s -D {aps_log_dir}",
+                    ],
+                    mpi=False,
+                    redirect="{log_file}",
+                )
             )
 
         return pre_exec, post_exec
 
-    figure_of_merit_context('APS Executable',
-                            regex=r'APS Results for executable (?P<exec_name>\w+)',
-                            output_format='APS on {exec_name}')
+    figure_of_merit_context(
+        "APS Executable",
+        regex=r"APS Results for executable (?P<exec_name>\w+)",
+        output_format="APS on {exec_name}",
+    )
 
     summary_foms = [
-        'Application',
-        'Report creation date',
-        'Number of ranks',
-        'Ranks per node',
-        'Used statistics'
+        "Application",
+        "Report creation date",
+        "Number of ranks",
+        "Ranks per node",
+        "Used statistics",
     ]
 
     for fom in summary_foms:
-        figure_of_merit(fom, fom_regex=r'\s*' + f'{fom}' + r'\s+:\s+(?P<value>.*)', group_name='value',
-                        units='', log_file='{log_file}', contexts=['APS Executable'])
+        figure_of_merit(
+            fom,
+            fom_regex=r"\s*" + f"{fom}" + r"\s+:\s+(?P<value>.*)",
+            group_name="value",
+            units="",
+            log_file="{log_file}",
+            contexts=["APS Executable"],
+        )
 
-    elapsed_time_regex = r'\s*Elapsed Time:\s*(?P<time>[0-9\.]+)'
-    figure_of_merit('Elapsed Time', fom_regex=elapsed_time_regex, group_name='time',
-                    units='s', log_file='{log_file}', contexts=['APS Executable'])
+    elapsed_time_regex = r"\s*Elapsed Time:\s*(?P<time>[0-9\.]+)"
+    figure_of_merit(
+        "Elapsed Time",
+        fom_regex=elapsed_time_regex,
+        group_name="time",
+        units="s",
+        log_file="{log_file}",
+        contexts=["APS Executable"],
+    )
 
-    mpi_time_regex = r'\s*MPI Time:\s*(?P<time>[0-9\.]+)\s*s\s*(?P<percent>[0-9\.]+)%.*'
-    figure_of_merit('MPI Time', fom_regex=mpi_time_regex, group_name='time',
-                    units='s', log_file='{log_file}', contexts=['APS Executable'])
-    figure_of_merit('MPI Percent', fom_regex=mpi_time_regex, group_name='percent',
-                    units='%', log_file='{log_file}', contexts=['APS Executable'])
+    mpi_time_regex = (
+        r"\s*MPI Time:\s*(?P<time>[0-9\.]+)\s*s\s*(?P<percent>[0-9\.]+)%.*"
+    )
+    figure_of_merit(
+        "MPI Time",
+        fom_regex=mpi_time_regex,
+        group_name="time",
+        units="s",
+        log_file="{log_file}",
+        contexts=["APS Executable"],
+    )
+    figure_of_merit(
+        "MPI Percent",
+        fom_regex=mpi_time_regex,
+        group_name="percent",
+        units="%",
+        log_file="{log_file}",
+        contexts=["APS Executable"],
+    )
 
-    mpi_imba_regex = r'\s*MPI Imbalance:\s*(?P<time>[0-9\.]+)\s*s\s*(?P<percent>[0-9\.]+)%.*'
-    figure_of_merit('MPI Imbalance Time', fom_regex=mpi_imba_regex, group_name='time',
-                    units='s', log_file='{log_file}', contexts=['APS Executable'])
-    figure_of_merit('MPI Imbalance Percent', fom_regex=mpi_imba_regex, group_name='percent',
-                    units='%', log_file='{log_file}', contexts=['APS Executable'])
+    mpi_imba_regex = r"\s*MPI Imbalance:\s*(?P<time>[0-9\.]+)\s*s\s*(?P<percent>[0-9\.]+)%.*"
+    figure_of_merit(
+        "MPI Imbalance Time",
+        fom_regex=mpi_imba_regex,
+        group_name="time",
+        units="s",
+        log_file="{log_file}",
+        contexts=["APS Executable"],
+    )
+    figure_of_merit(
+        "MPI Imbalance Percent",
+        fom_regex=mpi_imba_regex,
+        group_name="percent",
+        units="%",
+        log_file="{log_file}",
+        contexts=["APS Executable"],
+    )
 
-    disk_io_regex = r'\s*Disk I/O Bound:\s*(?P<time>[0-9\.]+)\s*s\s*(?P<percent>[0-9\.]+)%.*'
-    figure_of_merit('Disk I/O Time', fom_regex=disk_io_regex, group_name='time',
-                    units='s', log_file='{log_file}', contexts=['APS Executable'])
-    figure_of_merit('Disk I/O Percent', fom_regex=disk_io_regex, group_name='percent',
-                    units='%', log_file='{log_file}', contexts=['APS Executable'])
+    disk_io_regex = r"\s*Disk I/O Bound:\s*(?P<time>[0-9\.]+)\s*s\s*(?P<percent>[0-9\.]+)%.*"
+    figure_of_merit(
+        "Disk I/O Time",
+        fom_regex=disk_io_regex,
+        group_name="time",
+        units="s",
+        log_file="{log_file}",
+        contexts=["APS Executable"],
+    )
+    figure_of_merit(
+        "Disk I/O Percent",
+        fom_regex=disk_io_regex,
+        group_name="percent",
+        units="%",
+        log_file="{log_file}",
+        contexts=["APS Executable"],
+    )
 
-    mpi_func_regex = r'\s*(?P<func_name>MPI_\S+):\s+(?P<time>[0-9\.]+) s\s+(?P<perc>[0-9\.]+)% of Elapsed Time'
-    figure_of_merit('{func_name} Time', fom_regex=mpi_func_regex, group_name='time',
-                    units='s', log_file='{log_file}', contexts=['APS Executable'])
-    figure_of_merit('{func_name} Percent', fom_regex=mpi_func_regex, group_name='perc',
-                    units='%', log_file='{log_file}', contexts=['APS Executable'])
+    mpi_func_regex = r"\s*(?P<func_name>MPI_\S+):\s+(?P<time>[0-9\.]+) s\s+(?P<perc>[0-9\.]+)% of Elapsed Time"
+    figure_of_merit(
+        "{func_name} Time",
+        fom_regex=mpi_func_regex,
+        group_name="time",
+        units="s",
+        log_file="{log_file}",
+        contexts=["APS Executable"],
+    )
+    figure_of_merit(
+        "{func_name} Percent",
+        fom_regex=mpi_func_regex,
+        group_name="perc",
+        units="%",
+        log_file="{log_file}",
+        contexts=["APS Executable"],
+    )

--- a/var/ramble/repos/builtin/modifiers/lscpu/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/lscpu/modifier.py
@@ -16,65 +16,83 @@ class Lscpu(BasicModifier):
     modifier allows experiments to easily extract system information while the
     experiment is being performed.
     """
+
     name = "lscpu"
 
-    tags('system-info', 'sysinfo', 'platform-info')
+    tags("system-info", "sysinfo", "platform-info")
 
-    maintainers('douglasjacobsen')
+    maintainers("douglasjacobsen")
 
-    mode('standard', description='Standard execution mode for lscpu')
-    default_mode('standard')
+    mode("standard", description="Standard execution mode for lscpu")
+    default_mode("standard")
 
-    variable_modification('lscpu_log', '{experiment_run_dir}/lscpu_output.log', method='set', modes=['standard'])
+    variable_modification(
+        "lscpu_log",
+        "{experiment_run_dir}/lscpu_output.log",
+        method="set",
+        modes=["standard"],
+    )
 
-    archive_pattern('lscpu_output.log')
+    archive_pattern("lscpu_output.log")
 
-    figure_of_merit_context('architecture', regex=r'Architecture:\s+(?P<arch>[\w-]+)', output_format='{arch}')
+    figure_of_merit_context(
+        "architecture",
+        regex=r"Architecture:\s+(?P<arch>[\w-]+)",
+        output_format="{arch}",
+    )
 
     section_list = [
-        'CPU op-mode(s)',
-        'Address sizes',
-        'Byte Order',
-        'CPU(s)',
-        'On-line CPU(s) list',
-        'Vendor ID',
-        'Model name',
-        'CPU family',
-        'Model',
-        'Thread(s) per core',
-        'Core(s) per socket',
-        'Socket(s)',
-        'Stepping',
-        'CPU(s) scaling MHz',
-        'CPU max MHz',
-        'CPU min MHz',
-        'BogoMIPS',
-        'Virtualization',
-        'L1d cache',
-        'L1i cache',
-        'L2 cache',
-        'L3 cache',
-        'NUMA',
-        'NUMA node(s)',
-        'NUMA node0 CPU(s)',
-        'Vulnerability Itlb multihit',
-        'Vulnerability L1tf',
-        'Vulnerability Mds',
-        'Vulnerability Meltdown',
-        'Vulnerability Mmio stale data',
-        'Vulnerability Retbleed',
-        'Vulnerability Spec store bypass',
-        'Vulnerability Spectre v1',
-        'Vulnerability Spectre v2',
-        'Vulnerability Srbds',
-        'Vulnerability Tsx async abort',
+        "CPU op-mode(s)",
+        "Address sizes",
+        "Byte Order",
+        "CPU(s)",
+        "On-line CPU(s) list",
+        "Vendor ID",
+        "Model name",
+        "CPU family",
+        "Model",
+        "Thread(s) per core",
+        "Core(s) per socket",
+        "Socket(s)",
+        "Stepping",
+        "CPU(s) scaling MHz",
+        "CPU max MHz",
+        "CPU min MHz",
+        "BogoMIPS",
+        "Virtualization",
+        "L1d cache",
+        "L1i cache",
+        "L2 cache",
+        "L3 cache",
+        "NUMA",
+        "NUMA node(s)",
+        "NUMA node0 CPU(s)",
+        "Vulnerability Itlb multihit",
+        "Vulnerability L1tf",
+        "Vulnerability Mds",
+        "Vulnerability Meltdown",
+        "Vulnerability Mmio stale data",
+        "Vulnerability Retbleed",
+        "Vulnerability Spec store bypass",
+        "Vulnerability Spectre v1",
+        "Vulnerability Spectre v2",
+        "Vulnerability Srbds",
+        "Vulnerability Tsx async abort",
     ]
 
     for section in section_list:
-        figure_of_merit(section, fom_regex=r'\s*' + f'{section}'.replace('(', r'\(').replace(')', r'\)') + r':\s+(?P<fom>.*)',
-                        group_name='fom', units='', log_file='{lscpu_log}', contexts=['architecture'])
+        figure_of_merit(
+            section,
+            fom_regex=r"\s*"
+            + f"{section}".replace("(", r"\(").replace(")", r"\)")
+            + r":\s+(?P<fom>.*)",
+            group_name="fom",
+            units="",
+            log_file="{lscpu_log}",
+            contexts=["architecture"],
+        )
 
-    register_builtin('lscpu_exec')
+    register_builtin("lscpu_exec")
 
     def lscpu_exec(self):
-        return ['lscpu >> {lscpu_log}']
+        return ["lscpu >> {lscpu_log}"]

--- a/var/ramble/repos/builtin/modifiers/pre-exec-print/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/pre-exec-print/modifier.py
@@ -18,37 +18,37 @@ class PreExecPrint(BasicModifier):
     The content of this echo can be overridden by setting the value of the
     'pre_exec_print_template' variable to a print template you would like to use.
     """
+
     name = "pre-exec-print"
 
-    tags('experiment-info')
+    tags("experiment-info")
 
-    maintainers('douglasjacobsen')
+    maintainers("douglasjacobsen")
 
-    mode('standard', description='Standard execution mode for pre-print')
-    default_mode('standard')
+    mode("standard", description="Standard execution mode for pre-print")
+    default_mode("standard")
 
-    executable_modifier('pre_exec_print')
+    executable_modifier("pre_exec_print")
 
-    _attr_name = '_applied_pre_exec_print'
+    _attr_name = "_applied_pre_exec_print"
 
     def pre_exec_print(self, executable_name, executable, app_inst=None):
         from ramble.util.executable import CommandExecutable
+
         pre_cmds = []
         post_cmds = []
 
         if not hasattr(self, self._attr_name):
             echo_string = "Index: {experiment_index} -- Namespace: {experiment_namespace}"
-            if 'pre_exec_print_template' in app_inst.variables:
-                echo_string = '{pre_exec_print_template}'
+            if "pre_exec_print_template" in app_inst.variables:
+                echo_string = "{pre_exec_print_template}"
             pre_cmds.append(
                 CommandExecutable(
-                    'perform-pre-exec-print',
-                    template=[
-                        f'echo "Running: {echo_string}"'
-                    ],
+                    "perform-pre-exec-print",
+                    template=[f'echo "Running: {echo_string}"'],
                     mpi=False,
-                    redirect='',
-                    output_capture=''
+                    redirect="",
+                    output_capture="",
                 )
             )
             setattr(self, self._attr_name, True)


### PR DESCRIPTION
* Add support for formatting object files (apps and mods) in the `style` cmd
* Add a new config file for these object files, to accommodate for the different `line-length` requirement they have compared with primary files
* Run `ramble style -af` to auto-format these object files

Also a (small but separate) change:

* Do not fallback to checking all-files when no file is changed (this can happen say on a new checkout of develop, or a branch that only modifies files that are not in the style check scope.)