### PR TITLE
Fix wait-for-bg-jobs undefined variable

### DIFF
--- a/var/ramble/repos/builtin/modifiers/wait-for-bg-jobs/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/wait-for-bg-jobs/modifier.py
@@ -39,6 +39,7 @@ class WaitForBgJobs(BasicModifier):
         post_exec = []
 
         if executable.run_in_background:
+            shell = ramble.config.get("config:shell")
             last_pid_str = last_pid_var(shell)
             post_exec.append(
                 CommandExecutable(


### PR DESCRIPTION
This got accidentally removed. Will add a test for it in a follow-up