### PR TITLE
Update variable modifications with separators

### DIFF
--- a/var/ramble/repos/builtin/modifiers/apptainer/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/apptainer/modifier.py
@@ -189,10 +189,6 @@ class Apptainer(BasicModifier):
             # Define container_mounts
             input_mounts = app_inst.expander.expand_var("{container_mounts}")
 
-            prefix = ""
-            if len(input_mounts) > 0:
-                prefix = ","
-
             exp_mount = "{experiment_run_dir}:{experiment_run_dir}"
             expanded_exp_mount = app_inst.expander.expand_var(exp_mount)
 
@@ -209,7 +205,8 @@ class Apptainer(BasicModifier):
                 if add_mod:
                     self.variable_modification(
                         "container_mounts",
-                        modification=prefix + exp_mount,
+                        modification=exp_mount,
+                        separator=",",
                         method="append",
                         mode=self._usage_mode,
                     )

--- a/var/ramble/repos/builtin/modifiers/pyxis-enroot/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/pyxis-enroot/modifier.py
@@ -175,10 +175,6 @@ class PyxisEnroot(BasicModifier):
             # Define container_mounts
             input_mounts = app_inst.expander.expand_var("{container_mounts}")
 
-            prefix = ""
-            if len(input_mounts) > 0:
-                prefix = ","
-
             exp_mount = "{experiment_run_dir}:{experiment_run_dir}"
             expanded_exp_mount = app_inst.expander.expand_var(exp_mount)
 
@@ -196,7 +192,8 @@ class PyxisEnroot(BasicModifier):
                 if add_mod:
                     self.variable_modification(
                         "container_mounts",
-                        modification=prefix + exp_mount,
+                        modification=exp_mount,
+                        separator=",",
                         method="append",
                         mode=self._usage_mode,
                     )


### PR DESCRIPTION
This merge adds the separator argument to some variable modification definitions. This allows the prefix definitions to be removed from the modifiers.