### PR TITLE
Purge all log files at beginning of experiment

### DIFF
--- a/var/ramble/repos/builtin/applications/openfoam-org/application.py
+++ b/var/ramble/repos/builtin/applications/openfoam-org/application.py
@@ -467,7 +467,7 @@ class OpenfoamOrg(SpackApplication):
             f.write(f"simpleFoam ranks: {simple_ranks}\n")
             f.write(f"potentialFoam ranks: {simple_ranks}\n")
 
-    def _define_commands(self, exec_graph):
+    def _define_commands(self, exec_graph, success_list):
         export_prefix = self.expander.expand_var_name("export_prefix")
         export_vars = self.expander.expand_var_name("export_variables").split(
             ","


### PR DESCRIPTION
This merge updates the log purge logic to ensure all logs where a figure of merit or success criteria is extracted from would be purged as part of an experiment starting.