### PR TITLE
Fix undefined variable err when deactivate in csh

### DIFF
--- a/lib/ramble/ramble/workspace/shell.py
+++ b/lib/ramble/ramble/workspace/shell.py
@@ -60,8 +60,8 @@ def deactivate_header(shell):
     if shell == "csh":
         cmds += "unsetenv %s;\n" % (ramble.workspace.ramble_workspace_var)
         cmds += "if ( $?RAMBLE_OLD_PROMPT ) "
-        cmds += 'set prompt="$RAMBLE_OLD_PROMPT" && '
-        cmds += "unsetenv RAMBLE_OLD_PROMPT;\n"
+        cmds += '    eval \'set prompt="$RAMBLE_OLD_PROMPT" &&'
+        cmds += "        unsetenv RAMBLE_OLD_PROMPT';\n"
     elif shell == "fish":
         cmds += "set -e %s;\n" % (ramble.workspace.ramble_workspace_var)
         #


### PR DESCRIPTION
The `$RAMBLE_OLD_PROMPT` gets evaluated regardless of the if condition. The fix is to use eval to defer the evaluation.

This follows the same fix as done in spack:
https://github.com/spack/spack/pull/32816.