### PR TITLE
Add activation support in `workspace create`

### DIFF
--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -261,6 +261,12 @@ def workspace_create_setup_parser(subparser):
         metavar="dir",
         help="external directory to link as inputs directory in workspace",
     )
+    subparser.add_argument(
+        "-a",
+        "--activate",
+        action="store_true",
+        help="activate the created workspace, if specified. Default is false",
+    )
 
 
 def workspace_create(args):
@@ -271,11 +277,18 @@ def workspace_create(args):
         args.template_execute,
         software_dir=args.software_dir,
         inputs_dir=args.inputs_dir,
+        activate=args.activate,
     )
 
 
 def _workspace_create(
-    name_or_path, dir=False, config=None, template_execute=None, software_dir=None, inputs_dir=None
+    name_or_path,
+    dir=False,
+    config=None,
+    template_execute=None,
+    software_dir=None,
+    inputs_dir=None,
+    activate=False,
 ):
     """Create a new workspace
 
@@ -292,6 +305,7 @@ def _workspace_create(
                             instead of creating a new directory.
         inputs_dir (str): Path to inputs dir that should be linked
                           instead of creating a new directory.
+        activate (bool): if True, activate the created workspace. Default is False.
     """
 
     # Sanity check file paths, to avoid half-creating an incomplete workspace
@@ -310,10 +324,7 @@ def _workspace_create(
         workspace = ramble.workspace.Workspace(
             name_or_path, read_default_template=read_default_template
         )
-
-        logger.msg(f"Created workspace in {workspace.path}")
-        logger.msg("You can activate this workspace with:")
-        logger.msg(f"  ramble workspace activate {workspace.path}")
+        ws_loc = workspace.path
 
     else:
         workspace = ramble.workspace.create(
@@ -321,9 +332,13 @@ def _workspace_create(
         )
 
         workspace.read_default_template = read_default_template
-        logger.msg(f"Created workspace in {name_or_path}")
+        ws_loc = name_or_path
+
+    activate_cmd = f"ramble workspace activate {ws_loc}"
+    if not activate:
+        logger.msg(f"Created workspace in {ws_loc}")
         logger.msg("You can activate this workspace with:")
-        logger.msg(f"  ramble workspace activate {name_or_path}")
+        logger.msg(f"  {activate_cmd}")
 
     workspace.write(inputs_dir=inputs_dir, software_dir=software_dir)
 
@@ -339,6 +354,8 @@ def _workspace_create(
             workspace._read_template(template_name, f.read())
             workspace._write_templates()
 
+    if activate:
+        sys.stdout.write(activate_cmd)
     return workspace
 
 

--- a/share/ramble/csh/ramble.csh
+++ b/share/ramble/csh/ramble.csh
@@ -98,6 +98,19 @@ case workspace:
                     eval `\ramble $_rmb_flags workspace deactivate --csh`
                 endif
                 breaksw
+            case create:
+                echo $_rmb_args
+                if ( "$_rmb_args" =~ *" -a"* || \
+                     "$_rmb_args" =~ *" --activate"* ) then
+                    # Args contain activate flag
+                    set _activate_cmd = `\ramble $_rmb_flags workspace $_rmb_args`
+                    eval $_activate_cmd
+                    set _ws = `echo $_activate_cmd | awk '{print $NF}'`
+                    echo "==> Created and activated workspace in $_ws"
+                else
+                    \ramble $_rmb_flags workspace $_rmb_args
+                endif
+                breaksw
             default:
                 \ramble $_rmb_flags workspace $_rmb_args
                 breaksw

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -658,7 +658,7 @@ _ramble_workspace_deactivate() {
 _ramble_workspace_create() {
     if $list_options
     then
-        RAMBLE_COMPREPLY="-h --help -c --config -t --template_execute -d --dir --software-dir --inputs-dir"
+        RAMBLE_COMPREPLY="-h --help -c --config -t --template_execute -d --dir --software-dir --inputs-dir -a --activate"
     else
         RAMBLE_COMREPLY=""
     fi

--- a/share/ramble/setup-env.fish
+++ b/share/ramble/setup-env.fish
@@ -359,6 +359,20 @@ function check_workspace_deactivate_flags -d "check ramble workspace subcommand 
 end
 
 
+function check_workspace_create_with_activate_flags -d "check create for activate flags"
+    set -l _a "$argv"
+
+    if test -n "$_a"
+        if match_flag $_a "-a"
+            return 0
+        end
+        if match_flag $_a "--activate"
+            return 0
+        end
+    end
+
+    return 1
+end
 
 
 #
@@ -470,6 +484,23 @@ function ramble_runner -d "Runner function for the `ramble` wrapper"
                                 end
                                 return 1
                             end
+                        end
+
+                    case "create"
+                        set -l _a (stream_args $__rmb_remaining_args)
+
+                        if check_workspace_create_with_activate_flags $_a
+                            set -l rmb_workspace_cmd "command ramble $rmb_flags workspace create $__rmb_remaining_args"
+                            capture_all $rmb_workspace_cmd __rmb_stat __rmb_stdout __rmb_stderr
+                            if test -n "$__rmb_stderr"
+                                echo -s \n$__rmb_stderr 1>&2  # current fish bug: handle stderr manually
+                            end
+                            set -l activate_cmd $__rmb_stdout
+                            eval $activate_cmd
+                            set -l ws (echo $activate_cmd | awk '{print $NF}')
+                            echo "==> Created and activated workspace in $ws"
+                        else
+                            command ramble workspace create $_a
                         end
 
                     case "*"

--- a/share/ramble/setup-env.sh
+++ b/share/ramble/setup-env.sh
@@ -145,6 +145,23 @@ _ramble_shell_wrapper() {
                             eval $(command ramble $_rmb_flags workspace deactivate --sh)
                         fi
                         ;;
+                    create)
+                        _a=" $@"
+                        if [ "${_a#* -a}" != "$_a" ] || \
+                           [ "${_a#* --activate}" != "$_a" ];
+                        then
+                            # With -a, the command writes only the activation command
+                            # into stdout (`ramble workspace activate <ws>`.)
+                            # And the eval routes that command back to the wrapper to
+                            # inject shell args, etc.
+                            _activate_cmd="$(command ramble $_rmb_flags workspace create "$@")"
+                            eval $_activate_cmd
+                            _workspace="$(echo $_activate_cmd | awk '{print $NF}')"
+                            echo "==> Created and activated workspace in $_workspace"
+                        else
+                            command ramble $_rmb_flags workspace create "$@"
+                        fi
+                        ;;
                     *)
                         command ramble $_rmb_flags workspace $_rmb_arg "$@"
                         ;;


### PR DESCRIPTION
I find it a nice convenience.

```
// Create without -a remains the same
$ ramble workspace create act-test1
==> Created workspace in act-test1
==> You can activate this workspace with:
==>   ramble workspace activate act-test1

$ ramble workspace activate act-test1
$ echo $RAMBLE_WORKSPACE
/usr/local/google/home/linsword/hpc-dev/ramble/var/ramble/workspaces/act-test1

// With -a
$ ramble workspace create act-test2 -a
==> Created and activated workspace in act-test2

$ echo $RAMBLE_WORKSPACE
/usr/local/google/home/linsword/hpc-dev/ramble/var/ramble/workspaces/act-test2
```
