### PR TITLE
Refactor app result into a class

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -1870,7 +1870,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
                 continue
 
             # When strict success is off for repeats (loose success), skip failed exps
-            if exp_inst.result.status == "FAILED":
+            if exp_inst.result.status == experiment_status.FAILED:
                 continue
 
             if exp_inst.result.contexts:

--- a/lib/ramble/ramble/experiment_result.py
+++ b/lib/ramble/ramble/experiment_result.py
@@ -6,14 +6,16 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+from ramble.namespace import namespace
+
 
 _DICT_MAPPING = {
     "name": "name",
     "status": "RAMBLE_STATUS",
     "experiment_chain": "EXPERIMENT_CHAIN",
-    "n_repeats": "N_REPEATS",
-    "tags": "TAGS",
-    "variables": "RAMBLE_VARIABLES",
+    namespace.n_repeats: "N_REPEATS",
+    namespace.tags: "TAGS",
+    namespace.variables: "RAMBLE_VARIABLES",
     "raw_variables": "RAMBLE_RAW_VARIABLES",
     "contexts": "CONTEXTS",
 }

--- a/lib/ramble/ramble/experiment_result.py
+++ b/lib/ramble/ramble/experiment_result.py
@@ -1,0 +1,64 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+
+_DICT_MAPPING = {
+    "name": "name",
+    "status": "RAMBLE_STATUS",
+    "experiment_chain": "EXPERIMENT_CHAIN",
+    "n_repeats": "N_REPEATS",
+    "tags": "TAGS",
+    "variables": "RAMBLE_VARIABLES",
+    "raw_variables": "RAMBLE_RAW_VARIABLES",
+    "contexts": "CONTEXTS",
+}
+
+
+# TODO: would be better to use dataclass after 3.6 support is dropped
+class ExperimentResult:
+    """Class containing results and related metadata of an experiment"""
+
+    def __init__(self, app_inst):
+        """Build up the result from the given app instance"""
+        self.name = app_inst.expander.experiment_namespace
+        self.status = app_inst.get_status()
+        self.n_repeats = app_inst.repeats.n_repeats
+        self.experiment_chain = app_inst.chain_order.copy()
+        self.tags = list(app_inst.experiment_tags)
+        self.contexts = []
+
+        self.keys = {}
+        for key in app_inst.keywords.keys:
+            if app_inst.keywords.is_key_level(key):
+                self.keys[key] = app_inst.expander.expand_var_name(key)
+
+        self.raw_variables = {}
+        self.variables = {}
+        for var, val in app_inst.variables.items():
+            self.raw_variables[var] = val
+            if var not in app_inst.keywords.keys or not app_inst.keywords.is_key_level(var):
+                self.variables[var] = app_inst.expander.expand_var(val)
+
+    def to_dict(self):
+        """Generate a dict for encoders (json, yaml) and uploaders.
+
+        The generated dict preserves the existing serialized format
+        so that previous result files work as expected.
+        """
+        import copy
+
+        obj_dict = copy.deepcopy(self.__dict__)
+        if "keys" in obj_dict:
+            res = obj_dict["keys"]
+        else:
+            res = {}
+        for name, val in obj_dict.items():
+            if name in _DICT_MAPPING:
+                res[_DICT_MAPPING[name]] = val
+
+        return res

--- a/lib/ramble/ramble/test/experiment_result.py
+++ b/lib/ramble/ramble/test/experiment_result.py
@@ -1,0 +1,29 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+"""Tests on the ExperimentResult class"""
+
+from ramble.experiment_result import ExperimentResult
+
+
+def test_to_dict(mutable_mock_apps_repo):
+    basic_app_inst = mutable_mock_apps_repo.get("basic")
+    basic_app_inst.set_variables({"experiment_status": "Unknown", "test_var": "my_var"}, None)
+    exp_res = ExperimentResult(basic_app_inst)
+    res_dict = exp_res.to_dict()
+    assert "name" in res_dict
+    assert "application_name" in res_dict
+    assert res_dict["RAMBLE_STATUS"] == "Unknown"
+    assert res_dict["RAMBLE_RAW_VARIABLES"]["experiment_status"] == "Unknown"
+    assert "EXPERIMENT_CHAIN" in res_dict
+    assert "CONTEXTS" in res_dict
+    assert "TAGS" in res_dict
+    assert res_dict["N_REPEATS"] == 0
+    assert res_dict["RAMBLE_VARIABLES"]["test_var"] == "my_var"
+    assert res_dict["RAMBLE_RAW_VARIABLES"]["test_var"] == "my_var"
+    assert "RAMBLE_RAW_VARIABLES" in res_dict


### PR DESCRIPTION
For now when pass the result into workspace, it still uses the old dict format so that encoders and uploaders work without needing to change. That also ensures existing serialized results do not break.