### PR TITLE
Allow modifiers to add attributes into experiment inventories

### DIFF
--- a/lib/ramble/ramble/modifier.py
+++ b/lib/ramble/ramble/modifier.py
@@ -244,6 +244,20 @@ class ModifierBase(metaclass=ModifierMeta):
 
                 phase_func(workspace)
 
+    def artifact_inventory(self, workspace, app_inst=None):
+        """Return an inventory of modifier artifacts
+
+        Artifact inventories are up to the individual modifier to define the
+        format of.
+
+        This will then show up in an experiment inventory.
+
+        Returns:
+            (Any) Artifact inventory for this modifier
+        """
+
+        return None
+
     def _prepare_analysis(self, workspace):
         """Hook to perform analysis that a modifier defines.
 


### PR DESCRIPTION
This merge defines a new hook in modifier classes to allow artifacts to be added into inventories. These are then tracked within the experiment inventories, and propagated into the workspace inventory (which is then hashed).