### PR TITLE
Add support for arbitrary commands in formatted executables

### DIFF
--- a/etc/ramble/defaults/formatted_executables.yaml
+++ b/etc/ramble/defaults/formatted_executables.yaml
@@ -1,3 +1,5 @@
 formatted_executables:
   command:
     join_separator: '\n'
+    commands:
+    - '{unformatted_command}'

--- a/lib/ramble/ramble/keywords.py
+++ b/lib/ramble/ramble/keywords.py
@@ -47,6 +47,7 @@ default_keys = {
     "batch_submit": {"type": key_type.required, "level": output_level.variable},
     "mpi_command": {"type": key_type.required, "level": output_level.variable},
     "experiment_template_name": {"type": key_type.reserved, "level": output_level.key},
+    "unformatted_command": {"type": key_type.reserved, "level": output_level.variable},
 }
 
 

--- a/lib/ramble/ramble/namespace.py
+++ b/lib/ramble/ramble/namespace.py
@@ -59,6 +59,7 @@ class namespace:
     indentation = "indentation"
     prefix = "prefix"
     join_separator = "join_separator"
+    commands = "commands"
 
     # For variants
     package_manager = "package_manager"

--- a/lib/ramble/ramble/schema/formatted_executables.py
+++ b/lib/ramble/ramble/schema/formatted_executables.py
@@ -26,6 +26,13 @@ properties = {
                 "prefix": {"type": "string", "default": ""},
                 "indentation": {"type": "number", "default": 0},
                 "join_separator": {"type": "string", "default": "\n"},
+                "commands": {
+                    "type": "array",
+                    "default": ["{unformatted_command}"],
+                    "items": {
+                        "type": "string",
+                    },
+                },
             },
         },
     }

--- a/lib/ramble/ramble/test/data/config/formatted_executables.yaml
+++ b/lib/ramble/ramble/test/data/config/formatted_executables.yaml
@@ -1,3 +1,5 @@
 formatted_executables:
   command:
     join_separator: '\n'
+    commands:
+    - '{unformatted_command}'

--- a/lib/ramble/ramble/test/end_to_end/formatted_executables.py
+++ b/lib/ramble/ramble/test/end_to_end/formatted_executables.py
@@ -36,6 +36,11 @@ ramble:
       prefix: 'from_ws '
       indentation: 9
       join_separator: ';'
+    ws_test_def:
+      prefix: 'test_from_ws '
+      indentation: 2
+      commands:
+      - '{mpi_command} test'
   applications:
     basic:
       formatted_executables:
@@ -74,6 +79,7 @@ ramble:
             f.write("{app_exec_def}\n")
             f.write("{wl_exec_def}\n")
             f.write("{exp_exec_def}\n")
+            f.write("{ws_test_def}\n")
         ws._re_read()
 
         workspace("setup", "--dry-run", global_args=["-w", workspace_name])
@@ -88,6 +94,7 @@ ramble:
             assert ";" + " " * 9 + "from_ws echo" in data
             assert "\n" + " " * 11 + "from_wl echo" in data
             assert "\n" + " " * 10 + "from_exp echo" in data
+            assert "\n" + " " * 2 + "test_from_ws mpirun -n 16 -ppn 16 test" in data
 
 
 def test_redefined_executable_errors(


### PR DESCRIPTION
This merge allows formatted_executable definitions to have a `commands` attribute, which can define the lines that should be in the formatted output.

The default is to format all of the commands for the experiment, but this can be override to format arbitrary strings / variables. Item in the `commands` list will be expanded as a variable definition, and then split over new-lines before formatting based on the formatted executable definition.