### PR TITLE
Add separator functionality to variable modification directives

### DIFF
--- a/lib/ramble/ramble/language/modifier_language.py
+++ b/lib/ramble/ramble/language/modifier_language.py
@@ -61,7 +61,9 @@ def default_mode(name, **kwargs):
 
 
 @modifier_directive("variable_modifications")
-def variable_modification(name, modification, method="set", mode=None, modes=None, **kwargs):
+def variable_modification(
+    name, modification, method="set", mode=None, modes=None, separator=" ", **kwargs
+):
     """Define a new variable modification for a mode in this modifier.
 
     A variable modification will apply a change to a defined variable within an experiment.
@@ -72,6 +74,8 @@ def variable_modification(name, modification, method="set", mode=None, modes=Non
         method (str): How the modification should be applied
         mode (str): Single mode to group this modification into
         modes (str): List of modes to group this modification into
+        separator (str): Optional separator to use when modifying with 'append' or
+                         'prepend' methods.
 
     Supported values are 'append', 'prepend', and 'set':
         'append' will add the modification to the end of 'name'
@@ -98,6 +102,7 @@ def variable_modification(name, modification, method="set", mode=None, modes=Non
             mod.variable_modifications[mode_name][name] = {
                 "modification": modification,
                 "method": method,
+                "separator": separator,
             }
 
     return _execute_variable_modification

--- a/lib/ramble/ramble/modifier.py
+++ b/lib/ramble/ramble/modifier.py
@@ -150,10 +150,15 @@ class ModifierBase(metaclass=ModifierMeta):
                 else:
                     prev_val = ""
 
+                if prev_val != "" and prev_val is not None:
+                    sep = var_mod["separator"]
+                else:
+                    sep = ""
+
                 if var_mod["method"] == "append":
-                    mods[var] = f'{prev_val}{var_mod["modification"]}'
+                    mods[var] = f'{prev_val}{sep}{var_mod["modification"]}'
                 else:  # method == prepend
-                    mods[var] = f'{var_mod["modification"]}{prev_val}'
+                    mods[var] = f'{var_mod["modification"]}{sep}{prev_val}'
             else:  # method == set
                 mods[var] = var_mod["modification"]
 

--- a/var/ramble/repos/builtin.mock/modifiers/test-mod-2/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/test-mod-2/modifier.py
@@ -25,7 +25,7 @@ class TestMod2(BasicModifier):
 
     variable_modification(
         "test_var_mod",
-        " test-mod-2-append",
+        "test-mod-2-append",
         method="append",
         modes=["test"],
     )

--- a/var/ramble/repos/builtin.mock/modifiers/test-mod/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/test-mod/modifier.py
@@ -34,14 +34,14 @@ class TestMod(BasicModifier):
 
     variable_modification(
         "test_var_mod",
-        " test-mod-append",
+        "test-mod-append",
         method="append",
         modes=["test"],
     )
 
     variable_modification(
         "mpi_command",
-        'echo "prefix_mpi_command" >> {log_file}; ',
+        'echo "prefix_mpi_command" >> {log_file};',
         method="prepend",
         modes=["test"],
     )

--- a/var/ramble/repos/builtin/modifiers/intel-aps/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/intel-aps/modifier.py
@@ -54,7 +54,7 @@ class IntelAps(BasicModifier):
         "aps_flags", "-c mpi -r {aps_log_dir}", method="set", modes=["mpi"]
     )
     variable_modification(
-        "mpi_command", " aps {aps_flags} ", method="append", modes=["mpi"]
+        "mpi_command", "aps {aps_flags} ", method="append", modes=["mpi"]
     )
 
     modifier_variable(

--- a/var/ramble/repos/builtin/modifiers/pyxis-enroot/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/pyxis-enroot/modifier.py
@@ -192,6 +192,7 @@ class PyxisEnroot(BasicModifier):
                         "container_mounts",
                         modification=prefix + exp_mount,
                         method="append",
+                        separator=",",
                         mode=self._usage_mode,
                     )
 


### PR DESCRIPTION
This merge allows `variable_modification` directives to define a separator attribute that can be used when the method of modification is `append` or `prepend`.