### PR TITLE
Ensure ssh is used when executing pdsh commands

### DIFF
--- a/var/ramble/repos/builtin/modifiers/gcp-metadata/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/gcp-metadata/modifier.py
@@ -74,7 +74,7 @@ class GcpMetadata(BasicModifier):
             prefix = ""
             suffix = ""
             if per_node:
-                prefix = "pdsh -N -w {hostlist} '"
+                prefix = "pdsh -R ssh -N -w {hostlist} '"
                 suffix = "'"
             log_name = end_point.split("/")[-1]
             pre_cmds.append(

--- a/var/ramble/repos/builtin/modifiers/tuned-adm/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/tuned-adm/modifier.py
@@ -44,8 +44,8 @@ class TunedAdm(BasicModifier):
 
     def set_tuning_profile(self):
         return [
-            "pdsh -w {hostlist} sudo tuned-adm profile {tuned-profile}",
-            "pdsh -w {hostlist} sudo tuned-adm active > {experiment_run_dir}/tuning_profile",
+            "pdsh -R ssh -w {hostlist} sudo tuned-adm profile {tuned-profile}",
+            "pdsh -R ssh -w {hostlist} sudo tuned-adm active > {experiment_run_dir}/tuning_profile",
         ]
 
     def _prepare_analysis(self, workspace):


### PR DESCRIPTION
This merge configured the rcmd module for pdsh to be ssh in existing pdsh uses.

This gets around an issue where a machine might not have a default rcmd module, and as a result pdsh fails to execute remote commands.