### PR TITLE
Add package manager variable directive

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -854,9 +854,6 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         # (note: the base ramble variables are checked earlier too)
         self.keywords.check_required_keys(self.variables)
 
-    def define_modifier_variables(self):
-        """Extract default variable definitions from modifier instances"""
-
     def _define_custom_executables(self):
         # Define custom executables
         if namespace.custom_executables in self.internals:
@@ -941,6 +938,9 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
         var_sets = []
         if self.expander.workload_name in self.workloads:
             var_sets.append(self.workloads[self.expander.workload_name].variables)
+
+        if self.package_manager is not None:
+            var_sets.append(self.package_manager.package_manager_variables)
 
         for mod_inst in self._modifier_instances:
             var_sets.append(mod_inst.mode_variables())

--- a/lib/ramble/ramble/language/language_base.py
+++ b/lib/ramble/ramble/language/language_base.py
@@ -31,7 +31,7 @@ __all__ = ["DirectiveMeta", "DirectiveError"]
 #: them
 reserved_names = []
 
-namespaces = ["ramble.app", "ramble.mod", "ramble.pkg_man"]
+namespaces = ["ramble.app", "ramble.mod", "ramble.pkg_man", "ramble.package_manager"]
 
 
 class DirectiveMeta(type):

--- a/lib/ramble/ramble/language/package_manager_language.py
+++ b/lib/ramble/ramble/language/package_manager_language.py
@@ -6,6 +6,8 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+from typing import Optional
+
 import ramble.language.language_helpers
 import ramble.language.language_base
 import ramble.language.shared_language
@@ -17,3 +19,34 @@ class PackageManagerMeta(ramble.language.shared_language.SharedMeta):
 
 
 package_manager_directive = PackageManagerMeta.directive
+
+
+@package_manager_directive("package_manager_variables")
+def package_manager_variable(
+    name: str,
+    default,
+    description: str,
+    values: Optional[list] = None,
+    expandable: bool = True,
+    **kwargs,
+):
+    """Define a variable for this package manager
+
+    Args:
+        name (str): Name of variable to define
+        default: Default value of variable definition
+        description (str): Description of variable's purpose
+        values (list): Optional list of suggested values for this variable
+        expandable (bool): True if the variable should be expanded, False if not.
+    """
+
+    def _define_package_manager_variable(pm):
+        pm.package_manager_variables[name] = ramble.workload.WorkloadVariable(
+            name,
+            default=default,
+            description=description,
+            values=values,
+            expandable=expandable,
+        )
+
+    return _define_package_manager_variable

--- a/lib/ramble/ramble/test/package_manager_language.py
+++ b/lib/ramble/ramble/test/package_manager_language.py
@@ -1,0 +1,79 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+"""Perform tests of the package manager class"""
+
+import pytest
+import enum
+
+from ramble.pkgmankit import *  # noqa
+
+
+pm_types = [
+    PackageManagerBase,  # noqa: F405
+]
+
+func_types = enum.Enum("func_types", ["method", "directive"])
+
+
+def generate_pkg_man_class(base_class):
+
+    class GeneratedClass(base_class):
+        _language_classes = base_class._language_classes.copy()
+
+        def __init__(self, file_path):
+            super().__init__(file_path)
+
+    return GeneratedClass
+
+
+@pytest.mark.parametrize("base_class", pm_types)
+def test_pkg_man_type_features(base_class):
+    pm_path = "/path/to/pm"
+    pm_class = generate_pkg_man_class(base_class)
+    test_pm = pm_class(pm_path)
+    assert hasattr(test_pm, "package_manager_variable")
+    assert hasattr(test_pm, "maintainers")
+
+
+def add_variable(pm_inst, pm_num=1, func_type=func_types.directive):
+    var_name = f"TestVariable{pm_num}"
+    var_default = f"DefaultValue{pm_num}"
+    var_description = f"Description{pm_num}"
+
+    if func_type == func_types.directive:
+        package_manager_variable(var_name, default=var_default, description=var_description)(
+            pm_inst
+        )
+    elif func_type == func_types.method:
+        pm_inst.package_manager_variable(
+            var_name, default=var_default, description=var_description
+        )
+    else:
+        return False
+
+    var_def = {"name": var_name, "default": var_default, "description": var_description}
+
+    return var_def
+
+
+@pytest.mark.parametrize("func_type", func_types)
+@pytest.mark.parametrize("base_class", pm_types)
+def test_pkg_man_variables(base_class, func_type):
+    pm_class = generate_pkg_man_class(base_class)
+    pm_inst = pm_class("/not/a/path")
+    test_defs = {}
+    test_defs.update(add_variable(pm_inst, func_type=func_type))
+
+    var_name = test_defs["name"]
+
+    assert hasattr(pm_inst, "package_manager_variables")
+    assert var_name in pm_inst.package_manager_variables
+    assert pm_inst.package_manager_variables[var_name].default is not None
+    assert pm_inst.package_manager_variables[var_name].default == test_defs["default"]
+    assert pm_inst.package_manager_variables[var_name].description is not None
+    assert pm_inst.package_manager_variables[var_name].description == test_defs["description"]


### PR DESCRIPTION
This merge adds the ability for package managers to define variables which can be used to parameterize aspects of their behavior.