### PR TITLE
Remove required MPI package for conditional PSM3 modifier

### DIFF
--- a/var/ramble/repos/builtin/modifiers/conditional-psm3/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/conditional-psm3/modifier.py
@@ -39,7 +39,6 @@ class ConditionalPsm3(BasicModifier):
     executable_modifier("apply_psm3")
 
     required_variable("psm3_mpi")
-    required_package("intel-oneapi-mpi", package_manager="spack*")
 
     modifier_variable(
         "apply_psm3_exec_regex",


### PR DESCRIPTION
This merge removes the required MPI package for the conditional PSM3 modifier. This allows the conditional PSM3 modifier to be used with other MPI packages.