### PR TITLE
Fix workflow filters that map to no workloads

### DIFF
--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -2240,3 +2240,29 @@ def test_workspace_info_software(request):
     assert "spack-pkg" in output
     assert "pip-test" in output
     assert "spack-test" not in output
+
+
+def test_workspace_no_empty_workloads(request):
+    workspace_name = request.node.name
+    global_args = ["-w", workspace_name]
+
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+
+        workspace(
+            "manage",
+            "experiments",
+            "basic",
+            "--wf",
+            "nothing*",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "n_ranks=1",
+            global_args=global_args,
+        )
+
+        with open(ws.config_file_path) as f:
+            data = f.read()
+            assert "basic:" not in data
+            assert "workloads: {}" not in data

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1141,6 +1141,8 @@ ramble:
 
         import ruamel.yaml as yaml
 
+        edited = False
+
         workspace_vars = self.get_workspace_vars()
         apps_dict = self.get_applications().copy()
 
@@ -1219,6 +1221,7 @@ ramble:
             workload_names = [ramble.expander.Expander.expansion_str(workload_name_variable)]
 
         for workload_name in workload_names:
+            edited = True
             if workload_name not in workloads_dict:
                 workloads_dict[workload_name] = syaml.syaml_dict()
                 workloads_dict[workload_name][namespace.experiment] = syaml.syaml_dict()
@@ -1301,11 +1304,11 @@ ramble:
                 if namespace.matrix not in exp_dict:
                     exp_dict[namespace.matrix] = exp_matrix.copy()
 
-        if not self.dry_run:
+        if edited and not self.dry_run:
             ramble.config.config.update_config(
                 namespace.application, apps_dict, scope=self.ws_file_config_scope_name()
             )
-        else:
+        elif edited:
             workspace_dict = self._get_workspace_dict()
             workspace_dict[namespace.ramble][namespace.application] = apps_dict
 


### PR DESCRIPTION
This merge fixes an issue where the `ramble workspace manage experiments` command could be given a workload filter (`--wf "None!"`) that would match no workloads in the experiment. In this case, an empty dict was written to the ramble.yaml file for the application, while it probably makes more sense to write nothing (since no experiments will be added).

A test was also added to fix this issue.