### PR TITLE
Avoid locking workspace in pipelines

### DIFF
--- a/lib/ramble/ramble/cmd/on.py
+++ b/lib/ramble/ramble/cmd/on.py
@@ -72,7 +72,7 @@ def ramble_on(args):
         suppress_run_header=suppress_run_header,
     )
 
-    with ws.write_transaction():
+    with ws.read_transaction():
         pipeline.run()
 
 

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -483,7 +483,7 @@ def workspace_setup(args):
     logger.debug("Setting up workspace")
     pipeline = pipeline_cls(ws, filters)
 
-    with ws.write_transaction():
+    with ws.read_transaction():
         workspace_run_pipeline(args, pipeline)
 
 
@@ -554,7 +554,7 @@ def workspace_analyze(args):
         summary_only=args.summary_only,
     )
 
-    with ws.write_transaction():
+    with ws.read_transaction():
         workspace_run_pipeline(args, pipeline)
 
 

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -2020,6 +2020,10 @@ ramble:
             workspace_dict[namespace.ramble][namespace.application] = syaml.syaml_dict()
         return workspace_dict[namespace.ramble][namespace.application]
 
+    def read_transaction(self):
+        """Get a read lock context manager for use in a `with` block."""
+        return lk.ReadTransaction(self.txlock, acquire=self._re_read)
+
     def write_transaction(self):
         """Get a write lock context manager for use in a `with` block."""
         return lk.WriteTransaction(self.txlock, acquire=self._re_read)


### PR DESCRIPTION
This fixes an issue where you cannot activate a workspace while a pipeline (such as setup, or execute / on) is running.