### PR TITLE
Fix formatting of managed software

### DIFF
--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -872,6 +872,10 @@ ramble:
         software_dict = self.get_software_dict().copy()
 
         environments = software_dict[namespace.environments]
+        # Ensure package dict is an syaml_dict, for formatting
+        if not environments:
+            software_dict[namespace.environments] = syaml.syaml_dict()
+            environments = software_dict[namespace.environments]
 
         if remove:
             if env_name in environments:
@@ -939,6 +943,11 @@ ramble:
         software_dict = self.get_software_dict().copy()
 
         packages = software_dict[namespace.packages]
+
+        # Ensure package dict is an syaml_dict, for formatting
+        if not packages:
+            software_dict[namespace.packages] = syaml.syaml_dict()
+            packages = software_dict[namespace.packages]
 
         if remove:
             if pkg_name in packages:


### PR DESCRIPTION
This merge fixes the formatting of the software dictionaries (packages and environments) when they are auto-generated using the `ramble workspace manage software` commands