### PR TITLE
Create Cloud-build tutorial triggers

### DIFF
--- a/lib/ramble/docs/tutorials/10_using_modifiers.rst
+++ b/lib/ramble/docs/tutorials/10_using_modifiers.rst
@@ -65,7 +65,7 @@ To discover which modifiers are available, execute:
 
 .. code-block:: console
 
-    $ ramble mods list
+    $ ramble list --type modifiers
 
 Which might output the following:
 
@@ -82,7 +82,7 @@ about the ``lscpu`` modifier, execute:
 
 .. code-block:: console
 
-    $ ramble mods info lscpu
+    $ ramble info --type modifiers lscpu
 
 This modifier adds the execution of ``lscpu`` to each experiment in a workspace
 (to capture additional platform level details, such as the CPU model), and
@@ -157,7 +157,7 @@ To get information about the ``intel-aps`` modifier, execute:
 
 .. code-block:: console
 
-    $ ramble mods info intel-aps
+    $ ramble info --type modifiers intel-aps
 
 In the output from this command, you should see a ``mode`` named ``mpi``. One
 additional difference relateive to ``lscpu`` is that the ``Software Specs:``

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-10.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-10.yaml
@@ -1,0 +1,85 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+
+steps:
+  - name: gcr.io/cloud-builders/git
+    args:
+      - fetch
+      - '--unshallow'
+    id: ramble-clone
+  - name: us-central1-docker.pkg.dev/$PROJECT_ID/ramble-repo/ramble-${_BASE_IMG}-${_BASE_VER}-spack${_SPACK_REF}-python${_PYTHON_VER}:latest
+    args:
+      - '-c'
+      - |
+        cd /workspace
+
+        export PATH=$$(. /opt/spack/share/spack/setup-env.sh && spack location -i miniconda3)/bin:$${PATH}
+
+        . /opt/spack/share/spack/setup-env.sh
+        . /workspace/share/ramble/setup-env.sh
+
+        echo "Spack version is $(spack --version)"
+        echo "Python version is $(python3 --version)"
+
+        spack mirror add ci_cache ${_CI_CACHE}
+        spack buildcache keys --install --trust
+
+        set -e
+
+        ramble workspace create -d modifiers_wrf -c /workspace/examples/tutorial_10_lscpu_config.yaml
+
+        ramble workspace activate ./modifiers_wrf
+
+        # Cloud build VMs only have 4 cores
+        ramble config add "variables:processes_per_node:4"
+
+        ramble list --type modifiers
+
+        ramble info --type modifiers lscpu
+
+        ramble workspace info
+
+        ramble workspace setup --where '{n_nodes} == 1'
+
+        ramble on --where '{n_nodes} == 1'
+        
+        ramble workspace analyze --where '{n_nodes} == 1'
+
+        ramble info --type modifiers intel-aps
+
+        cp /workspace/examples/tutorial_10_aps_error_config.yaml modifiers_wrf/configs/ramble.yaml
+
+        set +e
+
+        # Expected to error
+        ramble workspace setup --dry-run
+
+        set -e
+
+        cp /workspace/examples/tutorial_10_aps_final_config.yaml modifiers_wrf/configs/ramble.yaml
+
+        # Cloud build VMs only have 4 cores
+        ramble config add "variables:processes_per_node:4"
+
+        ramble workspace setup --where '{n_nodes} == 1'
+        ramble on --where '{n_nodes} == 1'
+        ramble workspace analyze --where '{n_nodes} == 1'
+
+        ramble workspace deactivate
+    id: ramble-tutorial-test
+    entrypoint: /bin/bash
+substitutions:
+  _SPACK_REF: v0.21.2
+  _PYTHON_VER: 3.11.6
+  _BASE_IMG: centos
+  _BASE_VER: '7'
+  _CI_CACHE: gs://spack/latest
+timeout: 1500s
+options:
+  machineType: N1_HIGHCPU_8

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-11.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-11.yaml
@@ -1,0 +1,68 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+
+steps:
+  - name: gcr.io/cloud-builders/git
+    args:
+      - fetch
+      - '--unshallow'
+    id: ramble-clone
+  - name: us-central1-docker.pkg.dev/$PROJECT_ID/ramble-repo/ramble-${_BASE_IMG}-${_BASE_VER}-spack${_SPACK_REF}-python${_PYTHON_VER}:latest
+    args:
+      - '-c'
+      - |
+        cd /workspace
+
+        export PATH=$$(. /opt/spack/share/spack/setup-env.sh && spack location -i miniconda3)/bin:$${PATH}
+
+        . /opt/spack/share/spack/setup-env.sh
+        . /workspace/share/ramble/setup-env.sh
+
+        echo "Spack version is $(spack --version)"
+        echo "Python version is $(python3 --version)"
+
+        spack mirror add ci_cache ${_CI_CACHE}
+        spack buildcache keys --install --trust
+
+        set -e
+
+        ramble workspace create -d internals_wrf -c /workspace/examples/tutorial_11_new_exec_config.yaml
+
+        ramble workspace activate ./internals_wrf
+
+        ramble workspace info
+
+        ramble workspace setup --dry-run
+
+        grep "date +" internals_wrf/experiments/wrfv4/CONUS_12km/scaling_1/execute_experiment
+
+        cp /workspace/examples/tutorial_11_exec_order_config.yaml internals_wrf/configs/ramble.yaml
+
+        ramble workspace setup --dry-run
+
+        grep "date +" internals_wrf/experiments/wrfv4/CONUS_12km/scaling_1/execute_experiment
+
+        cp /workspace/examples/tutorial_11_exec_injection_config.yaml internals_wrf/configs/ramble.yaml
+
+        ramble workspace setup --dry-run
+
+        grep "date +" internals_wrf/experiments/wrfv4/CONUS_12km/scaling_1/execute_experiment
+
+        ramble workspace deactivate
+    id: ramble-tutorial-test
+    entrypoint: /bin/bash
+substitutions:
+  _SPACK_REF: v0.21.2
+  _PYTHON_VER: 3.11.6
+  _BASE_IMG: centos
+  _BASE_VER: '7'
+  _CI_CACHE: gs://spack/latest
+timeout: 1500s
+options:
+  machineType: N1_HIGHCPU_8

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-2.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-2.yaml
@@ -1,0 +1,54 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+
+steps:
+  - name: gcr.io/cloud-builders/git
+    args:
+      - fetch
+      - '--unshallow'
+    id: ramble-clone
+  - name: us-central1-docker.pkg.dev/$PROJECT_ID/ramble-repo/ramble-${_BASE_IMG}-${_BASE_VER}-spack${_SPACK_REF}-python${_PYTHON_VER}:latest
+    args:
+      - '-c'
+      - |
+        cd /workspace
+
+        export PATH=$$(. /opt/spack/share/spack/setup-env.sh && spack location -i miniconda3)/bin:$${PATH}
+
+        . /opt/spack/share/spack/setup-env.sh
+        . /workspace/share/ramble/setup-env.sh
+
+        echo "Spack version is $(spack --version)"
+        echo "Python version is $(python3 --version)"
+
+        spack mirror add ci_cache ${_CI_CACHE}
+        spack buildcache keys --install --trust
+
+        set -e
+
+        ramble info gromacs
+
+        ramble workspace create -d basic_gromacs -c /workspace/examples/basic_gromacs_config.yaml
+
+        ramble workspace activate ./basic_gromacs
+
+        ramble workspace setup --dry-run
+
+        ramble workspace deactivate
+    id: ramble-tutorial-test
+    entrypoint: /bin/bash
+substitutions:
+  _SPACK_REF: v0.21.2
+  _PYTHON_VER: 3.11.6
+  _BASE_IMG: centos
+  _BASE_VER: '7'
+  _CI_CACHE: gs://spack/latest
+timeout: 1500s
+options:
+  machineType: N1_HIGHCPU_8

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-3.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-3.yaml
@@ -1,0 +1,58 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+
+steps:
+  - name: gcr.io/cloud-builders/git
+    args:
+      - fetch
+      - '--unshallow'
+    id: ramble-clone
+  - name: us-central1-docker.pkg.dev/$PROJECT_ID/ramble-repo/ramble-${_BASE_IMG}-${_BASE_VER}-spack${_SPACK_REF}-python${_PYTHON_VER}:latest
+    args:
+      - '-c'
+      - |
+        cd /workspace
+
+        export PATH=$$(. /opt/spack/share/spack/setup-env.sh && spack location -i miniconda3)/bin:$${PATH}
+
+        . /opt/spack/share/spack/setup-env.sh
+        . /workspace/share/ramble/setup-env.sh
+
+        echo "Spack version is $(spack --version)"
+        echo "Python version is $(python3 --version)"
+
+        spack mirror add ci_cache ${_CI_CACHE}
+        spack buildcache keys --install --trust
+
+        set -e
+
+        ramble workspace create basic_gromacs -c /workspace/examples/basic_gromacs_config.yaml
+
+        ramble workspace activate basic_gromacs
+
+        ramble workspace info
+
+        ramble workspace info --expansions
+
+        ramble info gromacs
+
+        ramble workspace setup --dry-run
+
+        ramble workspace deactivate
+    id: ramble-tutorial-test
+    entrypoint: /bin/bash
+substitutions:
+  _SPACK_REF: v0.21.2
+  _PYTHON_VER: 3.11.6
+  _BASE_IMG: centos
+  _BASE_VER: '7'
+  _CI_CACHE: gs://spack/latest
+timeout: 1500s
+options:
+  machineType: N1_HIGHCPU_8

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-4.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-4.yaml
@@ -1,0 +1,63 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+
+steps:
+  - name: gcr.io/cloud-builders/git
+    args:
+      - fetch
+      - '--unshallow'
+    id: ramble-clone
+  - name: us-central1-docker.pkg.dev/$PROJECT_ID/ramble-repo/ramble-${_BASE_IMG}-${_BASE_VER}-spack${_SPACK_REF}-python${_PYTHON_VER}:latest
+    args:
+      - '-c'
+      - |
+        cd /workspace
+
+        export PATH=$$(. /opt/spack/share/spack/setup-env.sh && spack location -i miniconda3)/bin:$${PATH}
+
+        . /opt/spack/share/spack/setup-env.sh
+        . /workspace/share/ramble/setup-env.sh
+
+        echo "Spack version is $(spack --version)"
+        echo "Python version is $(python3 --version)"
+
+        spack mirror add ci_cache ${_CI_CACHE}
+        spack buildcache keys --install --trust
+
+        set -e
+
+        ramble workspace create -d basic_gromacs -c /workspace/examples/basic_gromacs_config.yaml -a
+
+        ramble workspace info
+
+        ramble workspace info --expansions
+
+        ramble workspace info -vvv
+
+        cp /workspace/examples/vector_matrix_gromacs_config.yaml basic_gromacs/config/ramble.yaml
+
+        ramble workspace setup
+
+        ramble on
+
+        ramble workspace analyze
+
+        ramble workspace deactivate
+
+    id: ramble-tutorial-test
+    entrypoint: /bin/bash
+substitutions:
+  _SPACK_REF: v0.21.2
+  _PYTHON_VER: 3.11.6
+  _BASE_IMG: centos
+  _BASE_VER: '7'
+  _CI_CACHE: gs://spack/latest
+timeout: 7200s
+options:
+  machineType: N1_HIGHCPU_8

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-5.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-5.yaml
@@ -1,0 +1,65 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+
+steps:
+  - name: gcr.io/cloud-builders/git
+    args:
+      - fetch
+      - '--unshallow'
+    id: ramble-clone
+  - name: us-central1-docker.pkg.dev/$PROJECT_ID/ramble-repo/ramble-${_BASE_IMG}-${_BASE_VER}-spack${_SPACK_REF}-python${_PYTHON_VER}:latest
+    args:
+      - '-c'
+      - |
+        cd /workspace
+
+        export PATH=$$(. /opt/spack/share/spack/setup-env.sh && spack location -i miniconda3)/bin:$${PATH}
+
+        . /opt/spack/share/spack/setup-env.sh
+        . /workspace/share/ramble/setup-env.sh
+
+        echo "Spack version is $(spack --version)"
+        echo "Python version is $(python3 --version)"
+
+        spack mirror add ci_cache ${_CI_CACHE}
+        spack buildcache keys --install --trust
+
+        set -e
+
+        ramble workspace create -d vector_gromacs -c /workspace/examples/vector_matrix_gromacs_config.yaml
+
+        ramble workspace activate ./vector_gromacs
+
+        ramble workspace info
+
+        spack info gromacs
+
+        cp /workspace/examples/vector_gromacs_software_config.yaml vector_gromacs/configs/ramble.yaml
+
+        ramble workspace info
+
+        ramble workspace setup --dry-run
+
+        # Test no package manager works.
+        ramble -c "variables:gromacs_path:/not/a/path" -c "variants:package_manager:null" workspace setup --dry-run
+
+        ramble list --type package_managers
+
+        ramble workspace deactivate
+    id: ramble-tutorial-test
+    entrypoint: /bin/bash
+substitutions:
+  _SPACK_REF: v0.21.2
+  _PYTHON_VER: 3.11.6
+  _BASE_IMG: centos
+  _BASE_VER: '7'
+  _CI_CACHE: gs://spack/latest
+timeout: 7200s
+options:
+  machineType: N1_HIGHCPU_8

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-6.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-6.yaml
@@ -1,0 +1,76 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+
+steps:
+  - name: gcr.io/cloud-builders/git
+    args:
+      - fetch
+      - '--unshallow'
+    id: ramble-clone
+  - name: us-central1-docker.pkg.dev/$PROJECT_ID/ramble-repo/ramble-${_BASE_IMG}-${_BASE_VER}-spack${_SPACK_REF}-python${_PYTHON_VER}:latest
+    args:
+      - '-c'
+      - |
+        cd /workspace
+
+        export PATH=$$(. /opt/spack/share/spack/setup-env.sh && spack location -i miniconda3)/bin:$${PATH}
+
+        . /opt/spack/share/spack/setup-env.sh
+        . /workspace/share/ramble/setup-env.sh
+
+        echo "Spack version is $(spack --version)"
+        echo "Python version is $(python3 --version)"
+
+        spack mirror add ci_cache ${_CI_CACHE}
+        spack buildcache keys --install --trust
+
+        set -e
+
+        ramble workspace create -d scaling_wrf
+
+        ramble workspace activate ./scaling_wrf
+
+        # Cloud build VMs only have 4 cores
+        ramble config add "variables:processes_per_node:4"
+        ramble config add "variables:n_ranks:'{processes_per_node}*{n_nodes}'"
+
+        ramble info --attrs workloads wrfv4
+
+        ramble workspace generate-config wrfv4 -e scaling_{n_nodes} -p spack --wf "CONUS_12km" -v "n_nodes=[1, 2]"
+
+        set +e
+        ramble workspace info
+        set -e
+
+        ramble workspace concretize
+
+        ramble workspace info
+
+        cp /workspace/examples/tutorial_6_config.yaml /workspace/scaling_wrf/configs/ramble.yaml
+
+        ramble workspace info
+
+        ramble workspace setup
+
+        ramble on --where '{n_nodes} == 1'
+
+        ramble workspace analyze
+
+        ramble workspace deactivate
+    id: ramble-tutorial-test
+    entrypoint: /bin/bash
+substitutions:
+  _SPACK_REF: v0.21.2
+  _PYTHON_VER: 3.11.6
+  _BASE_IMG: centos
+  _BASE_VER: '7'
+  _CI_CACHE: gs://spack/latest
+timeout: 7200s
+options:
+  machineType: N1_HIGHCPU_8

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-7.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-7.yaml
@@ -1,0 +1,78 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+
+steps:
+  - name: gcr.io/cloud-builders/git
+    args:
+      - fetch
+      - '--unshallow'
+    id: ramble-clone
+  - name: us-central1-docker.pkg.dev/$PROJECT_ID/ramble-repo/ramble-${_BASE_IMG}-${_BASE_VER}-spack${_SPACK_REF}-python${_PYTHON_VER}:latest
+    args:
+      - '-c'
+      - |
+        cd /workspace
+
+        export PATH=$$(. /opt/spack/share/spack/setup-env.sh && spack location -i miniconda3)/bin:$${PATH}
+
+        . /opt/spack/share/spack/setup-env.sh
+        . /workspace/share/ramble/setup-env.sh
+
+        echo "Spack version is $(spack --version)"
+        echo "Python version is $(python3 --version)"
+
+        spack mirror add ci_cache ${_CI_CACHE}
+        spack buildcache keys --install --trust
+
+        set -e
+
+        ramble workspace create -d zips_and_matrices_wrf -c /workspace/examples/wrf_scaling_config.yaml
+
+        ramble workspace activate ./zips_and_matrices_wrf
+
+        ramble workspace info
+
+        set +e
+
+        cp /workspace/examples/tutorial_7_base_config.yaml zips_and_matrices_wrf/configs/ramble.yaml
+
+        # Expected to give an error
+        ramble workspace info
+
+
+        cp /workspace/examples/tutorial_7_matrix_config.yaml zips_and_matrices_wrf/configs/ramble.yaml
+
+        # Expected to give an error
+        ramble workspace info
+
+        set -e
+
+
+        cp /workspace/examples/tutorial_7_final_config.yaml zips_and_matrices_wrf/configs/ramble.yaml
+
+        ramble workspace info
+
+        ramble workspace setup
+
+        ramble workspace setup --where '{n_ranks} >= 20'
+
+        # Skip execution / analysis because cloud-build machines don't have the right number of cores.
+
+        ramble workspace deactivate
+    id: ramble-tutorial-test
+    entrypoint: /bin/bash
+substitutions:
+  _SPACK_REF: v0.21.2
+  _PYTHON_VER: 3.11.6
+  _BASE_IMG: centos
+  _BASE_VER: '7'
+  _CI_CACHE: gs://spack/latest
+timeout: 1500s
+options:
+  machineType: N1_HIGHCPU_8

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-8.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-8.yaml
@@ -1,0 +1,72 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+
+steps:
+  - name: gcr.io/cloud-builders/git
+    args:
+      - fetch
+      - '--unshallow'
+    id: ramble-clone
+  - name: us-central1-docker.pkg.dev/$PROJECT_ID/ramble-repo/ramble-${_BASE_IMG}-${_BASE_VER}-spack${_SPACK_REF}-python${_PYTHON_VER}:latest
+    args:
+      - '-c'
+      - |
+        cd /workspace
+
+        export PATH=$$(. /opt/spack/share/spack/setup-env.sh && spack location -i miniconda3)/bin:$${PATH}
+
+        . /opt/spack/share/spack/setup-env.sh
+        . /workspace/share/ramble/setup-env.sh
+
+        echo "Spack version is $(spack --version)"
+        echo "Python version is $(python3 --version)"
+
+        spack mirror add ci_cache ${_CI_CACHE}
+        spack buildcache keys --install --trust
+
+        set -e
+
+        ramble workspace create -d var_expanison_and_indirection -c /workspace/examples/tutorial_8_base_config.yaml
+
+        ramble workspace activate ./var_expanison_and_indirection
+
+        ramble workspace info
+
+        set +e
+
+        cp /workspace/examples/tutorial_8_mpi_config.yaml var_expansion_and_indirection/configs/ramble.yaml
+        #Expected to error
+        ramble workspace info
+
+        cp /workspace/examples/tutorial_8_mpi_matrix_config.yaml var_expansion_and_indirection/configs/ramble.yaml
+        # Expected to error
+        ramble workspace info
+
+        cp /workspace/examples/tutorial_8_expansion_indirection_config.yaml var_expansion_and_indirection/configs/ramble.yaml
+        # Expected to error
+        ramble workspace info
+        set -e
+
+        cp /workspace/examples/tutorial_8_software_environments_config.yaml var_expansion_and_indirection/configs/ramble.yaml
+        ramble workspace info
+
+        ramble workspace setup --dry-run
+
+        ramble workspace deactivate
+    id: ramble-tutorial-test
+    entrypoint: /bin/bash
+substitutions:
+  _SPACK_REF: v0.21.2
+  _PYTHON_VER: 3.11.6
+  _BASE_IMG: centos
+  _BASE_VER: '7'
+  _CI_CACHE: gs://spack/latest
+timeout: 1500s
+options:
+  machineType: N1_HIGHCPU_8

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-9.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-9.yaml
@@ -1,0 +1,65 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+
+steps:
+  - name: gcr.io/cloud-builders/git
+    args:
+      - fetch
+      - '--unshallow'
+    id: ramble-clone
+  - name: us-central1-docker.pkg.dev/$PROJECT_ID/ramble-repo/ramble-${_BASE_IMG}-${_BASE_VER}-spack${_SPACK_REF}-python${_PYTHON_VER}:latest
+    args:
+      - '-c'
+      - |
+        cd /workspace
+
+        export PATH=$$(. /opt/spack/share/spack/setup-env.sh && spack location -i miniconda3)/bin:$${PATH}
+
+        . /opt/spack/share/spack/setup-env.sh
+        . /workspace/share/ramble/setup-env.sh
+
+        echo "Spack version is $(spack --version)"
+        echo "Python version is $(python3 --version)"
+
+        spack mirror add ci_cache ${_CI_CACHE}
+        spack buildcache keys --install --trust
+
+        set -e
+
+        ramble workspace create -d success_wrf -c /workspace/examples/tutorial_9_regex_criteria_config.yaml
+
+        ramble workspace activate ./success_wrf
+
+        ramble workspace info
+
+        cp /workspace/examples/tutorial_9_fom_criteria_config.yaml success_wrf/configs/ramble.yaml
+
+        # Cloud build VMs only have 4 cores
+        ramble config add "variables:processes_per_node:4"
+
+        ramble workspace info
+
+        ramble workspace setup
+
+        ramble on --where '{n_nodes} == 1'
+
+        ramble workspace analyze --always-print-foms --where '{n_nodes} == 1'
+
+        ramble workspace deactivate
+    id: ramble-tutorial-test
+    entrypoint: /bin/bash
+substitutions:
+  _SPACK_REF: v0.21.2
+  _PYTHON_VER: 3.11.6
+  _BASE_IMG: centos
+  _BASE_VER: '7'
+  _CI_CACHE: gs://spack/latest
+timeout: 7200s
+options:
+  machineType: N1_HIGHCPU_8


### PR DESCRIPTION
This merge adds cloud-build triggers for running through the ramble tutorials, to ensure they function the way they should.