### PR TITLE
Add software provenance extraction to analysis pipeline

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -1742,6 +1742,17 @@ class ApplicationBase(metaclass=ApplicationMeta):
             else:
                 self.result.contexts.append(context_map)
 
+    register_phase(
+        "append_results_to_workspace", pipeline="analyze", run_after=["analyze_experiments"]
+    )
+
+    def _append_results_to_workspace(self, workspace, app_inst=None):
+        """Phase for injected experiment results into workspace results
+
+        This allows an experiment to register its results into the workspace,
+        so when the workspace dumps results they are included.
+        """
+
         workspace.append_result(self.result.to_dict())
 
     def calculate_statistics(self, workspace):

--- a/lib/ramble/ramble/experiment_result.py
+++ b/lib/ramble/ramble/experiment_result.py
@@ -15,6 +15,7 @@ _OUTPUT_MAPPING = {
     namespace.n_repeats: "N_REPEATS",
     "keys": "keys",
     "contexts": "CONTEXTS",
+    "software": "SOFTWARE",
     namespace.variables: "RAMBLE_VARIABLES",
     "raw_variables": "RAMBLE_RAW_VARIABLES",
     namespace.tags: "TAGS",
@@ -34,6 +35,7 @@ class ExperimentResult:
         self.experiment_chain = app_inst.chain_order.copy()
         self.tags = list(app_inst.experiment_tags)
         self.contexts = []
+        self.software = {}
 
         self.keys = {}
         for key in app_inst.keywords.keys:
@@ -70,3 +72,19 @@ class ExperimentResult:
                 output[output_val] = obj_dict[lookup_key]
 
         return output
+
+
+def build_software_map(package_manager):
+    """Create a software map dictionary, for housing software stack results
+
+    Returns:
+        (dict): Software map dictionary
+    """
+    software_map = {
+        "name": "software_stack",
+        "packages": [],
+        "package_manager": package_manager._spec_prefix,
+        "display_name": package_manager._spec_prefix,
+    }
+
+    return software_map

--- a/lib/ramble/ramble/experiment_result.py
+++ b/lib/ramble/ramble/experiment_result.py
@@ -72,19 +72,3 @@ class ExperimentResult:
                 output[output_val] = obj_dict[lookup_key]
 
         return output
-
-
-def build_software_map(package_manager):
-    """Create a software map dictionary, for housing software stack results
-
-    Returns:
-        (dict): Software map dictionary
-    """
-    software_map = {
-        "name": "software_stack",
-        "packages": [],
-        "package_manager": package_manager._spec_prefix,
-        "display_name": package_manager._spec_prefix,
-    }
-
-    return software_map

--- a/lib/ramble/ramble/package_manager.py
+++ b/lib/ramble/ramble/package_manager.py
@@ -14,7 +14,7 @@ import textwrap
 from typing import List
 
 from ramble.language.package_manager_language import PackageManagerMeta
-from ramble.language.shared_language import SharedMeta
+from ramble.language.shared_language import SharedMeta, register_phase
 from ramble.error import RambleError
 import ramble.util.directives
 import ramble.util.class_attributes
@@ -185,6 +185,25 @@ class PackageManagerBase(metaclass=PackageManagerMeta):
             require_exist (boolean): Whether to require environment hashes exist or not.
         """
 
+        pass
+
+    register_phase(
+        "add_software_to_results",
+        pipeline="analyze",
+        run_after=["analyze_experiments"],
+        run_before=["append_results_to_workspace"],
+    )
+
+    def _add_software_to_results(self, workspace, app_inst=None):
+        """Stub class method for injecting software information into results
+
+        Args:
+            workspace (Workspace): Reference to the workspace that is currently
+                                   being acted on.
+            app_inst (Application): Reference to the application instance that
+            owns the results.
+
+        """
         pass
 
 

--- a/lib/ramble/ramble/test/end_to_end/experiment_repeats.py
+++ b/lib/ramble/ramble/test/end_to_end/experiment_repeats.py
@@ -127,12 +127,6 @@ ramble:
                 file_path = os.path.join(software_path, file)
                 assert os.path.exists(file_path)
 
-            lock_file = os.path.join(software_path, "spack.lock")
-            with open(lock_file, "w+") as f:
-                f.write("{\n")
-                f.write('\t"test_key": "val"\n')
-                f.write("}\n")
-
         # Each tuple (workload, exp base, n_repeats) expands to 1 base exp plus n_repeats exps
         expected_experiments = [
             ("water_gmx50", "pme_single_rank", 2),

--- a/lib/ramble/ramble/test/end_to_end/explicit_zips.py
+++ b/lib/ramble/ramble/test/end_to_end/explicit_zips.py
@@ -170,13 +170,6 @@ licenses:
                 file_path = os.path.join(software_path, file)
                 assert os.path.exists(file_path)
 
-            # Create a mock spack.lock file
-            lock_file = os.path.join(software_path, "spack.lock")
-            with open(lock_file, "w+") as f:
-                f.write("{\n")
-                f.write('\t"test_key": "val"\n')
-                f.write("}\n")
-
         expected_experiments = [
             "scaling_1_part1_wrfv4",
             "scaling_2_part1_wrfv4",

--- a/lib/ramble/ramble/test/end_to_end/included_configuration_files.py
+++ b/lib/ramble/ramble/test/end_to_end/included_configuration_files.py
@@ -155,12 +155,6 @@ software:
             spack_file = os.path.join(software_path, "spack.yaml")
             assert os.path.exists(spack_file)
 
-            lock_file = os.path.join(software_path, "spack.lock")
-            with open(lock_file, "w+") as f:
-                f.write("{\n")
-                f.write('\t"test_key": "val"\n')
-                f.write("}\n")
-
         expected_experiments = [
             "scaling_1_part1_wrfv4",
             "scaling_2_part1_wrfv4",

--- a/lib/ramble/ramble/test/end_to_end/package_manager_provenance.py
+++ b/lib/ramble/ramble/test/end_to_end/package_manager_provenance.py
@@ -1,0 +1,68 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.workspace
+import ramble.config
+import ramble.software_environments
+from ramble.main import RambleCommand
+
+
+pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_path")
+
+workspace = RambleCommand("workspace")
+
+
+def test_spack_package_manager_provenance_zlib(mock_applications, request):
+    workspace_name = request.node.name
+
+    ws = ramble.workspace.create(workspace_name)
+
+    global_args = ["-w", workspace_name]
+
+    workspace("manage", "experiments", "zlib", "-p", "spack-lightweight", global_args=global_args)
+
+    workspace("concretize", global_args=global_args)
+
+    workspace("setup", global_args=global_args)
+
+    spack_yaml = os.path.join(ws.software_dir, "zlib", "spack.yaml")
+    spack_lock = os.path.join(ws.software_dir, "zlib", "spack.lock")
+
+    assert os.path.isfile(spack_yaml)
+
+    with open(spack_yaml) as f:
+        data = f.read()
+        assert "- zlib" in data
+
+    assert os.path.isfile(spack_lock)
+
+    with open(spack_lock) as f:
+        data = f.read()
+        assert '"spec":"zlib"' in data
+
+    out_log = os.path.join(
+        ws.experiment_dir, "zlib", "ensure_installed", "generated", "generated.out"
+    )
+
+    with open(out_log, "w+") as f:
+        f.write("libz.so.2\n")
+
+    workspace("analyze", global_args=global_args)
+
+    results_file = os.path.join(ws.root, "results.latest.txt")
+
+    assert os.path.isfile(results_file)
+
+    with open(results_file) as f:
+        data = f.read()
+        assert "Software definitions" in data
+        assert "spack packages:" in data

--- a/lib/ramble/ramble/test/end_to_end/wrfv4_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/wrfv4_dry_run.py
@@ -73,9 +73,9 @@ ramble:
   software:
     packages:
       gcc:
-        pkg_spec: gcc@8.5.0
+        pkg_spec: gcc@13.2.0
       intel-mpi:
-        pkg_spec: intel-mpi@2018.4.274
+        pkg_spec: intel-oneapi-mpi@2021.11.0
         compiler: gcc
       wrfv4:
         pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf
@@ -102,12 +102,32 @@ licenses:
       WRF_LICENSE: port@server
 """
 
+    test_compilers = """
+compilers:
+- compiler:
+    spec: gcc@=13.2.0
+    paths:
+      cc: /usr/bin/gcc
+      cxx: /usr/bin/g++
+      f77: null
+      fc: null
+    flags: {}
+    operating_system: rocky8
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+"""
+
     workspace_name = "test_end_to_end_wrfv4"
     with ramble.workspace.create(workspace_name) as ws1:
         ws1.write()
 
         config_path = os.path.join(ws1.config_dir, ramble.workspace.config_file_name)
         license_path = os.path.join(ws1.config_dir, "licenses.yaml")
+        compilers_path = os.path.join(
+            ws1.config_dir, ramble.workspace.auxiliary_software_dir_name, "compilers.yaml"
+        )
 
         aux_software_path = os.path.join(
             ws1.config_dir, ramble.workspace.auxiliary_software_dir_name
@@ -119,6 +139,9 @@ licenses:
 
         with open(license_path, "w+") as f:
             f.write(test_licenses)
+
+        with open(compilers_path, "w+") as f:
+            f.write(test_compilers)
 
         for file in aux_software_files:
             file_path = os.path.join(aux_software_path, file)
@@ -153,12 +176,6 @@ licenses:
             for file in aux_software_files:
                 file_path = os.path.join(software_path, file)
                 assert os.path.exists(file_path)
-
-            lock_file = os.path.join(software_path, "spack.lock")
-            with open(lock_file, "w+") as f:
-                f.write("{\n")
-                f.write('\t"test_key": "val"\n')
-                f.write("}\n")
 
         expected_experiments = [
             "scaling_1_part1_wrfv4",
@@ -278,6 +295,8 @@ licenses:
                 assert "Maximum Timestep Time = 55.5 s" in data
                 assert "Avg. Max Ratio Time = 0.6" in data
                 assert "Number of timesteps = 5" in data
+                assert "Software definitions:" in data
+                assert "spack packages:" in data
 
         workspace("archive", global_args=["-w", workspace_name])
 

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1537,6 +1537,15 @@ ramble:
                                     f.write(f"    {fom_name}:\n")
                                     for fom_val in fom_val_list:
                                         f.write(f"      {fom_val.strip()}\n")
+
+                            # Print software section if it contains info
+                            if "SOFTWARE" in exp and exp["SOFTWARE"]:
+                                f.write("  Software definitions:\n")
+                                for package_manager, packages in exp["SOFTWARE"].items():
+                                    f.write(f"    {package_manager} packages:\n")
+                                    for pkg in packages:
+                                        f.write(f"      {pkg['name']} @{pkg['version']}\n")
+
                         else:
                             for context in exp["CONTEXTS"]:
                                 f.write(f'  {context["display_name"]} figures of merit:\n')
@@ -1549,6 +1558,14 @@ ramble:
 
                                     output = "{} = {} {}".format(name, fom["value"], fom["units"])
                                     f.write("    %s\n" % (output.strip()))
+
+                            # Print software section if it contains info
+                            if "SOFTWARE" in exp and exp["SOFTWARE"]:
+                                f.write("  Software definitions:\n")
+                                for package_manager, packages in exp["SOFTWARE"].items():
+                                    f.write(f"    {package_manager} packages:\n")
+                                    for pkg in packages:
+                                        f.write(f"      {pkg['name']} @{pkg['version']}\n")
 
                 else:
                     logger.msg("No results to write")


### PR DESCRIPTION
This merge updates the analyze pipeline to extract software package information from the package managers supported by Ramble.

Additionally, this breaks up the analyze pipeline so that modifiers and package managers can inject additional attributes into the results file if needed.