### PR TITLE
Issue a warning for empty `mpi_command`

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -945,7 +945,16 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                 for cmd_conf in command_configs:
                     mpi_cmd = ""
                     if cmd_conf.mpi:
-                        mpi_cmd = " " + self.expander.expand_var("{mpi_command}", exec_vars) + " "
+                        raw_mpi_cmd = self.expander.expand_var("{mpi_command}", exec_vars).strip()
+                        if (
+                            not raw_mpi_cmd
+                            and int(self.expander.expand_var_name(self.keywords.n_nodes)) > 1
+                        ):
+                            logger.warn(
+                                f"Command {cmd_conf} requires a non-empty `mpi_cmd` "
+                                "variable in a multi-node experiment"
+                            )
+                        mpi_cmd = " " + raw_mpi_cmd + " "
 
                     redirect = ""
                     if cmd_conf.redirect:

--- a/lib/ramble/ramble/test/end_to_end/missing_mpi_cmd.py
+++ b/lib/ramble/ramble/test/end_to_end/missing_mpi_cmd.py
@@ -1,0 +1,78 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.workspace
+import ramble.config
+import ramble.software_environments
+from ramble.main import RambleCommand
+
+
+# everything here uses the mock_workspace_path
+pytestmark = pytest.mark.usefixtures(
+    "mutable_config",
+    "mutable_mock_workspace_path",
+)
+
+workspace = RambleCommand("workspace")
+
+
+def test_missing_mpi_cmd():
+    test_config = """
+ramble:
+  variables:
+    mpi_command: ''
+    batch_submit: 'batch_submit {execute_experiment}'
+    processes_per_node: '1'
+  applications:
+    hostname:
+      workloads:
+        local:
+          experiments:
+            multi-node-test:
+              variables:
+                n_ranks: '3'
+            single-node-test:
+              variables:
+                n_nodes: '1'
+  modifiers:
+  - name: gcp-metadata
+  spack:
+    packages: {}
+    environments: {}
+"""
+    workspace_name = "test-missing-mpi-cmd"
+    ws = ramble.workspace.create(workspace_name)
+    ws.write()
+
+    config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+
+    with open(config_path, "w+") as f:
+        f.write(test_config)
+
+    ws._re_read()
+
+    workspace("setup", "--dry-run", global_args=["-w", workspace_name])
+
+    single_setup_out = os.path.join(
+        ws.log_dir, "setup.latest", "hostname.local.single-node-test.out"
+    )
+    with open(single_setup_out) as f:
+        content = f.read()
+        assert "Warning:" not in content
+
+    multi_setup_out = os.path.join(
+        ws.log_dir, "setup.latest", "hostname.local.multi-node-test.out"
+    )
+    with open(multi_setup_out) as f:
+        content = f.read()
+        assert "Warning:" in content
+        assert "requires a non-empty `mpi_cmd` variable" in content


### PR DESCRIPTION
The warning applies to when a command is configured with `use_mpi=True`, and that it's a multi-node experiment.

One use case of this is when the main application does not need an explicit mpi command to function properly (for example, ansys-fluent,) but that the added modifiers require a valid mpi command (for example, gcp-metadata.)