### PR TITLE
Allow staging inputs in variable defined directory

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -1154,7 +1154,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                 input_path = self.expander.expand_var(
                     input_conf["target_dir"], extra_vars=input_vars
                 )
-                input_tuple = ("input-file", input_path)
+                input_tuple = (f"input-file-{input_file}", input_path)
 
                 # Skip inputs that have already been cached
                 if workspace.check_cache(input_tuple):
@@ -1167,10 +1167,9 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                 with ramble.stage.InputStage(
                     input_conf["fetcher"],
                     name=input_namespace,
-                    path=self.expander.workload_input_dir,
+                    path=input_path,
                     mirror_paths=mirror_paths,
                 ) as stage:
-                    stage.set_subdir(input_path)
                     stage.fetch()
                     if input_conf["fetcher"].digest:
                         stage.check()


### PR DESCRIPTION
This merge fixes an issue where input files staged into the same directoy are skipped (as the cache only included the stage directory previously).

Additionally, this merge allows the target directory for an input file to be a variable that is expanded.