### PR TITLE
Allow staging inputs in variable defined directories

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -1252,12 +1252,16 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                     input_conf["fetcher"], os.path.join(self.name, input_file)
                 )
 
+                input_dir = os.path.dirname(input_path)
+                input_base = os.path.basename(input_path)
+
                 with ramble.stage.InputStage(
                     input_conf["fetcher"],
                     name=input_namespace,
-                    path=input_path,
+                    path=input_dir,
                     mirror_paths=mirror_paths,
                 ) as stage:
+                    stage.set_subdir(input_base)
                     stage.fetch()
                     if input_conf["fetcher"].digest:
                         stage.check()

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -1242,7 +1242,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                 input_path = self.expander.expand_var(
                     input_conf["target_dir"], extra_vars=input_vars
                 )
-                input_tuple = ("input-file", input_path)
+                input_tuple = (f"input-file-{input_file}", input_path)
 
                 # Skip inputs that have already been cached
                 if workspace.check_cache(input_tuple):
@@ -1255,10 +1255,9 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                 with ramble.stage.InputStage(
                     input_conf["fetcher"],
                     name=input_namespace,
-                    path=self.expander.workload_input_dir,
+                    path=input_path,
                     mirror_paths=mirror_paths,
                 ) as stage:
-                    stage.set_subdir(input_path)
                     stage.fetch()
                     if input_conf["fetcher"].digest:
                         stage.check()

--- a/lib/ramble/ramble/language/application_language.py
+++ b/lib/ramble/ramble/language/application_language.py
@@ -6,6 +6,7 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+import os
 import ramble.workload
 import ramble.language.language_base
 from ramble.language.language_base import DirectiveError
@@ -149,7 +150,7 @@ def input_file(
     name,
     url,
     description,
-    target_dir="{input_name}",
+    target_dir=os.path.join("{workload_input_dir}", "{input_name}"),
     sha256=None,
     extension=None,
     expand=True,
@@ -165,7 +166,8 @@ def input_file(
         url: Path to the input file / archive
         description: Description of this input file
         target_dir (Optional): The directory where the archive will be
-                               expanded. Defaults to 'input'
+                               expanded. Defaults to the '{workload_input_dir}'
+                               + os.sep + '{input_name}'
         sha256 (Optional): The expected sha256 checksum for the input file
         extension (Optional): The extension to use for the input, if it isn't part of the
                               file name.

--- a/lib/ramble/ramble/test/application_language.py
+++ b/lib/ramble/ramble/test/application_language.py
@@ -238,7 +238,7 @@ def add_input_file(app_inst, input_num=1, func_type=func_types.directive):
     input_defs[input_name] = {
         "url": input_url,
         "description": input_desc,
-        "target_dir": "{input_name}",
+        "target_dir": os.path.join("{workload_input_dir}", "{input_name}"),
     }
 
     return input_defs


### PR DESCRIPTION
This merge is a re-introduction of https://github.com/GoogleCloudPlatform/ramble/pull/534 with a fix to preserve the previous input location as the default.