### PR TITLE
Clean up unit-test warnings

### DIFF
--- a/lib/ramble/ramble/test/cmd/mods.py
+++ b/lib/ramble/ramble/test/cmd/mods.py
@@ -6,8 +6,6 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-import pytest
-
 from ramble.main import RambleCommand
 
 mods = RambleCommand("mods")
@@ -52,7 +50,6 @@ def test_mods_info(mutable_mock_mods_repo, mock_modifier):
     check_info(out)
 
 
-@pytest.mark.filterwarnings("ignore:invalid decimal literal:DeprecationWarning")
 def test_mods_info_all_real_modifiers(modifier):
     mod_info = mods("info", modifier)
 

--- a/lib/ramble/ramble/test/end_to_end/chained_experiment_var_inheritance.py
+++ b/lib/ramble/ramble/test/end_to_end/chained_experiment_var_inheritance.py
@@ -24,7 +24,7 @@ pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_p
 workspace = RambleCommand("workspace")
 
 
-@pytest.mark.filterwarnings("ignore:invalid decimal literal:DeprecationWarning")
+@pytest.mark.filterwarnings("ignore:invalid decimal literal")
 def test_chained_experiment_variable_inheritance(mutable_config, mutable_mock_workspace_path):
     test_config = r"""
 ramble:

--- a/lib/ramble/ramble/test/end_to_end/dryrun_chained_experiments.py
+++ b/lib/ramble/ramble/test/end_to_end/dryrun_chained_experiments.py
@@ -28,7 +28,7 @@ pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_p
 workspace = RambleCommand("workspace")
 
 
-@pytest.mark.filterwarnings("ignore:invalid decimal literal:DeprecationWarning")
+@pytest.mark.filterwarnings("ignore:invalid decimal literal")
 def test_dryrun_chained_experiments(mutable_config, mutable_mock_workspace_path):
     test_config = r"""
 ramble:

--- a/lib/ramble/ramble/test/end_to_end/known_applications.py
+++ b/lib/ramble/ramble/test/end_to_end/known_applications.py
@@ -26,6 +26,7 @@ workspace = RambleCommand("workspace")
 
 
 @pytest.mark.long
+@pytest.mark.filterwarnings("ignore:invalid escape sequence:DeprecationWarning")
 def test_known_applications(application, capsys):
     info_cmd = RambleCommand("info")
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,6 +5,17 @@ testpaths = lib/ramble/ramble/test
 python_files = *.py
 filterwarnings =
   ignore::UserWarning
+  # The following suppressed warnings are introduced in 3.12,
+  # see https://docs.python.org/3.12/whatsnew/3.12.html#deprecated
+  # Suppress deprecation warnings on Ast
+  # TODO: this needs to be updated before the older Ast nodes are
+  # dropped in 3.14.
+  ignore:.*use ast\.Constant instead:DeprecationWarning
+  ignore:.*use value instead:DeprecationWarning
+  # Suppress fork warning
+  # This happens when running multiple commands in the same test,
+  # which does not actually have deadlock danger.
+  ignore:.*use of fork:DeprecationWarning
 markers =
   db: tests that require creating a DB
   maybeslow: tests that may be slow (e.g. access a lot the filesystem, etc.)


### PR DESCRIPTION
* Fix up the suppression of "invalid decimal" in chained tests. In 3.11/3.12 it changed from being a `DeprecationWarning` to a `SyntaxWarning`.
* Suppress "invalid escape sequence" in known_apps test. This aligns with ignoring W503 in flake8_applications.
* Suppress a couple new deprecation warnings introduced in 3.12
  - Deprecation on AST node types (future TODO)
  - Warning on mix of thread and fork

Tested:

```sh
$ python3 --version
Python 3.12.3

$ ramble unit-test
...
==== 1050 passed in 496.54s (0:08:16) ====

$ python3 --version
Python 3.10.14

$ ramble unit-test
...
==== 1050 passed in 515.27s (0:08:35) ====
```