### PR TITLE
Change default shell to bash

### DIFF
--- a/etc/ramble/defaults/config.yaml
+++ b/etc/ramble/defaults/config.yaml
@@ -19,7 +19,7 @@ config:
   verify_ssl: true
   connect_timeout: 10
   checksum: true
-  shell: sh
+  shell: bash
   input_cache: $ramble/var/ramble/cache
   workspace_dirs: $ramble/var/ramble/workspaces
   include_phase_dependencies: false

--- a/lib/ramble/ramble/config.py
+++ b/lib/ramble/ramble/config.py
@@ -142,7 +142,7 @@ config_defaults = {
         "build_stage": "$tempdir/ramble-stage",
         "concretizer": "clingo",
         "license_dir": spack.paths.default_license_dir,
-        "shell": "sh",
+        "shell": "bash",
         "spack": {"flags": {"install": "--reuse", "concretize": "--reuse"}},
         "pip": {"install": {"flags": []}},
         "input_cache": "$ramble/var/ramble/cache",

--- a/lib/ramble/ramble/test/config_test.py
+++ b/lib/ramble/ramble/test/config_test.py
@@ -1,0 +1,34 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import ramble.config
+
+
+# A crude assertion to check there's no conflicting value.
+# It supports only list and dict as containers, instead of
+# the more general abstract types.
+def _assert_no_conflict_recurse(a, b):
+    if a is None or b is None:
+        return
+    if isinstance(a, dict):
+        for k, v in a.items():
+            _assert_no_conflict_recurse(v, b.get(k))
+    elif isinstance(a, list):
+        for i, v in enumerate(a):
+            _assert_no_conflict_recurse(v, b[i])
+    else:
+        assert a == b
+
+
+def test_default_configs_no_conflict(default_config):
+    """Ensure the hard-coded config_defaults do not conflict with etc/defaults/config.yaml"""
+    defaults_in_mem = ramble.config.config_defaults["config"]
+    assert defaults_in_mem
+    for k, v in defaults_in_mem.items():
+        in_file_def = ramble.config.get(f"config:{k}")
+        _assert_no_conflict_recurse(v, in_file_def)

--- a/lib/ramble/ramble/test/conftest.py
+++ b/lib/ramble/ramble/test/conftest.py
@@ -253,7 +253,7 @@ def mutable_mock_pkg_mans_repo(mock_mods_repo_path):
         yield mock_repo_path
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def default_config():
     """Isolates the default configuration from the user configs.
 


### PR DESCRIPTION
Some of our apps and modifiers implicitly support only bash shell. The default sh becomes problematic on platforms where it does not alias to bash (like Debian's dash.) So feels better to change the default to bash, also given bash is widely available.

Also add in a test to ensure `config_defaults` does not conflict with `etc/defaults/config.yaml`.