### PR TITLE
Fix up undefined vars in llnl util

### DIFF
--- a/lib/ramble/llnl/util/tty/__init__.py
+++ b/lib/ramble/llnl/util/tty/__init__.py
@@ -292,6 +292,7 @@ def get_number(prompt, **kwargs):
     number = None
     while number is None:
         msg(prompt, newline=False)
+        ans = input()
         if ans == str(abort):
             return None
 
@@ -324,6 +325,7 @@ def get_yes_or_no(prompt, **kwargs):
     result = None
     while result is None:
         msg(prompt, newline=False)
+        ans = input().lower()
         if not ans:
             result = default_value
             if result is None:


### PR DESCRIPTION
This shows up say when confirming removal:

```
$ ramble workspace rm fluent-all
==> Error: name 'ans' is not defined
```

Doug also noticed this in his package-manager PR. But there's another method that has the same missing var issue, so creating a separate PR to get both in.