### PR TITLE
Allow package managers to have their own sub-directories under a workspace's software dir

### DIFF
--- a/lib/ramble/docs/workspace_config.rst
+++ b/lib/ramble/docs/workspace_config.rst
@@ -964,7 +964,9 @@ Ramble automatically generates definitions for the following variables:
 * ``experiment_index`` - Index, in set, of experiment. If part of a chain,
   shares a value with its root.
 * ``env_path`` - Absolute path to
-  ``$workspace_root/software/{env_name}.{workload_name}``
+  ``$workspace_root/software/{package_manager_name}/{env_name}.{workload_name}``
+  if no package manager is used, ``{package_manager_name}`` is replaced with
+  ``no-package-manager``.
 * ``log_dir`` - Absolute path to ``$workspace_root/logs``
 * ``log_file`` - Absolute path to
   ``{experiment_run_dir}/{experiment_name}.out``

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -264,10 +264,6 @@ class ExperimentSet:
         Returns:
             (Application): Instance of an application class for this experiment
         """
-        variables[self.keywords.env_path] = os.path.join(
-            self._workspace.software_dir, Expander.expansion_str(self.keywords.env_name)
-        )
-
         experiment_suffix = ""
         # After generating the base experiment, append the index to repeat experiments
         if repeats.repeat_index:
@@ -294,6 +290,12 @@ class ExperimentSet:
         app_inst.set_modifiers(context.modifiers)
         app_inst.set_tags(context.tags)
         app_inst.set_formatted_executables(context.formatted_executables)
+
+        if app_inst.package_manager is not None:
+            variables[self.keywords.env_path] = os.path.join(
+                app_inst.package_manager.package_manager_dir(self._workspace),
+                Expander.expansion_str(self.keywords.env_name),
+            )
 
         final_wl_name = expander.expand_var_name(
             self.keywords.workload_name, allow_passthrough=False

--- a/lib/ramble/ramble/package_manager.py
+++ b/lib/ramble/ramble/package_manager.py
@@ -7,6 +7,7 @@
 # except according to those terms.
 """Define base classes for package manager definitions"""
 
+import os
 import re
 import six
 import fnmatch
@@ -72,6 +73,18 @@ class PackageManagerBase(metaclass=PackageManagerMeta):
         new_copy._verbosity = self._verbosity
 
         return new_copy
+
+    def package_manager_dir(self, workspace):
+        """Get the path to the package manager's software environment directory
+
+        Args:
+            workspace (Workspace): Reference to workspace that owns a software directory
+
+        Returns:
+            (str) Path to package manager directory within workspace's software directory
+
+        """
+        return os.path.join(workspace.software_dir, self.name)
 
     def environment_required(self):
         app_inst = self.app_inst

--- a/lib/ramble/ramble/test/end_to_end/dryrun_copies_external_env.py
+++ b/lib/ramble/ramble/test/end_to_end/dryrun_copies_external_env.py
@@ -79,7 +79,7 @@ ramble:
         setup_pipeline = setup_cls(ws, filters)
         setup_pipeline.run()
 
-        env_file = os.path.join(ws.software_dir, "wrfv4", "spack.yaml")
+        env_file = os.path.join(ws.software_dir, "spack", "wrfv4", "spack.yaml")
 
         assert os.path.exists(env_file)
 

--- a/lib/ramble/ramble/test/end_to_end/experiment_excludes.py
+++ b/lib/ramble/ramble/test/end_to_end/experiment_excludes.py
@@ -162,7 +162,7 @@ licenses:
         software_base_dir = os.path.join(ws1.root, ramble.workspace.workspace_software_path)
         assert os.path.exists(software_base_dir)
         for software_dir in software_dirs:
-            software_path = os.path.join(software_base_dir, software_dir)
+            software_path = os.path.join(software_base_dir, "spack", software_dir)
             assert os.path.exists(software_path)
 
             spack_file = os.path.join(software_path, "spack.yaml")

--- a/lib/ramble/ramble/test/end_to_end/experiment_hashes.py
+++ b/lib/ramble/ramble/test/end_to_end/experiment_hashes.py
@@ -85,7 +85,7 @@ def test_experiment_hashes(mutable_config, mutable_mock_workspace_path, request)
     assert len(expected_templates) == 0
 
     # Test software environments
-    expected_envs = {"software/gromacs"}
+    expected_envs = {"software/spack/gromacs"}
     assert "software" in data
     for env in data["software"]:
         if env["name"] in expected_envs:

--- a/lib/ramble/ramble/test/end_to_end/experiment_repeats.py
+++ b/lib/ramble/ramble/test/end_to_end/experiment_repeats.py
@@ -115,10 +115,10 @@ ramble:
 
         # Test software directories
         software_dirs = ["gromacs"]
-        software_base_dir = os.path.join(ws1.root, ramble.workspace.workspace_software_path)
+        software_base_dir = ws1.software_dir
         assert os.path.exists(software_base_dir)
         for software_dir in software_dirs:
-            software_path = os.path.join(software_base_dir, software_dir)
+            software_path = os.path.join(software_base_dir, "spack", software_dir)
             assert os.path.exists(software_path)
 
             spack_file = os.path.join(software_path, "spack.yaml")

--- a/lib/ramble/ramble/test/end_to_end/explicit_zips.py
+++ b/lib/ramble/ramble/test/end_to_end/explicit_zips.py
@@ -158,10 +158,10 @@ licenses:
 
         # Test software directories
         software_dirs = ["wrfv4", "wrfv4-portable"]
-        software_base_dir = os.path.join(ws1.root, ramble.workspace.workspace_software_path)
+        software_base_dir = ws1.software_dir
         assert os.path.exists(software_base_dir)
         for software_dir in software_dirs:
-            software_path = os.path.join(software_base_dir, software_dir)
+            software_path = os.path.join(software_base_dir, "spack", software_dir)
             assert os.path.exists(software_path)
 
             spack_file = os.path.join(software_path, "spack.yaml")

--- a/lib/ramble/ramble/test/end_to_end/included_configuration_files.py
+++ b/lib/ramble/ramble/test/end_to_end/included_configuration_files.py
@@ -146,10 +146,10 @@ software:
 
         # Test software directories
         software_dirs = ["wrfv4", "wrfv4-portable"]
-        software_base_dir = os.path.join(ws1.root, ramble.workspace.workspace_software_path)
+        software_base_dir = ws1.software_dir
         assert os.path.exists(software_base_dir)
         for software_dir in software_dirs:
-            software_path = os.path.join(software_base_dir, software_dir)
+            software_path = os.path.join(software_base_dir, "spack", software_dir)
             assert os.path.exists(software_path)
 
             spack_file = os.path.join(software_path, "spack.yaml")

--- a/lib/ramble/ramble/test/end_to_end/package_manager_config.py
+++ b/lib/ramble/ramble/test/end_to_end/package_manager_config.py
@@ -60,7 +60,7 @@ ramble:
 
         workspace("setup", "--dry-run", global_args=["-w", workspace_name])
 
-        spack_yaml = os.path.join(ws.software_dir, "zlib-configs", "spack.yaml")
+        spack_yaml = os.path.join(ws.software_dir, "spack", "zlib-configs", "spack.yaml")
 
         assert os.path.isfile(spack_yaml)
 

--- a/lib/ramble/ramble/test/end_to_end/package_manager_requirements.py
+++ b/lib/ramble/ramble/test/end_to_end/package_manager_requirements.py
@@ -71,7 +71,7 @@ ramble:
 
         workspace("setup", global_args=["-w", workspace_name])
 
-        spack_yaml = os.path.join(ws.software_dir, "zlib-configs", "spack.yaml")
+        spack_yaml = os.path.join(ws.software_dir, "spack", "zlib-configs", "spack.yaml")
 
         assert os.path.isfile(spack_yaml)
 

--- a/lib/ramble/ramble/test/end_to_end/package_manager_unique_env_dirs.py
+++ b/lib/ramble/ramble/test/end_to_end/package_manager_unique_env_dirs.py
@@ -1,0 +1,87 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import ramble.workspace
+from ramble.main import RambleCommand
+
+workspace = RambleCommand("workspace")
+config = RambleCommand("config")
+
+
+def test_env_dirs_do_not_collide(mutable_config, mutable_mock_workspace_path, request):
+    workspace_name = request.node.name
+
+    ws = ramble.workspace.create(workspace_name)
+
+    global_args = ["-w", workspace_name]
+
+    # Add tests to workspace
+    workspace(
+        "generate-config",
+        "gromacs",
+        "-v",
+        "n_nodes=1",
+        "-v",
+        "n_ranks=1",
+        "-v",
+        "env_name=multiple_env",
+        "-p",
+        "spack",
+        "--wf",
+        "water_bare",
+        global_args=global_args,
+    )
+
+    workspace(
+        "generate-config",
+        "pip-test",
+        "-v",
+        "n_nodes=1",
+        "-v",
+        "n_ranks=1",
+        "-v",
+        "env_name=multiple_env",
+        "-p",
+        "pip",
+        "--wf",
+        "import",
+        global_args=global_args,
+    )
+
+    # Add software packages to workspace
+    config("add", "software:packages:package:spack_pkg_spec:gromacs", global_args=global_args)
+    config("add", "software:packages:package:pip_pkg_spec:semver", global_args=global_args)
+
+    config("add", "software:environments:multiple_env:packages:[package]", global_args=global_args)
+
+    workspace("setup", "--dry-run", global_args=global_args)
+
+    # Check pip and spack directories exist
+    spack_dir = os.path.join(ws.software_dir, "spack")
+    pip_dir = os.path.join(ws.software_dir, "pip")
+
+    for pm_dir in [spack_dir, pip_dir]:
+        assert os.path.isdir(pm_dir)
+        env_dir = os.path.join(pm_dir, "multiple_env")
+        assert os.path.isdir(env_dir)
+
+        req_file = os.path.join(env_dir, "requirements.txt")
+        spack_file = os.path.join(env_dir, "spack.yaml")
+
+        if os.path.isfile(req_file):
+            with open(req_file) as f:
+                content = f.read()
+                assert "gromacs" not in content
+                assert "semver" in content
+        elif os.path.isfile(spack_file):
+            with open(spack_file) as f:
+                content = f.read()
+                assert "gromacs" in content
+                assert "semver" not in content

--- a/lib/ramble/ramble/test/end_to_end/spack_env_cache.py
+++ b/lib/ramble/ramble/test/end_to_end/spack_env_cache.py
@@ -91,9 +91,9 @@ ramble:
         )
 
         # spack env should be present only at the env_name level.
-        assert os.path.exists(os.path.join(ws.software_dir, "gromacs"))
-        assert os.path.exists(os.path.join(ws.software_dir, "g2"))
-        assert not os.path.exists(os.path.join(ws.software_dir, "g2.water_bare"))
+        assert os.path.exists(os.path.join(ws.software_dir, "spack", "gromacs"))
+        assert os.path.exists(os.path.join(ws.software_dir, "spack", "g2"))
+        assert not os.path.exists(os.path.join(ws.software_dir, "spack", "g2.water_bare"))
 
         # First encounter of an env_name (test1 -> gromacs, test2 -> g2) requires spack usage.
         test1_log = os.path.join(ws.log_dir, "setup.latest", "gromacs.water_bare.test1.out")

--- a/lib/ramble/ramble/test/end_to_end/test_configvar_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/test_configvar_dry_run.py
@@ -98,7 +98,7 @@ ramble:
         software_base_dir = os.path.join(ws.root, ramble.workspace.workspace_software_path)
         assert os.path.exists(software_base_dir)
 
-        software_path = os.path.join(software_base_dir, software_dir)
+        software_path = os.path.join(software_base_dir, "spack", software_dir)
         assert os.path.exists(software_path)
 
         for i, exp in enumerate(expected_experiments):

--- a/lib/ramble/ramble/test/end_to_end/wrfv4_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/wrfv4_dry_run.py
@@ -142,10 +142,10 @@ licenses:
 
         # Test software directories
         software_dirs = ["wrfv4", "wrfv4-portable"]
-        software_base_dir = os.path.join(ws1.root, ramble.workspace.workspace_software_path)
+        software_base_dir = ws1.software_dir
         assert os.path.exists(software_base_dir)
         for software_dir in software_dirs:
-            software_path = os.path.join(software_base_dir, software_dir)
+            software_path = os.path.join(software_base_dir, "spack", software_dir)
             assert os.path.exists(software_path)
 
             spack_file = os.path.join(software_path, "spack.yaml")

--- a/lib/ramble/ramble/test/modifier_application.py
+++ b/lib/ramble/ramble/test/modifier_application.py
@@ -78,7 +78,7 @@ ramble:
 
         workspace("setup", "--dry-run", global_args=["-w", workspace_name])
 
-        software_path = os.path.join(ws1.software_dir, "wrfv4", "spack.yaml")
+        software_path = os.path.join(ws1.software_dir, "spack", "wrfv4", "spack.yaml")
         with open(software_path) as f:
             assert "intel-oneapi-vtune" in f.read()
 

--- a/lib/ramble/ramble/test/modifier_functionality/mock_env_var_modifiers.py
+++ b/lib/ramble/ramble/test/modifier_functionality/mock_env_var_modifiers.py
@@ -71,7 +71,7 @@ def test_gromacs_dry_run_mock_env_vars_mod(
         workspace("setup", "--dry-run", global_args=["-D", ws1.root])
 
         # Test software directories
-        software_base_dir = ws1.software_dir
+        software_base_dir = os.path.join(ws1.software_dir, "spack")
 
         modifier_helpers.check_software_env(software_base_dir, software_tests)
 

--- a/lib/ramble/ramble/test/modifier_functionality/mock_modifier_spack_configs.py
+++ b/lib/ramble/ramble/test/modifier_functionality/mock_modifier_spack_configs.py
@@ -54,7 +54,7 @@ def test_gromacs_mock_spack_config_mod(
 
         assert os.path.isfile(exp_script)
 
-        spack_yaml = os.path.join(ws1.software_dir, "gromacs", "spack.yaml")
+        spack_yaml = os.path.join(ws1.software_dir, "spack", "gromacs", "spack.yaml")
         assert os.path.isfile(spack_yaml)
 
         with open(spack_yaml) as f:

--- a/lib/ramble/ramble/test/modifier_functionality/mock_spack_modifier.py
+++ b/lib/ramble/ramble/test/modifier_functionality/mock_spack_modifier.py
@@ -71,6 +71,6 @@ def test_gromacs_dry_run_mock_spack_mod(
         assert search_files_for_string(out_files, expected_str)
 
         # Test software directories
-        software_base_dir = ws1.software_dir
+        software_base_dir = os.path.join(ws1.software_dir, "spack")
 
         modifier_helpers.check_software_env(software_base_dir, software_tests)

--- a/lib/ramble/ramble/test/modifier_functionality/multi_modifier_dry_run.py
+++ b/lib/ramble/ramble/test/modifier_functionality/multi_modifier_dry_run.py
@@ -82,7 +82,7 @@ def test_gromacs_multi_modifier_dry_run(
         workspace("setup", "--dry-run", global_args=["-D", ws1.root])
 
         # Test software directories
-        software_base_dir = ws1.software_dir
+        software_base_dir = os.path.join(ws1.software_dir, "spack")
 
         modifier_helpers.check_software_env(software_base_dir, software_tests)
 

--- a/lib/ramble/ramble/test/modifier_functionality/single_modifier_dry_run.py
+++ b/lib/ramble/ramble/test/modifier_functionality/single_modifier_dry_run.py
@@ -58,7 +58,7 @@ def test_gromacs_single_full_modifier_dry_run(
         workspace("setup", "--dry-run", global_args=["-D", ws1.root])
 
         # Test software directories
-        software_base_dir = ws1.software_dir
+        software_base_dir = os.path.join(ws1.software_dir, "spack")
 
         modifier_helpers.check_software_env(software_base_dir, software_tests)
 
@@ -109,7 +109,7 @@ def test_gromacs_single_stub_modifier_dry_run(
         workspace("setup", "--dry-run", global_args=["-D", ws1.root])
 
         # Test software directories
-        software_base_dir = ws1.software_dir
+        software_base_dir = os.path.join(ws1.software_dir, "spack")
 
         modifier_helpers.check_software_env(software_base_dir, software_tests)
 


### PR DESCRIPTION
This merge allows a workspace to have multiple package manager directories under the `software` directory, which can be used to house independent software environments.

This allows the same named environment to render differently for different experiments (if needed) without causing collisions.

Tests and documentation are updated for this as well.