### PR TITLE
Add a `disabled` mode to all modifier definitions

### DIFF
--- a/lib/ramble/docs/configuration_files.rst
+++ b/lib/ramble/docs/configuration_files.rst
@@ -459,6 +459,9 @@ experiments ramble generates. Its format is as follows:
       - executables to apply
       - modifier to
 
+**NOTE**: Every modifier has a ``disabled`` mode by default that can be set
+(only explicitly) to turn off all of the modifier's functionality.
+
 
 .. _repos-config:
 

--- a/lib/ramble/docs/dev_guides/modifier_dev_guide.rst
+++ b/lib/ramble/docs/dev_guides/modifier_dev_guide.rst
@@ -141,6 +141,10 @@ some aspects of the modifier change under different usage models.
 If a modifier only has a single ``mode`` defined, this becomes the default
 mode. The default mode can be specified using the ``default_mode`` directive.
 
+Every modifier has a ``disabled`` mode added by default, which cannot be passed
+into the ``default_mode`` directive. This mode allows turning off modifiers
+without having to remove them from the workspace configuration file.
+
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Modifier Variables and Variable Modifications
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/lib/ramble/docs/workspace_config.rst
+++ b/lib/ramble/docs/workspace_config.rst
@@ -696,6 +696,11 @@ If it is not set, modifiers will attempt to determine their own ``mode``
 attribute. This will succeed if the modifier has a single mode of operation. If
 there are multiple modes, this will raise an exception.
 
+Every modifier has a ``disabled`` mode that is defined by default. This mode
+will never be automatically enabled, but it will allow experiments to turn off
+the modifier without having to remove the modifier from the experiment
+definitions.
+
 If the ``on_executable`` attribute is not set, it will default to ``'*'`` which
 will match all executables. Modifier classes can (and should) be implemented to
 only act on the correct executable types (i.e. executables with ``use_mpi=true``).

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -36,6 +36,7 @@ import ramble.keywords
 import ramble.repeats
 import ramble.repository
 import ramble.modifier
+import ramble.modifier_types.disabled
 import ramble.pipeline
 import ramble.success_criteria
 import ramble.util.executable
@@ -791,7 +792,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
         self.variables[var_name] = var_value
         self.expander._variables[var_name] = var_value
         for mod_inst in self._modifier_instances:
-            mod_inst.expander._variables[var_name] = var_value
+            mod_inst.define_variable(var_name, var_value)
 
     def build_modifier_instances(self):
         """Built a map of modifier names to modifier instances needed for this
@@ -819,8 +820,11 @@ class ApplicationBase(metaclass=ApplicationMeta):
             else:
                 mod_inst.set_usage_mode(None)
 
-            mod_inst.inherit_from_application(self)
-            mod_inst.modify_experiment(self)
+            if not mod_inst.disabled:
+                mod_inst.inherit_from_application(self)
+                mod_inst.modify_experiment(self)
+            else:
+                mod_inst = ramble.modifier_types.disabled.DisabledModifier(mod_inst)
 
             self._modifier_instances.append(mod_inst)
 

--- a/lib/ramble/ramble/language/modifier_language.py
+++ b/lib/ramble/ramble/language/modifier_language.py
@@ -28,12 +28,19 @@ def mode(name, description, **kwargs):
 
     Modes allow a modifier to bundle a set of modifications together.
 
+    NOTE: A mode 'disabled' is defined by default for all modifiers.
+
     Args:
         name (str): Name of the mode to define
         description (str): Description of the new mode
     """
 
     def _execute_mode(mod):
+        if name in mod.modes:
+            raise DirectiveError(
+                f"mode directive given an already defined mode for modifier "
+                f"{mod.name}. Provided mode is {name}."
+            )
         mod.modes[name] = {"description": description}
 
     return _execute_mode
@@ -54,6 +61,12 @@ def default_mode(name, **kwargs):
             raise DirectiveError(
                 f"default_mode directive given an invalid mode for modifier "
                 f"{mod.name}. Valid modes are {str(list(mod.modes.keys()))}"
+            )
+
+        if name == "disabled":
+            raise DirectiveError(
+                f"default_mode directive given an invalid mode for modifier "
+                f"{mod.name}. The disabled mode cannot be set as the default mode"
             )
         mod._default_usage_mode = name
 

--- a/lib/ramble/ramble/modifier_types/basic.py
+++ b/lib/ramble/ramble/modifier_types/basic.py
@@ -13,8 +13,8 @@ from ramble.modifier import ModifierBase
 class BasicModifier(ModifierBase):
     """Specialized class for basic modifiers.
 
-    This class can be used to set up a modifier that does not need additional
-    software to be installed.
+    This class can be used to set up a modifier that can be composed into
+    experiment definitions.
     """
 
     modifier_class = "BasicModifier"

--- a/lib/ramble/ramble/modifier_types/disabled.py
+++ b/lib/ramble/ramble/modifier_types/disabled.py
@@ -1,0 +1,35 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+
+from ramble.modifier import ModifierBase
+
+
+class DisabledModifier(ModifierBase):
+    """Specialized class for disabled modifiers.
+
+    This class can be used to create a disabled modifier from an active
+    modifier instance.
+    """
+
+    modifier_class = "DisabledModifier"
+
+    disabled = True
+
+    name = "disabled"
+
+    def __init__(self, instance_to_disable):
+        super().__init__(instance_to_disable._file_path)
+
+        self.name = instance_to_disable.name
+        self.maintainers = instance_to_disable.maintainers.copy()
+        self.tags = instance_to_disable.tags.copy()
+
+    def define_variable(self, var_name, var_value):
+        """Given this modifier is disabled, never define variables in it"""
+        pass

--- a/lib/ramble/ramble/test/modifier_functionality/mock_modifier_dry_run.py
+++ b/lib/ramble/ramble/test/modifier_functionality/mock_modifier_dry_run.py
@@ -30,13 +30,19 @@ workspace = RambleCommand("workspace")
         SCOPES.experiment,
     ],
 )
+@pytest.mark.parametrize("modifier_mode", [None, "disabled"])  # Default mode
 def test_gromacs_dry_run_mock_mods(
-    mutable_mock_workspace_path, mutable_applications, mock_modifier, mock_modifiers, scope
+    mutable_mock_workspace_path,
+    mutable_applications,
+    mock_modifier,
+    mock_modifiers,
+    scope,
+    modifier_mode,
 ):
     workspace_name = "test_gromacs_dry_run_mock_mods"
 
     test_modifiers = [
-        (scope, modifier_helpers.named_modifier(mock_modifier)),
+        (scope, modifier_helpers.named_modifier(mock_modifier, modifier_mode)),
     ]
 
     expected_failures = {
@@ -56,7 +62,7 @@ def test_gromacs_dry_run_mock_mods(
 
         ws1._re_read()
 
-        if mock_modifier in expected_failures:
+        if modifier_mode != "disabled" and mock_modifier in expected_failures:
             with pytest.raises(expected_failures[mock_modifier]["error"]) as err:
                 workspace("concretize", global_args=["-D", ws1.root])
                 assert expected_failures[mock_modifier]["msg"] in err

--- a/lib/ramble/ramble/test/modifier_functionality/modifier_helpers.py
+++ b/lib/ramble/ramble/test/modifier_functionality/modifier_helpers.py
@@ -40,9 +40,11 @@ def check_execute_script(script_path, tests):
             assert test in data
 
 
-def named_modifier(name):
+def named_modifier(name, mode=None):
     modifier_def = syaml.syaml_dict()
     modifier_def["name"] = name
+    if mode is not None:
+        modifier_def["mode"] = mode
     return modifier_def
 
 

--- a/var/ramble/repos/builtin/modifiers/pyxis-enroot/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/pyxis-enroot/modifier.py
@@ -49,7 +49,6 @@ class PyxisEnroot(BasicModifier):
     maintainers("douglasjacobsen")
 
     mode("standard", description="Standard execution mode for pyxis-enroot")
-    mode("disabled", description="Disabled execution mode for pyxis-enroot")
     default_mode("standard")
 
     required_variable("container_name")
@@ -209,9 +208,6 @@ class PyxisEnroot(BasicModifier):
         (using enroot) into the target container_dir.
         """
 
-        if self._usage_mode == "disabled":
-            return
-
         self._build_commands(workspace.dry_run)
 
         uri = self.expander.expand_var_name("container_uri")
@@ -237,9 +233,6 @@ class PyxisEnroot(BasicModifier):
 
     def _extract_from_sqsh(self, workspace, app_inst=None):
         """Extract paths from the sqsh file into the workload inputs path"""
-
-        if self._usage_mode == "disabled":
-            return
 
         self._build_commands(workspace.dry_run)
 
@@ -285,9 +278,6 @@ class PyxisEnroot(BasicModifier):
         container_path = self.expander.expand_var_name("container_path")
         container_uri = self.expander.expand_var_name("container_uri")
         inventory = []
-
-        if self._usage_mode == "disabled":
-            return inventory
 
         inventory.append(
             {


### PR DESCRIPTION
This merge adds a `disabled` mode to every modifier in Ramble, which can be used to turn off the modifier's functionality without having to remove it from a workspace configuration file.

Documentation and tests are updated to support / exercise this as well.