### PR TITLE
Allow dlb auto mode

### DIFF
--- a/var/ramble/repos/builtin/applications/gromacs/application.py
+++ b/var/ramble/repos/builtin/applications/gromacs/application.py
@@ -241,7 +241,7 @@ class Gromacs(ExecutableApplication):
     workload_variable(
         "dlb",
         default="yes",
-        values=["yes", "no"],
+        values=["yes", "no", "auto"],
         description="Whether to use dynamic load balancing for mdrun",
         workload_group="all_workloads",
     )


### PR DESCRIPTION
As documented, the dlb option can accept yes, no and auto: https://manual.gromacs.org/current/user-guide/mdrun-performance.html#running-mdrun-on-more-than-one-node.