### PR TITLE
Allow force writing workspace config files

### DIFF
--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -341,7 +341,7 @@ def _workspace_create(
     if config:
         with open(config) as f:
             workspace._read_config("workspace", f)
-            workspace._write_config("workspace")
+            workspace._write_config("workspace", force=True)
 
     if template_execute:
         with open(template_execute) as f:

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -680,14 +680,14 @@ class Workspace:
 
             self._write_templates()
 
-    def _write_config(self, section):
+    def _write_config(self, section, force=False):
         """Update YAML config file for this workspace, based on
         changes and write it"""
         config = self.config_sections[section]
 
         changed = not yaml_equivalent(config["raw_yaml"], config["yaml"])
         written = os.path.exists(config["path"])
-        if changed or not written:
+        if changed or not written or force:
             config["raw_yaml"] = copy.deepcopy(config["yaml"])
             with fs.write_tmp_and_move(config["path"]) as f:
                 _write_yaml(config["yaml"], f, config["schema"])


### PR DESCRIPTION
This merge allows the _write_config method in workspace's to force writing the workspace config.

This gets around a problem where reading with _read_config causes _write_config to think the file has already been written as is.