### PR TITLE
Allow templates registered into other workspace paths

### DIFF
--- a/lib/ramble/ramble/test/end_to_end/test_template.py
+++ b/lib/ramble/ramble/test/end_to_end/test_template.py
@@ -58,6 +58,9 @@ ramble:
         content = f.read()
         assert script_path in content
 
+    script_path = os.path.join(ws.shared_dir, "script.sh")
+    assert os.path.isfile(script_path)
+
 
 def test_template_inherited():
     test_config = """
@@ -93,3 +96,6 @@ ramble:
     with open(execute_path) as f:
         content = f.read()
         assert script_path in content
+
+    script_path = os.path.join(ws.shared_dir, "script.sh")
+    assert os.path.isfile(script_path)

--- a/var/ramble/repos/builtin.mock/applications/template/application.py
+++ b/var/ramble/repos/builtin.mock/applications/template/application.py
@@ -41,3 +41,10 @@ class Template(ExecutableApplication):
         expander = self.expander
         val = expander.expand_var('"hello {hello_name}"')
         return {"dynamic_hello_world": val}
+
+    register_template(
+        name="test",
+        src_name="script.sh",
+        dest_name="$workspace_shared/script.sh",
+        output_perm="755",
+    )

--- a/var/ramble/repos/builtin.mock/applications/template/script.sh
+++ b/var/ramble/repos/builtin.mock/applications/template/script.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# This is a test script that should end up in a rendered location
+
+if [ ! -f file_list ]; then
+  exit 1
+fi
+
+for FILE in `cat file_list`
+do
+  wc -l $FILE
+done


### PR DESCRIPTION
This merge allows workspace path variables to be replaced in destination paths for templates that are registered in objects.

This allows a template to be rendered into the shared directory of a workspace, as an example.