### PR TITLE
Skip stat calc when no aggregatable FOMs

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -1903,6 +1903,9 @@ class ApplicationBase(metaclass=ApplicationMeta):
 
         # Iterate through the aggregated foms, calculate stats, and insert into results
         for context, fom_dict in repeat_foms.items():
+            if not fom_dict:
+                continue
+
             context_map = {
                 "name": context,
                 "foms": [],


### PR DESCRIPTION
This is an edge case, but can happen when use `n_repeats` on apps that don't have numeric FOMs. Without this change, `workspace analyze` will fail with out-of-bound index.