### PR TITLE
Allow spack-stack to define external packages that should be automatically detected

### DIFF
--- a/var/ramble/repos/builtin/applications/spack-stack/application.py
+++ b/var/ramble/repos/builtin/applications/spack-stack/application.py
@@ -49,6 +49,7 @@ class SpackStack(ExecutableApplication):
         "create",
         executables=[
             "builtin::remove_env_files",
+            "builtin::find_externals",
             "configure",
             "install",
             "builtin::remove_packages",
@@ -70,6 +71,13 @@ class SpackStack(ExecutableApplication):
         "install_flags",
         default="",
         description="Flags to use for `spack install`",
+        workloads=["create"],
+    )
+
+    workload_variable(
+        "external_packages",
+        default=[],
+        description="List of packages to `spack external find` and mark not buildable",
         workloads=["create"],
     )
 
@@ -144,6 +152,28 @@ class SpackStack(ExecutableApplication):
 
     def remove_env_files(self):
         cmds = ["rm -f {env_path}/spack.lock", "rm -rf {env_path}/.spack-env"]
+        return cmds
+
+    register_builtin("find_externals", required=False)
+
+    def find_externals(self):
+        """Inject commands to find external non buildable packages
+
+        This allows spack find external system packages before building,
+        to ensure system packages are used for some dependencies.
+        """
+        cmds = []
+
+        # Package finding is only supported in bash or sh
+        if ramble.config.get("config:shell") in ["sh", "bash"]:
+            # Do not expand the `external_packages` variable, so it will not be
+            # used to render experiments.
+            external_packages = self.expander.expand_var_name(
+                "external_packages", merge_used_stage=False, typed=True
+            )
+            self.expander.flush_used_variable_stage()
+            for pkg in external_packages:
+                cmds.append(f"spack external find --not-buildable {pkg}")
         return cmds
 
     register_builtin("remove_packages", required=False)

--- a/var/ramble/repos/builtin/applications/spack-stack/application.py
+++ b/var/ramble/repos/builtin/applications/spack-stack/application.py
@@ -69,7 +69,7 @@ class SpackStack(ExecutableApplication):
 
     workload_variable(
         "install_flags",
-        default="",
+        default="--fail-fast",
         description="Flags to use for `spack install`",
         workloads=["create"],
     )


### PR DESCRIPTION
This merge adds the ability for the spack-stack application to define packages that should be detected as externals by spack. Additionally, `--fail-fast` is added as a default argument to the installation of spack packages.