### PR TITLE
Add caching to the expander

### DIFF
--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -434,6 +434,7 @@ class ExperimentSet(object):
                     exclude_exp_name = expander.expand_var(
                         experiment_template_name, allow_passthrough=False
                     )
+                    logger.debug(f"  Excluding experiment {exclude_exp_name}")
                     excluded_experiments.add(exclude_exp_name)
 
         exclude_where = []

--- a/lib/ramble/ramble/renderer.py
+++ b/lib/ramble/ramble/renderer.py
@@ -430,15 +430,16 @@ class Renderer(object):
         where_expander = ramble.expander.Expander(object_variables, None)
 
         for obj in new_objects:
-            logger.debug(f"Rendering {render_group.object}:")
+            where_expander._cache.flush()
             for var, val in obj.items():
                 object_variables[var] = val
+                where_expander._variables[var] = val
 
             keep_object = True
             if exclude_where:
                 for where in exclude_where:
-                    evaluated = where_expander.expand_var(where)
-                    if evaluated == "True":
+                    evaluated = where_expander.evaluate_predicate(where)
+                    if evaluated:
                         keep_object = False
 
             if keep_object:


### PR DESCRIPTION
This merge adds a cache to the expander to reduce repeatedly expanding the same string multiple times.