### PR TITLE
Fix an issue with the `target_dir` arg on input files

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -925,12 +925,16 @@ class ApplicationBase(metaclass=ApplicationMeta):
         self._inputs_and_fetchers(self.expander.workload_name)
 
         for input_file, input_conf in self._input_fetchers.items():
-            input_vars = {self.keywords.input_name: input_conf["input_name"]}
-            if not input_conf["expand"]:
+            input_vars = {}
+            if input_conf["expand"]:
+                input_vars[self.keywords.input_name] = input_conf["input_name"]
+            else:
                 input_vars[self.keywords.input_name] = input_file
+
             input_path = os.path.join(
-                self.expander.workload_input_dir,
-                self.expander.expand_var(input_conf["target_dir"], extra_vars=input_vars),
+                self.expander.expand_var(
+                    os.path.join(input_conf["target_dir"], input_file), extra_vars=input_vars
+                ),
             )
             self.variables[input_conf["input_name"]] = input_path
 
@@ -1264,7 +1268,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
                 input_vars = {self.keywords.input_name: input_conf["input_name"]}
                 input_namespace = workload_namespace + "." + input_file
                 input_path = self.expander.expand_var(
-                    input_conf["target_dir"], extra_vars=input_vars
+                    os.path.join(input_conf["target_dir"], input_file), extra_vars=input_vars
                 )
                 input_tuple = (f"input-file-{input_file}", input_path)
 

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -339,6 +339,7 @@ class ExperimentSet:
             ),
         )
 
+        app_inst.add_expand_vars(self._workspace)
         app_inst.read_status()
 
         try:

--- a/lib/ramble/ramble/language/application_language.py
+++ b/lib/ramble/ramble/language/application_language.py
@@ -6,7 +6,6 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-import os
 import ramble.workload
 import ramble.language.language_base
 from ramble.language.language_base import DirectiveError
@@ -152,7 +151,7 @@ def input_file(
     name,
     url,
     description,
-    target_dir=os.path.join("{workload_input_dir}", "{input_name}"),
+    target_dir="{workload_input_dir}",
     sha256=None,
     extension=None,
     expand=True,

--- a/lib/ramble/ramble/test/application_language.py
+++ b/lib/ramble/ramble/test/application_language.py
@@ -174,7 +174,7 @@ def add_input_file(app_inst, input_num=1):
     input_defs[input_name] = {
         "url": input_url,
         "description": input_desc,
-        "target_dir": os.path.join("{workload_input_dir}", "{input_name}"),
+        "target_dir": "{workload_input_dir}",
     }
 
     return input_defs

--- a/lib/ramble/ramble/test/application_tests.py
+++ b/lib/ramble/ramble/test/application_tests.py
@@ -325,7 +325,7 @@ def test_set_input_path(mutable_mock_apps_repo):
 
     executable_application_instance._set_input_path()
 
-    default_answer = "/workspace/inputs/bar/test_wl2/input"
+    default_answer = "/workspace/inputs/bar/test_wl2/test_file.log"
 
     assert executable_application_instance.variables["input"] == default_answer
 
@@ -349,8 +349,8 @@ def test_set_input_path_multi_input(mutable_mock_apps_repo):
 
     executable_application_instance._set_input_path()
 
-    input1_path = "/workspace/inputs/bar/test_wl2/test-input1"
-    input2_path = "/workspace/inputs/bar/test_wl2/test-input2"
+    input1_path = "/workspace/inputs/bar/test_wl2/input1"
+    input2_path = "/workspace/inputs/bar/test_wl2/input2"
     input3_path = "/workspace/inputs/bar/test_wl2/input3.txt"
 
     assert executable_application_instance.variables["test-input1"] == input1_path


### PR DESCRIPTION
This merge fixes an issue where the target_dir (and url) attributes of the input_file directive were not rendered properly. This allows new directories to be created to refer to the location of fetched input files.