### PR TITLE
fix/update tutorial issues

### DIFF
--- a/examples/tutorial_11_exec_order_config.yaml
+++ b/examples/tutorial_11_exec_order_config.yaml
@@ -37,8 +37,8 @@ ramble:
                     use_mpi: false
                 executables:
                 - builtin::env_vars
-                - builtin::spack_source
-                - builtin::spack_activate
+                - package_manager_builtin::spack::spack_source
+                - package_manager_builtin::spack::spack_activate
                 - cleanup
                 - copy
                 - fix_12km

--- a/lib/ramble/docs/tutorials/10_using_modifiers.rst
+++ b/lib/ramble/docs/tutorials/10_using_modifiers.rst
@@ -77,7 +77,7 @@ Which might output the following:
 This shows there are four modifiers in this installation of Ramble. Two very
 general modifiers in this list are ``lscpu`` and ``intel-aps``. Modifiers are
 allowed to behave in different ways. Their functionality should be documented
-at a high-level through the ``ramble mods info`` command. To get information
+at a high-level through the ``ramble info --type modifiers`` command. To get information
 about the ``lscpu`` modifier, execute:
 
 .. code-block:: console

--- a/lib/ramble/docs/tutorials/9_success_criteria.rst
+++ b/lib/ramble/docs/tutorials/9_success_criteria.rst
@@ -166,14 +166,7 @@ explore using this after you perform experiments.
 To ensure the success criteria are checked and the experiments pass them,
 ensure ``SUCCESS`` is printed for the status of each experiment.
 
-When an experiment fails, you can force Ramble to print the figure of merit
-data using:
-
-.. code-block:: console
-
-    $ ramble workspace analyze --always-print-foms
-
-Also, running analyze in debug mode as:
+Running analyze in debug mode as:
 
 .. code-block:: console
 

--- a/lib/ramble/docs/tutorials/mirrors.rst
+++ b/lib/ramble/docs/tutorials/mirrors.rst
@@ -518,9 +518,9 @@ For example, using the  mirror directories we created above,
 
 .. code-block:: console
 
-    $ ramble mirror add --scope=[site,user] $HOME/wrfv4_mirror/inputs
+    $ ramble mirror add --scope={site,user} ramble_mirror $HOME/wrfv4_mirror/inputs
 
-    $ spack mirror add $HOME/wrfv4_mirror/software
+    $ spack mirror add spack_mirror $HOME/wrfv4_mirror/software
 
 To validate that the mirrors were installed correctly, try something like the following,
 

--- a/lib/ramble/docs/tutorials/mirrors.rst
+++ b/lib/ramble/docs/tutorials/mirrors.rst
@@ -46,6 +46,8 @@ Write the following configuration into the file, save, and exit:
 .. code-block:: yaml
 
     ramble:
+      variants:
+        package_manager: spack
       env_vars:
         set:
           OMP_NUM_THREADS: '{n_threads}'
@@ -74,6 +76,8 @@ will look something like this:
 .. code-block:: yaml
 
     ramble:
+      variants:
+        package_manager: spack
       env_vars:
         set:
           OMP_NUM_THREADS: '{n_threads}'

--- a/lib/ramble/docs/tutorials/mirrors.rst
+++ b/lib/ramble/docs/tutorials/mirrors.rst
@@ -518,9 +518,14 @@ For example, using the  mirror directories we created above,
 
 .. code-block:: console
 
-    $ ramble mirror add --scope={site,user} ramble_mirror $HOME/wrfv4_mirror/inputs
+    $ ramble mirror add --scope=site ramble_mirror $HOME/wrfv4_mirror/inputs
 
     $ spack mirror add spack_mirror $HOME/wrfv4_mirror/software
+
+**NOTE**: The ``--scope`` argument controls at what level Ramble is configured to use this mirror. The default scope
+is ``user`` which places the config within the ``~/.ramble`` directory, and it only applies to the user that executed
+this comment. Using ``--scope=site`` applies the config to the installation directory for Ramble, and all users that
+use this same installation would have the config option applied to them.
 
 To validate that the mirrors were installed correctly, try something like the following,
 


### PR DESCRIPTION
- In tut 9, remove section with ramble workspace analyze --always-print-foms command as flag is deprecated
- In tut 10, ramble mods info command is deprecated, change to updated command
- In tut 11, update spack builtin reference in example code
- In mirrors tut, add spack package manager to fix required key 'wrf_path' not defined warning
- In mirrors tut, update mirror add commands for ramble and spack