### PR TITLE
update sphinx requirements to avoid blocking erorrs

### DIFF
--- a/lib/ramble/docs/requirements.txt
+++ b/lib/ramble/docs/requirements.txt
@@ -4,3 +4,5 @@ sphinx_rtd_theme
 sphinxcontrib-programoutput
 sphinxcontrib-jquery
 sphinx-copybutton
+tdqm
+deprecation


### PR DESCRIPTION
This fixes an issue where RTD was not generating Command References, and other commands

This isn't an amazing fix, in that the docs do not depend on these 2 libs in the strictest sense, but given we are about to take on matplotlib as a dep it makes more sense to me to install just what is blocking, not every ramble dep 