### PR TITLE
Deploy base classes that are in an object repo

### DIFF
--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -575,7 +575,14 @@ class PushDeploymentPipeline(Pipeline):
         fs.mkdirp(aux_software_dir)
         aux_repo_conf = os.path.join(aux_software_dir, "repos.yaml")
 
-        repo_conf_defs = [("repos", "repos.yaml"), ("modifier_repos", "modifier_repos.yaml")]
+        repo_conf_defs = [
+            ("repos", "repos.yaml"),
+            ("modifier_repos", "modifier_repos.yaml"),
+            ("package_manager_repos", "package_manager_repos.yaml"),
+            ("base_application_repos", "base_application_repos.yaml"),
+            ("base_modifier_repos", "base_modifier_repos.yaml"),
+            ("base_package_manager_repos", "base_package_manager_repos.yaml"),
+        ]
 
         for repo_conf in repo_conf_defs:
             aux_repo_conf = os.path.join(aux_software_dir, repo_conf[1])
@@ -597,11 +604,26 @@ class PushDeploymentPipeline(Pipeline):
                 f.write(syaml.dump_config(repo_data))
 
         repo_path = os.path.join(self.workspace.named_deployment, self.object_repo_name)
-        object_types = ["applications", "modifiers", "packages"]
+        object_types = [
+            "applications",
+            "modifiers",
+            "packages",
+            "package_managers",
+            "base_applications",
+            "base_modifiers",
+            "base_package_managers",
+        ]
         for object_type in object_types:
             fs.mkdirp(os.path.join(repo_path, object_type))
 
-        for conf_file in ["repo.yaml", "modifier_repo.yaml"]:
+        for conf_file in [
+            "repo.yaml",
+            "modifier_repo.yaml",
+            "package_manager_repo.yaml",
+            "base_application_repo.yaml",
+            "base_modifier_repo.yaml",
+            "base_package_manager_repo.yaml",
+        ]:
             with open(os.path.join(repo_path, conf_file), "w+") as f:
                 f.write("repo:\n")
                 f.write(f"  namespace: deployment_{self.deployment_name}\n")

--- a/lib/ramble/ramble/test/repository.py
+++ b/lib/ramble/ramble/test/repository.py
@@ -62,6 +62,56 @@ def test_repo_unknown_app(mutable_mock_apps_repo):
         mutable_mock_apps_repo.get("builtin.mock.nonexistentapplication")
 
 
+@pytest.mark.parametrize(
+    "obj_name,obj_type,expected",
+    [
+        (
+            "openfoam-org",
+            ramble.repository.ObjectTypes.applications,
+            [
+                ("applications", "openfoam-org/application.py"),
+                ("base_applications", "openfoam/base_application.py"),
+            ],
+        ),
+        (
+            "lscpu",
+            ramble.repository.ObjectTypes.modifiers,
+            [
+                ("modifiers", "lscpu/modifier.py"),
+            ],
+        ),
+        (
+            "spack",
+            ramble.repository.ObjectTypes.package_managers,
+            [
+                ("package_managers", "spack/package_manager.py"),
+                ("package_managers", "spack-lightweight/package_manager.py"),
+            ],
+        ),
+    ],
+)
+def test_list_object_files(
+    obj_name,
+    obj_type,
+    expected,
+    mutable_apps_repo_path,
+    mutable_mods_repo_path,
+    mutable_pkg_mans_repo_path,
+):
+    if obj_type == ramble.repository.ObjectTypes.applications:
+        repo = mutable_apps_repo_path
+    elif obj_type == ramble.repository.ObjectTypes.modifiers:
+        repo = mutable_mods_repo_path
+    else:
+        repo = mutable_pkg_mans_repo_path
+    obj_inst = repo.get(obj_name)
+    actual = ramble.repository.list_object_files(obj_inst, obj_type)
+    assert len(expected) == len(actual)
+    for i in range(len(expected)):
+        assert expected[i][0] == actual[i][0]
+        assert actual[i][1].endswith(expected[i][1])
+
+
 #
 #
 # def test_repo_anonymous_app(mutable_mock_apps_repo):


### PR DESCRIPTION
Deploy base classes that are in an object repo
Also add in support for deploying package_manager, as well as all the
base_* objects.

Here's an example [deployment](https://pantheon.corp.google.com/storage/browser/ramble-deployment-lin/test-deploy1).