### PR TITLE
Allow licenses section in merged config

### DIFF
--- a/lib/ramble/ramble/schema/licenses.py
+++ b/lib/ramble/ramble/schema/licenses.py
@@ -44,7 +44,8 @@ env_var_actions = {
     "unset": array_of_strings_or_num,
 }
 
-licenses_schema = {
+#: Properties for inclusion in other schemas
+properties = {
     "licenses": {
         "type": "object",
         "default": {},
@@ -64,5 +65,5 @@ schema = {
     "title": "Ramble licenses configuration file schema",
     "type": "object",
     "additionalProperties": False,
-    "properties": licenses_schema,
+    "properties": properties,
 }

--- a/lib/ramble/ramble/schema/merged.py
+++ b/lib/ramble/ramble/schema/merged.py
@@ -16,6 +16,7 @@ from llnl.util.lang import union_dicts
 import ramble.schema.applications
 import ramble.schema.config
 import ramble.schema.formatted_executables
+import ramble.schema.licenses
 import ramble.schema.repos
 import ramble.schema.spack
 import ramble.schema.success_criteria
@@ -30,6 +31,7 @@ properties = union_dicts(
     ramble.schema.applications.properties,
     ramble.schema.config.properties,
     ramble.schema.formatted_executables.properties,
+    ramble.schema.licenses.properties,
     ramble.schema.repos.properties,
     ramble.schema.spack.properties,
     ramble.schema.success_criteria.properties,


### PR DESCRIPTION
This enables using `ramble config add` to add in license config file (versus currently explicitly placing it under the configs directory.) It also allows for co-locating licensing info inside workspace config.