### PR TITLE
Take in user-defined `batch_submit`

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -2389,6 +2389,10 @@ class ApplicationBase(metaclass=ApplicationMeta):
         for obj, tpl_config in self._object_templates(workspace):
             var_name = tpl_config["var_name"]
             if var_name is not None:
+                if var_name in self.variables:
+                    old_var = f"_old_{var_name}"
+                    self.variables[old_var] = self.variables[var_name]
+                    self.keywords.update_keys({old_var: var_attr})
                 self.variables[var_name] = tpl_config["dest_path"]
                 self.keywords.update_keys({var_name: var_attr})
             if callable(getattr(obj, "template_render_vars", None)):

--- a/var/ramble/repos/builtin/workflow_managers/slurm/batch_submit.tpl
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/batch_submit.tpl
@@ -1,2 +1,2 @@
 #!/bin/bash
-sbatch {slurm_experiment_sbatch} | tee >(awk '{print $NF}' > {experiment_run_dir}/.slurm_job)
+{batch_submit_cmd} | tee >(awk '{print $NF}' > {experiment_run_dir}/.slurm_job)

--- a/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
@@ -95,7 +95,24 @@ class Slurm(WorkflowManagerBase):
         name="batch_submit",
         src_path="batch_submit.tpl",
         dest_path="batch_submit",
+        extra_vars_func="batch_submit_vars",
     )
+
+    def _batch_submit_vars(self):
+        vars = self.app_inst.variables
+        old_var_name = "_old_batch_submit"
+        if old_var_name in vars:
+            batch_submit_cmd = vars[old_var_name]
+            if "sbatch" not in batch_submit_cmd:
+                logger.warn(
+                    "`sbatch` is missing in the given `batch_submit` command"
+                )
+        else:
+            batch_submit_script = vars["batch_submit"]
+            batch_submit_cmd = f"sbatch {batch_submit_script}"
+        return {
+            "batch_submit_cmd": batch_submit_cmd,
+        }
 
     register_template(
         name="batch_query",


### PR DESCRIPTION
This allows user to define their own `batch_submit`, and the final script will tack on the part of storing the job id.

To preserve the user-defined variable, it stores a `var` into `_old_var`, before overriding its value as part of the `register_template`.