### PR TITLE
Allow specifying `spack:concretizer` settings in Ramble config

### DIFF
--- a/lib/ramble/ramble/config.py
+++ b/lib/ramble/ramble/config.py
@@ -143,7 +143,10 @@ config_defaults = {
         "concretizer": "clingo",
         "license_dir": spack.paths.default_license_dir,
         "shell": "sh",
-        "spack": {"flags": {"install": "--reuse", "concretize": "--reuse"}},
+        "spack": {
+            "flags": {"install": "--reuse", "concretize": "--reuse"},
+            "concretizer": {"unify": True},
+        },
         "pip": {"install": {"flags": []}},
         "input_cache": "$ramble/var/ramble/cache",
         "workspace_dirs": "$ramble/var/ramble/workspaces",

--- a/lib/ramble/ramble/schema/config.py
+++ b/lib/ramble/ramble/schema/config.py
@@ -13,7 +13,9 @@
 """
 
 import spack.schema.config
-import spack.schema.concretizer
+
+import ramble.schema.util.import_util as import_util
+
 
 #: Properties for inclusion in other schemas
 properties = {
@@ -22,6 +24,9 @@ properties = {
 
 properties["config"]["shell"] = {"type": "string", "enum": ["sh", "bash", "csh", "tcsh", "fish"]}
 
+# Get the concretizer schema from the external spack instead of the one included in ramble src.
+# This aligns since the concretizer settings are fed into the external spack instance.
+spack_concretizer = import_util.import_external_spack_schema("spack.schema.concretizer")
 properties["config"]["spack"] = {
     "type": "object",
     "default": {"install": {"flags": "--reuse"}, "concretize": {"flags": "--reuse"}},
@@ -104,7 +109,7 @@ properties["config"]["spack"] = {
             },
             "additionalProperties": False,
         },
-        "concretizer": spack.schema.concretizer.properties["concretizer"],
+        "concretizer": spack_concretizer.properties["concretizer"],
     },
     "additionalProperties": False,
 }

--- a/lib/ramble/ramble/schema/config.py
+++ b/lib/ramble/ramble/schema/config.py
@@ -13,6 +13,7 @@
 """
 
 import spack.schema.config
+import spack.schema.concretizer
 
 #: Properties for inclusion in other schemas
 properties = {
@@ -103,6 +104,7 @@ properties["config"]["spack"] = {
             },
             "additionalProperties": False,
         },
+        "concretizer": spack.schema.concretizer.properties["concretizer"],
     },
     "additionalProperties": False,
 }

--- a/lib/ramble/ramble/schema/util/import_util.py
+++ b/lib/ramble/ramble/schema/util/import_util.py
@@ -1,0 +1,29 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import importlib
+import importlib.util
+import os
+
+
+# TODO: This does not work with nested imports
+def import_external_spack_schema(fullname):
+    """Import a single schema source from the external Spack, if available"""
+    ext_spack_root = os.environ.get("SPACK_ROOT")
+    module = None
+    if ext_spack_root is not None:
+        _, _, leaf = fullname.rpartition(".")
+        src_path = os.path.join(ext_spack_root, "lib", "spack", "spack", "schema", leaf + ".py")
+        if os.path.exists(src_path):
+            spec = importlib.util.spec_from_file_location(fullname, src_path)
+            module = importlib.util.module_from_spec(spec)
+            if module is not None:
+                spec.loader.exec_module(module)
+    if module is None:
+        module = importlib.import_module(fullname)
+    return module

--- a/lib/ramble/ramble/test/end_to_end/package_manager_config.py
+++ b/lib/ramble/ramble/test/end_to_end/package_manager_config.py
@@ -26,6 +26,11 @@ def test_package_manager_config_zlib(mock_applications):
 ramble:
   variants:
     package_manager: spack
+  config:
+    spack:
+      concretizer:
+        targets:
+          host_compatible: false
   variables:
     mpi_command: ''
     batch_submit: 'batch_submit {execute_experiment}'
@@ -68,3 +73,8 @@ ramble:
             data = f.read()
             assert "config:" in data
             assert "debug: true" in data
+
+            # assert on concretizer settings
+            # unify true is the default
+            assert "unify: true" in data
+            assert "host_compatible: false" in data

--- a/lib/ramble/ramble/test/schema/util/import_util.py
+++ b/lib/ramble/ramble/test/schema/util/import_util.py
@@ -1,0 +1,28 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import ramble.schema.util.import_util as import_util
+
+
+def test_import_external_spack_schema(tmpdir, working_env):
+    ramble_root = os.environ["RAMBLE_ROOT"]
+    # fallback to internal spack when path not-exist
+    os.environ["SPACK_ROOT"] = "/not-exist/"
+    mod = import_util.import_external_spack_schema("spack.schema.concretizer")
+    assert mod.__file__.startswith(ramble_root)
+
+    # reads in external spack when available
+    tmp_file = os.path.join(tmpdir, "lib", "spack", "spack", "schema", "concretizer.py")
+    os.makedirs(os.path.dirname(tmp_file))
+    with open(tmp_file, "a"):
+        pass
+    os.environ["SPACK_ROOT"] = str(tmpdir)
+    mod = import_util.import_external_spack_schema("spack.schema.concretizer")
+    assert mod.__file__.startswith(str(tmpdir))

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
@@ -521,6 +521,7 @@ class SpackRunner(object):
     buildcache_config_name = "config:spack:buildcache"
     concretize_config_name = "config:spack:concretize"
     env_create_config_name = "config:spack:env_create"
+    concretizer_config_name = "config:spack:concretizer"
 
     env_create_args = ["env", "create", "-d", "."]
 
@@ -995,8 +996,9 @@ class SpackRunner(object):
         """Construct a dictionary with the env file contents in it"""
         env_file = syaml.syaml_dict()
         env_file[spack_namespace] = syaml.syaml_dict()
-        env_file[spack_namespace]["concretizer"] = syaml.syaml_dict()
-        env_file[spack_namespace]["concretizer"]["unify"] = True
+        env_file[spack_namespace]["concretizer"] = syaml.syaml_dict(
+            ramble.config.get(self.concretizer_config_name)
+        )
 
         env_file[spack_namespace]["specs"] = syaml.syaml_list()
         # Ensure the specs content are consistently sorted.


### PR DESCRIPTION
This is useful for enabling cross-compilation when using Ramble on a per-ramble-workspace basis.

Example Ramble config snip:

```
ramble:
  variants:
    package_manager: spack
  config:
    spack:
      concretizer:
        targets:
          host_compatible: false
  ...
```