### PR TITLE
Expand deployment arguments and clean URLs

### DIFF
--- a/lib/ramble/docs/workspace.rst
+++ b/lib/ramble/docs/workspace.rst
@@ -267,6 +267,29 @@ And upload the deployment to a remote URL using:
 
   $ ramble deployment push -u <remote_url>
 
+The arguments ``-d`` and ``-u`` can refer to ``variables`` defined within any
+configuration scope that is workspace level or lower (i.e. site, user, etc..).
+This does not include variables defined within the ``applications``
+configuration section.
+
+For example:
+
+.. code-block:: yaml
+
+  ramble:
+    variables:
+      test_name: test
+      test_url: gs://test-bucket/test-dir
+    ...
+
+When paired with
+
+.. code-block:: console
+
+  $ ramble deployment push -d '{test_name}' -u '{test_url}'
+
+Would attempt to create a deployment in ``gs://test-bucket/test-dir/test``.
+
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Pulling a Workspace Deployment

--- a/lib/ramble/ramble/cmd/deployment.py
+++ b/lib/ramble/ramble/cmd/deployment.py
@@ -120,7 +120,7 @@ def deployment_pull(args):
         push_cls = ramble.pipeline.PushDeploymentPipeline
 
         # Handle local relative path
-        deployment_path = ramble.util.path.get_maybe_local_path(args.deployment_path)
+        deployment_path = ramble.util.path.normalize_path_or_url(args.deployment_path)
 
         remote_index_path = surl.join(
             deployment_path, ramble.pipeline.PushDeploymentPipeline.index_filename

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -30,6 +30,8 @@ import ramble.expander
 
 import ramble.experimental.uploader
 
+import ramble.util.path
+
 from ramble.namespace import namespace
 from ramble.util.logger import logger
 
@@ -608,7 +610,8 @@ class PushDeploymentPipeline(Pipeline):
         self.action_string = "Pushing deployment of"
         self.require_inventory = True
         self.create_tar = create_tar
-        self.upload_url = workspace_expander.expand_var(upload_url)
+        expanded_url = workspace_expander.expand_var(upload_url)
+        self.upload_url = ramble.util.path.normalize_path_or_url(expanded_url)
 
         if deployment_name:
             expanded_name = workspace_expander.expand_var(deployment_name)

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -26,6 +26,7 @@ import ramble.util.hashing
 import ramble.fetch_strategy
 import ramble.stage
 import ramble.workspace
+import ramble.expander
 
 import ramble.experimental.uploader
 
@@ -601,14 +602,18 @@ class PushDeploymentPipeline(Pipeline):
         self, workspace, filters, create_tar=False, upload_url=None, deployment_name=None
     ):
         super().__init__(workspace, filters)
+
+        workspace_expander = ramble.expander.Expander(workspace.get_workspace_vars(), None)
+
         self.action_string = "Pushing deployment of"
         self.require_inventory = True
         self.create_tar = create_tar
-        self.upload_url = upload_url
+        self.upload_url = workspace_expander.expand_var(upload_url)
 
         if deployment_name:
-            workspace.deployment_name = deployment_name
-            self.deployment_name = deployment_name
+            expanded_name = workspace_expander.expand_var(deployment_name)
+            workspace.deployment_name = expanded_name
+            self.deployment_name = expanded_name
         else:
             self.deployment_name = workspace.name
 

--- a/lib/ramble/ramble/test/util/path.py
+++ b/lib/ramble/ramble/test/util/path.py
@@ -20,8 +20,11 @@ import pytest
         ("rel/path", os.path.abspath("rel/path")),
         ("/abs/path", "/abs/path"),
         ("file:/abs/path", "file:/abs/path"),
+        ("file:/abs/path/", "file:/abs/path"),
         ("gs://my-bucket", "gs://my-bucket"),
+        ("gs://my-bucket/", "gs://my-bucket"),
+        ("gs://my-bucket///", "gs://my-bucket"),
     ],
 )
-def test_get_maybe_local_path(path, expect):
-    assert ramble.util.path.get_maybe_local_path(path) == expect
+def test_normalize_path_or_url(path, expect):
+    assert ramble.util.path.normalize_path_or_url(path) == expect

--- a/lib/ramble/ramble/util/path.py
+++ b/lib/ramble/ramble/util/path.py
@@ -102,9 +102,21 @@ def canonicalize_path(path):
     return path
 
 
-def get_maybe_local_path(path):
-    """Convert a scheme-less path to absolute local path"""
-    parsed = urllib.parse.urlparse(path)
+def normalize_path_or_url(path):
+    """Convert a scheme-less path to absolute local path
+    Also, remove trailing back-slashes from the input path
+
+    Args:
+        path (str): Input path
+
+    Returns:
+        (str): Absolute local path or cleaned remote url
+    """
+
+    # Remove trailing back-slashes from path
+    real_path = path.rstrip("/")
+
+    parsed = urllib.parse.urlparse(real_path)
     if not parsed.scheme:
-        return os.path.abspath(path)
-    return path
+        return os.path.abspath(real_path)
+    return real_path


### PR DESCRIPTION
This merge performs two primary functions. The first is to clean deployment URLs using the `get_maybe_local_path` helper utility. This fixes an issue when uploading to any cloud storage provider with a URL that has trailing back-slashes.

The second allows arguments on `deployment push` to be expanded using the workspace top-level variables.

Documentation is added around the second enhancement.