### PR TITLE
Fix `repo remove` to remove all applicable repos

### DIFF
--- a/lib/ramble/ramble/cmd/repo.py
+++ b/lib/ramble/ramble/cmd/repo.py
@@ -208,7 +208,7 @@ def repo_remove(args):
                 break
 
         if obj_complete:
-            break
+            continue
 
         # If it is a namespace, remove corresponding repo
         for path in repos:


### PR DESCRIPTION
Test session:

```sh
$ ramble repo add ../ramble-applications/
==> Added applications repo with namespace 'googleaux'.
==> Added modifiers repo with namespace 'googleaux'.
$ ramble repo remove ../ramble-applications/
==> Removed applications repository /usr/local/google/home/linsword/hpc-dev/ramble-applications
==> Removed modifiers repository /usr/local/google/home/linsword/hpc-dev/ramble-applications
```