### PR TITLE
If FOMs are None, float() raises a TypeError

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -1819,7 +1819,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
             try:
                 float(value)
                 return True
-            except ValueError:
+            except (ValueError, TypeError):
                 return False
 
         if not self.repeats.is_repeat_base:


### PR DESCRIPTION
This will gracefully ignore those FOMs