### PR TITLE
Add support for "anti-match" in success_criteria

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -1614,6 +1614,8 @@ class ApplicationBase(metaclass=ApplicationMeta):
                         criteria_obj = criteria_list.find_criteria(criteria)
                         if criteria_obj.passed(line, self):
                             criteria_obj.mark_found()
+                        if criteria_obj.anti_matched(line):
+                            criteria_obj.mark_anti_found()
 
                     for context in file_conf["contexts"]:
                         context_conf = contexts[context]

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -208,7 +208,14 @@ def required_package(name, package_manager="*"):
 
 @shared_directive("success_criteria")
 def success_criteria(
-    name, mode, match=None, file="{log_file}", fom_name=None, fom_context="null", formula=None
+    name,
+    mode,
+    match=None,
+    file="{log_file}",
+    fom_name=None,
+    fom_context="null",
+    formula=None,
+    anti_match=None,
 ):
     """Defines a success criteria used by experiments of this object
 
@@ -229,6 +236,8 @@ def success_criteria(
                    in. Accepts globbing.
       formula: For mode='fom_comparison'. Formula to use to evaluate success.
                '{value}' keyword is set as the value of the FOM.
+      anti_match: For mode='string'. Value to check indicate failure.
+                  This setting and `match` are mutually exclusive.
     """
 
     def _execute_success_criteria(obj):
@@ -239,6 +248,7 @@ def success_criteria(
         obj.success_criteria[name] = {
             "mode": mode,
             "match": match,
+            "anti_match": anti_match,
             "file": file,
             "fom_name": fom_name,
             "fom_context": fom_context,

--- a/lib/ramble/ramble/schema/success_criteria.py
+++ b/lib/ramble/ramble/schema/success_criteria.py
@@ -24,6 +24,7 @@ success_criteria_def = {
         "fom_name": {"type": "string", "default": None},
         "fom_context": {"type": "string", "default": None},
         "formula": {"type": "string", "default": None},
+        "anti_match": {"type": "string", "default": None},
     },
     "additionalProperties": False,
 }

--- a/lib/ramble/ramble/test/success_criteria/anti_match.py
+++ b/lib/ramble/ramble/test/success_criteria/anti_match.py
@@ -1,0 +1,61 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.workspace
+
+from ramble.main import RambleCommand
+from ramble.test.dry_run_helpers import dry_run_config, SCOPES
+
+workspace = RambleCommand("workspace")
+
+
+@pytest.mark.maybeslow
+def test_anti_match_criteria(mutable_config, mutable_mock_workspace_path, mock_applications):
+    ws_name = "test_anti_match_criteria"
+    with ramble.workspace.create(ws_name) as ws:
+        ws.write()
+
+        config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+
+        dry_run_config(
+            "success_criteria",
+            [
+                (
+                    SCOPES.application,
+                    {"name": "anti_match_criterion", "mode": "string", "anti_match": "Error:"},
+                )
+            ],
+            config_path,
+            "basic",
+            "test_wl",
+        )
+        ws._re_read()
+
+        workspace("setup", "--dry-run", global_args=["-w", ws_name])
+        result_path = os.path.join(
+            ws.experiment_dir, "basic", "test_wl", "test_exp", "test_exp.out"
+        )
+
+        with open(result_path, "w") as f:
+            f.write("1.2seconds\n")
+        workspace("analyze", global_args=["-w", ws_name])
+        with open(os.path.join(ws.root, "results.latest.txt")) as f:
+            content = f.read()
+            assert "Status = SUCCESS" in content
+            assert "1.2" in content
+
+        with open(result_path, "a") as f:
+            f.write("Error: invalid result\n")
+        workspace("analyze", global_args=["-w", ws_name])
+        with open(os.path.join(ws.root, "results.latest.txt")) as f:
+            content = f.read()
+            assert "Status = FAILED" in content


### PR DESCRIPTION
This can be useful to express semantic such as "the run should be deemed a failure if any error message is logged".