### PR TITLE
Update application path references to new format

### DIFF
--- a/var/ramble/repos/builtin/applications/cloverleaf/application.py
+++ b/var/ramble/repos/builtin/applications/cloverleaf/application.py
@@ -51,7 +51,7 @@ class Cloverleaf(ExecutableApplication):
     executable(
         "get_input",
         template=[
-            "cp {cloverleaf}/doc/tests/clover_{workload_name}.in {experiment_run_dir}/clover.in"
+            "cp {cloverleaf_path}/doc/tests/clover_{workload_name}.in {experiment_run_dir}/clover.in"
         ],
         use_mpi=False,
     )
@@ -59,7 +59,7 @@ class Cloverleaf(ExecutableApplication):
     executable(
         "get_default_input",
         template=[
-            "cp {cloverleaf}/doc/tests/clover.in {experiment_run_dir}/clover.in"
+            "cp {cloverleaf_path}/doc/tests/clover.in {experiment_run_dir}/clover.in"
         ],
         use_mpi=False,
     )

--- a/var/ramble/repos/builtin/applications/intel-hpl/application.py
+++ b/var/ramble/repos/builtin/applications/intel-hpl/application.py
@@ -41,7 +41,7 @@ class IntelHpl(ExecutableApplication):
 
     executable(
         "execute",
-        "{intel-oneapi-mkl}/mkl/latest/benchmarks/mp_linpack/xhpl_intel64_dynamic",
+        "{intel-oneapi-mkl_path}/mkl/latest/benchmarks/mp_linpack/xhpl_intel64_dynamic",
         use_mpi=True,
     )
 

--- a/var/ramble/repos/builtin/applications/intel-mpi-benchmarks/application.py
+++ b/var/ramble/repos/builtin/applications/intel-mpi-benchmarks/application.py
@@ -95,7 +95,7 @@ class IntelMpiBenchmarks(ExecutableApplication):
     # from intel-mpi-benchmarks by default
     workload_variable(
         "install_path",
-        default="{intel-mpi-benchmarks}/bin",
+        default="{intel-mpi-benchmarks_path}/bin",
         description="User configurable dir to executables",
         workloads=["pingpong", "multi-pingpong", "collective"],
     )

--- a/var/ramble/repos/builtin/applications/ior/application.py
+++ b/var/ramble/repos/builtin/applications/ior/application.py
@@ -62,7 +62,7 @@ class Ior(ExecutableApplication):
         template="ior -t {transfer-size} -b {block-size} -s {segment-count} -i {iterations}",
         use_mpi=True,
     )
-    executable(name="ior-shared", template="{ior} -F", use_mpi=True)
+    executable(name="ior-shared", template="{ior_path} -F", use_mpi=True)
 
     # FOMS
     # Match per iteration output in the format:

--- a/var/ramble/repos/builtin/applications/lammps/application.py
+++ b/var/ramble/repos/builtin/applications/lammps/application.py
@@ -98,7 +98,7 @@ class Lammps(ExecutableApplication):
         use_mpi=False,
     )
 
-    exec_path = os.path.join("{lammps}", "bin", "lmp")
+    exec_path = os.path.join("{lammps_path}", "bin", "lmp")
     executable(
         "execute",
         f"{exec_path}" + " -i input.txt {lammps_flags}",

--- a/var/ramble/repos/builtin/applications/minixyce/application.py
+++ b/var/ramble/repos/builtin/applications/minixyce/application.py
@@ -53,7 +53,7 @@ class Minixyce(ExecutableApplication):
     executable(
         "get_simple_network",
         template=[
-            "cp {minixyce}/doc/tests/{workload_name}.net {experiment_run_dir}/{workload_name}.net"
+            "cp {minixyce_path}/doc/tests/{workload_name}.net {experiment_run_dir}/{workload_name}.net"
         ],
         use_mpi=False,
     )
@@ -61,7 +61,7 @@ class Minixyce(ExecutableApplication):
     executable(
         "generate_RC_ladder",
         template=[
-            "perl {minixyce}/doc/tests/RC_ladder.pl {num_ladder_stages} > {experiment_run_dir}/{workload_name}.net; echo Running perl"
+            "perl {minixyce_path}/doc/tests/RC_ladder.pl {num_ladder_stages} > {experiment_run_dir}/{workload_name}.net; echo Running perl"
         ],
         use_mpi=False,
     )
@@ -69,7 +69,7 @@ class Minixyce(ExecutableApplication):
     executable(
         "generate_RLC_ladder",
         template=[
-            "perl {minixyce}/doc/tests/RLC_ladder.pl {num_ladder_stages} > {experiment_run_dir}/{workload_name}.net; echo Running perl"
+            "perl {minixyce_path}/doc/tests/RLC_ladder.pl {num_ladder_stages} > {experiment_run_dir}/{workload_name}.net; echo Running perl"
         ],
         use_mpi=False,
     )
@@ -77,7 +77,7 @@ class Minixyce(ExecutableApplication):
     executable(
         "generate_RC_ladder2",
         template=[
-            "perl {minixyce}/doc/tests/RC_ladder2.pl {num_ladder_stages} > {experiment_run_dir}/{workload_name}.net; echo Running perl"
+            "perl {minixyce_path}/doc/tests/RC_ladder2.pl {num_ladder_stages} > {experiment_run_dir}/{workload_name}.net; echo Running perl"
         ],
         use_mpi=False,
     )
@@ -85,7 +85,7 @@ class Minixyce(ExecutableApplication):
     executable(
         "generate_RLC_ladder2",
         template=[
-            "perl {minixyce}/doc/tests/RLC_ladder2.pl {num_ladder_stages} > {experiment_run_dir}/{workload_name}.net; echo Running perl"
+            "perl {minixyce_path}/doc/tests/RLC_ladder2.pl {num_ladder_stages} > {experiment_run_dir}/{workload_name}.net; echo Running perl"
         ],
         use_mpi=False,
     )

--- a/var/ramble/repos/builtin/applications/wrfv3/application.py
+++ b/var/ramble/repos/builtin/applications/wrfv3/application.py
@@ -59,7 +59,7 @@ class Wrfv3(ExecutableApplication):
         "copy",
         template=[
             "cp -R {input_path}/* {experiment_run_dir}/.",
-            "ln -s {wrf}/run/* {experiment_run_dir}/.",
+            "ln -s {wrf_path}/run/* {experiment_run_dir}/.",
         ],
         use_mpi=False,
         output_capture=OUTPUT_CAPTURE.ALL,

--- a/var/ramble/repos/builtin/applications/wrfv4/application.py
+++ b/var/ramble/repos/builtin/applications/wrfv4/application.py
@@ -62,7 +62,7 @@ class Wrfv4(ExecutableApplication):
         "copy",
         template=[
             "cp -R {input_path}/* {experiment_run_dir}/.",
-            "ln -s {wrf}/run/* {experiment_run_dir}/.",
+            "ln -s {wrf_path}/run/* {experiment_run_dir}/.",
         ],
         use_mpi=False,
         output_capture=OUTPUT_CAPTURE.ALL,


### PR DESCRIPTION
This merge updates the installation path references in application definitions to use the `{pkg}_path` syntax instead of just `{pkg}`.