### PR TITLE
Allow command runners to be given an alternative path

### DIFF
--- a/lib/ramble/ramble/util/command_runner.py
+++ b/lib/ramble/ramble/util/command_runner.py
@@ -20,7 +20,7 @@ class CommandRunner:
     Can be inherited to construct custom command runners.
     """
 
-    def __init__(self, name=None, command=None, shell="bash", dry_run=False):
+    def __init__(self, name=None, command=None, shell="bash", dry_run=False, path=None):
         """
         Ensure required command is found in the path
         """
@@ -29,7 +29,10 @@ class CommandRunner:
         self.shell = shell
         required = not self.dry_run
         try:
-            self.command = which(command, required=required)
+            if path is None:
+                self.command = which(command, required=required)
+            else:
+                self.command = which(command, required=required, path=path)
         except CommandNotFoundError:
             raise RunnerError(f"Command {name} is not found in path")
 


### PR DESCRIPTION
Allow a path argument when constructing command runners. When command runners are initialized with a path, the input path will be searched for the resulting command instead of just exploring the user's current path.