### PR TITLE
Clean up static methods

### DIFF
--- a/lib/ramble/ramble/experimental/uploader.py
+++ b/lib/ramble/ramble/experimental/uploader.py
@@ -310,13 +310,6 @@ class BigQueryUploader(Uploader):
     # results = query_job.result()  # Waits for job to complete.
     # return results[0]
 
-    def get_experiment_id(experiment):
-        # get_max_current_id(...) # Warning: dangerous..
-
-        # This should be stable per machine/python version, but is not
-        # guaranteed to be globally stable
-        return hash(json.dumps(experiment, sort_keys=True))
-
 
 class PrintOnlyUploader(Uploader):
     """An uploader that only prints out formatted data without actually uploading."""

--- a/lib/ramble/ramble/test/util/env.py
+++ b/lib/ramble/ramble/test/util/env.py
@@ -15,7 +15,7 @@ def test_env_var_set_command_gen(mutable_mock_apps_repo):
 
     answer = ["export var1=val1;", "export var2=val2;"]
 
-    out_cmds, _ = ramble.util.env.Env.get_env_set_commands(tests, set())
+    out_cmds, _ = ramble.util.env.action_funcs["set"](tests, set())
     for cmd in answer:
         assert cmd in out_cmds
 
@@ -40,7 +40,7 @@ def test_env_var_append_command_gen(mutable_mock_apps_repo):
         'export path2="${path2}:path2";',
     ]
 
-    out_cmds, _ = ramble.util.env.Env.get_env_append_commands(tests, set())
+    out_cmds, _ = ramble.util.env.action_funcs["append"](tests, set())
     for cmd in answer:
         assert cmd in out_cmds
 
@@ -53,7 +53,7 @@ def test_env_var_prepend_command_gen(mutable_mock_apps_repo):
 
     answer = ['export path1="path2:path1:${path1}";', 'export path2="path1:path2:${path2}";']
 
-    out_cmds, _ = ramble.util.env.Env.get_env_prepend_commands(tests, set())
+    out_cmds, _ = ramble.util.env.action_funcs["prepend"](tests, set())
     for cmd in answer:
         assert cmd in out_cmds
 
@@ -63,6 +63,6 @@ def test_env_var_unset_command_gen(mutable_mock_apps_repo):
 
     answer = ["unset var1;", "unset var2;"]
 
-    out_cmds, _ = ramble.util.env.Env.get_env_unset_commands(tests, set())
+    out_cmds, _ = ramble.util.env.action_funcs["unset"](tests, set())
     for cmd in answer:
         assert cmd in out_cmds

--- a/lib/ramble/ramble/util/env.py
+++ b/lib/ramble/ramble/util/env.py
@@ -10,82 +10,84 @@ import spack.util.environment
 from ramble.util.shell_utils import get_compatible_base_shell
 
 
-class Env:
-    def get_env_set_commands(var_conf, var_set, shell="sh"):
-        env_mods = RambleEnvModifications()
-        for var, val in var_conf.items():
-            var_set.add(var)
-            env_mods.set(var, val)
+def _get_env_set_commands(var_conf, var_set, shell="sh"):
+    env_mods = RambleEnvModifications()
+    for var, val in var_conf.items():
+        var_set.add(var)
+        env_mods.set(var, val)
 
-        env_cmds_arr = env_mods.shell_modifications(shell=shell, explicit=True)
+    env_cmds_arr = env_mods.shell_modifications(shell=shell, explicit=True)
 
-        return (env_cmds_arr.split("\n"), var_set)
+    return (env_cmds_arr.split("\n"), var_set)
 
-    def get_env_unset_commands(var_conf, var_set, shell="sh"):
-        env_mods = RambleEnvModifications()
-        for var in var_conf:
-            if var in var_set:
-                var_set.remove(var)
-            env_mods.unset(var)
 
-        env_cmds_arr = env_mods.shell_modifications(shell=shell, explicit=True)
+def _get_env_unset_commands(var_conf, var_set, shell="sh"):
+    env_mods = RambleEnvModifications()
+    for var in var_conf:
+        if var in var_set:
+            var_set.remove(var)
+        env_mods.unset(var)
 
-        return (env_cmds_arr.split("\n"), var_set)
+    env_cmds_arr = env_mods.shell_modifications(shell=shell, explicit=True)
 
-    def get_env_append_commands(var_conf, var_set, shell="sh"):
-        env_mods = RambleEnvModifications()
+    return (env_cmds_arr.split("\n"), var_set)
 
-        append_funcs = {
-            "vars": env_mods.append_flags,
-            "paths": env_mods.append_path,
-        }
 
-        var_set_orig = var_set.copy()
+def _get_env_append_commands(var_conf, var_set, shell="sh"):
+    env_mods = RambleEnvModifications()
 
-        for append_group in var_conf:
-            sep = " "
-            if "var-separator" in append_group:
-                sep = append_group["var-separator"]
+    append_funcs = {
+        "vars": env_mods.append_flags,
+        "paths": env_mods.append_path,
+    }
 
-            for group in append_funcs.keys():
-                if group in append_group.keys():
-                    for var, val in append_group[group].items():
-                        if var not in var_set:
-                            env_mods.set(var, "${%s}" % var)
-                            var_set.add(var)
-                        append_funcs[group](var, val, sep=sep)
+    var_set_orig = var_set.copy()
 
-        env_cmds_arr = env_mods.shell_modifications(shell=shell, explicit=True)
+    for append_group in var_conf:
+        sep = " "
+        if "var-separator" in append_group:
+            sep = append_group["var-separator"]
 
-        return (env_cmds_arr.split("\n"), var_set_orig)
-
-    def get_env_prepend_commands(var_conf, var_set, shell="sh"):
-        env_mods = RambleEnvModifications()
-
-        prepend_funcs = {
-            "paths": env_mods.prepend_path,
-        }
-
-        var_set_orig = var_set.copy()
-
-        for prepend_group in var_conf:
-            for group in prepend_group.keys():
-                for var, val in prepend_group[group].items():
+        for group in append_funcs.keys():
+            if group in append_group.keys():
+                for var, val in append_group[group].items():
                     if var not in var_set:
                         env_mods.set(var, "${%s}" % var)
                         var_set.add(var)
-                    prepend_funcs[group](var, val)
+                    append_funcs[group](var, val, sep=sep)
 
-        env_cmds_arr = env_mods.shell_modifications(shell=shell, explicit=True)
+    env_cmds_arr = env_mods.shell_modifications(shell=shell, explicit=True)
 
-        return (env_cmds_arr.split("\n"), var_set_orig)
+    return (env_cmds_arr.split("\n"), var_set_orig)
+
+
+def _get_env_prepend_commands(var_conf, var_set, shell="sh"):
+    env_mods = RambleEnvModifications()
+
+    prepend_funcs = {
+        "paths": env_mods.prepend_path,
+    }
+
+    var_set_orig = var_set.copy()
+
+    for prepend_group in var_conf:
+        for group in prepend_group.keys():
+            for var, val in prepend_group[group].items():
+                if var not in var_set:
+                    env_mods.set(var, "${%s}" % var)
+                    var_set.add(var)
+                prepend_funcs[group](var, val)
+
+    env_cmds_arr = env_mods.shell_modifications(shell=shell, explicit=True)
+
+    return (env_cmds_arr.split("\n"), var_set_orig)
 
 
 action_funcs = {
-    "set": Env.get_env_set_commands,
-    "unset": Env.get_env_unset_commands,
-    "append": Env.get_env_append_commands,
-    "prepend": Env.get_env_prepend_commands,
+    "set": _get_env_set_commands,
+    "unset": _get_env_unset_commands,
+    "append": _get_env_append_commands,
+    "prepend": _get_env_prepend_commands,
 }
 
 


### PR DESCRIPTION
* Convert methods in util.env.Env into module-level methods
* Remove an unused static method in uploader
* There are a couple remaining in util/file_cache.py, but those are legitimate and hard to untangle from the nested context manager.

Linting command:

```
pylint --disable=all --enable=E0213 lib/ramble/ramble/*
```