### PR TITLE
Migrate archival of spack files to package manager definition

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -1488,6 +1488,10 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
 
         # Copy all archive patterns
         archive_patterns = set(self.archive_patterns.keys())
+        if self.package_manager:
+            for pattern in self.package_manager.archive_patterns.keys():
+                archive_patterns.add(pattern)
+
         for mod in self._modifier_instances:
             for pattern in mod.archive_patterns.keys():
                 archive_patterns.add(pattern)
@@ -1495,7 +1499,9 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         for pattern in archive_patterns:
             exp_pattern = self.expander.expand_var(pattern)
             for file in glob.glob(exp_pattern):
-                shutil.copy(file, archive_experiment_dir)
+                dest_dir = os.path.dirname(file.replace(workspace.root, ws_archive_dir))
+                fs.mkdirp(dest_dir)
+                shutil.copy(file, dest_dir)
 
         for file_name in [self._inventory_file_name, self._status_file_name]:
             file = os.path.join(experiment_run_dir, file_name)

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -302,8 +302,6 @@ class ArchivePipeline(Pipeline):
             )
 
     def _prepare(self):
-        import glob
-
         super()._construct_hash()
         super()._prepare()
 
@@ -334,18 +332,6 @@ class ArchivePipeline(Pipeline):
             self.workspace.latest_archive_path, ramble.workspace.workspace_config_path
         )
         _copy_tree(self.workspace.config_dir, archive_configs)
-
-        # Copy current software spack files
-        file_names = ["spack.yaml", "spack.lock"]
-        archive_software = os.path.join(
-            self.workspace.latest_archive_path, ramble.workspace.workspace_software_path
-        )
-        fs.mkdirp(archive_software)
-        for file_name in file_names:
-            for file in glob.glob(os.path.join(self.workspace.software_dir, "*", file_name)):
-                dest = file.replace(self.workspace.software_dir, archive_software)
-                fs.mkdirp(os.path.dirname(dest))
-                shutil.copyfile(file, dest)
 
         # Copy shared files
         archive_shared = os.path.join(

--- a/var/ramble/repos/builtin/package_managers/spack/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack/package_manager.py
@@ -25,6 +25,9 @@ class Spack(SpackLightweight):
 
     name = "spack"
 
+    archive_pattern("{env_path}/spack.yaml")
+    archive_pattern("{env_path}/spack.lock")
+
     register_phase(
         "software_install",
         pipeline="setup",


### PR DESCRIPTION
This merge removes the pipeline definition of `spack.yaml` and `spack.lock` archival, and moves it into the standard `archive_pattern` syntax within the package manager object itself.