### PR TITLE
Allow customization of the link type in spack environments

### DIFF
--- a/etc/ramble/defaults/config.yaml
+++ b/etc/ramble/defaults/config.yaml
@@ -33,3 +33,5 @@ config:
       flags: ''
     env_create:
       flags: ''
+    env_view:
+      link_type: symlink

--- a/lib/ramble/docs/configuration_files.rst
+++ b/lib/ramble/docs/configuration_files.rst
@@ -176,11 +176,34 @@ The current default configuration is as follows:
           flags: ''
         global
           flags: ''
+        env_view:
+          link_type: 'symlink'
       input_cache: '$ramble/var/ramble/cache'
       workspace_dirs: '$ramble/var/ramble/workspaces'
       upload:
         type: 'BigQuery'
         uri: ''
+
+
+.. _spack-config-option:
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Spack
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``spack`` config options within the config configuration section can be used to
+customize Spack's behavior. The ``install``, ``concretize``, ``buildcache``,
+and ``env_create`` sections can be used to customize the flags passed to these
+Spack commands (with ``env_create`` being equivalent to ``spack env create``).
+
+The ``global`` section is used to define flags that should be passed to
+``spack`` directly, as in:
+``spack {flags} {subcommand}...``
+
+The ``env_view`` section is used to customize the `spack environment views
+<https://spack.readthedocs.io/en/latest/environments.html#environment-views>`_
+that Ramble creates. Currently, the only accepted option within this section is
+``link_type`` which can take any value supported via Spack.
 
 .. _upload-config-option:
 

--- a/lib/ramble/ramble/schema/config.py
+++ b/lib/ramble/ramble/schema/config.py
@@ -103,6 +103,19 @@ properties["config"]["spack"] = {
             },
             "additionalProperties": False,
         },
+        "env_view": {
+            "type": "object",
+            "default": {
+                "link_type": "symlink",
+            },
+            "properties": {
+                "link_type": {
+                    "type": "string",
+                    "default": "symlink",
+                },
+            },
+            "additionalProperties": False,
+        },
     },
     "additionalProperties": False,
 }

--- a/lib/ramble/ramble/test/data/config/config.yaml
+++ b/lib/ramble/ramble/test/data/config/config.yaml
@@ -5,5 +5,7 @@ config:
         flags: --reuse
       concretize:
         flags: --reuse
+      env_view:
+        link_type: symlink
     include:
       - test_include: include.yaml

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
@@ -1001,6 +1001,14 @@ class SpackRunner(CommandRunner):
         env_file[spack_namespace]["concretizer"] = syaml.syaml_dict()
         env_file[spack_namespace]["concretizer"]["unify"] = True
 
+        link_type = ramble.config.get("config:spack:env_view:link_type")
+        env_file[spack_namespace]["view"] = syaml.syaml_dict()
+        env_file[spack_namespace]["view"]["default"] = syaml.syaml_dict()
+        env_file[spack_namespace]["view"]["default"]["root"] = os.path.join(
+            self.env_path, "ramble"
+        )
+        env_file[spack_namespace]["view"]["default"]["link_type"] = link_type
+
         env_file[spack_namespace]["specs"] = syaml.syaml_list()
         # Ensure the specs content are consistently sorted.
         # Otherwise the hash checking may artificially miss due to ordering.


### PR DESCRIPTION
This merge allows Ramble to customize the link type used when creating a view in the generated spack environments.

This can be accomplished by setting the
`config:spack:env_view:link_type` config option.