### PR TITLE
Tweak `repo add` behavior

### DIFF
--- a/lib/ramble/ramble/repository.py
+++ b/lib/ramble/ramble/repository.py
@@ -815,6 +815,7 @@ class Repo(object):
             if os.path.exists(config_file):
                 self.config_name = config
                 self.config_file = config_file
+        check(self.config_file, "No valid config file found")
         check(os.path.isfile(self.config_file), "No %s found in '%s'" % (self.config_name, root))
 
         # Read configuration and validate namespace


### PR DESCRIPTION
Now when doing `ramble repo add <repo-path>`, it won't error out if the
repo does not contain all object types.

Behavior with the change:

* Complains when specified type not found (same as previous)

```sh
$ ramble repo create test-repo
$ ls test-repo
applications  modifiers  repo.yaml

$ rm -r test-repo/modifiers/
$ ramble repo add -t modifiers test-repo
==> Error: Failed to find valid repo with type ObjectTypes.modifiers
```

* Do not complain when no type is specified (changed from previous)

```sh
$ ramble repo add test-repo
==> Added applications repo with namespace 'test-repo'.
```

* Complain if no valid repo is found

```sh
$ rm -r test-repo/applications/
$ ramble repo add test-repo
==> Error: The given path test-repo is not a valid repo for any object types
```