### PR TITLE
consider `$RAMBLE_PYTHON` environment variable in `ramble` script to pick `python` command to use

### DIFF
--- a/bin/ramble
+++ b/bin/ramble
@@ -14,8 +14,8 @@
 # Following line is a shell no-op, and starts a multi-line Python comment.
 # See https://stackoverflow.com/a/47886254
 """:"
-# prefer python3, then python, then python2
-for cmd in python3 python python2; do
+# prefer $RAMBLE_PYTHON (if defined), then prefer python3, then python, then python2
+for cmd in ${RAMBLE_PYTHON} python3 python python2; do
    command -v > /dev/null $cmd && exec $cmd $0 "$@"
 done
 


### PR DESCRIPTION
On some systems multiple `python*` commands are available, like `python3.9` on a RHEL8 system next to the standard system Python `python3` which is equivalent to `python3.6`.

If `ramble` picks up on an environment variable like `$RAMBLE_PYTHON`, the user can control which `python*` command is used to run Ramble...