### PR TITLE
Fix up a unit-test that may fail when run in parallel

### DIFF
--- a/lib/ramble/ramble/test/stage.py
+++ b/lib/ramble/ramble/test/stage.py
@@ -567,8 +567,12 @@ class TestStage:
 
     def test_ensure_one_stage_entry(self, mock_stage_archive):
         archive = mock_stage_archive()
+        # If this is the only/first test that runs against the `self.stage_name`, then
+        # a stage lock file will be present under the `stage_path` and cause the
+        # `_ensure_one_stage_entry` to fail. Set lock=False to prevent creating the lock,
+        # as the focus of this test is to verify the fetch behavior.
         with InputStage(
-            archive.url, name=self.stage_name, path=archive.stage_path, keep=False
+            archive.url, name=self.stage_name, path=archive.stage_path, keep=False, lock=False
         ) as stage:
             stage.fetch()
             stage_path = stage.path


### PR DESCRIPTION
Avoid creating lock file that causes assertion failure.