### PR TITLE
Add mirror support check

### DIFF
--- a/lib/ramble/docs/tutorials/mirrors.rst
+++ b/lib/ramble/docs/tutorials/mirrors.rst
@@ -146,7 +146,7 @@ this mirror in the first place.
      -   <etc>        ^(short list of software prerequisistes for intel-mpi)
 
     ==>     Executing phase mirror_software
-    ==> Successfully updated spack software in $HOME/wrfv4_mirror
+    ==> Successfully updated software in $HOME/wrfv4_mirror
       Archive stats:
         44   already present
         44   added

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -1224,6 +1224,21 @@ class ApplicationBase(metaclass=ApplicationMeta):
                 }
         self._input_fetchers = inputs
 
+    register_phase("check_mirror_support", pipeline="mirror", run_before=["mirror_inputs"])
+
+    def _check_mirror_support(self, workspace, app_inst=None):
+        """Check if the given package manager supports mirroring"""
+        pkgman = self.package_manager
+        if pkgman is not None:
+            # Use the presence of a `mirror_software` phase as an indicator.
+            # This is not very robust, a better approach may be to claim support
+            # from individual package managers.
+            mirror_phases = self.get_pipeline_phases("mirror")
+            if "mirror_software" not in mirror_phases:
+                logger.die(
+                    f"The configured package manager {pkgman.name} does not support mirroring"
+                )
+
     register_phase("mirror_inputs", pipeline="mirror")
 
     def _mirror_inputs(self, workspace, app_inst=None):

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -1229,7 +1229,10 @@ class ApplicationBase(metaclass=ApplicationMeta):
     def _check_mirror_support(self, workspace, app_inst=None):
         """Check if the given package manager supports mirroring"""
         pkgman = self.package_manager
-        if pkgman is not None:
+        phase_filter = workspace.running_pipeline_inst.filters.phases
+        # When phases are explicitly specified, this check is disabled.
+        # This allows for running mirror-inputs only.
+        if pkgman is not None and phase_filter == ["*"]:
             # Use the presence of a `mirror_software` phase as an indicator.
             # This is not very robust, a better approach may be to claim support
             # from individual package managers.

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -415,7 +415,7 @@ class MirrorPipeline(Pipeline):
     def _complete(self):
         verb = "updated" if self.workspace.mirror_existed else "created"
         logger.msg(
-            f"Successfully {verb} spack software in {self.workspace.mirror_path}",
+            f"Successfully {verb} software in {self.workspace.mirror_path}",
             "Archive stats:",
             "  %-4d already present" % len(self.workspace.software_mirror_stats.present),
             "  %-4d added" % len(self.workspace.software_mirror_stats.new),

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -12,6 +12,7 @@ import os
 import shutil
 import py.path
 import shlex
+from contextlib import contextmanager
 
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
@@ -201,10 +202,11 @@ class Pipeline:
         if logger.enabled:
             self.create_simlink(self.log_path, self.log_path_latest)
 
-        self._prepare()
-        self._execute()
-        self._complete()
-        logger.remove_log()
+        with running_pipeline(self.workspace, self):
+            self._prepare()
+            self._execute()
+            self._complete()
+            logger.remove_log()
 
     def create_simlink(self, base, link):
         """
@@ -708,3 +710,10 @@ def pipeline_class(name):
         )
 
     return _pipeline_map[name]
+
+
+@contextmanager
+def running_pipeline(workspace, pipeline_inst):
+    workspace.running_pipeline_inst = pipeline_inst
+    yield
+    workspace.running_pipeline_inst = None

--- a/lib/ramble/ramble/test/end_to_end/mirror_support.py
+++ b/lib/ramble/ramble/test/end_to_end/mirror_support.py
@@ -29,10 +29,21 @@ def assert_text_in_mirror_log(ws, text):
 
 
 @pytest.mark.parametrize(
-    "pkgman,expect_error",
-    [("null", False), ("spack", False), ("pip", True), ("eessi", True)],
+    "pkgman,expect_error, extra_args",
+    [
+        ("null", False, []),
+        ("spack", False, []),
+        ("pip", True, []),
+        ("eessi", True, []),
+        # Allowed when phases are explicitly specified
+        (
+            "pip",
+            False,
+            ["--phases", "mirror_inputs", "--include-phase-dependencies"],
+        ),
+    ],
 )
-def test_mirror_support(pkgman, expect_error, tmpdir):
+def test_mirror_support(pkgman, expect_error, extra_args, tmpdir):
     test_config = f"""
 ramble:
   variants:
@@ -67,8 +78,8 @@ ramble:
     mirror_path = os.path.join(tmpdir, ws_name)
     if expect_error:
         with pytest.raises(RambleCommandError):
-            workspace("mirror", "--dry-run", "-d", mirror_path)
+            workspace("mirror", "--dry-run", "-d", mirror_path, *extra_args)
         assert_text_in_mirror_log(ws, f"{pkgman} does not support mirroring")
     else:
-        workspace("mirror", "--dry-run", "-d", mirror_path)
+        workspace("mirror", "--dry-run", "-d", mirror_path, *extra_args)
         assert_text_in_mirror_log(ws, "Successfully created software")

--- a/lib/ramble/ramble/test/end_to_end/mirror_support.py
+++ b/lib/ramble/ramble/test/end_to_end/mirror_support.py
@@ -1,0 +1,74 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.workspace
+from ramble.main import RambleCommand, RambleCommandError
+
+pytestmark = pytest.mark.usefixtures(
+    "mutable_config",
+    "mutable_mock_workspace_path",
+)
+
+workspace = RambleCommand("workspace")
+
+
+def assert_text_in_mirror_log(ws, text):
+    mirror_log = os.path.join(ws.log_dir, "mirror.latest.out")
+    with open(mirror_log) as f:
+        content = f.read()
+        assert text in content
+
+
+@pytest.mark.parametrize(
+    "pkgman,expect_error",
+    [("null", False), ("spack", False), ("pip", True), ("eessi", True)],
+)
+def test_mirror_support(pkgman, expect_error, tmpdir):
+    test_config = f"""
+ramble:
+  variants:
+    package_manager: {pkgman}
+  variables:
+    mpi_command: ''
+    batch_submit: '{{execute_experiment}}'
+    processes_per_node: 1
+    n_ranks: 1
+  applications:
+    hostname:
+      workloads:
+        local:
+          experiments:
+            test: {{}}
+  software:
+    packages: {{}}
+    environments: {{}}
+"""
+    ws_name = f"test_{pkgman}_mirror_support"
+    ws = ramble.workspace.create(ws_name)
+    ramble.workspace.activate(ws)
+    ws.write()
+
+    config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+
+    with open(config_path, "w+") as f:
+        f.write(test_config)
+
+    ws._re_read()
+
+    mirror_path = os.path.join(tmpdir, ws_name)
+    if expect_error:
+        with pytest.raises(RambleCommandError):
+            workspace("mirror", "--dry-run", "-d", mirror_path)
+        assert_text_in_mirror_log(ws, f"{pkgman} does not support mirroring")
+    else:
+        workspace("mirror", "--dry-run", "-d", mirror_path)
+        assert_text_in_mirror_log(ws, "Successfully created software")

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -486,6 +486,9 @@ class Workspace:
         self.software_environments = None
         self.hash_inventory = {"experiments": [], "versions": []}
 
+        # Reference to the currently running pipeline instance
+        self.running_pipeline_inst = None
+
         from ramble.main import get_version
 
         self.hash_inventory["versions"].append(


### PR DESCRIPTION
With this change, package managers that don't implement the `mirror_software` phase will error out when execute `workspace mirror`