### PR TITLE
Fix invalid escape sequence in spack-runner

### DIFF
--- a/lib/ramble/ramble/spack_runner.py
+++ b/lib/ramble/ramble/spack_runner.py
@@ -237,26 +237,13 @@ class SpackRunner(object):
         Add commands to load a package to the executable
         """
         if self.shell == "bash":
-            regex = re.compile(
-                "\A.*export "  # noqa: W605
-                + "(?P<var>[\S^=]+)="  # noqa: W605
-                + "(?P<val>[\S]+);\Z"  # noqa: W605
-            )
-
+            regex = re.compile(r"\A.*export (?P<var>[\S^=]+)=(?P<val>[\S]+);\Z")
             shell_flag = "--sh"
         elif self.shell == "csh":
-            regex = re.compile(
-                "\A.*setenv "  # noqa: W605
-                + "(?P<var>[\S^=]+) "  # noqa: W605
-                + "(?P<val>[\S]+);\Z"  # noqa: W605
-            )
+            regex = re.compile(r"\A.*setenv (?P<var>[\S^=]+) (?P<val>[\S]+);\Z")
             shell_flag = "--csh"
         elif self.shell == "fish":
-            regex = re.compile(
-                "\A.*set -gx "  # noqa: W605
-                + "(?P<var>[\S^=]+) "  # noqa: W605
-                + "(?P<val>[\S]+);\Z"  # noqa: W605
-            )
+            regex = re.compile(r"\A.*set -gx (?P<var>[\S^=]+) (?P<val>[\S]+);\Z")
             shell_flag = "--fish"
         else:
             raise RunnerError("Shell %s not supported" % self.shell)


### PR DESCRIPTION
This starts getting reported in python 3.12 as SyntaxWarning: https://docs.python.org/dev/whatsnew/3.12.html#other-language-changes