### PR TITLE
Only calculate n_successful_repeats once per exp

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -1908,6 +1908,26 @@ class ApplicationBase(metaclass=ApplicationMeta):
                 "display_name": _get_context_display_name(context),
             }
 
+            if context == _NULL_CONTEXT:
+                n_total_dict = {
+                    "value": self.repeats.n_repeats,
+                    "units": "repeats",
+                    "origin": list(fom_dict.keys())[0][2],
+                    "origin_type": "summary::n_total_repeats",
+                    "name": "Experiment Summary",
+                }
+                context_map["foms"].append(n_total_dict)
+
+                # Use the first FOM to count how many successful repeats values are present
+                n_success_dict = {
+                    "value": len(list(fom_dict.values())[0]),
+                    "units": "repeats",
+                    "origin": list(fom_dict.keys())[0][2],
+                    "origin_type": "summary::n_successful_repeats",
+                    "name": "Experiment Summary",
+                }
+                context_map["foms"].append(n_success_dict)
+
             for fom_key, fom_values in fom_dict.items():
                 fom_name = fom_key[0]
                 fom_units = fom_key[1]
@@ -1919,7 +1939,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
                     calcs.append(statistic.report(fom_values, fom_units))
 
                 for calc in calcs:
-                    fom_dict = {
+                    fom_calc_dict = {
                         "value": calc[0],
                         "units": calc[1],
                         "origin": fom_origin,
@@ -1927,7 +1947,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
                         "name": fom_name,
                     }
 
-                    context_map["foms"].append(fom_dict)
+                    context_map["foms"].append(fom_calc_dict)
 
             results.append(context_map)
 

--- a/lib/ramble/ramble/test/success_criteria/repeat_success_strict.py
+++ b/lib/ramble/ramble/test/success_criteria/repeat_success_strict.py
@@ -64,6 +64,7 @@ ramble:
             data = f.read()
             print(data)
             assert "FAILED" not in data
+            assert "summary::n_total_repeats = 2 repeats" in data
             assert "summary::n_successful_repeats = 2 repeats" in data
 
         # Write mock output to fail one of the experiments
@@ -80,6 +81,7 @@ ramble:
             print(data)
             assert "SUCCESS" in data
             assert "FAILED" in data
+            assert "summary::n_total_repeats = 2 repeats" in data
             assert "summary::n_successful_repeats = 1 repeats" in data
 
         # Write mock output to fail the second experiment
@@ -95,4 +97,5 @@ ramble:
             data = f.read()
             print(data)
             assert "SUCCESS" not in data
+            assert "summary::n_total_repeats" not in data
             assert "summary::n_successful_repeats" not in data

--- a/lib/ramble/ramble/test/util/stats.py
+++ b/lib/ramble/ramble/test/util/stats.py
@@ -22,12 +22,6 @@ import ramble.util.stats
         (ramble.util.stats.StatsVar(), [3], "s", ("NA", "", "summary::variance")),
         (ramble.util.stats.StatsStdev(), [-2, 0, 2, 5.5], "s", (3.2, "s", "summary::stdev")),
         (ramble.util.stats.StatsStdev(), [3], "s", ("NA", "", "summary::stdev")),
-        (
-            ramble.util.stats.StatsCountValues(),
-            [-2, 0, 2, 5.5],
-            "s",
-            (4, "repeats", "summary::n_successful_repeats"),
-        ),
         (ramble.util.stats.StatsCoefficientOfVariation(), [3], "s", ("NA", "", "summary::cv")),
         (ramble.util.stats.StatsCoefficientOfVariation(), [3, -3], "s", ("NA", "", "summary::cv")),
         (

--- a/lib/ramble/ramble/util/stats.py
+++ b/lib/ramble/ramble/util/stats.py
@@ -113,16 +113,6 @@ class StatsCoefficientOfVariation(StatsBase):
         return ""
 
 
-class StatsCountValues(StatsBase):
-    name = "n_successful_repeats"
-
-    def compute(self, values):
-        return len(values)
-
-    def get_unit(self, unit):
-        return "repeats"
-
-
 all_stats = [
     StatsMin(),
     StatsMax(),
@@ -131,5 +121,4 @@ all_stats = [
     StatsVar(),
     StatsStdev(),
     StatsCoefficientOfVariation(),
-    StatsCountValues(),
 ]


### PR DESCRIPTION
Updates calculate_statistics() to only add the number of successful repeats once per experiment instead of once per FOM. The n_successful_repeats value is added under a new FOM called "Experiment Summary" in the null context.

text: 
```
  default (null) context figures of merit:
    Experiment Summary:
      summary::n_successful_repeats = 2 repeats
```
json:
```
"CONTEXTS": [
        {
          "name": "null",
          "foms": [
            {
              "value": 2,
              "units": "repeats",
              "origin": "gromacs",
              "origin_type": "summary::n_successful_repeats",
              "name": "Experiment Summary"
            },
```