### PR TITLE
Allow description for `required_variable` directive

### DIFF
--- a/lib/ramble/ramble/language/modifier_language.py
+++ b/lib/ramble/ramble/language/modifier_language.py
@@ -256,7 +256,7 @@ def env_var_modification(name, modification=None, method="set", mode=None, modes
 
 
 @modifier_directive("required_vars")
-def required_variable(var: str, results_level="variable", modes=None):
+def required_variable(var: str, results_level="variable", modes=None, description=None):
     """Mark a variable as being required by this modifier
 
     Args:
@@ -265,6 +265,7 @@ def required_variable(var: str, results_level="variable", modes=None):
                              a key within JSON or YAML formatted results.
         modes (list[str] | None): modes that the required check should be applied. The
                             default None means apply to all modes.
+        description (str | None): Description of the required variable.
     """
 
     def _mark_required_var(mod):
@@ -273,6 +274,7 @@ def required_variable(var: str, results_level="variable", modes=None):
             "level": ramble.keywords.output_level.variable,
             # Extra prop that's only used for filtering
             "modes": set(modes) if modes is not None else None,
+            "description": description,
         }
 
     return _mark_required_var

--- a/var/ramble/repos/builtin/modifiers/apptainer/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/apptainer/modifier.py
@@ -35,13 +35,17 @@ class Apptainer(BasicModifier):
     mode("standard", description="Standard execution mode for apptainer")
     default_mode("standard")
 
-    # The container_name variable controls the name of the resulting container file.
-    # It will be of the format {container_name}.{container_extension}
-    required_variable("container_name")
+    required_variable(
+        "container_name",
+        description="The variable controls the name of the resulting container file. "
+        "It will be of the format {container_name}.{container_extension}.",
+    )
 
-    # The container_uri variable controls the URI the container is pulled from.
-    # This should be of the format that would be input into `apptainer pull <uri>`.
-    required_variable("container_uri")
+    required_variable(
+        "container_uri",
+        description="The variable controls the URI the container is pulled from. "
+        "This should be of the format that would be input into `apptainer pull <uri>`.",
+    )
 
     modifier_variable(
         "container_mounts",

--- a/var/ramble/repos/builtin/modifiers/conditional-psm3/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/conditional-psm3/modifier.py
@@ -38,7 +38,11 @@ class ConditionalPsm3(BasicModifier):
 
     executable_modifier("apply_psm3")
 
-    required_variable("psm3_mpi")
+    required_variable(
+        "psm3_mpi",
+        description="The name of the package used for MPI "
+        "within an experiment's software environment",
+    )
 
     modifier_variable(
         "apply_psm3_exec_regex",


### PR DESCRIPTION
Update several required vars with descriptions.
Verified that `ramble info -v` prints out the description.