### PR TITLE
Allow typed dictionaries, and dictionary subscripts from expander

### DIFF
--- a/lib/ramble/docs/workspace_config.rst
+++ b/lib/ramble/docs/workspace_config.rst
@@ -176,9 +176,13 @@ Supported functions are:
 * ``randint`` (from `random.randint`)
 * ``re_search(regex, str)`` (determine if ``str`` contains pattern ``regex``, based on ``re.search``)
 
-Additionally, string slicing is supported:
+String slicing is supported:
 
 * ``str[start:end:step]`` (string slicing)
+
+Dictionary references are supported:
+
+* ``dict_name["key"]`` (dictionary subscript)
 
 .. _ramble-escaped-variables:
 

--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -693,36 +693,40 @@ class Expander:
         Some operators will generate floating point, while
         others will generate integers (if the inputs are integers).
         """
-        if isinstance(node, ast.Num):
-            return self._ast_num(node)
-        elif isinstance(node, ast.Constant):
-            return self._ast_constant(node)
-        elif isinstance(node, ast.Name):
-            return self._ast_name(node)
-        # TODO: Remove when we drop support for 3.6
-        # DEPRECATED: Remove due to python 3.8
-        # See: https://docs.python.org/3/library/ast.html#node-classes
-        elif isinstance(node, ast.Str):
-            return node.s
-        elif isinstance(node, ast.Attribute):
-            return self._ast_attr(node)
-        elif isinstance(node, ast.Compare):
-            return self._eval_comparisons(node)
-        elif isinstance(node, ast.BoolOp):
-            return self._eval_bool_op(node)
-        elif isinstance(node, ast.BinOp):
-            return self._eval_binary_ops(node)
-        elif isinstance(node, ast.UnaryOp):
-            return self._eval_unary_ops(node)
-        elif isinstance(node, ast.Call):
-            return self._eval_function_call(node)
-        elif isinstance(node, ast.Subscript):
-            return self._eval_subscript_op(node)
-        else:
-            node_type = str(type(node))
-            raise MathEvaluationError(
-                f"Unsupported math AST node {node_type}:\n" + f"\t{node.__dict__}"
-            )
+        try:
+            if isinstance(node, ast.Num):
+                return self._ast_num(node)
+            elif isinstance(node, ast.Constant):
+                return self._ast_constant(node)
+            elif isinstance(node, ast.Name):
+                return self._ast_name(node)
+            # TODO: Remove when we drop support for 3.6
+            # DEPRECATED: Remove due to python 3.8
+            # See: https://docs.python.org/3/library/ast.html#node-classes
+            elif isinstance(node, ast.Str):
+                return node.s
+            elif isinstance(node, ast.Attribute):
+                return self._ast_attr(node)
+            elif isinstance(node, ast.Compare):
+                return self._eval_comparisons(node)
+            elif isinstance(node, ast.BoolOp):
+                return self._eval_bool_op(node)
+            elif isinstance(node, ast.BinOp):
+                return self._eval_binary_ops(node)
+            elif isinstance(node, ast.UnaryOp):
+                return self._eval_unary_ops(node)
+            elif isinstance(node, ast.Call):
+                return self._eval_function_call(node)
+            elif isinstance(node, ast.Subscript):
+                return self._eval_subscript_op(node)
+            else:
+                node_type = str(type(node))
+                raise MathEvaluationError(
+                    f"Unsupported math AST node {node_type}:\n" + f"\t{node.__dict__}"
+                )
+        except SyntaxError as e:
+            logger.debug(str(e))
+            raise e
 
     # Ast logic helper methods
     def __raise_syntax_error(self, node):
@@ -937,14 +941,17 @@ class Expander:
                         key = self.eval_math(slice_node)
 
                     if key is None:
-                        raise SyntaxError(
-                            "During dictionary extraction, key is None. Skipping extraction."
+                        msg = (
+                            "During dictionary extraction, key is None. " + "Skipping extraction."
                         )
+                        raise SyntaxError(msg)
 
                     if key not in op_dict:
-                        raise SyntaxError(
-                            f"Key {key} is not in dictionary {operand}. Cannot extract value."
+                        msg = (
+                            f"Key {key} is not in dictionary {operand}. " + "Cannot extract value."
                         )
+                        raise SyntaxError(msg)
+
                     return op_dict[key]
             raise SyntaxError(
                 "Currently subscripts are only support "

--- a/lib/ramble/ramble/renderer.py
+++ b/lib/ramble/ramble/renderer.py
@@ -158,6 +158,14 @@ class Renderer:
         object_variables = {}
         expander = ramble.expander.Expander(variables, None)
 
+        # Convert all dict types to base dicts
+        # This allows the expander to properly return typed dicts.
+        # Without this, all dicts are ruamel.CommentedMaps, and these
+        # cannot be evaled using ast.literal_eval
+        for var, val in variables.items():
+            if isinstance(val, dict):
+                variables[var] = dict(val)
+
         # Expand all variables that generate lists
         for name, unexpanded in variables.items():
             value = expander.expand_lists(unexpanded)

--- a/lib/ramble/ramble/test/expander.py
+++ b/lib/ramble/ramble/test/expander.py
@@ -32,6 +32,7 @@ def exp_dict():
         "size": '"0000.96"',  # Escaped as a string
         "test_mask": '"0x0"',
         "max_len": 9,
+        "test_dict": {"test_key1": "test_val1", "test_key2": "test_val2"},
     }
 
 
@@ -85,6 +86,11 @@ def exp_dict():
         ('"{env_name}"[:{max_len}:1]', "spack_foo", set(), 1),
         ("not_a_slice[0]", "not_a_slice[0]", set(), 1),
         ("not_a_valid_slice[0:a]", "not_a_valid_slice[0:a]", set(), 1),
+        ("{test_dict}", "{'test_key1': 'test_val1', 'test_key2': 'test_val2'}", set(), 1),
+        ("{test_dict['test_key1']}", "test_val1", set(), 1),
+        ("{test_dict['test_key2']}", "test_val2", set(), 1),
+        ("{test_dict['missing_key']}", "{test_dict['missing_key']}", set(), 1),
+        ("{test_dict[None]}", "{test_dict[None]}", set(), 1),
     ],
 )
 def test_expansions(input, output, no_expand_vars, passes):


### PR DESCRIPTION
This merge enables the expander to handle dictionaries better.

The most obvious change from this is that given:
```
variables:
  test_dict:
    key1: val1
    key2: val2
```
then `'{test_dict["key1"]}'` should expand to `"val1"`.

A more subtle change from this is that given the variable definition above, inside object definitions one can now do:
```
test_dict = app_inst.expander.expand_var_name("test_dict", typed=True)

for key, val in test_dict.items():
  print(f"Key {key} = {val}")
```

Tests and documentation have also been added for this.