### PR TITLE
Remove `_write_inventory` as a phase

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -1522,8 +1522,6 @@ class ApplicationBase(metaclass=ApplicationMeta):
 
         self.experiment_hash = ramble.util.hashing.hash_json(self.hash_inventory)
 
-    register_phase("write_inventory", pipeline="setup", run_after=["make_experiments"])
-
     def _write_inventory(self, workspace, app_inst=None):
         """Build and write an inventory of an experiment
 

--- a/lib/ramble/ramble/experiment_result.py
+++ b/lib/ramble/ramble/experiment_result.py
@@ -10,6 +10,7 @@ from ramble.namespace import namespace
 
 
 _DICT_MAPPING = {
+    "experiment_hash": "experiment_hash",
     "name": "name",
     "status": "RAMBLE_STATUS",
     "experiment_chain": "EXPERIMENT_CHAIN",
@@ -28,6 +29,7 @@ class ExperimentResult:
     def __init__(self, app_inst):
         """Build up the result from the given app instance"""
         self.name = app_inst.expander.experiment_namespace
+        self.experiment_hash = app_inst.experiment_hash
         self.status = app_inst.get_status()
         self.n_repeats = app_inst.repeats.n_repeats
         self.experiment_chain = app_inst.chain_order.copy()

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -76,6 +76,7 @@ class Pipeline:
                 force_compute=self.force_inventory,
                 require_exist=self.require_inventory,
             )
+            app_inst._write_inventory(self.workspace)
 
         workspace_inventory = os.path.join(self.workspace.root, self.workspace.inventory_file_name)
         workspace_hash_file = os.path.join(self.workspace.root, self.workspace.hash_file_name)
@@ -273,7 +274,6 @@ class AnalyzePipeline(Pipeline):
                 " Make sure your workspace is setup with\n"
                 "    ramble workspace setup"
             )
-
         super()._construct_hash()
         super()._prepare()
 


### PR DESCRIPTION
Currently we have a bug where we write the inventory before it is calculated, as that is often done outside of the phase system (eg in complete for setup).

The two fixes are:

1. Promote calls to caculating inventory into the phase system (not done here); or
2. Couple the inventory writing to the calculation, outside of the phase system (example here)

#2 might not actually be the right fix, but putting this up to start the discussion :) 