### PR TITLE
Update used variable tracking

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -545,7 +545,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
         if self.package_manager is not None:
             # Add package manager variable defaults as placeholder
             for var in self.package_manager.package_manager_variables.values():
-                self.expander._variables[var.name] = var.default
+                self.variables[var.name] = var.default
 
         ##########################################
         # Expand used variables to track all usage
@@ -582,6 +582,9 @@ class ApplicationBase(metaclass=ApplicationMeta):
         ############################
         # Reset variable definitions
         ############################
+        for var in self.variables:
+            if var not in backup_variables:
+                del self.variables[var]
 
         for var, val in backup_variables.items():
             self.variables[var] = val

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -530,22 +530,37 @@ class ApplicationBase(metaclass=ApplicationMeta):
         self.build_modifier_instances()
         self.add_expand_vars(workspace)
 
+        backup_variables = self.variables.copy()
+
+        ########################
+        # Define extra variables
+        ########################
+
+        # Add modifier mode variables defaults as a placeholder:
+        for mod_inst in self._modifier_instances:
+            for var in mod_inst.mode_variables().values():
+                if var.name not in self.variables:
+                    self.variables[var.name] = var.default
+
+        if self.package_manager is not None:
+            # Add package manager variable defaults as placeholder
+            for var in self.package_manager.package_manager_variables.values():
+                self.expander._variables[var.name] = var.default
+
+        ##########################################
+        # Expand used variables to track all usage
+        ##########################################
+
         # Add all known keywords
         for key in self.keywords.keys:
-            self.expander._used_variables.add(key)
             self.expander.expand_var_name(key)
-
-        # Add modifier mode variables:
-        for mod_inst in self._modifier_instances:
-            for var in mod_inst.mode_variables().keys():
-                self.expander._used_variables.add(var)
-                self.expander.expand_var_name(var)
 
         if self.chained_experiments:
             for chained_exp in self.chained_experiments:
                 if namespace.inherit_variables in chained_exp:
                     for var in chained_exp[namespace.inherit_variables]:
                         self.expander._used_variables.add(var)
+                        self.expander.expand_var_name(var)
 
         # Add variables from success criteria
         criteria_list = workspace.success_list
@@ -557,12 +572,19 @@ class ApplicationBase(metaclass=ApplicationMeta):
             elif criteria.mode == "application_function":
                 self.evaluate_success()
 
+        if self.package_manager is not None:
+            self.package_manager.build_used_variables(workspace)
+
         for template_name, template_conf in workspace.all_templates():
             self.expander._used_variables.add(template_name)
             self.expander.expand_var(template_conf["contents"])
 
-        if self.package_manager is not None:
-            self.package_manager.build_used_variables(workspace)
+        ############################
+        # Reset variable definitions
+        ############################
+
+        for var, val in backup_variables.items():
+            self.variables[var] = val
 
         return self.expander._used_variables
 

--- a/lib/ramble/ramble/language/application_language.py
+++ b/lib/ramble/ramble/language/application_language.py
@@ -197,7 +197,8 @@ def workload_variable(
     workload=None,
     workloads=None,
     workload_group=None,
-    expandable=True,
+    expandable: bool = True,
+    track_used: bool = True,
     **kwargs,
 ):
     """Define a new variable to be used in experiments
@@ -207,6 +208,19 @@ def workload_variable(
     an experiment.
 
     These are specific to each workload.
+
+    Args:
+        name (str): Name of variable to define
+        default: Default value of variable definition
+        description (str): Description of variable's purpose
+        values (list): Optional list of suggested values for this variable
+        workload (str): Single workload this variable is used in
+        workloads (list): List of modes this variable is used in
+        workload_group (str): Name of workload group this variable is used in
+        expandable (bool): True if the variable should be expanded, False if not.
+        track_used (bool): True if the variable should be tracked as used,
+                           False if not. Can help with allowing lists without vecotizing
+                           experiments.
     """
 
     def _execute_workload_variable(app):
@@ -216,7 +230,12 @@ def workload_variable(
         )
 
         workload_var = ramble.workload.WorkloadVariable(
-            name, default=default, description=description, values=values, expandable=expandable
+            name,
+            default=default,
+            description=description,
+            values=values,
+            expandable=expandable,
+            **kwargs,
         )
 
         for wl_name in all_workloads:

--- a/lib/ramble/ramble/language/modifier_language.py
+++ b/lib/ramble/ramble/language/modifier_language.py
@@ -257,6 +257,7 @@ def modifier_variable(
     mode: Optional[str] = None,
     modes: Optional[list] = None,
     expandable: bool = True,
+    track_used: bool = False,
     **kwargs,
 ):
     """Define a variable for this modifier
@@ -269,6 +270,9 @@ def modifier_variable(
         mode (str): Single mode this variable is used in
         modes (list): List of modes this variable is used in
         expandable (bool): True if the variable should be expanded, False if not.
+        track_used (bool): True if the variable should be tracked as used,
+                           False if not. Can help with allowing lists without vecotizing
+                           experiments.
     """
 
     def _define_modifier_variable(mod):
@@ -288,6 +292,7 @@ def modifier_variable(
                 description=description,
                 values=values,
                 expandable=expandable,
+                **kwargs,
             )
 
     return _define_modifier_variable

--- a/lib/ramble/ramble/workload.py
+++ b/lib/ramble/ramble/workload.py
@@ -22,6 +22,7 @@ class WorkloadVariable:
         description: str = None,
         values=None,
         expandable: bool = True,
+        track_used: bool = True,
         **kwargs,
     ):
         """Constructor for a new variable
@@ -32,12 +33,15 @@ class WorkloadVariable:
             description (str): Description of variable
             values: List of suggested values for variable
             expandable (bool): True if variable can be expanded, False otherwise
+            track_used (bool): True if variable should be considered used,
+                            False to ignore it for vectorizing experiments
         """
         self.name = name
         self.default = default
         self.description = description
         self.values = values.copy() if isinstance(values, list) else [values]
         self.expandable = expandable
+        self.track_used = track_used
 
     def __str__(self):
         if not hasattr(self, "_str_indent"):


### PR DESCRIPTION
This merge changes the used variable tracking logic to only track through expanding other variable definitions. This prevents modifier and package manager variables from being marked as used even if they aren't.