### PR TITLE
Add a command for generating new workspace configuration files

### DIFF
--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -966,7 +966,7 @@ def workspace_generate_config_setup_parser(subparser):
         "--wf",
         dest="workload_filters",
         action="append",
-        help="filter to use when selecting workloads in the application. "
+        help="glob filter to use when selecting workloads in the application. "
         + "Workload is kept if it matches any filter.",
     )
 
@@ -975,7 +975,7 @@ def workspace_generate_config_setup_parser(subparser):
         "--vf",
         dest="variable_filters",
         action="append",
-        help="filter to use when selecting variables in the workloads. "
+        help="glob filter to use when selecting variables in the workloads. "
         + "Variable is kept if it matches any filter.",
     )
 
@@ -1011,6 +1011,13 @@ def workspace_generate_config_setup_parser(subparser):
         action="store_true",
         help="perform a dry run. Print resulting config to screen and not "
         + "to the workspace configuration file",
+    )
+
+    subparser.add_argument(
+        "--overwrite",
+        dest="overwrite",
+        action="store_true",
+        help="overwrite existing definitions with newly generated definitions",
     )
 
     variable_control = subparser.add_mutually_exclusive_group()
@@ -1091,6 +1098,7 @@ def workspace_generate_config(args):
         args.package_manager,
         zips,
         matrix,
+        args.overwrite,
     )
 
 

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -1006,6 +1006,7 @@ def workspace_generate_config_setup_parser(subparser):
 
     subparser.add_argument(
         "--dry-run",
+        "--print",
         dest="dry_run",
         action="store_true",
         help="perform a dry run. Print resulting config to screen and not "
@@ -1046,7 +1047,18 @@ def workspace_generate_config_setup_parser(subparser):
 
 def workspace_generate_config(args):
     """Generate a configuration file for this ramble workspace"""
-    ws = ramble.cmd.require_active_workspace(cmd_name="workspace generate-config")
+    ws = ramble.cmd.find_workspace(args)
+
+    if ws is None:
+        import tempfile
+
+        logger.warn("No active workspace found. Defaulting to `--dry-run`")
+
+        root = tempfile.TemporaryDirectory()
+        ws = ramble.workspace.Workspace(str(root))
+        ws.dry_run = True
+    else:
+        ws.dry_run = args.dry_run
 
     workload_filters = ["*"]
     if args.workload_filters:
@@ -1067,8 +1079,6 @@ def workspace_generate_config(args):
     matrix = None
     if args.matrix:
         matrix = args.matrix
-
-    ws.dry_run = args.dry_run
 
     ws.add_experiments(
         args.application,

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -53,6 +53,7 @@ subcommands = [
     "mirror",
     ["list", "ls"],
     ["remove", "rm"],
+    "generate-config",
 ]
 
 
@@ -953,6 +954,134 @@ def workspace_mirror(args):
 
     workspace_run_pipeline(args, pipeline)
     pipeline.run()
+
+
+def workspace_generate_config_setup_parser(subparser):
+    """generate current workspace config"""
+
+    arguments.add_common_arguments(subparser, ["application"])
+
+    subparser.add_argument(
+        "--workload-filter",
+        "--wf",
+        dest="workload_filters",
+        action="append",
+        help="filter to use when selecting workloads in the application. "
+        + "Workload is kept if it matches any filter.",
+    )
+
+    subparser.add_argument(
+        "--variable-filter",
+        "--vf",
+        dest="variable_filters",
+        action="append",
+        help="filter to use when selecting variables in the workloads. "
+        + "Variable is kept if it matches any filter.",
+    )
+
+    subparser.add_argument(
+        "--variable-definition",
+        "-v",
+        dest="variable_definitions",
+        action="append",
+        help="variable definition to set in the generated experiments. "
+        + "Given in the form key=value",
+    )
+
+    subparser.add_argument(
+        "--experiment-name",
+        "-e",
+        dest="experiment_name",
+        default="generated",
+        help="name of generated experiment",
+    )
+
+    subparser.add_argument(
+        "--package-manager",
+        "-p",
+        dest="package_manager",
+        default=None,
+        help="name of (optional) package to define within the experiment scope",
+    )
+
+    subparser.add_argument(
+        "--dry-run",
+        dest="dry_run",
+        action="store_true",
+        help="perform a dry run. Print resulting config to screen and not "
+        + "to the workspace configuration file",
+    )
+
+    variable_control = subparser.add_mutually_exclusive_group()
+    variable_control.add_argument(
+        "--include-default-variables",
+        "-i",
+        action="store_true",
+        help="whether to include default variable values in the resulting config",
+    )
+
+    variable_control.add_argument(
+        "--workload-name-variable",
+        "-w",
+        default=None,
+        metavar="VAR",
+        help="variable name to collapse workloads in",
+    )
+
+    subparser.add_argument(
+        "--zip",
+        "-z",
+        dest="zips",
+        action="append",
+        help="zip to define for the experiments, in the format zipname=[zipvar1,zipvar2]",
+    )
+
+    subparser.add_argument(
+        "--matrix",
+        "-m",
+        dest="matrix",
+        help="comma delimited list of variable names to matrix in the experiments",
+    )
+
+
+def workspace_generate_config(args):
+    """Generate a configuration file for this ramble workspace"""
+    ws = ramble.cmd.require_active_workspace(cmd_name="workspace generate-config")
+
+    workload_filters = ["*"]
+    if args.workload_filters:
+        workload_filters = args.workload_filters
+
+    variable_filters = ["*"]
+    if args.variable_filters:
+        variable_filters = args.variable_filters
+
+    variable_definitions = []
+    if args.variable_definitions:
+        variable_definitions = args.variable_definitions
+
+    zips = []
+    if args.zips:
+        zips = args.zips
+
+    matrix = None
+    if args.matrix:
+        matrix = args.matrix
+
+    ws.dry_run = args.dry_run
+
+    ws.add_experiments(
+        args.application,
+        args.workload_name_variable,
+        workload_filters,
+        args.include_default_variables,
+        variable_filters,
+        variable_definitions,
+        args.experiment_name,
+        args.package_manager,
+        zips,
+        matrix,
+    )
 
 
 #: Dictionary mapping subcommand names and aliases to functions

--- a/lib/ramble/ramble/keywords.py
+++ b/lib/ramble/ramble/keywords.py
@@ -46,7 +46,7 @@ default_keys = {
     "n_threads": {"type": key_type.required, "level": output_level.key},
     "batch_submit": {"type": key_type.required, "level": output_level.variable},
     "mpi_command": {"type": key_type.required, "level": output_level.variable},
-    "experiment_template_name": {"type": key_type.required, "level": output_level.key},
+    "experiment_template_name": {"type": key_type.reserved, "level": output_level.key},
 }
 
 

--- a/lib/ramble/ramble/keywords.py
+++ b/lib/ramble/ramble/keywords.py
@@ -43,7 +43,7 @@ default_keys = {
     "n_ranks": {"type": key_type.required, "level": output_level.key},
     "n_nodes": {"type": key_type.required, "level": output_level.key},
     "processes_per_node": {"type": key_type.required, "level": output_level.key},
-    "n_threads": {"type": key_type.required, "level": output_level.key},
+    "n_threads": {"type": key_type.optional, "level": output_level.key},
     "batch_submit": {"type": key_type.required, "level": output_level.variable},
     "mpi_command": {"type": key_type.required, "level": output_level.variable},
     "experiment_template_name": {"type": key_type.reserved, "level": output_level.key},

--- a/lib/ramble/ramble/test/data/config/base_application_repos.yaml
+++ b/lib/ramble/ramble/test/data/config/base_application_repos.yaml
@@ -1,0 +1,2 @@
+base_application_repos:
+  - $ramble/var/ramble/repos/builtin

--- a/lib/ramble/ramble/test/data/config/base_modifier_repos.yaml
+++ b/lib/ramble/ramble/test/data/config/base_modifier_repos.yaml
@@ -1,0 +1,2 @@
+base_modifier_repos:
+  - $ramble/var/ramble/repos/builtin

--- a/lib/ramble/ramble/test/data/config/base_package_manager_repos.yaml
+++ b/lib/ramble/ramble/test/data/config/base_package_manager_repos.yaml
@@ -1,0 +1,2 @@
+base_package_manager_repos:
+  - $ramble/var/ramble/repos/builtin

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -978,9 +978,9 @@ class Workspace:
 
         if application not in apps_dict:
             apps_dict[application] = syaml.syaml_dict()
-            apps_dict[application]["workloads"] = syaml.syaml_dict()
+            apps_dict[application][namespace.workload] = syaml.syaml_dict()
 
-        workloads_dict = apps_dict[application]["workloads"]
+        workloads_dict = apps_dict[application][namespace.workload]
 
         exp_zips = {}
         for zip_def in zips:
@@ -1012,12 +1012,12 @@ class Workspace:
             if add_workload:
                 if application in apps_dict:
                     subdict = apps_dict[application]
-                    if "workloads" in subdict:
-                        subdict = subdict["workloads"]
+                    if namespace.workload in subdict:
+                        subdict = subdict[namespace.workload]
                         if workload.name in subdict:
                             subdict = subdict[workload.name]
-                            if "experiments" in subdict:
-                                subdict = subdict["experiments"]
+                            if namespace.experiment in subdict:
+                                subdict = subdict[namespace.experiment]
                                 if experiment_name in subdict:
                                     exp_name = f"{application}.{workload.name}.{experiment_name}"
                                     if not overwrite:
@@ -1037,21 +1037,21 @@ class Workspace:
         for workload_name in workload_names:
             if workload_name not in workloads_dict:
                 workloads_dict[workload_name] = syaml.syaml_dict()
-                workloads_dict[workload_name]["experiments"] = syaml.syaml_dict()
+                workloads_dict[workload_name][namespace.experiment] = syaml.syaml_dict()
 
-            exps_dict = workloads_dict[workload_name]["experiments"]
+            exps_dict = workloads_dict[workload_name][namespace.experiment]
             exps_dict[experiment_name] = syaml.syaml_dict()
             exp_dict = exps_dict[experiment_name]
 
             if package_manager is not None:
-                exp_dict["variants"] = syaml.syaml_dict()
-                variants_dict = exp_dict["variants"]
-                variants_dict["package_manager"] = package_manager
+                exp_dict[namespace.variants] = syaml.syaml_dict()
+                variants_dict = exp_dict[namespace.variants]
+                variants_dict[namespace.package_manager] = package_manager
 
-            if "variables" not in exp_dict:
-                exp_dict["variables"] = yaml.comments.CommentedMap()
+            if namespace.variables not in exp_dict:
+                exp_dict[namespace.variables] = yaml.comments.CommentedMap()
 
-            vars_dict = exp_dict["variables"]
+            vars_dict = exp_dict[namespace.variables]
 
             # Ensure required variables are defined
             for key in app_inst.keywords.all_required_keys():
@@ -1096,11 +1096,11 @@ class Workspace:
                                 )
 
                 if workload.environment_variables:
-                    if "env_vars" not in exps_dict[experiment_name]:
-                        exp_dict["env_vars"] = syaml.syaml_dict()
-                        exp_dict["env_vars"]["set"] = syaml.syaml_dict()
+                    if namespace.env_var not in exps_dict[experiment_name]:
+                        exp_dict[namespace.env_var] = syaml.syaml_dict()
+                        exp_dict[namespace.env_var]["set"] = syaml.syaml_dict()
 
-                    env_vars_dict = exp_dict["env_vars"]["set"]
+                    env_vars_dict = exp_dict[namespace.env_var]["set"]
 
                     for env_var in workload.environment_variables.values():
                         env_vars_dict[env_var.name] = env_var.value
@@ -1110,20 +1110,20 @@ class Workspace:
                 vars_dict.update(var_def_dict)
 
             if exp_zips:
-                if "zips" not in exp_dict:
-                    exp_dict["zips"] = exp_zips.copy()
+                if namespace.zips not in exp_dict:
+                    exp_dict[namespace.zips] = exp_zips.copy()
 
             if exp_matrix:
-                if "matrix" not in exp_dict:
-                    exp_dict["matrix"] = exp_matrix.copy()
+                if namespace.matrix not in exp_dict:
+                    exp_dict[namespace.matrix] = exp_matrix.copy()
 
         if not self.dry_run:
             ramble.config.config.update_config(
-                "applications", apps_dict, scope=self.ws_file_config_scope_name()
+                namespace.application, apps_dict, scope=self.ws_file_config_scope_name()
             )
         else:
             workspace_dict = self._get_workspace_dict().copy()
-            workspace_dict["ramble"]["applications"] = apps_dict
+            workspace_dict[namespace.ramble][namespace.application] = apps_dict
             print(f"\n{syaml.dump(workspace_dict)}")
 
     def concretize(self):

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -135,7 +135,7 @@ ramble:
   variables:
     mpi_command: mpirun -n {n_ranks}
     batch_submit: '{execute_experiment}'
-    processes_per_node: -1
+    processes_per_node: 1
   applications: {}
   software:
     packages: {}

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -638,7 +638,7 @@ _ramble_workspace() {
     then
         RAMBLE_COMPREPLY="-h --help"
     else
-        RAMBLE_COMPREPLY="activate archive deactivate create concretize setup analyze push-to-cache info edit mirror list ls remove rm"
+        RAMBLE_COMPREPLY="activate archive deactivate create concretize setup analyze push-to-cache info edit mirror list ls remove rm generate-config"
     fi
 }
 
@@ -719,5 +719,14 @@ _ramble_workspace_rm() {
         RAMBLE_COMPREPLY="-h --help -y --yes-to-all"
     else
         _workspaces
+    fi
+}
+
+_ramble_workspace_generate_config() {
+    if $list_options
+    then
+        RAMBLE_COMPREPLY="-h --help --workload-filter --wf --variable-filter --vf --variable-definition -v --experiment-name -e --package-manager -p --dry-run --print --overwrite --include-default-variables -i --workload-name-variable -w --zip -z --matrix -m"
+    else
+        _all_applications
     fi
 }


### PR DESCRIPTION
The primary purpose of this merge is to define a new front-end command (`ramble workspace generate-config`) which can be used to generate new workspace config files (or add new experiments to existing workspace config files).

The known_applications test is updated to use this to generate the test configs rather than through string manipulation.

Additionally, this merge updates some of the semantics around which variables are required, reserved, and optional.