### PR TITLE
Add support for regex match in expander

### DIFF
--- a/lib/ramble/docs/workspace_config.rst
+++ b/lib/ramble/docs/workspace_config.rst
@@ -174,6 +174,7 @@ Supported functions are:
 * ``simplify_str()`` (convert input string to only alphanumerical characters and dashes)
 * ``randrange`` (from `random.randrange`)
 * ``randint`` (from `random.randint`)
+* ``re_search(regex, str)`` (determine if ``str`` contains pattern ``regex``, based on ``re.search``)
 
 .. _ramble-escaped-variables:
 

--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -29,6 +29,12 @@ def _or(a, b):
     return a or b
 
 
+def _re_search(regex, s):
+    import re
+
+    return re.search(regex, s) is not None
+
+
 supported_math_operators = {
     ast.Add: operator.add,
     ast.Sub: operator.sub,
@@ -60,6 +66,7 @@ supported_scalar_function_pointers = {
     "randrange": random.randrange,
     "randint": random.randint,
     "simplify_str": spack.util.naming.simplify_name,
+    "re_search": _re_search,
 }
 
 

--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -35,6 +35,11 @@ def _re_search(regex, s):
     return re.search(regex, s) is not None
 
 
+def _safe_str_node_check(node):
+    # ast.Str was deprecated. short-circuit the test for it to avoid issues with newer python.
+    return hasattr(ast, "Str") and isinstance(node, ast.Str)
+
+
 supported_math_operators = {
     ast.Add: operator.add,
     ast.Sub: operator.sub,
@@ -828,7 +833,7 @@ class Expander:
         Perform extraction of `<variable> in <experiment>` syntax.
         Raises an exception if the experiment does not exist.
 
-        Also, evaluated `<value> in [list, of, values]` syntax.
+        Also, evaluated `<value> in [list, of, values]` and `<value> in "str"` syntaxes.
         """
         if isinstance(node.left, ast.Name):
             var_name = self._ast_name(node.left)
@@ -843,11 +848,8 @@ class Expander:
                     )
                     self.__raise_syntax_error(node)
                 return val
-        # ast.Str was deprecated. short-circuit the test for it to avoid issues with newer python.
         # TODO: Remove `or` logic after 3.6 & 3.7 series python are unsupported
-        elif isinstance(node.left, ast.Constant) or (
-            hasattr(ast, "Str") and isinstance(node.left, ast.Str)
-        ):
+        elif isinstance(node.left, ast.Constant) or _safe_str_node_check(node.left):
             lhs_value = self.eval_math(node.left)
 
             found = False
@@ -857,6 +859,11 @@ class Expander:
                         rhs_value = self.eval_math(elt)
                         if lhs_value == rhs_value:
                             found = True
+                elif isinstance(comp, ast.Constant) or _safe_str_node_check(comp):
+                    # Attempt evaluating `"str" in "string"`
+                    rhs_value = self.eval_math(comp)
+                    if isinstance(rhs_value, str) and lhs_value in rhs_value:
+                        found = True
             return found
 
         self.__raise_syntax_error(node)

--- a/lib/ramble/ramble/test/expander.py
+++ b/lib/ramble/ramble/test/expander.py
@@ -73,6 +73,8 @@ def exp_dict():
         ('"2.1.1" in ["2.1.1", "3.1.1", "4.2.1"]', "True", set(), 1),
         ('"2.1.2" in ["2.1.1", "3.1.1", "4.2.1"]', "False", set(), 1),
         ("{test_mask}", "0x0", {"test_mask"}, 1),
+        ('re_search(r"bz$", {experiment_name})', "False", set(), 1),
+        ('re_search("o+\\\\.b", {env_name})', "True", set(), 1),
     ],
 )
 def test_expansions(input, output, no_expand_vars, passes):

--- a/lib/ramble/ramble/test/expander.py
+++ b/lib/ramble/ramble/test/expander.py
@@ -75,6 +75,8 @@ def exp_dict():
         ("{test_mask}", "0x0", {"test_mask"}, 1),
         ('re_search(r"bz$", {experiment_name})', "False", set(), 1),
         ('re_search("o+\\\\.b", {env_name})', "True", set(), 1),
+        ('"foo" in "{env_name}"', "True", set(), 1),
+        ('"c" in "{experiment_name}"', "False", set(), 1),
     ],
 )
 def test_expansions(input, output, no_expand_vars, passes):


### PR DESCRIPTION
Can be useful for things like filtering experiments:

```sh
# setup only h3 experiments that use less than 10 nodes
ramble workspace setup --where 're_search(r"h3.*_node_\d_", {experiment_name})'
```

Also add in support for `"str" in {experiment_name}`.