### PR TITLE
Add a directive to allow objects to express platform support requirement

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -47,6 +47,7 @@ import ramble.util.stats
 import ramble.util.graph
 import ramble.util.class_attributes
 import ramble.util.lock as lk
+import ramble.util.web as web_util
 from ramble.util.logger import logger
 from ramble.util.shell_utils import source_str
 from ramble.util.naming import NS_SEPARATOR
@@ -89,6 +90,45 @@ def _check_shell_support(app_inst):
     for mod_inst in app_inst._modifier_instances:
         _check_match(mod_inst, shell)
     _check_match(app_inst.package_manager, shell)
+
+
+def _is_gcp():
+    """GCP check based on https://cloud.google.com/compute/docs/instances/detect-compute-engine"""
+    try:
+        _, headers, _ = web_util.read_from_url("http://metadata.google.internal")
+        flavor = web_util.get_header(headers, "Metadata-Flavor")
+        return flavor == "Google"
+    except web_util.SpackWebError:
+        return False
+
+
+_KNOWN_PLATFORM_CHECKS = {"GCP": _is_gcp}
+
+
+def _check_platform_support(app_inst):
+    def _is_supported(inst):
+        if not inst or not inst.target_platforms_spec:
+            return True
+        platforms = inst.target_platforms_spec["platforms"]
+        abort = inst.target_platforms_spec["abort_on_unsupported"]
+        for plat in platforms:
+            if plat not in _KNOWN_PLATFORM_CHECKS:
+                # This indicates an object definition error, so abort regardless.
+                logger.die(f"{inst.name} specifies an unknown platform {plat}")
+            supported = _KNOWN_PLATFORM_CHECKS[plat]()
+            if supported:
+                return True
+        if abort:
+            log_func = logger.die
+        else:
+            log_func = logger.warn
+        log_func(f"{inst.name} needs to run on a supported platform: {platforms}")
+        return False
+
+    _is_supported(app_inst)
+    for mod_inst in app_inst._modifier_instances:
+        _is_supported(mod_inst)
+    _is_supported(app_inst.package_manager)
 
 
 class ApplicationBase(metaclass=ApplicationMeta):
@@ -1335,6 +1375,18 @@ class ApplicationBase(metaclass=ApplicationMeta):
                                 if cmd:
                                     f.write(cmd + "\n")
 
+    register_phase("verify_objects", pipeline="setup", run_before=["get_inputs"])
+
+    def _verify_objects(self, workspace, app_inst=None):
+        """Verify if any objects are not supported with the given config and run environment."""
+        logger.debug("Checking if objects are supported")
+        _check_shell_support(self)
+        if not workspace.dry_run:
+            # The platform check happens at setup time, so it's not always desirable
+            # as this may not align with the platform that executes the experiment.
+            # TODO: consider adding runtime checks in the execution script.
+            _check_platform_support(self)
+
     register_phase("make_experiments", pipeline="setup", run_after=["get_inputs"])
 
     def _make_experiments(self, workspace, app_inst=None):
@@ -1345,8 +1397,6 @@ class ApplicationBase(metaclass=ApplicationMeta):
         templates, and injecting the experiment into the workspace all
         experiments file.
         """
-
-        _check_shell_support(self)
 
         exp_lock = self.experiment_lock()
 

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -460,3 +460,26 @@ def target_shells(shell_support_pattern=None):
             obj.shell_support_pattern = shell_support_pattern
 
     return _execute_target_shells
+
+
+@shared_directive(dicts="target_platforms_spec")
+def target_platforms(platforms=None, abort_on_unsupported=False):
+    """Directive to specify supported platforms.
+
+    If not specified, then it assumes there is no limitation on platform support.
+    A platform is defined broadly, for instance it can mean a CSP, or a particular OS.
+    The given list of platforms is interpreted as a union set.
+
+    Args:
+        platforms (list[str] | None): A list of supported platforms.
+        abort_on_unsupported (bool): Whether to abort if the running environment is not supported.
+    """
+
+    def _execute_target_platforms(obj):
+        if platforms is not None:
+            obj.target_platforms_spec = {
+                "platforms": [platforms] if isinstance(platforms, str) else platforms,
+                "abort_on_unsupported": abort_on_unsupported,
+            }
+
+    return _execute_target_platforms

--- a/lib/ramble/ramble/test/modifier_functionality/mock_modifier_phases.py
+++ b/lib/ramble/ramble/test/modifier_functionality/mock_modifier_phases.py
@@ -54,37 +54,30 @@ def test_gromacs_dry_run_mock_mod_phase(
 
         out_file = os.path.join(ws1.log_dir, "setup.latest", "gromacs.water_bare.test_exp.out")
 
-        found_phase = False
         found_make_experiments = False
         found_after_phase = False
-        found_first_phase = False
-        phase_regex = re.compile("Executing phase.*")
-        first_phase_regex = re.compile("Executing phase first_phase")
+        found_mod_phase = False
+        mod_phase_regex = re.compile("Executing phase mod_phase")
         make_experiments_regex = re.compile("Executing phase make_experiments")
         after_make_experiments_regex = re.compile("Executing phase after_make_experiments")
 
         with open(out_file) as f:
             for line in f.readlines():
-                if first_phase_regex.search(line):
-                    assert not found_phase
-                    found_first_phase = True
-
-                if phase_regex.search(line):
-                    found_phase = True
+                if mod_phase_regex.search(line):
+                    found_mod_phase = True
 
                 if make_experiments_regex.search(line):
-                    assert found_phase
+                    assert found_mod_phase
                     found_make_experiments = True
 
                 if after_make_experiments_regex.search(line):
                     assert found_make_experiments
                     found_after_phase = True
 
-        assert found_phase
-        assert found_first_phase
+        assert found_mod_phase
         assert found_after_phase
 
-        expected_str = "Inside a phase: first_phase"
+        expected_str = "Inside a phase: mod_phase"
 
         assert search_files_for_string(out_files, expected_str)
 

--- a/var/ramble/repos/builtin.mock/modifiers/mod-phase/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/mod-phase/modifier.py
@@ -19,10 +19,12 @@ class ModPhase(BasicModifier):
 
     mode("test", description="This is a test mode")
 
-    register_phase("first_phase", pipeline="setup", run_before=["get_inputs"])
+    register_phase(
+        "mod_phase", pipeline="setup", run_before=["make_experiments"]
+    )
 
-    def _first_phase(self, workspace, app_inst=None):
-        logger.all_msg("Inside a phase: first_phase")
+    def _mod_phase(self, workspace, app_inst=None):
+        logger.all_msg("Inside a phase: mod_phase")
 
     register_phase(
         "after_make_experiments",

--- a/var/ramble/repos/builtin/modifiers/gcp-metadata/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/gcp-metadata/modifier.py
@@ -36,6 +36,8 @@ class GcpMetadata(BasicModifier):
 
     required_variable("hostlist")
 
+    target_platforms("GCP")
+
     modifier_variable(
         "metadata_parallel_prefix",
         default="pdsh -R ssh -N -w {hostlist} '",


### PR DESCRIPTION
Right now the only user is gcp-metadata modifier, which only works on GCP.