### PR TITLE
Enable support for RAMBLE_PYTHON to control which python ramble uses

### DIFF
--- a/bin/ramble
+++ b/bin/ramble
@@ -15,8 +15,13 @@
 # See https://stackoverflow.com/a/47886254
 """:"
 # prefer python3, then python, then python2
-for cmd in python3 python python2; do
-   command -v > /dev/null $cmd && exec $cmd $0 "$@"
+## prefer RAMBLE_PYTHON environment variable, python3, python, then python2
+RAMBLE_PREFERRED_PYTHONS="python3 python python2 /usr/libexec/platform-python"
+for cmd in "${RAMBLE_PYTHON:-}" ${RAMBLE_PREFERRED_PYTHONS}; do
+    if command -v > /dev/null "$cmd"; then
+        export RAMBLE_PYTHON="$(command -v "$cmd")"
+        exec "${RAMBLE_PYTHON}" "$0" "$@"
+    fi
 done
 
 echo "==> Error: ramble could not find a python interpreter!" >&2


### PR DESCRIPTION
This merge adds support for the RAMBLE_PYTHON environment variable which can point at the python ramble should use.