### PR TITLE
Ensure package conflicts are printed correctly

### DIFF
--- a/lib/ramble/ramble/software_environments.py
+++ b/lib/ramble/ramble/software_environments.py
@@ -338,13 +338,19 @@ class TemplatePackage(SoftwarePackage):
 
         if new_pkg.name in self._rendered_packages[pm_name]:
             if new_pkg != self._rendered_packages[pm_name][name]:
+                new_info = new_pkg.info(only_used=False, color_level=-1).replace("@", "")
+                old_info = (
+                    self._rendered_packages[pm_name][name]
+                    .info(only_used=False, color_level=-1)
+                    .replace("@", "")
+                )
                 raise RambleSoftwareEnvironmentError(
                     f"Package {new_pkg.name} defined multiple times with "
                     "inconsistent definitions.\n"
                     "New definition is:\n"
-                    f"{new_pkg}"
+                    f"{new_info}\n"
                     "Old definition is:\n"
-                    f"{self._rendered_packages[pm_name][name]}"
+                    f"{old_info}\n"
                 )
             return self._rendered_packages[pm_name][name]
         else:

--- a/lib/ramble/ramble/util/colors.py
+++ b/lib/ramble/ramble/util/colors.py
@@ -16,7 +16,9 @@ plain_format = "@."
 
 
 def level_func(level):
-    if level <= 0:
+    if level < 0:
+        return str
+    elif level == 0:
         return section_title
     elif level == 1:
         return nested_1


### PR DESCRIPTION
This merge fixes an issue where package conflicts were omitted from the error message related to printing conflicts.