### PR TITLE
Remove `dry-run` option for workspace analyze

### DIFF
--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -508,14 +508,6 @@ def workspace_analyze_setup_parser(subparser):
     )
 
     subparser.add_argument(
-        "--dry-run",
-        dest="dry_run",
-        action="store_true",
-        help="perform a dry run. Allows going through analysis phases"
-        + "on workspaces which are not fully setup",
-    )
-
-    subparser.add_argument(
         "-p",
         "--print-results",
         dest="print_results",
@@ -534,9 +526,6 @@ def workspace_analyze(args):
     ws = ramble.cmd.require_active_workspace(cmd_name="workspace analyze")
     ws.always_print_foms = args.always_print_foms
     ws.repeat_success_strict = ramble.config.get("config:repeat_success_strict")
-
-    if args.dry_run:
-        ws.dry_run = True
 
     filters = ramble.filters.Filters(
         phase_filters=args.phases,

--- a/lib/ramble/ramble/experimental/uploader.py
+++ b/lib/ramble/ramble/experimental/uploader.py
@@ -9,6 +9,7 @@
 import json
 import sys
 import math
+from enum import Enum
 
 import ramble.config
 from ramble.util.logger import logger
@@ -16,6 +17,8 @@ from ramble.config import ConfigError
 
 
 default_node_type_val = "Not Specified"
+
+uploader_types = Enum("uploader_types", ["BigQuery", "PrintOnly"])
 
 
 class Uploader:
@@ -124,32 +127,31 @@ def determine_node_type(experiment, contexts):
 
 
 def upload_results(results):
-    if ramble.config.get("config:upload"):
-        # Read upload type and push it there
-        if ramble.config.get("config:upload:type") == "BigQuery":  # TODO: enum?
-            try:
-                formatted_data = ramble.experimental.uploader.format_data(results)
-            except KeyError:
-                logger.die("Error parsing file: Does not contain valid data to upload.")
-            # TODO: strategy object?
+    uploader_type = ramble.config.get("config:upload:type")
+    if uploader_type is None:
+        raise ConfigError("No upload type (config:upload:type) in config.")
+    if not hasattr(uploader_types, uploader_type):
+        raise ConfigError(f"Upload type {uploader_type} is not valid.")
+    uploader_type = getattr(uploader_types, uploader_type)
 
-            uploader = BigQueryUploader()
+    uri = ramble.config.get("config:upload:uri")
+    if not uri:
+        logger.die("No upload URI (config:upload:uri) in config.")
 
-            uri = ramble.config.get("config:upload:uri")
-            if not uri:
-                logger.die("No upload URI (config:upload:uri) in config.")
+    try:
+        formatted_data = format_data(results)
+    except KeyError:
+        logger.die("Error parsing file: Does not contain valid data to upload.")
+    if len(formatted_data) == 0:
+        logger.warn("No data to upload")
+        return
 
-            logger.msg(f"Uploading Results to {uri}")
-
-            if len(formatted_data) == 0:
-                logger.warn("No data to upload")
-            else:
-                uploader.perform_upload(uri, formatted_data)
-        else:
-            raise ConfigError("Unknown config:upload:type value")
-
+    logger.msg(f"Uploading Results to {uri} with {uploader_type} uploader")
+    if uploader_type == uploader_types.BigQuery:
+        uploader = BigQueryUploader()
     else:
-        raise ConfigError("Missing correct config:upload parameters")
+        uploader = PrintOnlyUploader()
+    uploader.perform_upload(uri, formatted_data)
 
 
 def format_data(data_in):
@@ -208,6 +210,27 @@ def format_data(data_in):
     return results
 
 
+def _prepare_data(results, uri):
+    # It is expected that the user will create these tables outside of this
+    # tooling
+    exp_table_id = f"{uri}.experiments"
+    fom_table_id = f"{uri}.foms"
+
+    exps_to_insert = []
+    foms_to_insert = []
+
+    for experiment in results:
+        exps_to_insert.append(experiment.to_json())
+
+        for fom in experiment.foms:
+            fom_data = fom
+            fom_data["experiment_id"] = experiment.get_hash()
+            fom_data["experiment_name"] = experiment.name
+            foms_to_insert.append(fom_data)
+
+    return exp_table_id, exps_to_insert, fom_table_id, foms_to_insert
+
+
 class BigQueryUploader(Uploader):
     """Class to handle upload of FOMs to BigQuery"""
 
@@ -246,22 +269,7 @@ class BigQueryUploader(Uploader):
 
     def insert_data(self, uri: str, results) -> None:
 
-        # It is expected that the user will create these tables outside of this
-        # tooling
-        exp_table_id = "{uri}.{table_name}".format(uri=uri, table_name="experiments")
-        fom_table_id = "{uri}.{table_name}".format(uri=uri, table_name="foms")
-
-        exps_to_insert = []
-        foms_to_insert = []
-
-        for experiment in results:
-            exps_to_insert.append(experiment.to_json())
-
-            for fom in experiment.foms:
-                fom_data = fom
-                fom_data["experiment_id"] = experiment.get_hash()
-                fom_data["experiment_name"] = experiment.name
-                foms_to_insert.append(fom_data)
+        exp_table_id, exps_to_insert, fom_table_id, foms_to_insert = _prepare_data(results, uri)
 
         logger.debug("Experiments to insert:")
         logger.debug(exps_to_insert)
@@ -304,3 +312,14 @@ class BigQueryUploader(Uploader):
         # This should be stable per machine/python version, but is not
         # guaranteed to be globally stable
         return hash(json.dumps(experiment, sort_keys=True))
+
+
+class PrintOnlyUploader(Uploader):
+    """An uploader that only prints out formatted data without actually uploading."""
+
+    def perform_upload(self, uri, results):
+        super().perform_upload(uri, results)
+        exp_table_id, exps_to_insert, fom_table_id, foms_to_insert = _prepare_data(results, uri)
+        logger.info("NOTE: The PrintOnly uploader only logs, but does not upload any data.")
+        logger.info(f"Experiments {exps_to_insert} would be uploaded to table {exp_table_id}")
+        logger.info(f"Foms {foms_to_insert} would be uploaded to table {fom_table_id}")

--- a/lib/ramble/ramble/experimental/uploader.py
+++ b/lib/ramble/ramble/experimental/uploader.py
@@ -321,5 +321,9 @@ class PrintOnlyUploader(Uploader):
         super().perform_upload(uri, results)
         exp_table_id, exps_to_insert, fom_table_id, foms_to_insert = _prepare_data(results, uri)
         logger.info("NOTE: The PrintOnly uploader only logs, but does not upload any data.")
-        logger.info(f"Experiments {exps_to_insert} would be uploaded to table {exp_table_id}")
-        logger.info(f"Foms {foms_to_insert} would be uploaded to table {fom_table_id}")
+        logger.info(f"{len(exps_to_insert)} experiment(s) would be uploaded to {exp_table_id}:")
+        for exp in exps_to_insert:
+            logger.info(f"  {exp}")
+        logger.info(f"{len(foms_to_insert)} fom(s) would be uploaded to {fom_table_id}:")
+        for fom in foms_to_insert:
+            logger.info(f"  {fom}")

--- a/lib/ramble/ramble/experimental/uploader.py
+++ b/lib/ramble/ramble/experimental/uploader.py
@@ -136,17 +136,17 @@ def upload_results(results):
 
     uri = ramble.config.get("config:upload:uri")
     if not uri:
-        logger.die("No upload URI (config:upload:uri) in config.")
+        raise ConfigError("No upload URI (config:upload:uri) in config.")
 
     try:
         formatted_data = format_data(results)
-    except KeyError:
-        logger.die("Error parsing file: Does not contain valid data to upload.")
+    except (KeyError, TypeError) as e:
+        raise ConfigError("Error parsing file: Does not contain valid data to upload.") from e
     if len(formatted_data) == 0:
         logger.warn("No data to upload")
         return
 
-    logger.msg(f"Uploading Results to {uri} with {uploader_type} uploader")
+    logger.msg(f"Uploading results to {uri} with {uploader_type} uploader")
     if uploader_type == uploader_types.BigQuery:
         uploader = BigQueryUploader()
     else:

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -246,11 +246,7 @@ class AnalyzePipeline(Pipeline):
                 if app_inst.get_status() != ramble.application.experiment_status.UNKNOWN.name:
                     found_valid_experiment = True
 
-        if (
-            not found_valid_experiment
-            and self._experiment_set.num_experiments()
-            and not self.workspace.dry_run
-        ):
+        if not found_valid_experiment and self._experiment_set.num_experiments():
             logger.die(
                 "No analyzeable experiment detected."
                 " Make sure your workspace is setup with\n"

--- a/lib/ramble/ramble/schema/config.py
+++ b/lib/ramble/ramble/schema/config.py
@@ -141,7 +141,7 @@ properties["config"]["upload"] = {
     "type": "object",
     "properties": {
         "uri": {"type": "string", "default": ""},
-        "type": {"type": "string", "default": "BigQuery"},
+        "type": {"type": "string", "default": "BigQuery", "enum": ["BigQuery", "PrintOnly"]},
     },
 }
 

--- a/lib/ramble/ramble/test/end_to_end/analyze_upload.py
+++ b/lib/ramble/ramble/test/end_to_end/analyze_upload.py
@@ -1,0 +1,72 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.workspace
+from ramble.main import RambleCommand
+
+pytestmark = pytest.mark.usefixtures(
+    "mutable_config",
+    "mutable_mock_workspace_path",
+)
+
+workspace = RambleCommand("workspace")
+
+
+@pytest.mark.maybeslow
+def test_analyze_upload():
+    test_config = """
+ramble:
+  config:
+    upload:
+      uri: fake-dataset
+      type: PrintOnly
+  variables:
+    mpi_command: ''
+    batch_submit: 'batch_submit {execute_experiment}'
+    processes_per_node: '1'
+  applications:
+    hostname:
+      workloads:
+        local:
+          experiments:
+            test:
+              variables:
+                n_nodes: '1'
+  software:
+    packages: {}
+    environments: {}
+"""
+    ws_name = "test_analyze_upload"
+    ws = ramble.workspace.create(ws_name)
+    ws.write()
+
+    config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+
+    with open(config_path, "w+") as f:
+        f.write(test_config)
+
+    ws._re_read()
+
+    workspace("setup", "--dry-run", global_args=["-w", ws_name])
+    exp_out = os.path.join(ws.experiment_dir, "hostname", "local", "test", "test.out")
+    with open(exp_out, "w") as f:
+        f.write("test-user.c.googlers.com\n")
+
+    workspace("analyze", "--upload", global_args=["-w", ws_name])
+
+    analyze_log = os.path.join(ws.log_dir, "analyze.latest.out")
+
+    with open(analyze_log) as f:
+        content = f.read()
+        assert "Uploading results to fake-dataset" in content
+        assert "The PrintOnly uploader only logs" in content
+        assert "test-user.c.googlers.com" in content

--- a/lib/ramble/ramble/test/end_to_end/analyze_upload.py
+++ b/lib/ramble/ramble/test/end_to_end/analyze_upload.py
@@ -69,4 +69,6 @@ ramble:
         content = f.read()
         assert "Uploading results to fake-dataset" in content
         assert "The PrintOnly uploader only logs" in content
+        assert "1 experiment(s) would be uploaded" in content
+        assert "1 fom(s) would be uploaded" in content
         assert "test-user.c.googlers.com" in content

--- a/lib/ramble/ramble/test/end_to_end/exclusive_filtered_vector_workloads.py
+++ b/lib/ramble/ramble/test/end_to_end/exclusive_filtered_vector_workloads.py
@@ -64,7 +64,6 @@ ramble:
         )
         workspace(
             "analyze",
-            "--dry-run",
             "--exclude-where",
             '"{workload_name}" == "serial"',
             global_args=["-w", workspace_name],

--- a/lib/ramble/ramble/test/end_to_end/inclusive_filtered_vector_workloads.py
+++ b/lib/ramble/ramble/test/end_to_end/inclusive_filtered_vector_workloads.py
@@ -63,7 +63,6 @@ ramble:
         )
         workspace(
             "analyze",
-            "--dry-run",
             "--where",
             '"{workload_name}" == "serial"',
             global_args=["-w", workspace_name],

--- a/lib/ramble/ramble/test/experimental/uploader.py
+++ b/lib/ramble/ramble/test/experimental/uploader.py
@@ -1,0 +1,30 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import pytest
+
+from ramble.experimental.uploader import upload_results, ConfigError
+import ramble.config
+
+
+_empty_results = {"experiments": []}
+
+
+@pytest.mark.parametrize(
+    "upload_uri,upload_type,results,expected_err_msg",
+    [
+        (None, None, _empty_results, "No upload type"),
+        (None, "UnknownUploader", _empty_results, "Upload type UnknownUploader is not valid"),
+        (None, "BigQuery", _empty_results, "No upload URI"),
+        ("fake-zeppelin", "PrintOnly", [], "Does not contain valid data to upload"),
+    ],
+)
+def test_upload_results_errs(upload_uri, upload_type, results, expected_err_msg):
+    with ramble.config.override("config:upload", {"uri": upload_uri, "type": upload_type}):
+        with pytest.raises(ConfigError, match=expected_err_msg):
+            upload_results(results)

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -677,7 +677,7 @@ _ramble_workspace_setup() {
 }
 
 _ramble_workspace_analyze() {
-    RAMBLE_COMPREPLY="-h --help -f --formats -u --upload --always-print-foms --dry-run -p --print-results --phases --include-phase-dependencies --where --exclude-where --filter-tags"
+    RAMBLE_COMPREPLY="-h --help -f --formats -u --upload --always-print-foms -p --print-results --phases --include-phase-dependencies --where --exclude-where --filter-tags"
 }
 
 _ramble_workspace_push_to_cache() {


### PR DESCRIPTION
Also add in a `PrintOnly` uploader as a way to test out uploader functionality.

Samle invocation:

```
ramble -c "config:upload:type:PrintOnly" -c "config:upload:uri:fake-db.all_data" workspace analyze --upload
```