### PR TITLE
Update output capture semantics to not always capture stderr

### DIFF
--- a/lib/ramble/ramble/appkit.py
+++ b/lib/ramble/ramble/appkit.py
@@ -30,4 +30,4 @@ from ramble.util.logger import logger as tty
 
 from ramble.util.file_util import get_file_path
 
-from ramble.schema.types import OUTPUT_CAPTURE
+from ramble.util.output_capture import OUTPUT_CAPTURE

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -55,7 +55,7 @@ from ramble.workspace import namespace
 from ramble.language.application_language import ApplicationMeta
 from ramble.language.shared_language import SharedMeta, register_builtin, register_phase
 from ramble.error import RambleError
-from ramble.schema.types import output_mapper
+from ramble.util.output_capture import output_mapper
 
 from enum import Enum
 

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -55,6 +55,7 @@ from ramble.workspace import namespace
 from ramble.language.application_language import ApplicationMeta
 from ramble.language.shared_language import SharedMeta, register_builtin, register_phase
 from ramble.error import RambleError
+from ramble.schema.types import output_mapper
 
 from enum import Enum
 
@@ -1057,9 +1058,9 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                     if cmd_conf.redirect:
                         out_log = self.expander.expand_var(cmd_conf.redirect, exec_vars)
                         output_operator = cmd_conf.output_capture
-                        redirect = f' {output_operator} "{out_log}"'
-                        if ramble.config.get("config:shell") in ["bash", "sh"]:
-                            redirect += " 2>&1"
+
+                        redirect_mapper = output_mapper()
+                        redirect = redirect_mapper.generate_out_string(out_log, output_operator)
 
                     if cmd_conf.run_in_background:
                         bg_cmd = " &"

--- a/lib/ramble/ramble/modkit.py
+++ b/lib/ramble/ramble/modkit.py
@@ -26,6 +26,6 @@ from ramble.spec import Spec
 import ramble.language.modifier_language
 from ramble.language.modifier_language import *
 from ramble.language.shared_language import *
-from ramble.schema.types import OUTPUT_CAPTURE
+from ramble.util.output_capture import OUTPUT_CAPTURE
 
 from ramble.util.file_util import get_file_path

--- a/lib/ramble/ramble/pkgmankit.py
+++ b/lib/ramble/ramble/pkgmankit.py
@@ -28,6 +28,6 @@ from ramble.spec import Spec
 import ramble.language.package_manager_language
 from ramble.language.package_manager_language import *
 from ramble.language.shared_language import *
-from ramble.schema.types import OUTPUT_CAPTURE
+from ramble.util.output_capture import OUTPUT_CAPTURE
 
 from ramble.software_environments import ExternalEnvironment

--- a/lib/ramble/ramble/schema/internals.py
+++ b/lib/ramble/ramble/schema/internals.py
@@ -16,6 +16,7 @@ from llnl.util.lang import union_dicts
 
 import ramble.schema.types
 import ramble.schema.variables
+from ramble.util.output_capture import OUTPUT_CAPTURE
 
 
 custom_executables_def = {
@@ -28,7 +29,7 @@ custom_executables_def = {
             "use_mpi": False,
             "redirect": "{log_file}",
             "variables": {},
-            "output_capture": ramble.schema.types.OUTPUT_CAPTURE.DEFAULT,
+            "output_capture": OUTPUT_CAPTURE.DEFAULT,
         },
         "properties": union_dicts(
             {

--- a/lib/ramble/ramble/schema/types.py
+++ b/lib/ramble/ramble/schema/types.py
@@ -8,12 +8,31 @@
 
 """Base types for building schema files from"""
 
+from enum import Enum
 
-class OUTPUT_CAPTURE:
-    STDERR = "2>"
-    STDOUT = ">>"
-    ALL = "&>"
-    DEFAULT = STDOUT
+
+class OUTPUT_CAPTURE(Enum):
+    STDOUT = 0
+    STDERR = 1
+    ALL = 2
+    DEFAULT = 2
+
+
+class output_mapper:
+    def __init__(self):
+        self.map = {
+            OUTPUT_CAPTURE.STDOUT: ">>",
+            OUTPUT_CAPTURE.STDERR: "2>>",
+            OUTPUT_CAPTURE.ALL: ">>",
+        }
+        self.SUFFIX = "2>&1"
+
+    def generate_out_string(self, out_log, output_operator):
+        redirect_str = f' {self.map.get(output_operator, output_operator)} "{out_log}"'
+        if output_operator is OUTPUT_CAPTURE.ALL:
+            redirect_str += f" {self.SUFFIX}"
+
+        return redirect_str
 
 
 string_or_num_list = [{"type": "string"}, {"type": "number"}]

--- a/lib/ramble/ramble/schema/types.py
+++ b/lib/ramble/ramble/schema/types.py
@@ -8,33 +8,6 @@
 
 """Base types for building schema files from"""
 
-from enum import Enum
-
-
-class OUTPUT_CAPTURE(Enum):
-    STDOUT = 0
-    STDERR = 1
-    ALL = 2
-    DEFAULT = 2
-
-
-class output_mapper:
-    def __init__(self):
-        self.map = {
-            OUTPUT_CAPTURE.STDOUT: ">>",
-            OUTPUT_CAPTURE.STDERR: "2>>",
-            OUTPUT_CAPTURE.ALL: ">>",
-        }
-        self.SUFFIX = "2>&1"
-
-    def generate_out_string(self, out_log, output_operator):
-        redirect_str = f' {self.map.get(output_operator, output_operator)} "{out_log}"'
-        if output_operator is OUTPUT_CAPTURE.ALL:
-            redirect_str += f" {self.SUFFIX}"
-
-        return redirect_str
-
-
 string_or_num_list = [{"type": "string"}, {"type": "number"}]
 
 string_or_num = {"anyOf": string_or_num_list}

--- a/lib/ramble/ramble/util/executable.py
+++ b/lib/ramble/ramble/util/executable.py
@@ -10,7 +10,7 @@ import shlex
 
 import ramble.error
 
-from ramble.schema.types import OUTPUT_CAPTURE
+from ramble.util.output_capture import OUTPUT_CAPTURE
 
 import spack.util.executable
 from spack.util.path import system_path_filter

--- a/lib/ramble/ramble/util/output_capture.py
+++ b/lib/ramble/ramble/util/output_capture.py
@@ -1,0 +1,33 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from enum import Enum
+
+
+class OUTPUT_CAPTURE(Enum):
+    STDOUT = 0
+    STDERR = 1
+    ALL = 2
+    DEFAULT = 2
+
+
+class output_mapper:
+    def __init__(self):
+        self.map = {
+            OUTPUT_CAPTURE.STDOUT: ">>",
+            OUTPUT_CAPTURE.STDERR: "2>>",
+            OUTPUT_CAPTURE.ALL: ">>",
+        }
+        self.SUFFIX = "2>&1"
+
+    def generate_out_string(self, out_log, output_operator):
+        redirect_str = f' {self.map.get(output_operator, output_operator)} "{out_log}"'
+        if output_operator is OUTPUT_CAPTURE.ALL:
+            redirect_str += f" {self.SUFFIX}"
+
+        return redirect_str


### PR DESCRIPTION
This PR makes the semantics around output capture more consistent, moves the logic to a single place, and allows ramble to not capture stdout/stderr when requested (which currently does not work as expected)

This is a more complex version of #577 