### PR TITLE
Allow using shorter name to specify dep in `register_builtin`

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -49,6 +49,7 @@ import ramble.util.graph
 import ramble.util.class_attributes
 from ramble.util.logger import logger
 from ramble.util.shell_utils import source_str
+from ramble.util.naming import NS_SEPARATOR
 
 from ramble.workspace import namespace
 
@@ -91,7 +92,7 @@ def _check_shell_support(app_inst):
 
 class ApplicationBase(metaclass=ApplicationMeta):
     name = None
-    _builtin_name = "builtin::{name}"
+    _builtin_name = NS_SEPARATOR.join(("builtin", "{name}"))
     _builtin_required_key = "required"
     _inventory_file_name = "ramble_inventory.json"
     _status_file_name = "ramble_status.json"
@@ -141,7 +142,6 @@ class ApplicationBase(metaclass=ApplicationMeta):
         self.modifiers = []
         self.experiment_tags = []
         self._modifier_instances = []
-        self._modifier_builtins = {}
         self._input_fetchers = None
         self.results = {}
         self._phase_times = {}

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -263,7 +263,10 @@ def register_builtin(name, required=True, injection_method="prepend", depends_on
     `modifier_builtin::modifier_name::method_name`.
 
     Application modifiers are named:
-    `builtin::method_name`
+    `builtin::method_name`.
+
+    Package manager builtins are named:
+    `package_manager_builtin::package_manager_name::method_name`.
 
     As an example, if the following builtin was defined:
 

--- a/lib/ramble/ramble/modifier.py
+++ b/lib/ramble/ramble/modifier.py
@@ -16,18 +16,19 @@ from typing import List
 from llnl.util.tty.colify import colified
 
 from ramble.language.modifier_language import ModifierMeta
-from ramble.language.shared_language import SharedMeta, register_builtin  # noqa: F401
+from ramble.language.shared_language import SharedMeta
 from ramble.error import RambleError
 import ramble.util.colors as rucolor
 import ramble.util.directives
 import ramble.util.class_attributes
 from ramble.util.logger import logger
+from ramble.util.naming import NS_SEPARATOR
 
 
 class ModifierBase(metaclass=ModifierMeta):
     name = None
-    _builtin_name = "modifier_builtin::{obj_name}::{name}"
-    _mod_prefix_builtin = r"modifier_builtin::"
+    _builtin_name = NS_SEPARATOR.join(("modifier_builtin", "{obj_name}", "{name}"))
+    _mod_prefix_builtin = f"modifier_builtin{NS_SEPARATOR}"
     _language_classes = [ModifierMeta, SharedMeta]
     _pipelines = ["analyze", "archive", "mirror", "setup", "pushtocache", "execute"]
 
@@ -266,7 +267,7 @@ class ModifierBase(metaclass=ModifierMeta):
     def applies_to_executable(self, executable):
         apply = False
 
-        mod_regex = re.compile(self._mod_prefix_builtin + f"{self.name}::")
+        mod_regex = re.compile(self._mod_prefix_builtin + f"{self.name}{NS_SEPARATOR}")
         for pattern in self._on_executables:
             if fnmatch.fnmatch(executable, pattern):
                 apply = True

--- a/lib/ramble/ramble/package_manager.py
+++ b/lib/ramble/ramble/package_manager.py
@@ -16,19 +16,19 @@ from typing import List
 from llnl.util.tty.colify import colified
 
 from ramble.language.package_manager_language import PackageManagerMeta
-from ramble.language.shared_language import SharedMeta, register_builtin  # noqa: F401
+from ramble.language.shared_language import SharedMeta
 from ramble.error import RambleError
 import ramble.util.colors as rucolor
 import ramble.util.directives
 import ramble.util.class_attributes
+from ramble.util.naming import NS_SEPARATOR
 
 import spack.util.naming
 
 
 class PackageManagerBase(metaclass=PackageManagerMeta):
     name = None
-    _builtin_name = "package_manager_builtin::{obj_name}::{name}"
-    _pkgman_prefix_builtin = r"package_manager_builtin::"
+    _builtin_name = NS_SEPARATOR.join(("package_manager_builtin", "{obj_name}", "{name}"))
     _language_classes = [PackageManagerMeta, SharedMeta]
     _pipelines = [
         "analyze",

--- a/lib/ramble/ramble/test/end_to_end/short_builtin_dep_name.py
+++ b/lib/ramble/ramble/test/end_to_end/short_builtin_dep_name.py
@@ -1,0 +1,58 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.workspace
+from ramble.main import RambleCommand
+from ramble.graphs import GraphNodeAmbiguousError
+
+pytestmark = pytest.mark.usefixtures(
+    "mutable_config",
+    "mutable_mock_workspace_path",
+)
+
+workspace = RambleCommand("workspace")
+
+
+def test_short_builtin_dep_name(mock_applications):
+    test_config = """
+ramble:
+  variants:
+    package_manager: spack
+  variables:
+    mpi_command: mpirun -n {n_ranks}
+    batch_submit: '{execute_experiment}'
+    processes_per_node: 1
+    n_nodes: 1
+  applications:
+    test-builtin-dep-name:
+      workloads:
+        standard:
+          experiments:
+            test: {}
+  software:
+    packages: {}
+    environments: {}
+"""
+    ws_name = "test_short_builtin_dep_name"
+    ws = ramble.workspace.create(ws_name)
+    ramble.workspace.activate(ws)
+    ws.write()
+
+    config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+
+    with open(config_path, "w+") as f:
+        f.write(test_config)
+
+    ws._re_read()
+
+    with pytest.raises(GraphNodeAmbiguousError):
+        workspace("setup", "--dry-run", global_args=["-w", ws_name])

--- a/lib/ramble/ramble/util/naming.py
+++ b/lib/ramble/ramble/util/naming.py
@@ -24,7 +24,10 @@ __all__ = [
     "possible_ramble_module_names",
     "simplify_name",
     "NamespaceTrie",
+    "NS_SEPARATOR",
 ]
+
+NS_SEPARATOR = "::"
 
 # Valid module names can contain '-' but can't start with it.
 _valid_module_re = r"^\w[\w-]*$"

--- a/var/ramble/repos/builtin.mock/applications/test-builtin-dep-name/application.py
+++ b/var/ramble/repos/builtin.mock/applications/test-builtin-dep-name/application.py
@@ -1,0 +1,51 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.appkit import *
+
+
+class TestBuiltinDepName(ExecutableApplication):
+    """This is an example application that will simply run the hostname command"""
+
+    name = "test-builtin-dep-name"
+
+    tags("test-app")
+
+    executable(
+        "standard",
+        "echo test-builtin-dep-name",
+        use_mpi=False,
+        output_capture=OUTPUT_CAPTURE.ALL,
+    )
+
+    workload("standard", executable="standard")
+
+    # Purposely register a builtin whose leaf name collides with a builtin from pip package manager
+    register_builtin("spack_activate")
+
+    register_builtin(
+        "good_pkgman_dep_name",
+        required=True,
+        depends_on=["package_manager_builtin::spack::spack_activate"],
+    )
+    register_builtin(
+        "ambiguous_dep_name", required=True, depends_on=["spack_activate"]
+    )
+
+    def spack_activate(self):
+        return _echo("spack_activate")
+
+    def ambiguous_dep_name(self):
+        return _echo("ambiguous_dep_name")
+
+    def good_pkgman_dep_name(self):
+        return _echo("good_pkgman_dep_name")
+
+
+def _echo(text):
+    return [f"echo {text}"]

--- a/var/ramble/repos/builtin/package_managers/pip/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/pip/package_manager.py
@@ -45,7 +45,7 @@ class Pip(PackageManagerBase):
     register_builtin(
         "pip_deactivate",
         required=False,
-        depends_on=["package_manager_builtin::pip::pip_activate"],
+        depends_on=["pip_activate"],
     )
 
     def pip_deactivate(self):


### PR DESCRIPTION
For instance, besides `package_manager_builtins::spack::spack_source`, either `spack::spack_source` or `spack_source` is recognized. However if will complain when the short name is ambiguous (pointing to more than one fully qualified names.)