### PR TITLE
Fix up string slicing evaluation

### DIFF
--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -910,9 +910,9 @@ class Expander:
         """Evaluate subscript operation in the ast"""
         try:
             operand = self.eval_math(node.value)
-            if not isinstance(operand, str):
-                raise SyntaxError("Currently only string slicing is supported for subscript")
             slice_node = node.slice
+            if not isinstance(operand, str) or not isinstance(slice_node, ast.Slice):
+                raise SyntaxError("Currently only string slicing is supported for subscript")
 
             def _get_with_default(s_node, attr, default):
                 v_node = getattr(s_node, attr)

--- a/lib/ramble/ramble/test/expander.py
+++ b/lib/ramble/ramble/test/expander.py
@@ -83,6 +83,8 @@ def exp_dict():
         ('"foo123" not in "{env_name}"', "True", set(), 1),
         ('"foo" not in "{env_name}"', "False", set(), 1),
         ('"{env_name}"[:{max_len}:1]', "spack_foo", set(), 1),
+        ("not_a_slice[0]", "not_a_slice[0]", set(), 1),
+        ("not_a_valid_slice[0:a]", "not_a_valid_slice[0:a]", set(), 1),
     ],
 )
 def test_expansions(input, output, no_expand_vars, passes):


### PR DESCRIPTION
Constrain the evaluation to string slicing only. This avoids evaluating strings like `my_fom[0]`.