### PR TITLE
Expand logs before adding to the purge set

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -999,7 +999,8 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
             if isinstance(exec_node.attribute, ramble.util.executable.CommandExecutable):
                 exec_cmd = exec_node.attribute
                 if exec_cmd.redirect:
-                    logs.add(exec_cmd.redirect)
+                    expanded_log = self.expander.expand_var(exec_cmd.redirect)
+                    logs.add(expanded_log)
 
         analysis_logs, _, _ = self._analysis_dicts(success_list)
 


### PR DESCRIPTION
This merge updates the set building logic for determining which logs need to be purged at the beginning of an experiment. Previously, the raw strings were used (and later expanded as part of a template) however duplicate entries were then added.

This merge expands log files that are added to the purge set to ensure duplicate entries are not added.