### PR TITLE
Support local rel path as deployment pull path

### DIFF
--- a/lib/ramble/ramble/cmd/deployment.py
+++ b/lib/ramble/ramble/cmd/deployment.py
@@ -25,6 +25,7 @@ import ramble.workspace.shell
 import ramble.pipeline
 import ramble.filters
 from ramble.main import RambleCommand
+import ramble.util.path
 
 
 description = "(experimental) manage workspace deployments"
@@ -118,8 +119,11 @@ def deployment_pull(args):
         # Fetch deployment index first:
         push_cls = ramble.pipeline.PushDeploymentPipeline
 
+        # Handle local relative path
+        deployment_path = ramble.util.path.get_maybe_local_path(args.deployment_path)
+
         remote_index_path = surl.join(
-            args.deployment_path, ramble.pipeline.PushDeploymentPipeline.index_filename
+            deployment_path, ramble.pipeline.PushDeploymentPipeline.index_filename
         )
         local_index_path = os.path.join(ws.root, push_cls.index_filename)
 
@@ -129,7 +133,7 @@ def deployment_pull(args):
             index_data = sjson.load(f)
 
         for file in index_data[push_cls.index_namespace]:
-            src = surl.join(args.deployment_path, file)
+            src = surl.join(deployment_path, file)
             dest = os.path.join(ws.root, file)
             if os.path.exists(dest):
                 fs.force_remove(dest)

--- a/lib/ramble/ramble/test/util/path.py
+++ b/lib/ramble/ramble/test/util/path.py
@@ -1,0 +1,27 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+"""Perform tests of the util/path functions"""
+
+import os
+
+import ramble.util.path
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "path,expect",
+    [
+        ("rel/path", os.path.abspath("rel/path")),
+        ("/abs/path", "/abs/path"),
+        ("file:/abs/path", "file:/abs/path"),
+        ("gs://my-bucket", "gs://my-bucket"),
+    ],
+)
+def test_get_maybe_local_path(path, expect):
+    assert ramble.util.path.get_maybe_local_path(path) == expect

--- a/lib/ramble/ramble/util/path.py
+++ b/lib/ramble/ramble/util/path.py
@@ -15,6 +15,7 @@ import re
 import getpass
 import subprocess
 import tempfile
+import urllib.parse
 
 from llnl.util.lang import memoized
 
@@ -98,4 +99,12 @@ def canonicalize_path(path):
     path = substitute_path_variables(path)
     path = os.path.abspath(path)
 
+    return path
+
+
+def get_maybe_local_path(path):
+    """Convert a scheme-less path to absolute local path"""
+    parsed = urllib.parse.urlparse(path)
+    if not parsed.scheme:
+        return os.path.abspath(path)
     return path


### PR DESCRIPTION
This allows for easier pulling for local paths:

```
ramble deployment pull -p intel-hpl-deployment
```