### PR TITLE
Add in a hook for supplying variables for template render

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -2324,12 +2324,15 @@ class ApplicationBase(metaclass=ApplicationMeta):
 
     def _render_object_templates(self, extra_vars, workspace):
         for obj, tpl_config in self._object_templates(workspace):
+            extra_vars = extra_vars.copy()
+            if callable(getattr(obj, "template_render_vars", None)):
+                extra_vars.update(obj.template_render_vars())
             src_path = tpl_config["src_path"]
             with open(src_path) as f_in:
                 content = f_in.read()
-            extra_vars_wm = tpl_config.get("extra_vars")
-            if extra_vars_wm is not None:
-                extra_vars.update(extra_vars_wm)
+            extra_vars_dict = tpl_config.get("extra_vars")
+            if extra_vars_dict is not None:
+                extra_vars.update(extra_vars_dict)
             extra_vars_func_name = tpl_config.get("extra_vars_func_name")
             if extra_vars_func_name is not None:
                 extra_vars_func = getattr(obj, extra_vars_func_name)

--- a/lib/ramble/ramble/workflow_manager.py
+++ b/lib/ramble/ramble/workflow_manager.py
@@ -70,6 +70,10 @@ class WorkflowManagerBase(metaclass=WorkflowManagerMeta):
                 continue
         return expanded
 
+    def template_render_vars(self):
+        """Define variables to be used in template rendering"""
+        return {"workflow_pragmas": "", "workflow_hostfile_cmd": ""}
+
     def copy(self):
         """Deep copy a workflow manager instance"""
         new_copy = type(self)(self._file_path)

--- a/var/ramble/repos/builtin/workflow_managers/slurm/slurm_execute_experiment.tpl
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/slurm_execute_experiment.tpl
@@ -1,8 +1,8 @@
 #!/bin/bash
-{sbatch_headers_str}
+{workflow_pragmas}
 
 cd {experiment_run_dir}
 
-scontrol show hostnames > {experiment_run_dir}/hostfile
+{workflow_hostfile_cmd}
 
 {command}


### PR DESCRIPTION
This is used as the basis to allow workflow manager to provide a set of variables for all its `register_template` directives.