### PR TITLE
Update several object definitions to use better paths

### DIFF
--- a/var/ramble/repos/builtin/applications/py-nemo/application.py
+++ b/var/ramble/repos/builtin/applications/py-nemo/application.py
@@ -16,6 +16,8 @@ import spack.util.spack_yaml as syaml
 
 import ramble.util.yaml_generation
 
+from spack.util.path import canonicalize_path
+
 
 class PyNemo(ExecutableApplication):
     """A scalable generative AI framework built for researchers and
@@ -473,12 +475,8 @@ class PyNemo(ExecutableApplication):
         not defined in the input ramble.yaml or workload definition."""
 
         base_config = get_file_path(
-            os.path.abspath(
-                os.path.expandvars(
-                    os.path.expanduser(
-                        self.expander.expand_var_name("nemo_base_config")
-                    )
-                )
+            canonicalize_path(
+                self.expander.expand_var_name("nemo_base_config")
             ),
             workspace,
         )
@@ -519,12 +517,8 @@ class PyNemo(ExecutableApplication):
 
     def _write_config(self, workspace, app_inst):
         base_config = get_file_path(
-            os.path.abspath(
-                os.path.expandvars(
-                    os.path.expanduser(
-                        self.expander.expand_var_name("nemo_base_config")
-                    )
-                )
+            canonicalize_path(
+                self.expander.expand_var_name("nemo_base_config")
             ),
             workspace,
         )
@@ -574,9 +568,11 @@ class PyNemo(ExecutableApplication):
                     config_data, var_name
                 )
 
-        config_path = os.path.join(
-            self.expander.expand_var("{nemo_generated_config_path}"),
-            self.expander.expand_var("{nemo_generated_config_name}"),
+        config_path = canonicalize_path(
+            os.path.join(
+                self.expander.expand_var("{nemo_generated_config_path}"),
+                self.expander.expand_var("{nemo_generated_config_name}"),
+            )
         )
 
         # Ensure all instances of ${data_dir} are replaced correctly
@@ -602,7 +598,7 @@ class PyNemo(ExecutableApplication):
 
     def _preprocess_log(self, workspace, app_inst):
         log_file = get_file_path(
-            os.path.abspath(self.expander.expand_var_name("log_file")),
+            canonicalize_path(self.expander.expand_var_name("log_file")),
             workspace,
         )
 

--- a/var/ramble/repos/builtin/modifiers/apptainer/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/apptainer/modifier.py
@@ -11,6 +11,7 @@ import os
 
 from ramble.modkit import *
 from ramble.util.hashing import hash_string
+from spack.util.path import canonicalize_path
 
 import llnl.util.filesystem as fs
 
@@ -231,8 +232,12 @@ class Apptainer(BasicModifier):
 
         uri = self.expander.expand_var_name("container_uri")
 
-        container_dir = self.expander.expand_var_name("container_dir")
-        container_path = self.expander.expand_var_name("container_path")
+        container_dir = canonicalize_path(
+            self.expander.expand_var_name("container_dir")
+        )
+        container_path = canonicalize_path(
+            self.expander.expand_var_name("container_path")
+        )
 
         pull_args = ["pull", container_path, uri]
 
@@ -261,7 +266,9 @@ class Apptainer(BasicModifier):
         id_regex = re.compile(r"\s*ID:\s*(?P<id>\S+)")
         container_name = self.expander.expand_var_name("container_name")
         container_uri = self.expander.expand_var_name("container_uri")
-        container_path = self.expander.expand_var_name("container_path")
+        container_path = canonicalize_path(
+            self.expander.expand_var_name("container_path")
+        )
         header_args = ["sif", "header", container_path]
 
         inventory = []

--- a/var/ramble/repos/builtin/modifiers/pyxis-enroot/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/pyxis-enroot/modifier.py
@@ -10,6 +10,7 @@ import os
 
 from ramble.modkit import *
 from ramble.util.hashing import hash_file, hash_string
+from spack.util.path import canonicalize_path
 
 import llnl.util.filesystem as fs
 
@@ -218,8 +219,12 @@ class PyxisEnroot(BasicModifier):
 
         uri = self.expander.expand_var_name("container_uri")
 
-        container_dir = self.expander.expand_var_name("container_dir")
-        container_path = self.expander.expand_var_name("container_path")
+        container_dir = canonicalize_path(
+            self.expander.expand_var_name("container_dir")
+        )
+        container_path = canonicalize_path(
+            self.expander.expand_var_name("container_path")
+        )
 
         import_args = ["import", "-o", container_path, "--", uri]
 
@@ -264,7 +269,9 @@ class PyxisEnroot(BasicModifier):
             ]
 
             for extract_path in extract_paths:
-                expanded_path = self.expander.expand_var(extract_path)
+                expanded_path = canonicalize_path(
+                    self.expander.expand_var(extract_path)
+                )
                 self.unsquashfs_runner.execute(
                     self.unsquashfs_runner.command,
                     unsquash_args + [expanded_path],
@@ -281,7 +288,9 @@ class PyxisEnroot(BasicModifier):
             (dict): Artifact inventory for container attributes
         """
         container_name = self.expander.expand_var_name("container_name")
-        container_path = self.expander.expand_var_name("container_path")
+        container_path = canonicalize_path(
+            self.expander.expand_var_name("container_path")
+        )
         container_uri = self.expander.expand_var_name("container_uri")
         inventory = []
 
@@ -298,9 +307,7 @@ class PyxisEnroot(BasicModifier):
         if os.path.isfile(container_path):
 
             hash_file_path = (
-                self.expander.expand_var_name("container_path")
-                + "."
-                + self.container_hash_file_extension
+                container_path + "." + self.container_hash_file_extension
             )
 
             if os.path.exists(hash_file_path):


### PR DESCRIPTION
This merge updates several object definitions to use the spack utility `canonicalize_path` on paths that are referred to internally. This allows referencing things like `${HOME}`.