### PR TITLE
Fix path to hpl-mxp script

### DIFF
--- a/var/ramble/repos/builtin/applications/nvidia-hpl-mxp/application.py
+++ b/var/ramble/repos/builtin/applications/nvidia-hpl-mxp/application.py
@@ -36,7 +36,7 @@ class NvidiaHplMxp(HplBase):
 
     executable(
         "execute",
-        './hpl-mxp.sh --gpu-affinity "{gpu_affinity}" --n {Ns} --nb {block_size} --nprow {Ps} --npcol {Qs} --nporder {nporder}',
+        '/workspace/hpl-mxp.sh --gpu-affinity "{gpu_affinity}" --n {Ns} --nb {block_size} --nprow {Ps} --npcol {Qs} --nporder {nporder}',
         use_mpi=True,
     )
 


### PR DESCRIPTION
This merge fixes the path to the hpl-mxp.sh script, to ensure it can run regardless of which directory the container is launched in.