### PR TITLE
Fix path references for zlib mock apps

### DIFF
--- a/var/ramble/repos/builtin.mock/applications/zlib-configs/application.py
+++ b/var/ramble/repos/builtin.mock/applications/zlib-configs/application.py
@@ -14,7 +14,7 @@ class ZlibConfigs(ExecutableApplication):
 
     software_spec("zlib", pkg_spec="zlib", package_manager="spack*")
 
-    executable("list_lib", "ls {zlib}/lib", use_mpi=False)
+    executable("list_lib", "ls {zlib_path}/lib", use_mpi=False)
 
     workload("ensure_installed", executable="list_lib")
 

--- a/var/ramble/repos/builtin.mock/applications/zlib/application.py
+++ b/var/ramble/repos/builtin.mock/applications/zlib/application.py
@@ -14,7 +14,7 @@ class Zlib(ExecutableApplication):
 
     software_spec("zlib", pkg_spec="zlib", package_manager="spack*")
 
-    executable("list_lib", "ls {zlib}/lib", use_mpi=False)
+    executable("list_lib", "ls {zlib_path}/lib", use_mpi=False)
 
     workload("ensure_installed", executable="list_lib")
 


### PR DESCRIPTION
The old path variables are deprecated, and should be converted.