### PR TITLE
Mark long-running tests

### DIFF
--- a/lib/ramble/ramble/test/conftest.py
+++ b/lib/ramble/ramble/test/conftest.py
@@ -54,7 +54,7 @@ def pytest_collection_modifyitems(config, items):
         # --fast not given, run all the tests
         return
 
-    slow_tests = ["db", "network", "maybeslow"]
+    slow_tests = ["db", "network", "maybeslow", "long"]
     skip_as_slow = pytest.mark.skip(reason="skipped slow test [--fast command line option given]")
     for item in items:
         if any(x in item.keywords for x in slow_tests):

--- a/lib/ramble/ramble/test/end_to_end/experiment_excludes.py
+++ b/lib/ramble/ramble/test/end_to_end/experiment_excludes.py
@@ -24,6 +24,7 @@ pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_p
 workspace = RambleCommand("workspace")
 
 
+@pytest.mark.long
 def test_wrfv4_exclusions(mutable_config, mutable_mock_workspace_path):
     test_config = """
 ramble:

--- a/lib/ramble/ramble/test/end_to_end/explicit_zips.py
+++ b/lib/ramble/ramble/test/end_to_end/explicit_zips.py
@@ -24,6 +24,7 @@ pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_p
 workspace = RambleCommand("workspace")
 
 
+@pytest.mark.long
 def test_wrfv4_explicit_zips(mutable_config, mutable_mock_workspace_path):
     test_config = """
 ramble:

--- a/lib/ramble/ramble/test/end_to_end/package_manager_requirements.py
+++ b/lib/ramble/ramble/test/end_to_end/package_manager_requirements.py
@@ -27,6 +27,7 @@ pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_p
 workspace = RambleCommand("workspace")
 
 
+@pytest.mark.long
 def test_package_manager_requirements_zlib(mock_applications, mock_modifiers):
     test_config = """
 ramble:

--- a/lib/ramble/ramble/test/end_to_end/phase_selection_with_dependencies.py
+++ b/lib/ramble/ramble/test/end_to_end/phase_selection_with_dependencies.py
@@ -33,6 +33,7 @@ def enable_verbose():
     llnl.util.tty._verbose = old_setting
 
 
+@pytest.mark.long
 def test_workspace_phase_selection_with_dependencies(
     mutable_config, mutable_mock_workspace_path, enable_verbose
 ):

--- a/lib/ramble/ramble/test/end_to_end/wrfv4_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/wrfv4_dry_run.py
@@ -24,6 +24,7 @@ pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_p
 workspace = RambleCommand("workspace")
 
 
+@pytest.mark.long
 def test_wrfv4_spack_dry_run(mutable_config, mutable_mock_workspace_path):
     test_config = """
 ramble:

--- a/lib/ramble/ramble/test/modifier_functionality/mock_modifier_dry_run.py
+++ b/lib/ramble/ramble/test/modifier_functionality/mock_modifier_dry_run.py
@@ -20,6 +20,7 @@ from ramble.main import RambleCommand
 workspace = RambleCommand("workspace")
 
 
+@pytest.mark.long
 @pytest.mark.parametrize(
     "scope",
     [

--- a/lib/ramble/ramble/test/modifier_functionality/mock_modifier_spack_configs.py
+++ b/lib/ramble/ramble/test/modifier_functionality/mock_modifier_spack_configs.py
@@ -18,6 +18,7 @@ from ramble.main import RambleCommand
 workspace = RambleCommand("workspace")
 
 
+@pytest.mark.long
 @pytest.mark.parametrize(
     "scope",
     [

--- a/lib/ramble/ramble/test/modifier_functionality/mock_spack_modifier.py
+++ b/lib/ramble/ramble/test/modifier_functionality/mock_spack_modifier.py
@@ -20,6 +20,7 @@ from ramble.main import RambleCommand
 workspace = RambleCommand("workspace")
 
 
+@pytest.mark.long
 @pytest.mark.parametrize(
     "scope",
     [

--- a/lib/ramble/ramble/test/modifier_functionality/modifier_prepare_analysis.py
+++ b/lib/ramble/ramble/test/modifier_functionality/modifier_prepare_analysis.py
@@ -22,6 +22,7 @@ workspace = RambleCommand("workspace")
 on_cmd = RambleCommand("on")
 
 
+@pytest.mark.long
 @pytest.mark.parametrize(
     "scope",
     [

--- a/lib/ramble/ramble/test/modifier_functionality/multi_modifier_dry_run.py
+++ b/lib/ramble/ramble/test/modifier_functionality/multi_modifier_dry_run.py
@@ -19,6 +19,7 @@ from ramble.main import RambleCommand
 workspace = RambleCommand("workspace")
 
 
+@pytest.mark.long
 @pytest.mark.parametrize(
     "scopes",
     [


### PR DESCRIPTION
Also update the test config so that `--fast` exclude these long tests.

The "long" definition is such that it takes more than 5 secs to run on my e2-standard-24 machine.