### PR TITLE
Add a util for ramble app to get file path

### DIFF
--- a/lib/ramble/ramble/appkit.py
+++ b/lib/ramble/ramble/appkit.py
@@ -28,4 +28,6 @@ from ramble.util.logger import logger
 # Import new logger as tty to preserve old behavior
 from ramble.util.logger import logger as tty
 
+from ramble.util.file_util import get_file_path
+
 from ramble.schema.types import OUTPUT_CAPTURE

--- a/lib/ramble/ramble/spack_runner.py
+++ b/lib/ramble/ramble/spack_runner.py
@@ -617,8 +617,8 @@ class SpackRunner(object):
             self._dry_run_print(self.spack, name_args)
             self._dry_run_print(self.spack, loc_args)
 
-            name = os.path.join(shlex.split(package_spec)[0])
-            location = os.path.join("dry-run", "path", "to", shlex.split(package_spec)[0])
+            name = shlex.split(package_spec)[0].split("@")[0]
+            location = os.path.join("dry-run", "path", "to", name)
             return (name, location)
 
     def mirror_environment(self, mirror_path):

--- a/lib/ramble/ramble/test/conftest.py
+++ b/lib/ramble/ramble/test/conftest.py
@@ -6,7 +6,9 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+import builtins
 import collections
+import io
 import os
 import os.path
 import shutil
@@ -21,6 +23,7 @@ import ramble.paths
 import ramble.repository
 import ramble.stage
 from ramble.fetch_strategy import FetchError, FetchStrategyComposite, URLFetchStrategy
+from ramble.util.file_util import is_dry_run_path
 
 import spack.platforms
 import spack.util.spack_yaml as syaml
@@ -546,6 +549,23 @@ def mock_fetch(mock_archive, monkeypatch):
     mock_fetcher.append(URLFetchStrategy(mock_archive.url))
 
     yield mock_fetcher
+
+
+@pytest.fixture()
+def mock_file_auto_create(monkeypatch):
+    builtin_open = builtins.open
+
+    def open_or_create_inmem(path, *args, **kwargs):
+        if not os.path.exists(path) and is_dry_run_path(path):
+            if path.endswith(".yaml") or path.endswith(".yml"):
+                content = "{}"
+            else:
+                content = ""
+            inmem = io.StringIO(content)
+            return inmem
+        return builtin_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", open_or_create_inmem)
 
 
 def pytest_generate_tests(metafunc):

--- a/lib/ramble/ramble/test/end_to_end/known_applications.py
+++ b/lib/ramble/ramble/test/end_to_end/known_applications.py
@@ -27,7 +27,7 @@ workspace = RambleCommand("workspace")
 
 @pytest.mark.long
 @pytest.mark.filterwarnings("ignore:invalid escape sequence:DeprecationWarning")
-def test_known_applications(application, capsys):
+def test_known_applications(application, capsys, mock_file_auto_create):
     info_cmd = RambleCommand("info")
 
     setup_type = ramble.pipeline.pipelines.setup

--- a/lib/ramble/ramble/test/get_file_path.py
+++ b/lib/ramble/ramble/test/get_file_path.py
@@ -1,0 +1,66 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.workspace
+import ramble.config
+import ramble.software_environments
+from ramble.main import RambleCommand
+
+
+# everything here uses the mock_workspace_path
+pytestmark = pytest.mark.usefixtures(
+    "mutable_config",
+    "mutable_mock_workspace_path",
+)
+
+workspace = RambleCommand("workspace")
+
+
+def test_get_file_path(mock_applications, mock_file_auto_create):
+    test_config = """
+ramble:
+  config:
+    disable_progress_bar: true
+  variables:
+    mpi_command: ''
+    batch_submit: 'batch_submit {execute_experiment}'
+    processes_per_node: '1'
+  applications:
+    file-open:
+      workloads:
+        test_wl:
+          experiments:
+            test:
+              variables:
+                n_ranks: '1'
+  spack:
+    packages: {}
+    environments: {}
+"""
+    workspace_name = "test-get-file-path"
+    ws = ramble.workspace.create(workspace_name)
+    ws.write()
+
+    config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+
+    with open(config_path, "w+") as f:
+        f.write(test_config)
+
+    ws._re_read()
+
+    workspace("setup", "--dry-run", global_args=["-w", workspace_name])
+
+    test_out = os.path.join(ws.log_dir, "setup.latest", "file-open.test_wl.test.out")
+    with open(test_out) as f:
+        content = f.read()
+        # When in dry-run, the test mock pretends the file exists
+        assert "Config loaded from dry-run/path/to/file-open/my/config.yaml" in content

--- a/lib/ramble/ramble/util/file_util.py
+++ b/lib/ramble/ramble/util/file_util.py
@@ -1,0 +1,32 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+
+_DRY_RUN_PATH_PREFIX = os.path.join("dry-run", "path", "to")
+
+
+def get_file_path(path: str, workspace) -> str:
+    """A wrapper for file paths used in a Ramble application, to facilitate testing.
+
+    Args:
+        path (str): A file path
+        workspace (Workspace): A ramble workspace
+
+    Returns:
+        (str): A file path
+    """
+    if not workspace.dry_run or is_dry_run_path(path):
+        return path
+    return os.path.join(_DRY_RUN_PATH_PREFIX, os.path.relpath(path))
+
+
+def is_dry_run_path(path: str) -> bool:
+    """Check if the path is already a dry_run path"""
+    return path.startswith(_DRY_RUN_PATH_PREFIX)

--- a/var/ramble/repos/builtin.mock/applications/file-open/application.py
+++ b/var/ramble/repos/builtin.mock/applications/file-open/application.py
@@ -1,0 +1,32 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+import ruamel.yaml as yaml
+
+from ramble.appkit import *
+
+
+class FileOpen(ExecutableApplication):
+    name = "file-open"
+
+    executable("foo", "echo 'bar'", use_mpi=False)
+
+    workload("test_wl", executable="foo")
+
+    register_phase(
+        "load_config", pipeline="setup", run_after=["make_experiments"]
+    )
+
+    def _load_config(self, workspace, app_inst):
+        config_path = get_file_path(
+            os.path.join("file-open", "my", "config.yaml"), workspace
+        )
+        with open(config_path) as conf:
+            yaml.safe_load(conf)
+            logger.info(f"Config loaded from {config_path}")


### PR DESCRIPTION
This serves as a thin wrapper to facilitate mocking out such paths during unit-tests.