### PR TITLE
Add the missing `ramble docs` command

### DIFF
--- a/lib/ramble/ramble/cmd/docs.py
+++ b/lib/ramble/ramble/cmd/docs.py
@@ -1,0 +1,17 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import webbrowser
+
+description = "open Ramble documentation in a web browser"
+section = "help"
+level = "short"
+
+
+def docs(parser, args):
+    webbrowser.open("https://ramble.readthedocs.io/")

--- a/lib/ramble/ramble/main.py
+++ b/lib/ramble/ramble/main.py
@@ -295,7 +295,7 @@ class RambleArgumentParser(argparse.ArgumentParser):
   ramble help --all       list all commands and options
   ramble help <command>   help on a specific command
   ramble help --spec      help on the application specification syntax
-  ramble docs             open https://ramble.rtfd.io/ in a browser
+  ramble docs             open https://ramble.readthedocs.io/ in a browser
 """.format(
                 help=section_descriptions["help"]
             )

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -267,7 +267,7 @@ _ramble() {
     then
         RAMBLE_COMPREPLY="-h --help -H --all-help --color -c --config -C --config-scope -d --debug --disable-passthrough -N --disable-logger -P --disable-progress-bar --timestamp --pdb -w --workspace -D --workspace-dir -W --no-workspace --use-workspace-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock --mock-applications --mock-modifiers --mock-package-managers --mock-base-applications --mock-base-modifiers --mock-base-package-managers -p --profile --sorted-profile --lines -v --verbose --stacktrace -V --version --print-shell-vars"
     else
-        RAMBLE_COMPREPLY="attributes clean commands config debug deployment edit flake8 help info license list mirror mods on python repo results software-definitions style unit-test workspace"
+        RAMBLE_COMPREPLY="attributes clean commands config debug deployment docs edit flake8 help info license list mirror mods on python repo results software-definitions style unit-test workspace"
     fi
 }
 
@@ -406,6 +406,10 @@ _ramble_deployment_push() {
 
 _ramble_deployment_pull() {
     RAMBLE_COMPREPLY="-h --help --deployment-path -p"
+}
+
+_ramble_docs() {
+    RAMBLE_COMPREPLY="-h --help"
 }
 
 _ramble_edit() {


### PR DESCRIPTION
It simply opens up the doc page, same as what Spack does.