### PR TITLE
Fix up the missing mpi_command warning

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -1051,7 +1051,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
                             and int(self.expander.expand_var_name(self.keywords.n_nodes)) > 1
                         ):
                             logger.warn(
-                                f"Command {cmd_conf} requires a non-empty `mpi_command` "
+                                f"Command {cmd_conf.name} requires a non-empty `mpi_command` "
                                 "variable in a multi-node experiment"
                             )
                         mpi_cmd = " " + raw_mpi_cmd + " "


### PR DESCRIPTION
Printing the cmd_conf directly gives out some weird characters.