### PR TITLE
Redirect root gh-pages to the new rtd doc site

### DIFF
--- a/.github/workflows/gh-pages-deploy.yaml
+++ b/.github/workflows/gh-pages-deploy.yaml
@@ -1,0 +1,43 @@
+# Workflow for deploying a single redirect page to GitHub Pages
+name: gh-pages deploy
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["develop"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Only deploy the redirect directory
+          path: './lib/ramble/docs/_gh_pages_redirect'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/lib/ramble/docs/_gh_pages_redirect/index.html
+++ b/lib/ramble/docs/_gh_pages_redirect/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+
+<head>
+  <meta http-equiv="refresh" content="0; url=https://ramble.readthedocs.io/" />
+</head>
+
+<body>
+  <p>
+    This page has moved to <a href="https://ramble.readthedocs.io/">https://ramble.readthedocs.io/</a>
+  </p>
+</body>
+
+</html>


### PR DESCRIPTION
Set up a workflow for the deployment.