### PR TITLE
Minor update on dry-run help texts

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -1574,7 +1574,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
         """
 
         if self.get_status() == experiment_status.UNKNOWN.name and not workspace.dry_run:
-            logger.warn(f"Experiment has status is {self.get_status()}. Skipping analysis..\n")
+            logger.warn(f"Experiment has status {self.get_status()}. Skipping analysis..\n")
             return
 
         def format_context(context_match, context_format):

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -511,7 +511,8 @@ def workspace_analyze_setup_parser(subparser):
         "--dry-run",
         dest="dry_run",
         action="store_true",
-        help="perform a dry run. Allows progress on workspaces which are not fully setup",
+        help="perform a dry run. Allows going through analysis phases"
+        + "on workspaces which are not fully setup",
     )
 
     subparser.add_argument(
@@ -945,8 +946,8 @@ def workspace_mirror_setup_parser(subparser):
         dest="dry_run",
         action="store_true",
         help="perform a dry run. Creates package environments, "
-        + "prints commands that would be executed "
-        + "for installation, and files that would be downloaded.",
+        + "prints package manager specific commands that would be executed "
+        + "for creating the mirror.",
     )
 
     arguments.add_common_arguments(


### PR DESCRIPTION
Currently under `workspace` cmd, there are three subcommands that support `--dry-run`:

* `setup`: WAI
* `mirror`: the dry-run is used by the `software_create_env` and the `mirror_software` stages (spack support only). Updated the help text to make it clearer
* `analyze`: the dry-run is used to proceed on partially setup workspace (https://github.com/GoogleCloudPlatform/ramble/pull/349.) The usefulness on having this for analyze is debatable, but keeping it for now. Only update the help text for better clarity.