### PR TITLE
Allow `workspace concretize` to be additive

### DIFF
--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -414,6 +414,14 @@ def workspace_concretize_setup_parser(subparser):
         help="Remove unused software and experiment templates from workspace config",
         required=False,
     )
+    subparser.add_argument(
+        "--quiet",
+        "-q",
+        dest="quiet",
+        action="store_true",
+        help="Silently ignore conflicting package definitions",
+        required=False,
+    )
 
 
 def workspace_concretize(args):
@@ -423,11 +431,8 @@ def workspace_concretize(args):
         logger.debug("Simplifying workspace config")
         ws.simplify()
     else:
-        if args.force_concretize:
-            ws.force_concretize = True
-
         logger.debug("Concretizing workspace")
-        ws.concretize()
+        ws.concretize(force=args.force_concretize, quiet=args.quiet)
 
 
 def workspace_run_pipeline(args, pipeline):

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -598,7 +598,7 @@ ramble:
   software:
     packages:
       zlib:
-        pkg_spec: 'zlib'
+        pkg_spec: 'zlib@1.3'
     environments:
       zlib:
         packages:
@@ -618,7 +618,7 @@ ramble:
 
     with pytest.raises(ramble.workspace.RambleWorkspaceError) as e:
         workspace("concretize", global_args=["-w", workspace_name])
-        assert "Cannot concretize an already concretized workspace." in e
+        assert "Package zlib would be defined in multiple conflicting ways" in e
 
 
 def test_force_concretize():
@@ -672,11 +672,12 @@ ramble:
 
     ws1._re_read()
 
-    with pytest.raises(ramble.workspace.RambleWorkspaceError) as e:
-        workspace("concretize", global_args=["-w", workspace_name])
-        assert "Cannot concretize an already concretized workspace." in e
-
     workspace("concretize", "-f", global_args=["-w", workspace_name])
+
+    assert search_files_for_string([config_path], "zlib:") is True
+    assert search_files_for_string([config_path], "zlib-test") is True
+
+    workspace("concretize", "--simplify", global_args=["-w", workspace_name])
 
     assert search_files_for_string([config_path], "zlib:") is True
     assert search_files_for_string([config_path], "zlib-test") is False

--- a/lib/ramble/ramble/test/cmd/workspace_concretize.py
+++ b/lib/ramble/ramble/test/cmd/workspace_concretize.py
@@ -1,0 +1,64 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+import pytest
+
+import ramble.workspace
+from ramble.main import RambleCommand
+
+# everything here uses the mock_workspace_path
+pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_path")
+
+workspace = RambleCommand("workspace")
+
+
+def test_workspace_concretize_additive(request):
+    workspace_name = request.node.name
+
+    ws = ramble.workspace.create(workspace_name)
+    global_args = ["-w", workspace_name]
+
+    workspace(
+        "generate-config", "gromacs", "-p", "spack", "--wf", "water_*", global_args=global_args
+    )
+    workspace("concretize", "-q", global_args=global_args)
+
+    with open(ws.config_file_path) as f:
+        content = f.read()
+        assert "spack_gromacs" in content
+        assert "gcc9" in content
+        assert "wrfv4" not in content
+        assert "intel-oneapi-vtune" not in content
+
+    workspace("generate-config", "wrfv4", "-p", "spack", global_args=global_args)
+    workspace("concretize", "-q", global_args=global_args)
+
+    with open(ws.config_file_path) as f:
+        content = f.read()
+        assert "spack_gromacs" in content
+        assert "gcc9" in content
+        assert "wrfv4" in content
+        assert "intel-oneapi-vtune" not in content
+
+    modifiers_path = os.path.join(ws.config_dir, "modifiers.yaml")
+
+    with open(modifiers_path, "w+") as f:
+        f.write(
+            """modifiers:
+- name: intel-aps"""
+        )
+
+    workspace("concretize", "-q", global_args=global_args)
+
+    with open(ws.config_file_path) as f:
+        content = f.read()
+        assert "spack_gromacs" in content
+        assert "gcc9" in content
+        assert "wrfv4" in content
+        assert "intel-oneapi-vtune" in content

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1180,8 +1180,7 @@ class Workspace:
                             logger.debug(f"  Spec 1: {str(info)}")
                             logger.debug(f"  Spec 2: {str(packages_dict[comp])}")
                             raise RambleConflictingDefinitionError(
-                                f"Compiler {comp} would be defined defined "
-                                "in multiple conflicting ways"
+                                f"Compiler {comp} would be defined " "in multiple conflicting ways"
                             )
 
             logger.debug(f"Trying to define packages for {env_name}")

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -669,7 +669,7 @@ _ramble_workspace_create() {
 }
 
 _ramble_workspace_concretize() {
-    RAMBLE_COMPREPLY="-h --help -f --force-concretize --simplify"
+    RAMBLE_COMPREPLY="-h --help -f --force-concretize --simplify --quiet -q"
 }
 
 _ramble_workspace_setup() {


### PR DESCRIPTION
This merge updates the `workspace concretize` command to augment a workspace when new experiments (or modifiers) are added to it.

Additionally, a `--quiet` mode is added to allow it to silently ignore errors when packages would normally be overwritten (and not overwrite the existing definitions)