### PR TITLE
Add `dependents` support for `register_builtin`

### DIFF
--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -273,7 +273,9 @@ def success_criteria(
 
 
 @shared_directive("builtins")
-def register_builtin(name, required=True, injection_method="prepend", depends_on=[]):
+def register_builtin(
+    name, required=True, injection_method="prepend", depends_on=[], dependents=[]
+):
     """Register a builtin
 
     Builtins are methods that return lists of strings. These methods represent
@@ -308,7 +310,7 @@ def register_builtin(name, required=True, injection_method="prepend", depends_on
     The 'required' attribute marks a builtin as required for all workloads. This
     will ensure the builtin is added to the workload if it is not explicitly
     added. If required builtins are not explicitly added to a workload, they
-    are injected  into the list of executables, based on the injection_method
+    are injected into the list of executables, based on the injection_method
     attribute.
 
     The 'injection_method' attribute controls where the builtin will be
@@ -324,6 +326,8 @@ def register_builtin(name, required=True, injection_method="prepend", depends_on
                                 'prepend' or 'append'
         depends_on (list(str)): The names of builtins this builtin depends on
                                 (and must execute after).
+        dependents (list(str)): The names of builtins that should come
+                                after the current one.
     """
     supported_injection_methods = ["prepend", "append"]
 
@@ -342,6 +346,7 @@ def register_builtin(name, required=True, injection_method="prepend", depends_on
             "required": required,
             "injection_method": injection_method,
             "depends_on": depends_on.copy(),
+            "dependents": dependents.copy(),
         }
 
     return _store_builtin

--- a/lib/ramble/ramble/test/application_tests.py
+++ b/lib/ramble/ramble/test/application_tests.py
@@ -189,6 +189,15 @@ def test_register_builtin_app(mutable_mock_apps_repo):
         for builtin in excluded_builtins:
             assert exec_graph.get_node(builtin) is None
 
+        # Test for dependency injection
+        found_prerequisite = False
+        for node in exec_graph.walk():
+            if node.key == "builtin::test_builtin":
+                break
+            if node.key == "builtin::test_builtin_pre":
+                found_prerequisite = True
+        assert found_prerequisite
+
 
 @pytest.mark.parametrize(
     "app", ["basic", "basic-inherited", "input-test", "interleved-env-vars", "register-builtin"]

--- a/var/ramble/repos/builtin.mock/applications/register-builtin/application.py
+++ b/var/ramble/repos/builtin.mock/applications/register-builtin/application.py
@@ -43,6 +43,10 @@ class RegisterBuiltin(ExecutableApplication):
     # Test disabling the typically included env_vars builtin.
     register_builtin("env_vars", required=False)
     register_builtin("test_builtin", required=True)
+    register_builtin("test_builtin_pre", dependents=["test_builtin"])
 
     def test_builtin(self):
         return ['echo "foo"']
+
+    def test_builtin_pre(self):
+        return ['echo "bar"']


### PR DESCRIPTION
The dependency can conflict with positional dependencies tied to `injection_methods`. This change will ignore `injection_methods` when `dependents` is present.