### PR TITLE
Fix / enable parallel unit tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,0 @@
-[run]
-omit =
-  lib/ramble/spack/*
-  lib/ramble/external/*
-  lib/ramble/llnl/*

--- a/lib/ramble/ramble/test/conftest.py
+++ b/lib/ramble/ramble/test/conftest.py
@@ -494,6 +494,13 @@ def no_path_access(monkeypatch):
     monkeypatch.setattr(os, "access", _can_access)
 
 
+@pytest.fixture(scope="function", autouse=True)
+def print_all_logs(monkeypatch):
+    import ramble.util.logger
+
+    monkeypatch.setattr(ramble.util.logger.logger, "msg", ramble.util.logger.logger.all_msg)
+
+
 ##########
 # Fake archives and repositories
 ##########

--- a/lib/ramble/ramble/test/package_manager_functionality/spack_runner.py
+++ b/lib/ramble/ramble/test/package_manager_functionality/spack_runner.py
@@ -18,18 +18,18 @@ from ramble.pkg_man.builtin.spack_lightweight import (
 )
 
 
-def test_env_create(tmpdir):
+def test_env_create(tmpdir, request):
     try:
-        env_path = tmpdir.join("spack-env")
+        env_path = tmpdir.join(request.node.name)
         sr = SpackRunner()
         sr.create_env(env_path)
     except RunnerError as e:
         pytest.skip("%s" % e)
 
 
-def test_env_activate(tmpdir):
+def test_env_activate(tmpdir, request):
     try:
-        env_path = tmpdir.join("spack-env")
+        env_path = tmpdir.join(request.node.name)
         sr = SpackRunner()
         sr.create_env(env_path)
         sr.activate()
@@ -37,9 +37,9 @@ def test_env_activate(tmpdir):
         pytest.skip("%s" % e)
 
 
-def test_env_deactivate(tmpdir):
+def test_env_deactivate(tmpdir, request):
     try:
-        env_path = tmpdir.join("spack-env")
+        env_path = tmpdir.join(request.node.name)
         sr = SpackRunner()
         sr.create_env(env_path)
         sr.activate()
@@ -48,9 +48,9 @@ def test_env_deactivate(tmpdir):
         pytest.skip("%s" % e)
 
 
-def test_env_add(tmpdir):
+def test_env_add(tmpdir, request):
     try:
-        env_path = tmpdir.join("spack-env")
+        env_path = tmpdir.join(request.node.name)
         sr = SpackRunner()
         sr.create_env(env_path)
         sr.activate()
@@ -60,9 +60,9 @@ def test_env_add(tmpdir):
         pytest.skip("%s" % e)
 
 
-def test_env_concretize(tmpdir):
+def test_env_concretize(tmpdir, request):
     try:
-        env_path = tmpdir.join("spack-env")
+        env_path = tmpdir.join(request.node.name)
         sr = SpackRunner()
         sr.create_env(env_path)
         sr.activate()
@@ -75,11 +75,11 @@ def test_env_concretize(tmpdir):
         pytest.skip("%s" % e)
 
 
-def test_env_concretize_skips_already_concretized_envs(tmpdir, capsys):
+def test_env_concretize_skips_already_concretized_envs(tmpdir, capsys, request):
     import time
 
     try:
-        env_path = tmpdir.join("spack-env")
+        env_path = tmpdir.join(request.node.name)
         sr = SpackRunner()
         sr.create_env(env_path)
         sr.activate()
@@ -103,8 +103,7 @@ def test_env_concretize_skips_already_concretized_envs(tmpdir, capsys):
         output = capsys.readouterr()
         assert f"Environment {env_path} will not be regenerated" in output.out
         assert (
-            f"Environment {env_path} is already concretized. Skipping concretize..."
-            in output.out
+            f"Environment {env_path} is already concretized. Skipping concretize..." in output.out
         )
 
         sr.deactivate()
@@ -114,9 +113,9 @@ def test_env_concretize_skips_already_concretized_envs(tmpdir, capsys):
         pytest.skip("%s" % e)
 
 
-def test_env_install(tmpdir, capsys):
+def test_env_install(tmpdir, capsys, request):
     try:
-        env_path = str(tmpdir.join("spack-env"))
+        env_path = str(tmpdir.join(request.node.name))
         # Dry run so we don't actually install zlib
         sr = SpackRunner(dry_run=True)
         sr.create_env(env_path)
@@ -135,16 +134,16 @@ def test_env_install(tmpdir, capsys):
 
         assert os.path.exists(env_file)
 
-        with open(env_file, "r") as f:
+        with open(env_file) as f:
             assert "zlib" in f.read()
 
     except RunnerError as e:
         pytest.skip("%s" % e)
 
 
-def test_env_configs_apply(tmpdir, capsys):
+def test_env_configs_apply(tmpdir, capsys, request):
     try:
-        env_path = str(tmpdir.join("spack-env"))
+        env_path = str(tmpdir.join(request.node.name))
         # Dry run so we don't actually install zlib
         sr = SpackRunner(dry_run=True)
         sr.create_env(env_path)
@@ -154,9 +153,7 @@ def test_env_configs_apply(tmpdir, capsys):
         sr.generate_env_file()
 
         captured = capsys.readouterr()
-        assert (
-            "with args: ['config', 'add', 'config:debug:true']" in captured.out
-        )
+        assert "with args: ['config', 'add', 'config:debug:true']" in captured.out
 
         sr.deactivate()
 
@@ -164,7 +161,7 @@ def test_env_configs_apply(tmpdir, capsys):
 
         assert os.path.exists(env_file)
 
-        with open(env_file, "r") as f:
+        with open(env_file) as f:
             data = f.read()
             assert "zlib" in data
             assert "debug: true" in data
@@ -173,9 +170,9 @@ def test_env_configs_apply(tmpdir, capsys):
         pytest.skip("%s" % e)
 
 
-def test_default_concretize_flags(tmpdir, capsys):
+def test_default_concretize_flags(tmpdir, capsys, request):
     try:
-        env_path = tmpdir.join("spack-env")
+        env_path = tmpdir.join(request.node.name)
         sr = SpackRunner(dry_run=True)
         sr.create_env(env_path)
         sr.activate()
@@ -196,14 +193,10 @@ def test_default_concretize_flags(tmpdir, capsys):
         ("prefix", "time", "would run time"),
     ],
 )
-def test_config_concretize_attribute(
-    tmpdir, capsys, attr, value, expected_str
-):
+def test_config_concretize_attribute(tmpdir, capsys, attr, value, expected_str, request):
     try:
-        env_path = tmpdir.join("spack-env")
-        with ramble.config.override(
-            "config:spack", {"concretize": {attr: value}}
-        ):
+        env_path = tmpdir.join(request.node.name)
+        with ramble.config.override("config:spack", {"concretize": {attr: value}}):
             sr = SpackRunner(dry_run=True)
             sr.create_env(env_path)
             sr.activate()
@@ -217,9 +210,9 @@ def test_config_concretize_attribute(
         pytest.skip("%s" % e)
 
 
-def test_default_install_flags(tmpdir, capsys):
+def test_default_install_flags(tmpdir, capsys, request):
     try:
-        env_path = tmpdir.join("spack-env")
+        env_path = tmpdir.join(request.node.name)
         sr = SpackRunner(dry_run=True)
         sr.create_env(env_path)
         sr.activate()
@@ -248,12 +241,10 @@ def test_default_install_flags(tmpdir, capsys):
         ("prefix", "time", "would run time"),
     ],
 )
-def test_config_install_attribute(tmpdir, capsys, attr, value, expected_str):
+def test_config_install_attribute(tmpdir, capsys, attr, value, expected_str, request):
     try:
-        env_path = tmpdir.join("spack-env")
-        with ramble.config.override(
-            "config:spack", {"install": {attr: value}}
-        ):
+        env_path = tmpdir.join(request.node.name)
+        with ramble.config.override("config:spack", {"install": {attr: value}}):
             sr = SpackRunner(dry_run=True)
             sr.create_env(env_path)
             sr.activate()
@@ -268,9 +259,9 @@ def test_config_install_attribute(tmpdir, capsys, attr, value, expected_str):
         pytest.skip("%s" % e)
 
 
-def test_env_include(tmpdir, capsys):
+def test_env_include(tmpdir, capsys, request):
     try:
-        env_path = tmpdir.join("spack-env")
+        env_path = tmpdir.join(request.node.name)
         sr = SpackRunner(dry_run=True)
         sr.create_env(env_path)
         sr.activate()
@@ -282,7 +273,7 @@ def test_env_include(tmpdir, capsys):
         sr.generate_env_file()
         sr.concretize()
 
-        with open(os.path.join(env_path, "spack.yaml"), "r") as f:
+        with open(os.path.join(env_path, "spack.yaml")) as f:
             data = f.read()
             assert good_include_path in data
             assert bad_include_path not in data
@@ -290,7 +281,7 @@ def test_env_include(tmpdir, capsys):
         pytest.skip("%s" % e)
 
 
-def test_new_compiler_installs(tmpdir, capsys):
+def test_new_compiler_installs(tmpdir, capsys, request):
 
     import os
 
@@ -335,9 +326,7 @@ packages:
             f.write(compilers_config)
 
         config_path = os.getcwd()
-        with ramble.config.override(
-            "config:spack", {"global": {"flags": f"-C {config_path}"}}
-        ):
+        with ramble.config.override("config:spack", {"global": {"flags": f"-C {config_path}"}}):
             try:
                 sr = SpackRunner(dry_run=True)
                 sr.create_env(os.getcwd())
@@ -348,15 +337,12 @@ packages:
                 sr.install_compiler("gcc@12.1.0")
                 captured = capsys.readouterr()
 
-                assert (
-                    "gcc@12.1.0 is already an available compiler"
-                    in captured.out
-                )
+                assert "gcc@12.1.0 is already an available compiler" in captured.out
             except RunnerError as e:
                 pytest.skip("%s" % e)
 
 
-def test_external_env_copies(tmpdir):
+def test_external_env_copies(tmpdir, request):
     src_spack_yaml = """
 spack:
   specs: [ 'zlib' ]
@@ -434,13 +420,13 @@ spack:
 
             assert os.path.exists(os.path.join(generated_env, "spack.yaml"))
 
-            with open(os.path.join(generated_env, "spack.yaml"), "r") as f:
+            with open(os.path.join(generated_env, "spack.yaml")) as f:
                 assert "zlib" in f.read()
         except RunnerError as e:
             pytest.skip("%s" % e)
 
 
-def test_configs_apply_to_external_env(tmpdir):
+def test_configs_apply_to_external_env(tmpdir, request):
     src_spack_yaml = """
 spack:
   specs: [ 'zlib' ]
@@ -459,7 +445,7 @@ spack:
 
             assert os.path.exists(os.path.join(generated_env, "spack.yaml"))
 
-            with open(os.path.join(generated_env, "spack.yaml"), "r") as f:
+            with open(os.path.join(generated_env, "spack.yaml")) as f:
                 data = f.read()
                 assert "zlib" in data
                 assert "config:" in data
@@ -468,7 +454,7 @@ spack:
             pytest.skip("%s" % e)
 
 
-def test_invalid_external_env_errors(tmpdir):
+def test_invalid_external_env_errors(tmpdir, request):
     with tmpdir.as_cwd():
         try:
             sr = SpackRunner(dry_run=True)
@@ -487,9 +473,7 @@ def test_invalid_external_env_errors(tmpdir):
         ("flags", "--scope site", "'--scope', 'site'"),
     ],
 )
-def test_config_compiler_find_attribute(
-    tmpdir, capsys, attr, value, expected_str
-):
+def test_config_compiler_find_attribute(tmpdir, capsys, attr, value, expected_str, request):
 
     import os
 
@@ -517,12 +501,8 @@ compilers::
             f.write(compilers_config)
 
         config_path = os.getcwd()
-        with ramble.config.override(
-            "config:spack", {"global": {"flags": f"-C {config_path}"}}
-        ):
-            with ramble.config.override(
-                "config:spack", {"compiler_find": {attr: value}}
-            ):
+        with ramble.config.override("config:spack", {"global": {"flags": f"-C {config_path}"}}):
+            with ramble.config.override("config:spack", {"compiler_find": {attr: value}}):
                 try:
                     sr = SpackRunner(dry_run=True)
                     sr.create_env(os.getcwd())
@@ -536,28 +516,24 @@ compilers::
                     pytest.skip("%s" % e)
 
 
-def test_env_create_no_view(tmpdir):
+def test_env_create_no_view(tmpdir, request):
 
     import os
 
     with tmpdir.as_cwd():
-        with ramble.config.override(
-            "config:spack", {"env_create": {"flags": "--without-view"}}
-        ):
+        with ramble.config.override("config:spack", {"env_create": {"flags": "--without-view"}}):
             try:
                 sr = SpackRunner()
                 sr.create_env(os.getcwd())
 
-                assert not os.path.exists(
-                    os.path.join(os.getcwd(), ".spack-env", "view")
-                )
+                assert not os.path.exists(os.path.join(os.getcwd(), ".spack-env", "view"))
             except RunnerError as e:
                 pytest.skip("%s" % e)
 
 
-def test_multiword_args(tmpdir, capsys):
+def test_multiword_args(tmpdir, capsys, request):
     try:
-        env_path = tmpdir.join("spack-env")
+        env_path = tmpdir.join(request.node.name)
         with ramble.config.override(
             "config:spack",
             {"install": {"flags": 'install="-multiword -args"'}},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,61 @@ force-exclude = '''
   | __pycache__
 )/
 '''
+
+[tool.coverage.run]
+parallel = true
+data_file = "./tests-coverage/.coverage"
+include = [
+  "**/bin/ramble",
+  "**/bin/ramble-python",
+  "**/lib/ramble/ramble/**",
+  "**/lib/ramble/ramble/schema/**",
+  "**/lib/ramble/ramble/cmd/**",
+]
+omit = [
+    "**/spack/lib/**",
+    "**/spack/var/**",
+    "lib/ramble/spack/**",
+    "lib/ramble/external/**",
+    "lib/ramble/llnl/**",
+    "share/**",
+]
+
+[tool.coverage.report]
+# Regexes for lines to exclude from consideration
+exclude_lines = [
+    # Have to re-enable the standard pragma
+    'pragma: no cover',
+
+    # Don't complain about missing debug-only code:
+    'def __repr__',
+    'if self\.debug',
+
+    # Don't complain if tests don't hit defensive assertion code:
+    'raise AssertionError',
+    'raise NotImplementedError',
+
+    # Don't complain if non-runnable code isn't run:
+    'if 0:',
+    'if False:',
+    'if __name__ == .__main__.:',
+]
+ignore_errors = true
+include = [
+  "**/bin/ramble",
+  "**/bin/ramble-python",
+  "**/lib/ramble/ramble/**",
+  "**/lib/ramble/ramble/schema/**",
+  "**/lib/ramble/ramble/cmd/**",
+]
+omit = [
+    "**/spack/lib/**",
+    "**/spack/var/**",
+    "lib/ramble/spack/**",
+    "lib/ramble/external/**",
+    "lib/ramble/llnl/**",
+    "share/**",
+]
+
+[tool.coverage.html]
+directory = "htmlcov"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,5 @@ flake8
 black
 coverage
 pre-commit
+pytest-xdist
+pytest-cov

--- a/share/ramble/cloud-build/ramble-pr-unit-tests.yaml
+++ b/share/ramble/cloud-build/ramble-pr-unit-tests.yaml
@@ -34,12 +34,12 @@ steps:
         echo "Spack version is $(spack --version)"
         echo "Python version is $(python3 --version)"
 
-        COVERAGE=true LONG=true /workspace/share/ramble/qa/run-unit-tests
+        UNIT_TEST_COVERAGE=true LONG=true /workspace/share/ramble/qa/run-unit-tests
         # $$ characters are required for cloud-build:
         # https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values
         unit_err=$$?
 
-        coverage report -m --fail-under=80
+        coverage report -m --fail-under=77
         # $$ characters are required for cloud-build:
         # https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values
         coverage_err=$$?

--- a/share/ramble/qa/run-unit-tests
+++ b/share/ramble/qa/run-unit-tests
@@ -47,17 +47,32 @@ if [ $? != 0 ]; then
     ERROR=1
 fi
 
+export UNIT_TEST_COVERAGE_ADDOPTS=""
+if [[ "$UNIT_TEST_COVERAGE" == "true" ]]; then
+  export UNIT_TEST_COVERAGE_ADDOPTS="--cov --cov-report= --cov-config=pyproject.toml"
+fi
+
+export PYTEST_ADDOPTS=""
+
+N_PROCS=${N_PROCS:-auto}
+# Check if xdist is available
+if python -m pytest -VV 2>&1 | grep xdist; then
+  export PYTEST_ADDOPTS="$PYTEST_ADDOPTS -n $N_PROCS"
+fi
+
 #-----------------------------------------------------------
 # Run unit tests with code coverage
 #-----------------------------------------------------------
-if [ -z $LONG ]; then
-    $coverage_run $(which ramble) unit-test -x --verbose -m "not long"
+
+if [[ "$LONG" == "true" ]]; then
+  $(which ramble) unit-test ${PYTEST_ADDOPTS} -x --verbose ${UNIT_TEST_COVERAGE_ADDOPTS}
 else
-    $coverage_run $(which ramble) unit-test -x --verbose
+  $(which ramble) unit-test ${PYTEST_ADDOPTS} -x --verbose ${UNIT_TEST_COVERAGE_ADDOPTS} -m "not long"
 fi
 if [ $? != 0 ]; then
     ERROR=1
 fi
+
 
 if [ $ERROR == 1 ]; then
     exit 1


### PR DESCRIPTION
This merge enables parallel unit tests in ramble.

The spack_runner tests were moved under the standard unit test directory, which allows them to use fixtures defined in the standard conftest.py file.

Additionally, a new fixture is defined in conftest.py to help fix thread issues with the logger utility.