### PR TITLE
Fix environment creation for spack package manager

### DIFF
--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
@@ -696,17 +696,16 @@ class SpackRunner(object):
             fs.mkdirp(path)
 
         # Create a spack env
-        if not self.dry_run:
-            if not os.path.exists(os.path.join(path, "spack.yaml")):
-                env_create_flags = ramble.config.get(
-                    f"{self.env_create_config_name}:flags"
-                )
-                env_create_args = self.env_create_args.copy()
-                if env_create_flags:
-                    for flag in shlex.split(env_create_flags):
-                        env_create_args.append(flag)
-                with fs.working_dir(path):
-                    self._run_command(self.spack, env_create_args)
+        if not os.path.exists(os.path.join(path, "spack.yaml")):
+            env_create_flags = ramble.config.get(
+                f"{self.env_create_config_name}:flags"
+            )
+            env_create_args = self.env_create_args.copy()
+            if env_create_flags:
+                for flag in shlex.split(env_create_flags):
+                    env_create_args.append(flag)
+            with fs.working_dir(path):
+                self._run_command(self.spack, env_create_args)
 
         # Ensure subsequent commands use the created env now.
         self.env_path = path

--- a/var/ramble/repos/builtin/package_managers/spack/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack/package_manager.py
@@ -48,17 +48,16 @@ class Spack(SpackLightweight):
         else:
             workspace.add_to_cache(cache_tupl)
 
-        if self.environment_required():
-            try:
-                self.runner.set_dry_run(workspace.dry_run)
-                self.runner.set_env(env_path)
+        try:
+            self.runner.set_dry_run(workspace.dry_run)
+            self.runner.set_env(env_path)
 
-                logger.msg("Installing software")
+            logger.msg("Installing software")
 
-                self.runner.activate()
-                self.runner.install()
-            except RunnerError as e:
-                logger.die(e)
+            self.runner.activate()
+            self.runner.install()
+        except RunnerError as e:
+            logger.die(e)
 
     register_phase(
         "define_package_paths",


### PR DESCRIPTION
This merge updates the environment creation logic for the spack package managers. Previously, environment creation only happened when not performing setup as a dry-run. Additionally, installation only happened if an environment was required (which meant the application had software specs defined in the application definition).

This merge fixes these issues.