### PR TITLE
Fix spack push_to_cache phase

### DIFF
--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
@@ -330,8 +330,7 @@ class SpackLightweight(PackageManagerBase):
     def _push_to_spack_cache(self, workspace, app_inst=None):
 
         # Test if experiment requires an environment
-        if not self.environment_required():
-            return
+        env_required = self.environment_required()
 
         env_path = self.app_inst.expander.env_path
         cache_tupl = ("push-to-cache", env_path)
@@ -343,7 +342,7 @@ class SpackLightweight(PackageManagerBase):
 
         try:
             self.runner.set_dry_run(workspace.dry_run)
-            self.runner.set_env(env_path)
+            self.runner.set_env(env_path, require_exists=env_required)
             self.runner.activate()
 
             self.runner.push_to_spack_cache(workspace.spack_cache_path)


### PR DESCRIPTION
This merge fixes an issue with spack's push_to_spack_cache phase. Previously, this phase skipped early if the application definition didn't contain any software specs.

This merge changes the behavior to allow an experiment that has an environment with software installed to be pushed.