### PR TITLE
Add a `register_template` directive to objects

### DIFF
--- a/lib/ramble/ramble/cmd/common/info.py
+++ b/lib/ramble/ramble/cmd/common/info.py
@@ -36,6 +36,7 @@ obj_attribute_map = {
     "archive_patterns": None,
     "success_criteria": None,
     "target_shells": "shell_support_pattern",
+    "templates": None,
     # Application specific:
     "workloads": None,
     "workload_groups": None,

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -476,3 +476,38 @@ def target_shells(shell_support_pattern=None):
             obj.shell_support_pattern = shell_support_pattern
 
     return _execute_target_shells
+
+
+@shared_directive("templates")
+def register_template(
+    name: str, src_name: str, dest_name: str, define_var: bool = True, output_perm=None
+):
+    """Directive to define an object-specific template to be rendered into experiment run_dir.
+
+    For instance, `register_template(name="foo", src_name="foo.tpl", dest_name="foo.sh")`
+    expects a "foo.tpl" template defined alongside the object source, and uses that to
+    render a file under "{experiment_run_dir}/foo.sh". The rendered path can also be
+    referenced with the `foo` variable name.
+
+    Args:
+        name: The name of the template. It is also used as the variable name
+              that an experiment can use to reference the rendered path, if
+              `define_var` is true.
+        src_name: The leaf name of the template. This is used to locate the
+                  the template under the containing directory of the object.
+        dest_name: The leaf name of the rendered output under the experiment
+                   run directory.
+        define_var: Controls if a variable named `name` should be defined.
+        output_perm: The chmod mask for the rendered output file.
+    """
+
+    def _define_template(obj):
+        var_name = name if define_var else None
+        obj.templates[name] = {
+            "src_name": src_name,
+            "dest_name": dest_name,
+            "var_name": var_name,
+            "output_perm": output_perm,
+        }
+
+    return _define_template

--- a/lib/ramble/ramble/test/end_to_end/test_template.py
+++ b/lib/ramble/ramble/test/end_to_end/test_template.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2024 The Ramble Authors
+# Copyright 2022-2025 The Ramble Authors
 #
 # Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 # https://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/lib/ramble/ramble/test/end_to_end/test_template.py
+++ b/lib/ramble/ramble/test/end_to_end/test_template.py
@@ -1,0 +1,57 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+import pytest
+
+import ramble.workspace
+from ramble.main import RambleCommand
+
+pytestmark = pytest.mark.usefixtures(
+    "mutable_config", "mutable_mock_workspace_path", "mutable_mock_apps_repo"
+)
+
+workspace = RambleCommand("workspace")
+
+
+def test_template():
+    test_config = """
+ramble:
+  variables:
+    mpi_command: mpirun -n {n_ranks}
+    batch_submit: 'batch_submit {execute_experiment}'
+    processes_per_node: 1
+  applications:
+    template:
+      workloads:
+        test_template:
+          experiments:
+            test:
+              variables:
+                n_nodes: 1
+                hello_name: santa
+"""
+    workspace_name = "test_template"
+    ws = ramble.workspace.create(workspace_name)
+    ws.write()
+    config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+    with open(config_path, "w+") as f:
+        f.write(test_config)
+    ws._re_read()
+
+    workspace("setup", "--dry-run", global_args=["-w", workspace_name])
+    run_dir = os.path.join(ws.experiment_dir, "template/test_template/test/")
+    script_path = os.path.join(run_dir, "bar.sh")
+    assert os.path.isfile(script_path)
+    with open(script_path) as f:
+        content = f.read()
+        assert "echo hello santa" in content
+    execute_path = os.path.join(run_dir, "execute_experiment")
+    with open(execute_path) as f:
+        content = f.read()
+        assert script_path in content

--- a/var/ramble/repos/builtin.mock/applications/template/application.py
+++ b/var/ramble/repos/builtin.mock/applications/template/application.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2024 The Ramble Authors
+# Copyright 2022-2025 The Ramble Authors
 #
 # Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 # https://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/var/ramble/repos/builtin.mock/applications/template/application.py
+++ b/var/ramble/repos/builtin.mock/applications/template/application.py
@@ -1,0 +1,39 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.appkit import *
+
+
+class Template(ExecutableApplication):
+    """An app for testing object templates."""
+
+    name = "template"
+
+    executable("foo", template=["bash {bar}"])
+
+    workload("test_template", executable="foo")
+
+    workload_variable(
+        "hello_name",
+        default="world",
+        description="hello name",
+        workload="test_template",
+    )
+
+    register_phase(
+        "ingest_dynamic_variables",
+        pipeline="setup",
+        run_before=["make_experiments"],
+    )
+
+    def _ingest_dynamic_variables(self, workspace, app_inst):
+        expander = self.expander
+        val = expander.expand_var('"hello {hello_name}"')
+        self.define_variable("dynamic_hello_world", val)
+
+    register_template("bar", src_name="bar.tpl", dest_name="bar.sh")

--- a/var/ramble/repos/builtin.mock/applications/template/bar.tpl
+++ b/var/ramble/repos/builtin.mock/applications/template/bar.tpl
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo {dynamic_hello_world}


### PR DESCRIPTION
This directive allows for specifying per-experiment template rendering, with the template defined as separate files alongside the main object source.

The testing app `template` is defined as an example.