### PR TITLE
Ensure the file util operates on a str

### DIFF
--- a/lib/ramble/ramble/util/file_util.py
+++ b/lib/ramble/ramble/util/file_util.py
@@ -29,4 +29,4 @@ def get_file_path(path: str, workspace) -> str:
 
 def is_dry_run_path(path: str) -> bool:
     """Check if the path is already a dry_run path"""
-    return path.startswith(_DRY_RUN_PATH_PREFIX)
+    return str(path).startswith(_DRY_RUN_PATH_PREFIX)


### PR DESCRIPTION
This merge ensures the `startswith` method is called on a string object inside Ramble's file util. Previously, it would sometimes be called on a PosixPath object, which is invalid.