### PR TITLE
Fix up a spack runner test

### DIFF
--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/test/spack_runner.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/test/spack_runner.py
@@ -344,6 +344,7 @@ packages:
                 sr.activate()
                 sr.add_include_file(packages_path)
                 sr.add_include_file(compilers_path)
+                sr.generate_env_file()
                 sr.install_compiler("gcc@12.1.0")
                 captured = capsys.readouterr()
 


### PR DESCRIPTION
The test starts failing with the latest develop of spack. It seems something changed such that it's no longer sufficient to simply write out the packages.yaml file and let spack pick that up. So add in a call to write the config into spack.yaml.