### PR TITLE
Allow `workspace info` to filter software displayed to only parts that are used by experiments

### DIFF
--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -726,6 +726,10 @@ def workspace_info(args):
                             app_inst.expander,
                             app_inst.package_manager,
                         )
+                        # Track this env as used, for printing purposes
+                        software_environments.use_environment(
+                            app_inst.package_manager, app_inst.expander.expand_var("{env_name}")
+                        )
 
                     if print_header:
                         color.cprint(
@@ -794,7 +798,6 @@ def workspace_info(args):
     # Print software stack information
     if args.software or args.all_software:
         color.cprint("")
-        #  software_environments.print_environments(verbosity=args.verbose)
         color.cprint(rucolor.section_title("Software Stack:"))
         only_used_software = args.software
         color.cprint(

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -588,10 +588,17 @@ def workspace_push_to_cache_setup_parser(subparser):
 
 def workspace_info_setup_parser(subparser):
     """Information about a workspace"""
-    subparser.add_argument(
+    software_opts = subparser.add_mutually_exclusive_group()
+    software_opts.add_argument(
         "--software",
         action="store_true",
-        help="If set, software stack information will be printed",
+        help="If set, used software stack information will be printed",
+    )
+
+    software_opts.add_argument(
+        "--all-software",
+        action="store_true",
+        help="If set, all software stack information will be printed",
     )
 
     subparser.add_argument(
@@ -785,11 +792,16 @@ def workspace_info(args):
             colify(all_pipelines[pipeline], indent=4)
 
     # Print software stack information
-    if args.software:
+    if args.software or args.all_software:
         color.cprint("")
         #  software_environments.print_environments(verbosity=args.verbose)
         color.cprint(rucolor.section_title("Software Stack:"))
-        color.cprint(software_environments.info(verbosity=args.verbose, indent=4, color_level=1))
+        only_used_software = args.software
+        color.cprint(
+            software_environments.info(
+                verbosity=args.verbose, indent=4, color_level=1, only_used=only_used_software
+            )
+        )
 
 
 #

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -927,7 +927,11 @@ ramble:
 
         software_dict = self.get_software_dict().copy()
 
-        environments = software_dict[namespace.environments]
+        if namespace.environments in software_dict:
+            environments = software_dict[namespace.environments]
+        else:
+            environments = None
+
         # Ensure package dict is an syaml_dict, for formatting
         if not environments:
             software_dict[namespace.environments] = syaml.syaml_dict()
@@ -998,7 +1002,10 @@ ramble:
 
         software_dict = self.get_software_dict().copy()
 
-        packages = software_dict[namespace.packages]
+        if namespace.packages in software_dict:
+            packages = software_dict[namespace.packages]
+        else:
+            packages = None
 
         # Ensure package dict is an syaml_dict, for formatting
         if not packages:

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -685,7 +685,7 @@ _ramble_workspace_push_to_cache() {
 }
 
 _ramble_workspace_info() {
-    RAMBLE_COMPREPLY="-h --help --software --templates --expansions --tags --phases --where --exclude-where --filter-tags -v --verbose"
+    RAMBLE_COMPREPLY="-h --help --software --all-software --templates --expansions --tags --phases --where --exclude-where --filter-tags -v --verbose"
 }
 
 _ramble_workspace_edit() {


### PR DESCRIPTION
This merge updates the `ramble workspace info` command to allow software to be filtered to only used environments and packages.

The `--software` flag is updated to filter displayed software to only what is used, while `--all-software` is added to allow printing all software, regardless of what is used.