### PR TITLE
Add filtering so warning is only given for non-default-selection

### DIFF
--- a/lib/ramble/ramble/filters.py
+++ b/lib/ramble/ramble/filters.py
@@ -8,13 +8,15 @@
 
 import itertools
 
+ALL_PHASES = ["*"]
+
 
 class Filters:
     """Object containing filters for limiting various operations in Ramble"""
 
     def __init__(
         self,
-        phase_filters=["*"],
+        phase_filters=ALL_PHASES,
         include_where_filters=None,
         exclude_where_filters=None,
         tags=None,

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -182,7 +182,7 @@ class Pipeline:
 
             count += 1
 
-        if phase_total == 0:
+        if phase_total == 0 and self.filters.phases != ramble.filters.ALL_PHASES:
             logger.warn("No valid phases were selected, please verify requested phases")
 
     def _complete(self):


### PR DESCRIPTION
Previously this would also work for pipelines that don't have phases (eg ramble on). This adds a simple check to only warn if the user requested a change to the phases away from the default path