### PR TITLE
Add an option for `workspace analyze` to print out results

### DIFF
--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -502,6 +502,14 @@ def workspace_analyze_setup_parser(subparser):
         help="perform a dry run. Allows progress on workspaces which are not fully setup",
     )
 
+    subparser.add_argument(
+        "-p",
+        "--print-results",
+        dest="print_results",
+        action="store_true",
+        help="print out the analysis result",
+    )
+
     arguments.add_common_arguments(
         subparser,
         ["phases", "include_phase_dependencies", "where", "exclude_where", "filter_tags"],
@@ -527,7 +535,13 @@ def workspace_analyze(args):
     pipeline_cls = ramble.pipeline.pipeline_class(current_pipeline)
 
     logger.debug("Analyzing workspace")
-    pipeline = pipeline_cls(ws, filters, output_formats=args.output_formats, upload=args.upload)
+    pipeline = pipeline_cls(
+        ws,
+        filters,
+        output_formats=args.output_formats,
+        upload=args.upload,
+        print_results=args.print_results,
+    )
 
     with ws.write_transaction():
         workspace_run_pipeline(args, pipeline)

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -220,7 +220,9 @@ class AnalyzePipeline(Pipeline):
 
     name = "analyze"
 
-    def __init__(self, workspace, filters, output_formats=["text"], upload=False):
+    def __init__(
+        self, workspace, filters, output_formats=["text"], upload=False, print_results=False
+    ):
         workspace_success = {namespace.success: ramble.config.config.get_config(namespace.success)}
 
         workspace.extract_success_criteria("workspace", workspace_success)
@@ -230,6 +232,7 @@ class AnalyzePipeline(Pipeline):
         self.output_formats = output_formats
         self.require_inventory = True
         self.upload_results = upload
+        self.print_results = print_results
 
     def _prepare(self):
 
@@ -262,8 +265,9 @@ class AnalyzePipeline(Pipeline):
 
             if app_inst.repeats.n_repeats > 0:
                 app_inst.calculate_statistics(self.workspace)
-
-        self.workspace.dump_results(output_formats=self.output_formats)
+        self.workspace.dump_results(
+            output_formats=self.output_formats, print_results=self.print_results
+        )
 
         if self.upload_results:
             ramble.experimental.uploader.upload_results(self.workspace.results)

--- a/lib/ramble/ramble/test/end_to_end/analyze_fom_output.py
+++ b/lib/ramble/ramble/test/end_to_end/analyze_fom_output.py
@@ -11,6 +11,8 @@ import glob
 
 import pytest
 
+import llnl.util.tty as tty
+
 import ramble.workspace
 import ramble.config
 import ramble.software_environments
@@ -25,8 +27,27 @@ pytestmark = pytest.mark.usefixtures(
 
 workspace = RambleCommand("workspace")
 
+common_test_config = """
+ramble:
+  variables:
+    mpi_command: ''
+    batch_submit: 'batch_submit {execute_experiment}'
+    processes_per_node: '1'
+  applications:
+    hostname:
+      workloads:
+        local:
+          experiments:
+            test:
+              variables:
+                n_nodes: '1'
+  spack:
+    packages: {}
+    environments: {}
+"""
 
-def test_analyze_fom_output():
+
+def _setup_workspace(ws_name):
     test_config = """
 ramble:
   variables:
@@ -45,8 +66,7 @@ ramble:
     packages: {}
     environments: {}
 """
-    workspace_name = "test-fom-output"
-    ws = ramble.workspace.create(workspace_name)
+    ws = ramble.workspace.create(ws_name)
     ws.write()
 
     config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
@@ -56,14 +76,41 @@ ramble:
 
     ws._re_read()
 
-    workspace("setup", "--dry-run", global_args=["-w", workspace_name])
+    workspace("setup", "--dry-run", global_args=["-w", ws_name])
     exp_out = os.path.join(ws.experiment_dir, "hostname", "local", "test", "test.out")
     with open(exp_out, "w+") as f:
         f.write("test-user.c.googlers.com\n")
-    workspace("analyze", global_args=["-w", workspace_name])
+    return ws
+
+
+def test_analyze_fom_output():
+    workspace_name = "test-fom-output"
+    ws = _setup_workspace(workspace_name)
+
+    workspace("analyze", "-p", global_args=["-w", workspace_name])
     result_file = glob.glob(os.path.join(ws.root, "results.latest.txt"))[0]
 
     with open(result_file, "r") as f:
         content = f.read()
         assert "default (null) context figures of merit" in content
         assert "possible hostname = test-user.c.googlers.com" in content
+
+
+def test_analyze_print(monkeypatch):
+    workspace_name = "test-analyze-print"
+    _setup_workspace(workspace_name)
+
+    msg_list = []
+
+    def _msg(msg, *args, **kwargs):
+        msg_list.append(msg)
+
+    # Assert whether the print is present or not
+    monkeypatch.setattr(tty, "msg", _msg)
+
+    workspace("analyze", global_args=["-w", workspace_name])
+    assert not any(m.startswith("Results from the analysis pipeline") for m in msg_list)
+
+    msg_list = []
+    workspace("analyze", "-p", global_args=["-w", workspace_name])
+    assert any(m.startswith("Results from the analysis pipeline") for m in msg_list)

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1039,7 +1039,7 @@ class Workspace(object):
 
         os.symlink(out_file, latest_file)
 
-    def dump_results(self, output_formats=["text"]):
+    def dump_results(self, output_formats=["text"], print_results=False):
         """
         Write out result file in desired format
 
@@ -1136,11 +1136,10 @@ class Workspace(object):
         for out_file in results_written:
             logger.all_msg(f"  {out_file}")
 
-        # Debug print the first written result file.
-        # Directly use tty to avoid cluttering the analyze log.
-        if ramble.config.get("config:debug"):
+        if print_results:
             with open(results_written[0], "r") as f:
-                tty.debug(f"Results from the analysis pipeline:\n{f.read()}")
+                # Use tty directly to avoid cluttering the analyze log
+                tty.msg(f"Results from the analysis pipeline:\n{f.read()}")
 
         return filename_base
 

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -705,7 +705,7 @@ _ramble_workspace_setup() {
 }
 
 _ramble_workspace_analyze() {
-    RAMBLE_COMPREPLY="-h --help -f --formats -u --upload --always-print-foms --dry-run --phases --include-phase-dependencies --where --exclude-where --filter-tags"
+    RAMBLE_COMPREPLY="-h --help -f --formats -u --upload --always-print-foms --dry-run -p --print-results --phases --include-phase-dependencies --where --exclude-where --filter-tags"
 }
 
 _ramble_workspace_push_to_cache() {


### PR DESCRIPTION
Previously I set it to print the results in debug mode, but often I find it more convenient to have it print out the results only without the other detailed debug logs.