### PR TITLE
Test activate shortcut in the tutorial test

### DIFF
--- a/lib/ramble/docs/tutorials/1_hello_world.rst
+++ b/lib/ramble/docs/tutorials/1_hello_world.rst
@@ -136,6 +136,13 @@ Ramble would create an anonymous workspace for you in ``${PWD}/hello_world``
 for more information on named and anonymous workspaces, see
 :ref:`Ramble workspace documentation<ramble-workspaces>`.
 
+For convenience, the workspace creation and activation can also be combined
+in one command with the activate flag (``-a``):
+
+.. code-block:: console
+
+    $ ramble workspace create hello_world -a
+
 Configure the Workspace
 ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-1.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-1.yaml
@@ -44,9 +44,7 @@ steps:
 
         ramble info hostname
 
-        ramble workspace create -d hello_world -c /workspace/examples/tutorial_1_config.yaml
-
-        ramble workspace activate ./hello_world
+        ramble workspace create -d hello_world -c /workspace/examples/tutorial_1_config.yaml -a
 
         ramble workspace setup
 


### PR DESCRIPTION
Currently the implementation of the activate shortcut (`-a`) for `workspace create` is fragile: it relies on the stdout from the create command, so any redundant log entries would break it. There's no current end-to-end test to catch its potential breakage (challenging to test given the impl lives in the shell wrapper layer.) So piggy-back on this tutorial e2e test to ensure its working.