### PR TITLE
Add vm-topology info to the vm-metadata modifier

### DIFF
--- a/var/ramble/repos/builtin/modifiers/gcp-metadata/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/gcp-metadata/modifier.py
@@ -44,6 +44,16 @@ class GcpMetadata(BasicModifier):
         post_cmds = []
         pre_cmds = []
 
+        pre_cmds.append(
+            CommandExecutable(
+                "save-old-loglevel",
+                template=[
+                    'old_pdsh_args="$PDSH_SSH_ARGS_APPEND"',
+                    'export PDSH_SSH_ARGS_APPEND="-q"',
+                ],
+            )
+        )
+
         payloads = [
             # type, end point, per_node
             ("instance", "machine-type", False),
@@ -55,6 +65,7 @@ class GcpMetadata(BasicModifier):
                 True,
             ),  # True since we want the gid of every node
             ("project", "numeric-project-id", False),
+            ("instance", "attributes/physical_host", True),
         ]
 
         for type, end_point, per_node in payloads:
@@ -63,22 +74,32 @@ class GcpMetadata(BasicModifier):
             if per_node:
                 prefix = "pdsh -N -w {hostlist} '"
                 suffix = "'"
-
+            log_name = end_point.split("/")[-1]
             pre_cmds.append(
                 CommandExecutable(
                     "machine-type",
                     template=[
-                        f'{prefix} curl -s -w "\\n" "http://metadata.google.internal/computeMetadata/v1/{type}/{end_point}" -H "Metadata-Flavor: Google" {suffix}'
+                        # Fail silently (-f) to avoid jamming the log (say with 404 html)
+                        # This is especially pertinent to /attribute/physical_host,
+                        # which is only available for VMs with placement policy.
+                        f'{prefix} curl -s -f -w "\\n" "http://metadata.google.internal/computeMetadata/v1/{type}/{end_point}" -H "Metadata-Flavor: Google" {suffix}'
                     ],
                     mpi=False,
-                    redirect=f"{{experiment_run_dir}}/gcp-metadata.{end_point}.log",
+                    redirect=f"{{experiment_run_dir}}/gcp-metadata.{log_name}.log",
                     output_capture=">",
                 )
             )
 
+        pre_cmds.append(
+            CommandExecutable(
+                "restore-old-loglevel",
+                template=['export PDSH_SSH_ARGS_APPEND="$old_pdsh_args"'],
+            )
+        )
+
         return pre_cmds, post_cmds
 
-    def _prepare_analysis(self, workspace):
+    def _process_id_list(self):
         import os.path
 
         ids = set()
@@ -87,7 +108,7 @@ class GcpMetadata(BasicModifier):
         )
 
         if os.path.isfile(file_name):
-            with open(file_name, "r") as f:
+            with open(file_name) as f:
                 for cur_id in f.readlines():
                     cur_id = cur_id.strip()
                     if cur_id.isnumeric():
@@ -100,6 +121,43 @@ class GcpMetadata(BasicModifier):
                 "w+",
             ) as f:
                 f.write(", ".join(sorted(ids)))
+
+    def _process_physical_hosts(self):
+        level0_groups = set()
+        level1_groups = set()
+        level2_groups = set()
+        all_hosts = set()
+
+        with open(
+            self.expander.expand_var(
+                "{experiment_run_dir}/gcp-metadata.physical_host.log"
+            )
+        ) as f:
+            for raw_host in f.readlines():
+                physical_host = raw_host[1:].strip()
+                tty.debug(f"  Host line: {physical_host}")
+                all_hosts.add(physical_host)
+                levels = physical_host.split("/")
+                tty.debug(f"   Levels: {levels}")
+                if len(levels) == 3:
+                    level0_groups.add(levels[0])
+                    level1_groups.add(levels[1])
+                    level2_groups.add(levels[2])
+
+        with open(
+            self.expander.expand_var(
+                "{experiment_run_dir}/gcp-metadata.topology_summary.log"
+            ),
+            "w+",
+        ) as f:
+            f.write(f"Level 0 groups = {len(level0_groups)}\n")
+            f.write(f"Level 1 groups = {len(level1_groups)}\n")
+            f.write(f"Level 2 groups = {len(level2_groups)}\n")
+            f.write(f'All hosts = {",".join(all_hosts)}\n')
+
+    def _prepare_analysis(self, workspace):
+        self._process_id_list()
+        self._process_physical_hosts()
 
     figure_of_merit(
         "machine-type",
@@ -135,4 +193,28 @@ class GcpMetadata(BasicModifier):
         fom_regex=r"(?P<numeric_project_id>\d+)",
         group_name="numeric_project_id",
         log_file="{experiment_run_dir}/gcp-metadata.numeric-project-id.log",
+    )
+
+    figure_of_merit(
+        "Level {level_num} Groups",
+        fom_regex="Level (?P<level_num>[0-9]) groups = (?P<num_groups>[0-9]+)",
+        log_file="{experiment_run_dir}/gcp-metadata.topology_summary.log",
+        group_name="num_groups",
+        units="",
+    )
+
+    figure_of_merit(
+        "Level 0 Groups",
+        fom_regex="Level 0 groups = (?P<num_groups>.*)",
+        log_file="{experiment_run_dir}/gcp-metadata.topology_summary.log",
+        group_name="num_groups",
+        units="",
+    )
+
+    figure_of_merit(
+        "All Hosts",
+        fom_regex="All hosts = (?P<hostlist>.*)",
+        log_file="{experiment_run_dir}/gcp-metadata.topology_summary.log",
+        group_name="hostlist",
+        units="",
     )

--- a/var/ramble/repos/builtin/modifiers/gcp-metadata/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/gcp-metadata/modifier.py
@@ -150,10 +150,11 @@ class GcpMetadata(BasicModifier):
             ),
             "w+",
         ) as f:
-            f.write(f"Level 0 groups = {len(level0_groups)}\n")
-            f.write(f"Level 1 groups = {len(level1_groups)}\n")
-            f.write(f"Level 2 groups = {len(level2_groups)}\n")
-            f.write(f'All hosts = {",".join(all_hosts)}\n')
+            if len(level0_groups) > 0:
+                f.write(f"Level 0 groups = {len(level0_groups)}\n")
+                f.write(f"Level 1 groups = {len(level1_groups)}\n")
+                f.write(f"Level 2 groups = {len(level2_groups)}\n")
+                f.write(f'All hosts = {",".join(all_hosts)}\n')
 
     def _prepare_analysis(self, workspace):
         self._process_id_list()


### PR DESCRIPTION
Example output:

```sh
default (null) context figures of merit:
    possible hostname = caeslurmv6-h3nodeset-0
    modifier::GcpMetadata::machine-type = h3-standard-88
    modifier::GcpMetadata::image = projects/schedmd-slurm-public/global/images/slurm-gcp-6-6-hpc-rocky-linux-8-1721332881
    modifier::GcpMetadata::ghostname = caeslurmv6-h3nodeset-0.c.hpc-workload-performance.internal
    modifier::GcpMetadata::gids = 533091373936486779, 8389644254146668923
    modifier::GcpMetadata::project-id = 767663353010
    modifier::GcpMetadata::Level 0 Groups = 1
    modifier::GcpMetadata::Level 1 Groups = 1
    modifier::GcpMetadata::Level 2 Groups = 2
    modifier::GcpMetadata::All Hosts = f76852c04794ea2bfd4db49ae723fb5c/9840147cb2de928ab66b22687e59b72a/9009d21c910cb07c50717b37a53bd1af,f76852c04794ea2bfd4db49ae723fb5c/9840147cb2de928ab66b22687e59b72a/8418c73f86f4f46558b97ea15593dd98
```