### PR TITLE
Set RAMBLE_PYTHON when setup-env is sourced

### DIFF
--- a/share/ramble/cloud-build/ramble-pr-software-conflicts.yaml
+++ b/share/ramble/cloud-build/ramble-pr-software-conflicts.yaml
@@ -22,9 +22,14 @@ steps:
         git branch develop origin/develop
 
         . /opt/spack/share/spack/setup-env.sh
-        . /workspace/share/ramble/setup-env.sh
 
         spack load py-pip ^python
+
+        pip install -r /workspace/requirements-dev.txt
+
+        export SPACK_PYTHON=`which python3`
+
+        . /workspace/share/ramble/setup-env.sh
 
         echo "Spack version is $(spack --version)"
         echo "Python version is $(python3 --version)"

--- a/share/ramble/cloud-build/ramble-pr-style.yaml
+++ b/share/ramble/cloud-build/ramble-pr-style.yaml
@@ -22,9 +22,14 @@ steps:
         git branch develop origin/develop
 
         . /opt/spack/share/spack/setup-env.sh
-        . /workspace/share/ramble/setup-env.sh
 
         spack load py-pip ^python
+
+        pip install -r /workspace/requirements-dev.txt
+
+        export SPACK_PYTHON=`which python3`
+
+        . /workspace/share/ramble/setup-env.sh
 
         echo "Spack version is $(spack --version)"
         echo "Python version is $(python3 --version)"
@@ -50,7 +55,7 @@ steps:
         license_err=$$?
 
         # Test removing a dependency
-        conda uninstall -qy pytest
+        pip uninstall -y pytest
 
         ramble help
         # $$ characters are required for cloud-build:

--- a/share/ramble/cloud-build/ramble-pr-unit-tests.yaml
+++ b/share/ramble/cloud-build/ramble-pr-unit-tests.yaml
@@ -22,9 +22,14 @@ steps:
         git branch develop origin/develop
 
         . /opt/spack/share/spack/setup-env.sh
-        . /workspace/share/ramble/setup-env.sh
 
         spack load py-pip ^python
+
+        pip install -r /workspace/requirements-dev.txt
+
+        export SPACK_PYTHON=`which python3`
+
+        . /workspace/share/ramble/setup-env.sh
 
         echo "Spack version is $(spack --version)"
         echo "Python version is $(python3 --version)"

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-1.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-1.yaml
@@ -20,9 +20,14 @@ steps:
         cd /workspace
 
         . /opt/spack/share/spack/setup-env.sh
-        . /workspace/share/ramble/setup-env.sh
 
         spack load py-pip ^python
+
+        pip install -r /workspace/requirements-dev.txt
+
+        export SPACK_PYTHON=`which python3`
+
+        . /workspace/share/ramble/setup-env.sh
 
         echo "Spack version is $(spack --version)"
         echo "Python version is $(python3 --version)"

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-10.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-10.yaml
@@ -19,9 +19,14 @@ steps:
       - |
         cd /workspace
 
-        export PATH=$$(. /opt/spack/share/spack/setup-env.sh && spack location -i miniconda3)/bin:$${PATH}
-
         . /opt/spack/share/spack/setup-env.sh
+
+        spack load py-pip ^python
+
+        pip install -r /workspace/requirements-dev.txt
+
+        export SPACK_PYTHON=`which python3`
+
         . /workspace/share/ramble/setup-env.sh
 
         echo "Spack version is $(spack --version)"

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-11.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-11.yaml
@@ -19,9 +19,14 @@ steps:
       - |
         cd /workspace
 
-        export PATH=$$(. /opt/spack/share/spack/setup-env.sh && spack location -i miniconda3)/bin:$${PATH}
-
         . /opt/spack/share/spack/setup-env.sh
+
+        spack load py-pip ^python
+
+        pip install -r /workspace/requirements-dev.txt
+
+        export SPACK_PYTHON=`which python3`
+
         . /workspace/share/ramble/setup-env.sh
 
         echo "Spack version is $(spack --version)"

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-2.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-2.yaml
@@ -19,9 +19,14 @@ steps:
       - |
         cd /workspace
 
-        export PATH=$$(. /opt/spack/share/spack/setup-env.sh && spack location -i miniconda3)/bin:$${PATH}
-
         . /opt/spack/share/spack/setup-env.sh
+
+        spack load py-pip ^python
+
+        pip install -r /workspace/requirements-dev.txt
+
+        export SPACK_PYTHON=`which python3`
+
         . /workspace/share/ramble/setup-env.sh
 
         echo "Spack version is $(spack --version)"

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-3.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-3.yaml
@@ -19,9 +19,14 @@ steps:
       - |
         cd /workspace
 
-        export PATH=$$(. /opt/spack/share/spack/setup-env.sh && spack location -i miniconda3)/bin:$${PATH}
-
         . /opt/spack/share/spack/setup-env.sh
+
+        spack load py-pip ^python
+
+        pip install -r /workspace/requirements-dev.txt
+
+        export SPACK_PYTHON=`which python3`
+
         . /workspace/share/ramble/setup-env.sh
 
         echo "Spack version is $(spack --version)"

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-4.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-4.yaml
@@ -19,9 +19,14 @@ steps:
       - |
         cd /workspace
 
-        export PATH=$$(. /opt/spack/share/spack/setup-env.sh && spack location -i miniconda3)/bin:$${PATH}
-
         . /opt/spack/share/spack/setup-env.sh
+
+        spack load py-pip ^python
+
+        pip install -r /workspace/requirements-dev.txt
+
+        export SPACK_PYTHON=`which python3`
+
         . /workspace/share/ramble/setup-env.sh
 
         echo "Spack version is $(spack --version)"

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-5.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-5.yaml
@@ -19,9 +19,14 @@ steps:
       - |
         cd /workspace
 
-        export PATH=$$(. /opt/spack/share/spack/setup-env.sh && spack location -i miniconda3)/bin:$${PATH}
-
         . /opt/spack/share/spack/setup-env.sh
+
+        spack load py-pip ^python
+
+        pip install -r /workspace/requirements-dev.txt
+
+        export SPACK_PYTHON=`which python3`
+
         . /workspace/share/ramble/setup-env.sh
 
         echo "Spack version is $(spack --version)"

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-6.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-6.yaml
@@ -19,9 +19,14 @@ steps:
       - |
         cd /workspace
 
-        export PATH=$$(. /opt/spack/share/spack/setup-env.sh && spack location -i miniconda3)/bin:$${PATH}
-
         . /opt/spack/share/spack/setup-env.sh
+
+        spack load py-pip ^python
+
+        pip install -r /workspace/requirements-dev.txt
+
+        export SPACK_PYTHON=`which python3`
+
         . /workspace/share/ramble/setup-env.sh
 
         echo "Spack version is $(spack --version)"

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-7.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-7.yaml
@@ -19,9 +19,14 @@ steps:
       - |
         cd /workspace
 
-        export PATH=$$(. /opt/spack/share/spack/setup-env.sh && spack location -i miniconda3)/bin:$${PATH}
-
         . /opt/spack/share/spack/setup-env.sh
+
+        spack load py-pip ^python
+
+        pip install -r /workspace/requirements-dev.txt
+
+        export SPACK_PYTHON=`which python3`
+
         . /workspace/share/ramble/setup-env.sh
 
         echo "Spack version is $(spack --version)"

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-8.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-8.yaml
@@ -19,9 +19,14 @@ steps:
       - |
         cd /workspace
 
-        export PATH=$$(. /opt/spack/share/spack/setup-env.sh && spack location -i miniconda3)/bin:$${PATH}
-
         . /opt/spack/share/spack/setup-env.sh
+
+        spack load py-pip ^python
+
+        pip install -r /workspace/requirements-dev.txt
+
+        export SPACK_PYTHON=`which python3`
+
         . /workspace/share/ramble/setup-env.sh
 
         echo "Spack version is $(spack --version)"

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-9.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-9.yaml
@@ -19,9 +19,14 @@ steps:
       - |
         cd /workspace
 
-        export PATH=$$(. /opt/spack/share/spack/setup-env.sh && spack location -i miniconda3)/bin:$${PATH}
-
         . /opt/spack/share/spack/setup-env.sh
+
+        spack load py-pip ^python
+
+        pip install -r /workspace/requirements-dev.txt
+
+        export SPACK_PYTHON=`which python3`
+
         . /workspace/share/ramble/setup-env.sh
 
         echo "Spack version is $(spack --version)"

--- a/share/ramble/setup-env.csh
+++ b/share/ramble/setup-env.csh
@@ -60,6 +60,18 @@ set _ramble_share_dir = $RAMBLE_ROOT/share/ramble
 alias ramble          'set _rmb_args = (\!*); source $_ramble_share_dir/csh/ramble.csh'
 alias _ramble_pathadd 'set _pa_args = (\!*) && source $_ramble_share_dir/csh/pathadd.csh'
 
+# Identify and lock the python interpreter
+if (! $?RAMBLE_PYTHON) then
+    setenv RAMBLE_PYTHON ""
+endif
+foreach cmd ("$RAMBLE_PYTHON" python3 python python2)
+    command -v "$cmd" >& /dev/null
+    if ($status == 0) then
+        setenv RAMBLE_PYTHON `command -v "$cmd"`
+        break
+    endif
+end
+
 # Set variables needed by this script
 _ramble_pathadd PATH "$RAMBLE_ROOT/bin"
 eval `ramble --print-shell-vars csh`

--- a/share/ramble/setup-env.fish
+++ b/share/ramble/setup-env.fish
@@ -635,6 +635,17 @@ end
 #
 set -l rmb_source_file (status -f)  # name of current file
 
+#
+# Identify and lock the python interpreter
+#
+for cmd in "$RAMBLE_PYTHON" python3 python python2
+    set -l _rmb_python (command -v "$cmd")
+    if test $status -eq 0
+        set -x RAMBLE_PYTHON $_rmb_python
+        break
+    end
+end
+
 
 
 #

--- a/share/ramble/setup-env.sh
+++ b/share/ramble/setup-env.sh
@@ -308,6 +308,14 @@ if [ "$_rmb_shell" = bash ]; then
     export -f _ramble_shell_wrapper
 fi
 
+# Identify and lock the python interpreter
+for cmd in "${RAMBLE_PYTHON:-}" python3 python python2; do
+    if command -v > /dev/null "$cmd"; then
+        export RAMBLE_PYTHON="$(command -v "$cmd")"
+        break
+    fi
+done
+
 # Add programmable tab completion for Bash
 #
 if [ "$_rmb_shell" = bash ]; then


### PR DESCRIPTION
This merge ensures RAMBLE_PYTHON is defined when setup-env is sourced, to ensure longer paths don't break ramble's ability to function properly.