### PR TITLE
Update modifiers which use mpirun to use pdsh

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -1047,7 +1047,7 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                             and int(self.expander.expand_var_name(self.keywords.n_nodes)) > 1
                         ):
                             logger.warn(
-                                f"Command {cmd_conf} requires a non-empty `mpi_cmd` "
+                                f"Command {cmd_conf} requires a non-empty `mpi_command` "
                                 "variable in a multi-node experiment"
                             )
                         mpi_cmd = " " + raw_mpi_cmd + " "

--- a/lib/ramble/ramble/test/end_to_end/missing_mpi_cmd.py
+++ b/lib/ramble/ramble/test/end_to_end/missing_mpi_cmd.py
@@ -32,10 +32,11 @@ ramble:
     mpi_command: ''
     batch_submit: 'batch_submit {execute_experiment}'
     processes_per_node: '1'
+    hostlist: 'foo'
   applications:
-    hostname:
+    gromacs:
       workloads:
-        local:
+        water_bare:
           experiments:
             multi-node-test:
               variables:
@@ -43,8 +44,6 @@ ramble:
             single-node-test:
               variables:
                 n_nodes: '1'
-  modifiers:
-  - name: gcp-metadata
   spack:
     packages: {}
     environments: {}
@@ -63,16 +62,16 @@ ramble:
     workspace("setup", "--dry-run", global_args=["-w", workspace_name])
 
     single_setup_out = os.path.join(
-        ws.log_dir, "setup.latest", "hostname.local.single-node-test.out"
+        ws.log_dir, "setup.latest", "gromacs.water_bare.single-node-test.out"
     )
     with open(single_setup_out) as f:
         content = f.read()
         assert "Warning:" not in content
 
     multi_setup_out = os.path.join(
-        ws.log_dir, "setup.latest", "hostname.local.multi-node-test.out"
+        ws.log_dir, "setup.latest", "gromacs.water_bare.multi-node-test.out"
     )
     with open(multi_setup_out) as f:
         content = f.read()
         assert "Warning:" in content
-        assert "requires a non-empty `mpi_cmd` variable" in content
+        assert "requires a non-empty `mpi_command` variable" in content

--- a/var/ramble/repos/builtin/modifiers/gcp-metadata/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/gcp-metadata/modifier.py
@@ -27,6 +27,8 @@ class GcpMetadata(BasicModifier):
     mode("standard", description="Standard execution mode")
     default_mode("standard")
 
+    software_spec("pdsh", pkg_spec="pdsh", package_manager="spack*")
+
     required_variable("hostlist")
 
     executable_modifier("gcp_metadata_exec")


### PR DESCRIPTION
Previously, the gcp-metadata modifier used mpirun to get per-node metadata. This merge updates the modifier to use pdsh instead.