### PR TITLE
Add a modifier to make it easy to wrap perf tools around an executable

### DIFF
--- a/lib/ramble/ramble/test/util/shell_utils.py
+++ b/lib/ramble/ramble/test/util/shell_utils.py
@@ -6,7 +6,13 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-from ramble.util.shell_utils import last_pid_var, source_str, get_compatible_base_shell
+from ramble.util.shell_utils import (
+    last_pid_var,
+    source_str,
+    get_compatible_base_shell,
+    cmd_sub_str,
+    UnsupportedError,
+)
 
 import pytest
 
@@ -26,3 +32,11 @@ import pytest
 )
 def test_shell_specializations(var_func, shell, expect):
     assert var_func(shell) == expect
+
+
+def test_cmd_sub_str():
+    with pytest.raises(UnsupportedError):
+        cmd_sub_str("bat", "VER")
+
+    assert cmd_sub_str("fish", "uname -n") == "(uname -n)"
+    assert cmd_sub_str("bash", "uname -n") == "`uname -n`"

--- a/lib/ramble/ramble/util/shell_utils.py
+++ b/lib/ramble/ramble/util/shell_utils.py
@@ -8,6 +8,10 @@
 
 """Utils for handling shell specialization"""
 
+from ramble.error import RambleError
+
+_SUPPORTED_BASE_SHELLS = frozenset(["sh", "fish", "csh", "bat"])
+
 
 def last_pid_var(shell: str) -> str:
     if shell == "fish":
@@ -53,3 +57,17 @@ def get_compatible_base_shell(shell):
         (str): The base compatible shell.
     """
     return _base_shell_map.get(shell, shell)
+
+
+def cmd_sub_str(shell, cmd: str):
+    """Get the command substitution string of the given shell"""
+    base_shell = get_compatible_base_shell(shell)
+    if base_shell not in _SUPPORTED_BASE_SHELLS or base_shell == "bat":
+        raise UnsupportedError(f"Command substitution is not supported in {shell} shell")
+    if shell == "fish":
+        return f"({cmd})"
+    return f"`{cmd}`"
+
+
+class UnsupportedError(RambleError):
+    """Error when certain shell features are not supported."""

--- a/var/ramble/repos/builtin/modifiers/sys-stat/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/sys-stat/modifier.py
@@ -1,0 +1,127 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms
+
+import re
+
+import ramble.util.shell_utils
+from ramble.modkit import *
+from ramble.util.executable import CommandExecutable
+
+
+class SysStat(BasicModifier):
+    """Define a modifier for capturing system metrics.
+
+    Example usage: Below is a ramble config that outputs iostat every 5s
+    for the duration of the sleep application.
+    ```
+    ramble:
+      variants:
+        package_manager: spack
+      variables:
+        apply_sampler_exe_regex: 'sleep'
+        sampler_cmd: 'iostat -xz 5'
+        processes_per_node: 1
+        n_nodes: 1
+        mpi_command: ''
+        batch_submit: '{execute_experiment}'
+    applications:
+      sleep:
+        workloads:
+          sleep:
+            experiments:
+              test1:
+                variables:
+                  sleep_seconds: 6
+    software:
+      packages:
+        sysstat:
+          pkg_spec: sysstat
+      environments:
+        hostname:
+          packages:
+          - sysstat
+    modifiers:
+    - name: sys-stat
+    ```
+    """
+
+    name = "sys-stat"
+
+    tags("system-info", "performance-analysis")
+
+    mode("standard", description="Collect system metrics during program run")
+    default_mode("standard")
+
+    # sysstat contains common tools such as mpstat and iostat
+    software_spec(
+        "sysstat",
+        pkg_spec="sysstat",
+        package_manager="spack*",
+    )
+
+    required_package("sysstat", package_manager="spack*")
+
+    archive_pattern("{experiment_run_dir}/sampler_*")
+
+    modifier_variable(
+        "apply_sampler_exe_regex",
+        default="",
+        description="Apply the sampler when exe_name matches with the regex",
+        mode="standard",
+    )
+
+    modifier_variable(
+        "sampler_cmd",
+        default="mpstat 10",
+        description="Apply the sampler when exec_name matches with the regex",
+        mode="standard",
+    )
+
+    executable_modifier("apply_sampler")
+
+    def apply_sampler(self, exe_name, exe, app_inst=None):
+        pre_cmds = []
+        post_cmds = []
+
+        exe_regex = self.expander.expand_var_name("apply_sampler_exe_regex")
+        applicable = exe_regex and re.match(exe_regex, exe_name)
+
+        if applicable:
+            shell = ramble.config.get("config:shell")
+
+            pre_cmds.append(
+                CommandExecutable(
+                    f"add-sampler-{exe_name}",
+                    template=[
+                        f'log_path="{{experiment_run_dir}}/sampler_{exe_name}_$HOSTNAME.out"',
+                        '{sampler_cmd} > "$log_path" 2>&1 &',
+                        f"sampler_cmd_pid={ramble.util.shell_utils.last_pid_var(shell)}",
+                    ],
+                    mpi=False,
+                    redirect="",
+                    output_capture="",
+                ),
+            )
+
+            post_cmds.append(
+                CommandExecutable(
+                    f"cleanup-sampler-{exe_name}",
+                    template=[
+                        r"""
+if ps -p "$sampler_cmd_pid" > /dev/null; then
+    kill "$sampler_cmd_pid"
+fi
+            """.strip(),
+                    ],
+                    mpi=False,
+                    redirect="",
+                    output_capture="",
+                )
+            )
+
+        return pre_cmds, post_cmds

--- a/var/ramble/repos/builtin/modifiers/sys-stat/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/sys-stat/modifier.py
@@ -93,14 +93,18 @@ class SysStat(BasicModifier):
 
         if applicable:
             shell = ramble.config.get("config:shell")
+            last_pid_str = ramble.util.shell_utils.last_pid_var(shell)
+            hostname_str = ramble.util.shell_utils.cmd_sub_str(
+                shell, "uname -n"
+            )
 
             pre_cmds.append(
                 CommandExecutable(
                     f"add-sampler-{exe_name}",
                     template=[
-                        f'log_path="{{experiment_run_dir}}/sampler_{exe_name}_$HOSTNAME.out"',
+                        f'log_path="{{experiment_run_dir}}/sampler_{exe_name}_{hostname_str}.out"',
                         '{sampler_cmd} > "$log_path" 2>&1 &',
-                        f"sampler_cmd_pid={ramble.util.shell_utils.last_pid_var(shell)}",
+                        f"sampler_cmd_pid={last_pid_str}",
                     ],
                     mpi=False,
                     redirect="",

--- a/var/ramble/repos/builtin/modifiers/sys-stat/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/sys-stat/modifier.py
@@ -24,7 +24,7 @@ class SysStat(BasicModifier):
         package_manager: spack
       variables:
         apply_sampler_exe_regex: 'sleep'
-        sampler_cmd: 'iostat -xz 5'
+        sampler_cmd: 'iostat -xzt 5'
         processes_per_node: 1
         n_nodes: 1
         mpi_command: ''
@@ -54,8 +54,11 @@ class SysStat(BasicModifier):
 
     tags("system-info", "performance-analysis")
 
-    mode("standard", description="Collect system metrics during program run")
-    default_mode("standard")
+    mode(
+        "custom",
+        description="Use user-defined collection command during program run",
+    )
+    default_mode("custom")
 
     # sysstat contains common tools such as mpstat and iostat
     software_spec(
@@ -72,14 +75,14 @@ class SysStat(BasicModifier):
         "apply_sampler_exe_regex",
         default="",
         description="Apply the sampler when exe_name matches with the regex",
-        mode="standard",
+        mode="custom",
     )
 
     modifier_variable(
         "sampler_cmd",
         default="mpstat 10",
         description="Apply the sampler when exec_name matches with the regex",
-        mode="standard",
+        mode="custom",
     )
 
     executable_modifier("apply_sampler")


### PR DESCRIPTION
Given that this allows for custom commands, it does not include any FOMs for extracting metrics. It can serve as a base modifier for others to extend, such that more well-defined FOMs can be included in the extended modifier. Alternatively additional modes can be added to use specific commands (iostat, sar, mpstat, vmstat, etc.)

Example usage (run iostat during the app execution):

```sh
$ cat $RAMBLE_WORKSPACE/configs/ramble.yaml
ramble:
  variants:
    package_manager: spack
  variables:
    apply_sampler_exe_regex: 'sleep'
    sampler_cmd: 'iostat -xzt 5'
    processes_per_node: 1
    n_nodes: 1
    mpi_command: ''
    batch_submit: '{execute_experiment}'
  applications:
    sleep:
      workloads:
        sleep:
          experiments:
            test1:
              variables:
                sleep_seconds: 6
  software:
    packages:
      sysstat:
        pkg_spec: sysstat
    environments:
      hostname:
        packages:
        - sysstat
  modifiers:
  - name: sys-stat

$ ramble on

$ cat $RAMBLE_WORKSPACE/experiments/sleep/sleep/test1/sampler_sleep_linsword-13.c.googlers.com.out
Linux 6.9.10-1rodete3-amd64 (linsword-13.c.googlers.com)        08/30/2024      _x86_64_        (24 CPU)

08/30/2024 02:01:45 PM
avg-cpu:  %user   %nice %system %iowait  %steal   %idle
           0.36    0.51    0.78    0.03    0.06   98.26

Device            r/s     rkB/s   rrqm/s  %rrqm r_await rareq-sz     w/s     wkB/s   wrqm/s  %wrqm w_await wareq-sz     d/s     dkB/s   drqm/s  %drqm d_await dareq-sz     f/s f_await  aqu-sz  %util
dm-0             5.88    173.00     0.00   0.00    1.10    29.43   26.70    634.69     0.00   0.00   34.14    23.77    0.08    246.00     0.00   0.00    0.50  3024.59    0.00    0.00    0.92   0.62
dm-1             5.78    172.57     0.00   0.00    1.10    29.87   26.29    634.25     0.00   0.00   13.68    24.12    0.08    246.00     0.00   0.00    0.50  3024.59    0.00    0.00    0.37   0.70
dm-2             0.10      0.41     0.00   0.00    0.86     4.04    0.11      0.45     0.00   0.00    2.49     4.00    0.00      0.00     0.00   0.00    0.00     0.00    0.00    0.00    0.00   0.00
sda              5.33    174.53     0.59   9.89    1.00    32.72   19.08    635.61     9.17  32.47    2.67    33.32    0.08    253.91     0.00   0.00    0.52  3110.16    3.21    0.12    0.06   0.55


08/30/2024 02:01:50 PM
avg-cpu:  %user   %nice %system %iowait  %steal   %idle
           0.38    0.03    0.54    0.00    0.03   99.02

Device            r/s     rkB/s   rrqm/s  %rrqm r_await rareq-sz     w/s     wkB/s   wrqm/s  %wrqm w_await wareq-sz     d/s     dkB/s   drqm/s  %drqm d_await dareq-sz     f/s f_await  aqu-sz  %util
dm-0             0.00      0.00     0.00   0.00    0.00     0.00   32.20    130.40     0.00   0.00    0.82     4.05    0.00      0.00     0.00   0.00    0.00     0.00    0.00    0.00    0.03   0.08
dm-1             0.00      0.00     0.00   0.00    0.00     0.00   32.20    130.40     0.00   0.00    0.82     4.05    0.00      0.00     0.00   0.00    0.00     0.00    0.00    0.00    0.03   0.08
sda              0.00      0.00     0.00   0.00    0.00     0.00    9.40    130.40    22.80  70.81    0.94    13.87    0.00      0.00     0.00   0.00    0.00     0.00    2.00    0.20    0.01   0.00
```