### PR TITLE
Add symlink paths to analyze and reports output

### DIFF
--- a/lib/ramble/ramble/fetch_strategy.py
+++ b/lib/ramble/ramble/fetch_strategy.py
@@ -385,7 +385,7 @@ class URLFetchStrategy(FetchStrategy):
             save_file = self.stage.save_filename
         logger.msg(f"Fetching {url}")
 
-        # Check if we're about to try and open a broken simlink, and if so
+        # Check if we're about to try and open a broken symlink, and if so
         # remove that file to avoid a bad situation where a file "exists" but
         # cannot be opened (warning: this is not atomic)
         if os.path.islink(save_file) and not os.path.exists(save_file):

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -35,7 +35,7 @@ import ramble.util.path
 
 from ramble.namespace import namespace
 from ramble.util.logger import logger
-from ramble.util.file_util import create_simlink
+from ramble.util.file_util import create_symlink
 
 import spack.util.spack_json as sjson
 from spack.util.executable import which, Executable
@@ -139,8 +139,8 @@ class Pipeline:
 
         if logger.enabled:
             fs.mkdirp(self.log_dir)
-            # Also create simlink to give known paths
-            create_simlink(self.log_dir, self.log_dir_latest)
+            # Also create symlink to give known paths
+            create_symlink(self.log_dir, self.log_dir_latest)
 
         if self.suppress_per_experiment_prints and not self.suppress_run_header:
             logger.all_msg(f"  Log files for experiments are stored in: {self.log_dir}")
@@ -223,7 +223,7 @@ class Pipeline:
 
         logger.add_log(self.log_path)
         if logger.enabled:
-            create_simlink(self.log_path, self.log_path_latest)
+            create_symlink(self.log_path, self.log_path_latest)
 
         self._prepare()
         self._execute()
@@ -402,7 +402,7 @@ class ArchivePipeline(Pipeline):
                     shutil.copyfile(src, dest)
 
         archive_path_latest = os.path.join(self.workspace.archive_dir, "archive.latest")
-        create_simlink(archive_path, archive_path_latest)
+        create_symlink(archive_path, archive_path_latest)
 
     def _complete(self):
         if self.create_tar:
@@ -421,7 +421,7 @@ class ArchivePipeline(Pipeline):
                 self.workspace.archive_dir, "archive.latest" + tar_extension
             )
 
-            create_simlink(tar_path, tar_path_latest)
+            create_symlink(tar_path, tar_path_latest)
 
             logger.debug(f"Archive url: {archive_url}")
 

--- a/lib/ramble/ramble/reports.py
+++ b/lib/ramble/ramble/reports.py
@@ -23,7 +23,7 @@ import ramble.pipeline
 import ramble.util.path
 from ramble.util.foms import BetterDirection, FomType
 from ramble.util.logger import logger
-from ramble.util.file_util import create_simlink
+from ramble.util.file_util import create_symlink
 
 try:
     import matplotlib.pyplot as plt
@@ -894,18 +894,24 @@ def make_report(results_df, ws_name, args):
         plot.generate_plot_data(pdf_report)
 
     if os.path.isfile(pdf_path):
+        symlinks_created = []
 
         for base in report_base, "reports":
-            # Simlink specific workspace latest file
+            # Symlink specific workspace latest file
             latest_file = f"{base}.latest.pdf"
             latest_path = os.path.join(report_dir_root, latest_file)
-            create_simlink(pdf_path, latest_path)
+            symlinks_created.append(latest_path)
+            create_symlink(pdf_path, latest_path)
 
             latest_file = f"{base}.{plot_type}.latest.pdf"
             latest_path = os.path.join(report_dir_root, latest_file)
-            create_simlink(pdf_path, latest_path)
+            symlinks_created.append(latest_path)
+            create_symlink(pdf_path, latest_path)
 
-        logger.msg(
-            "Report generated successfully. A PDF summary is available at:\n" f"    {pdf_path}"
-        )
-        logger.msg("Individual chart images are available at:\n" f"    {report_dir_path}")
+        logger.all_msg("Report generated successfully. A PDF summary is available at:")
+        logger.all_msg(f"  {pdf_path}")
+        logger.all_msg("Individual chart images are available at:")
+        logger.all_msg(f"  {report_dir_path}")
+        logger.all_msg("Symlinks updated:")
+        for path in symlinks_created:
+            logger.all_msg(f"  {path}")

--- a/lib/ramble/ramble/test/end_to_end/experiment_excludes.py
+++ b/lib/ramble/ramble/test/end_to_end/experiment_excludes.py
@@ -283,11 +283,11 @@ compilers:
                 f.close()
 
         workspace("analyze", "-f", "text", "json", "yaml", global_args=["-w", workspace_name])
-        text_simlink_results_files = glob.glob(os.path.join(ws1.root, "results.latest.txt"))
+        text_symlink_results_files = glob.glob(os.path.join(ws1.root, "results.latest.txt"))
         text_results_files = glob.glob(os.path.join(ws1.root, "results*.txt"))
         json_results_files = glob.glob(os.path.join(ws1.root, "results*.json"))
         yaml_results_files = glob.glob(os.path.join(ws1.root, "results*.yaml"))
-        assert len(text_simlink_results_files) == 1
+        assert len(text_symlink_results_files) == 1
         assert len(text_results_files) == 2
         assert len(json_results_files) == 2
         assert len(yaml_results_files) == 2

--- a/lib/ramble/ramble/test/end_to_end/experiment_repeats.py
+++ b/lib/ramble/ramble/test/end_to_end/experiment_repeats.py
@@ -164,7 +164,7 @@ ramble:
         json_results_files = glob.glob(os.path.join(ws1.root, "results*.json"))
         yaml_results_files = glob.glob(os.path.join(ws1.root, "results*.yaml"))
 
-        # Match both the file and the simlink
+        # Match both the file and the symlink
         assert len(text_results_files) == 2
         assert len(json_results_files) == 2
         assert len(yaml_results_files) == 2

--- a/lib/ramble/ramble/test/end_to_end/explicit_zips.py
+++ b/lib/ramble/ramble/test/end_to_end/explicit_zips.py
@@ -252,11 +252,11 @@ licenses:
                 f.close()
 
         workspace("analyze", "-f", "text", "json", "yaml", global_args=["-w", workspace_name])
-        text_simlink_results_files = glob.glob(os.path.join(ws1.root, "results.latest.txt"))
+        text_symlink_results_files = glob.glob(os.path.join(ws1.root, "results.latest.txt"))
         text_results_files = glob.glob(os.path.join(ws1.root, "results*.txt"))
         json_results_files = glob.glob(os.path.join(ws1.root, "results*.json"))
         yaml_results_files = glob.glob(os.path.join(ws1.root, "results*.yaml"))
-        assert len(text_simlink_results_files) == 1
+        assert len(text_symlink_results_files) == 1
         assert len(text_results_files) == 2
         assert len(json_results_files) == 2
         assert len(yaml_results_files) == 2

--- a/lib/ramble/ramble/test/end_to_end/wrfv4_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/wrfv4_dry_run.py
@@ -267,12 +267,12 @@ compilers:
                 f.close()
 
         tmp_results_file = os.path.join(ws1.root, "temp.results.txt")
-        simlink_results_file = os.path.join(ws1.root, "results.latest.txt")
+        symlink_results_file = os.path.join(ws1.root, "results.latest.txt")
         # Temporarily store some temp data in the "latest" result and check it
         # gets updated
         with open(tmp_results_file, "w+") as f:
             f.write("Dummy data...")
-        os.symlink(tmp_results_file, simlink_results_file)
+        os.symlink(tmp_results_file, symlink_results_file)
 
         workspace("analyze", "-f", "text", "json", "yaml", global_args=["-w", workspace_name])
 
@@ -280,7 +280,7 @@ compilers:
         json_results_files = glob.glob(os.path.join(ws1.root, "results*.json"))
         yaml_results_files = glob.glob(os.path.join(ws1.root, "results*.yaml"))
 
-        # Match both the file and the simlink
+        # Match both the file and the symlink
         assert len(text_results_files) == 2
         assert len(json_results_files) == 2
         assert len(yaml_results_files) == 2
@@ -493,12 +493,12 @@ licenses:
                 f.close()
 
         tmp_results_file = os.path.join(ws1.root, "temp.results.txt")
-        simlink_results_file = os.path.join(ws1.root, "results.latest.txt")
+        symlink_results_file = os.path.join(ws1.root, "results.latest.txt")
         # Temporarily store some temp data in the "latest" result and check it
         # gets updated
         with open(tmp_results_file, "w+") as f:
             f.write("Dummy data...")
-        os.symlink(tmp_results_file, simlink_results_file)
+        os.symlink(tmp_results_file, symlink_results_file)
 
         workspace("analyze", "-f", "text", "json", "yaml", global_args=["-w", workspace_name])
 
@@ -506,7 +506,7 @@ licenses:
         json_results_files = glob.glob(os.path.join(ws1.root, "results*.json"))
         yaml_results_files = glob.glob(os.path.join(ws1.root, "results*.yaml"))
 
-        # Match both the file and the simlink
+        # Match both the file and the symlink
         assert len(text_results_files) == 2
         assert len(json_results_files) == 2
         assert len(yaml_results_files) == 2

--- a/lib/ramble/ramble/util/file_util.py
+++ b/lib/ramble/ramble/util/file_util.py
@@ -32,9 +32,9 @@ def is_dry_run_path(path: str) -> bool:
     return str(path).startswith(_DRY_RUN_PATH_PREFIX)
 
 
-def create_simlink(base, link):
+def create_symlink(base, link):
     """
-    Create simlink of a file to give a known and predictable path
+    Create symlink of a file to give a known and predictable path
     """
     if os.path.islink(link):
         os.unlink(link)


### PR DESCRIPTION
Adds symlink paths to output for analyze:
```
==> Results are written to:
==>   /usr/local/foo/ramble/var/ramble/workspaces/workspace/results.2024-11-21_17.53.26.txt
==>   /usr/local/foo/ramble/var/ramble/workspaces/workspace/results.2024-11-21_17.53.26.json
==>   /usr/local/foo/ramble/var/ramble/workspaces/workspace/results.2024-11-21_17.53.26.yaml
==> Symlinks updated:
==>   /usr/local/foo/ramble/var/ramble/workspaces/workspace/results.latest.txt
==>   /usr/local/foo/ramble/var/ramble/workspaces/workspace/results.latest.json
==>   /usr/local/foo/ramble/var/ramble/workspaces/workspace/results.latest.yaml
```

Adds symlink paths to output for reports:
```
==> Report generated successfully. A PDF summary is available at:
==>   /usr/local/foo/.ramble/reports/workspace.2024-11-21_17.59.28/workspace.2024-11-21_17.59.28.multi_line.pdf
==> Individual chart images are available at:
==>   /usr/local/foo/.ramble/reports/workspace.2024-11-21_17.59.28
==> Symlinks updated:
==>   /usr/local/foo/.ramble/reports/workspace.latest.pdf
==>   /usr/local/foo/.ramble/reports/workspace.multi_line.latest.pdf
==>   /usr/local/foo/.ramble/reports/reports.latest.pdf
==>   /usr/local/foo/.ramble/reports/reports.multi_line.latest.pdf
```