### PR TITLE
fix errors in tutorial docs

### DIFF
--- a/lib/ramble/docs/tutorials/4_using_vectors_and_matrices.rst
+++ b/lib/ramble/docs/tutorials/4_using_vectors_and_matrices.rst
@@ -393,7 +393,7 @@ experiment definition to perform a basic rank based scaling study.
 
 Edit the ``ramble.yaml`` file, and perform the following steps:
 
- #. Update the value for ``n_ranks`` to be ``[1, 2, 4]``
+ #. Update the value for ``n_ranks`` to be ``[1, 2]``
  #. Add the ``n_ranks`` variable to the matrix definition
  #. Ensure your experiment name uses the ``{n_ranks}`` placeholder
 
@@ -422,16 +422,12 @@ Which should contain the following output:
         Workload: {app_workload}
           Experiment: gromacs.water_bare.pme_1ranks
           Experiment: gromacs.water_bare.pme_2ranks
-          Experiment: gromacs.water_bare.pme_4ranks
           Experiment: gromacs.water_bare.rf_1ranks
           Experiment: gromacs.water_bare.rf_2ranks
-          Experiment: gromacs.water_bare.rf_4ranks
           Experiment: gromacs.water_gmx50.pme_1ranks
           Experiment: gromacs.water_gmx50.pme_2ranks
-          Experiment: gromacs.water_gmx50.pme_4ranks
           Experiment: gromacs.water_gmx50.rf_1ranks
           Experiment: gromacs.water_gmx50.rf_2ranks
-          Experiment: gromacs.water_gmx50.rf_4ranks
 
 .. include:: shared/gromacs_execute.rst
 

--- a/lib/ramble/docs/tutorials/8_var_expansion_indirection_and_stack_parameterization.rst
+++ b/lib/ramble/docs/tutorials/8_var_expansion_indirection_and_stack_parameterization.rst
@@ -213,7 +213,7 @@ resulting configuration might look like the following:
 system if you require additional arguments. To be able to execute these on your
 system, make sure you modify these appropriately.
 
-At this point, you have described the 12 experiments you want to run, however
+At this point, you have described the 8 experiments you want to run, however
 they are still not completely defined. Running:
 
 .. code-block:: console


### PR DESCRIPTION
- In tutorial 8, expected number of experiments created should be 8. Change typo 12 to 8
- In tutorial 4, instructions and sample output correlates with n_ranks: [1, 2, 4], but sample config uses n_ranks: [1, 2]. Change instructions and output to correlate with [1, 2] to be consistent with other tutorial sections.