### PR TITLE
Add a command runner utility class

### DIFF
--- a/lib/ramble/ramble/appkit.py
+++ b/lib/ramble/ramble/appkit.py
@@ -31,3 +31,10 @@ from ramble.util.logger import logger as tty
 from ramble.util.file_util import get_file_path
 
 from ramble.util.output_capture import OUTPUT_CAPTURE
+
+from ramble.util.command_runner import (
+    CommandRunner,
+    RunnerError,
+    NoPathRunnerError,
+    ValidationFailedError,
+)

--- a/lib/ramble/ramble/modkit.py
+++ b/lib/ramble/ramble/modkit.py
@@ -29,3 +29,10 @@ from ramble.language.shared_language import *
 from ramble.util.output_capture import OUTPUT_CAPTURE
 
 from ramble.util.file_util import get_file_path
+
+from ramble.util.command_runner import (
+    CommandRunner,
+    RunnerError,
+    NoPathRunnerError,
+    ValidationFailedError,
+)

--- a/lib/ramble/ramble/pkgmankit.py
+++ b/lib/ramble/ramble/pkgmankit.py
@@ -31,3 +31,10 @@ from ramble.language.shared_language import *
 from ramble.util.output_capture import OUTPUT_CAPTURE
 
 from ramble.software_environments import ExternalEnvironment
+
+from ramble.util.command_runner import (
+    CommandRunner,
+    RunnerError,
+    NoPathRunnerError,
+    ValidationFailedError,
+)

--- a/lib/ramble/ramble/test/end_to_end/package_manager_requirements.py
+++ b/lib/ramble/ramble/test/end_to_end/package_manager_requirements.py
@@ -15,9 +15,9 @@ import ramble.config
 import ramble.software_environments
 from ramble.main import RambleCommand
 
+from ramble.util.command_runner import RunnerError
 from ramble.pkg_man.builtin.spack_lightweight import (
     SpackRunner,
-    RunnerError,
     ValidationFailedError,
 )
 

--- a/lib/ramble/ramble/test/end_to_end/spack_env_cache.py
+++ b/lib/ramble/ramble/test/end_to_end/spack_env_cache.py
@@ -15,9 +15,7 @@ import ramble.config
 import ramble.software_environments
 from ramble.main import RambleCommand
 
-from ramble.pkg_man.builtin.spack_lightweight import (
-    RunnerError,
-)
+from ramble.util.command_runner import RunnerError
 
 
 # everything here uses the mock_workspace_path

--- a/lib/ramble/ramble/util/command_runner.py
+++ b/lib/ramble/ramble/util/command_runner.py
@@ -1,0 +1,173 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+from typing import List
+from spack.util.executable import CommandNotFoundError, ProcessError
+from ramble.util.executable import which
+from ramble.util.logger import logger
+
+
+class CommandRunner:
+    """Runner for executing external commands
+
+    This class provides a generic wrapper on external commands, to provide a
+    unified way to handle dry-run execution of external commands.
+
+    Can be inherited to construct custom command runners.
+    """
+
+    def __init__(self, name=None, command=None, shell="bash", dry_run=False):
+        """
+        Ensure required command is found in the path
+        """
+        self.name = name
+        self.command = None
+        self.dry_run = dry_run
+        if command is not None:
+            try:
+                self.command = which(command, required=True)
+            except CommandNotFoundError:
+                raise RunnerError(f"Command {name} is not found in path")
+
+        self.shell = shell
+
+    def get_version(self):
+        """Hook to get the version of the executable
+
+        Should return a string representation of the executable's version.
+        """
+        pass
+
+    def set_dry_run(self, dry_run=False):
+        """
+        Set the dry_run state of this spack runner
+        """
+        self.dry_run = dry_run
+
+    def execute(self, executable, args: List[str], return_output: bool = False):
+        """Wrapper around execution of a command
+
+        Handles execution of a command when the execution path is dependent on
+        whether dry run is enabled or disabled.
+
+        Args:
+            executable (spack.util.executable.Executable): Executable to run with arguments
+            args (list(str)): List of string arguments to pass into executable
+            return_output (bool): Whether the output of the command should be returned or not
+        """
+        if not self.dry_run:
+            return self._run_command(executable, args, return_output=return_output)
+        else:
+            return self._dry_run_print(executable, args, return_output=return_output)
+
+    def _raise_validation_error(self, command, validation_type):
+        """Wrapper to raise a validation error for this command"""
+        raise ValidationFailedError(
+            f'Validation of: "{self.name} {command}" failed '
+            f' with a validation_type of "{validation_type}"'
+        )
+
+    def _dry_run_print(self, executable, args, return_output=False):
+        """Print the command that would be executed if dry-run was false.
+
+        Args match the execute method.
+        """
+        logger.msg(f"DRY-RUN: would run {executable}")
+        logger.msg(f"         with args: {args}")
+        if return_output:
+            return None
+
+    def _cmd_start(self, executable, args: List[str]):
+        """Print a banner for the start of executing a command
+
+        Args:
+            executable (spack.util.executable.Executable): Executable that will be run
+            args (list(str)): List of string arguments to pass into executable
+        """
+        start_str = f"********** Running {self.name} Command **********"
+        banner = "*" * len(start_str)
+        logger.msg("")
+        logger.msg(banner)
+        logger.msg(start_str)
+        logger.msg(f"**     command: {executable}")
+        if args:
+            logger.msg(f"**     with args: {args}")
+        logger.msg(banner)
+        logger.msg("")
+
+    def _cmd_end(self, executable, args):
+        """Print a banner for the start of executing a command
+
+        Args:
+            executable (spack.util.executable.Executable): Executable that will be run
+            args (list(str)): List of string arguments to pass into executable
+        """
+        finished_str = f"***** Finished Running {self.name} Command ******"
+        banner = "*" * len(finished_str)
+        logger.msg("")
+        logger.msg(banner)
+        logger.msg(finished_str)
+        logger.msg(banner)
+        logger.msg("")
+
+    def _run_command(self, executable, args, return_output=False):
+        """Perform execution of executable with args, and optionally return the output
+
+        Args:
+            executable (spack.util.executable.Executable): Executable to run with arguments
+            args (list(str)): List of string arguments to pass into executable
+            return_output (bool): Whether the output of the command should be returned or not
+
+        Returns:
+            (str): Output of the invocation as a string, if return_output is True.
+        """
+        active_stream = logger.active_stream()
+        active_log = logger.active_log()
+        error = False
+
+        self._cmd_start(executable, args)
+        try:
+            if active_stream is None:
+                if return_output:
+                    out_str = executable(*args, output=str)
+                else:
+                    executable(*args)
+            else:
+                if return_output:
+                    out_str = executable(*args, output=str, error=active_stream)
+                else:
+                    executable(*args, output=active_stream, error=active_stream)
+        except ProcessError as e:
+            logger.error(e)
+            error = True
+            pass
+
+        if error:
+            err = f"Error running {self.name} command: {executable} " + " ".join(args)
+            if active_stream is None:
+                logger.die(err)
+            else:
+                logger.error(err)
+                logger.die(f"For more details, see the log file: {active_log}")
+
+        self._cmd_end(executable, args)
+
+        if return_output:
+            return out_str
+        return
+
+
+class RunnerError(Exception):
+    """Raised when a problem occurs with a spack environment"""
+
+
+class NoPathRunnerError(RunnerError):
+    """Raised when a runner is used that does not have a path set"""
+
+
+class ValidationFailedError(RunnerError):
+    """Raised when a package manager requirement was not met"""

--- a/lib/ramble/ramble/util/command_runner.py
+++ b/lib/ramble/ramble/util/command_runner.py
@@ -78,8 +78,6 @@ class CommandRunner:
         """
         logger.msg(f"DRY-RUN: would run {executable}")
         logger.msg(f"         with args: {args}")
-        if return_output:
-            return None
 
     def _cmd_start(self, executable, args: List[str]):
         """Print a banner for the start of executing a command

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/test/spack_runner.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/test/spack_runner.py
@@ -11,9 +11,9 @@ import pytest
 
 
 import ramble.config
+from ramble.util.command_runner import RunnerError
 from ramble.pkg_man.builtin.spack_lightweight import (
     SpackRunner,
-    RunnerError,
     InvalidExternalEnvironment,
 )
 

--- a/var/ramble/repos/builtin/package_managers/spack/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack/package_manager.py
@@ -10,10 +10,9 @@ import deprecation
 
 from ramble.pkgmankit import *  # noqa: F403
 
-from ramble.pkg_man.builtin.spack_lightweight import (
-    SpackLightweight,
-    RunnerError,
-)
+from ramble.util.command_runner import RunnerError
+
+from ramble.pkg_man.builtin.spack_lightweight import SpackLightweight
 
 
 class Spack(SpackLightweight):


### PR DESCRIPTION
This merge adds a utility class for creating command runners, which are external commands to Ramble that have behaviors that change whether the workspace is executing under dry-run or not.

The command runner is also applied to the spack package managers.