### PR TITLE
Prune circular imports

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -38,7 +38,6 @@ import ramble.repeats
 import ramble.repository
 import ramble.modifier
 import ramble.modifier_types.disabled
-import ramble.pipeline
 import ramble.success_criteria
 import ramble.util.executable
 import ramble.util.colors as rucolor

--- a/lib/ramble/ramble/cmd/__init__.py
+++ b/lib/ramble/ramble/cmd/__init__.py
@@ -20,6 +20,7 @@ import ramble.error
 import ramble.paths
 import ramble.workspace
 from ramble.util.logger import logger
+from ramble.error import RambleCommandError
 
 import spack.extensions
 import spack.util.string
@@ -119,8 +120,6 @@ def get_module(cmd_name):
         try:
             module = spack.extensions.get_module(cmd_name)
         except AttributeError:
-            from ramble.main import RambleCommandError
-
             raise RambleCommandError("Command %s does not exist." % cmd_name)
 
     attr_setdefault(module, SETUP_PARSER, lambda *args: None)  # null-op

--- a/lib/ramble/ramble/cmd/debug.py
+++ b/lib/ramble/ramble/cmd/debug.py
@@ -16,7 +16,7 @@ from llnl.util.filesystem import working_dir
 
 import ramble.config
 import ramble.paths
-from ramble.main import get_version
+import ramble.util.version
 
 import spack.platforms
 from spack.util.executable import which
@@ -61,7 +61,7 @@ def report(args):
     host_os = host_platform.operating_system("frontend")
     host_target = host_platform.target("frontend")
     architecture = spack.spec.ArchSpec((str(host_platform), str(host_os), str(host_target)))
-    print("* **Ramble:**", get_version())
+    print("* **Ramble:**", ramble.util.version.get_version())
     print("* **Python:**", platform.python_version())
     print("* **Platform:**", architecture)
 

--- a/lib/ramble/ramble/cmd/results.py
+++ b/lib/ramble/ramble/cmd/results.py
@@ -167,9 +167,51 @@ def import_results_file(filename):
             logger.die("Unable to parse file: Please provide a valid JSON or YAML results file.")
 
 
+def _load_results(args):
+    """Loads results from a file or workspace to use for reports.
+
+    Check for results in this order:
+        1. via ``ramble results report -f FILENAME``
+        2. via ``ramble -w WRKSPC`` or ``ramble -D DIR`` or
+        ``ramble results report --workspace WRKSPC``(arguments)
+        3. via a path in the ramble.workspace.ramble_workspace_var environment variable.
+    """
+    results_dict = {}
+
+    if args.file:
+        if os.path.exists(args.file):
+            results_dict = import_results_file(args.file)
+        else:
+            logger.die(f"Cannot find file {args.file}")
+    else:
+        ramble_ws = ramble.cmd.find_workspace_path(args)
+
+        if not ramble_ws:
+            logger.die(
+                "ramble results report requires either a results filename, "
+                "a command line workspace, or an active workspace"
+            )
+
+        logger.debug("Looking for workspace results file...")
+        json_results_path = os.path.join(ramble_ws, "results.latest.json")
+        yaml_results_path = os.path.join(ramble_ws, "results.latest.yaml")
+        if os.path.exists(json_results_path):
+            logger.debug(f"Importing {json_results_path}")
+            results_dict = import_results_file(json_results_path)
+        elif os.path.exists(yaml_results_path):
+            logger.debug(f"Importing {yaml_results_path}")
+            results_dict = import_results_file(yaml_results_path)
+        else:
+            logger.die(
+                "No JSON or YAML results file was found. Please run "
+                "'ramble workspace analyze -f json'."
+            )
+    return results_dict
+
+
 def results_report(args):
     """Create a report with charts from Ramble experiment results."""
-    results_dict = ramble.reports.load_results(args)
+    results_dict = _load_results(args)
 
     ws_name = results_dict["workspace_name"]
     if not ws_name:

--- a/lib/ramble/ramble/error.py
+++ b/lib/ramble/ramble/error.py
@@ -93,3 +93,7 @@ class RambleError(Exception):
 
 class SpecError(RambleError):
     """Superclass for all errors that occur while constructing specs."""
+
+
+class RambleCommandError(Exception):
+    """Raised when RambleCommand execution fails."""

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -15,7 +15,6 @@ import ramble.expander
 from ramble.expander import Expander
 from ramble.namespace import namespace
 import ramble.repository
-import ramble.workspace
 import ramble.keywords
 import ramble.error
 import ramble.renderer

--- a/lib/ramble/ramble/reports.py
+++ b/lib/ramble/ramble/reports.py
@@ -15,7 +15,6 @@ import re
 import llnl.util.filesystem as fs
 import spack.util.spack_yaml as syaml
 
-import ramble.cmd.results
 import ramble.cmd.workspace
 import ramble.config
 import ramble.filters
@@ -75,48 +74,6 @@ def get_direction_suffix(self):
         return " (Lower is Better)"
     else:
         return ""
-
-
-def load_results(args):
-    """Loads results from a file or workspace to use for reports.
-
-    Check for results in this order:
-        1. via ``ramble results report -f FILENAME``
-        2. via ``ramble -w WRKSPC`` or ``ramble -D DIR`` or
-        ``ramble results report --workspace WRKSPC``(arguments)
-        3. via a path in the ramble.workspace.ramble_workspace_var environment variable.
-    """
-    results_dict = {}
-
-    if args.file:
-        if os.path.exists(args.file):
-            results_dict = ramble.cmd.results.import_results_file(args.file)
-        else:
-            logger.die(f"Cannot find file {args.file}")
-    else:
-        ramble_ws = ramble.cmd.find_workspace_path(args)
-
-        if not ramble_ws:
-            logger.die(
-                "ramble results report requires either a results filename, "
-                "a command line workspace, or an active workspace"
-            )
-
-        logger.debug("Looking for workspace results file...")
-        json_results_path = os.path.join(ramble_ws, "results.latest.json")
-        yaml_results_path = os.path.join(ramble_ws, "results.latest.yaml")
-        if os.path.exists(json_results_path):
-            logger.debug(f"Importing {json_results_path}")
-            results_dict = ramble.cmd.results.import_results_file(json_results_path)
-        elif os.path.exists(yaml_results_path):
-            logger.debug(f"Importing {yaml_results_path}")
-            results_dict = ramble.cmd.results.import_results_file(yaml_results_path)
-        else:
-            logger.die(
-                "No JSON or YAML results file was found. Please run "
-                "'ramble workspace analyze -f json'."
-            )
-    return results_dict
 
 
 def is_repeat_child(experiment):

--- a/lib/ramble/ramble/software_environments.py
+++ b/lib/ramble/ramble/software_environments.py
@@ -9,7 +9,6 @@
 from collections import defaultdict
 
 import ramble.repository
-import ramble.workspace
 import ramble.keywords
 import ramble.error
 import ramble.renderer

--- a/lib/ramble/ramble/spec.py
+++ b/lib/ramble/ramble/spec.py
@@ -7,11 +7,9 @@
 # except according to those terms.
 
 import io
-import os
 
 import llnl.util.tty.color as clr
 
-import ramble.repository
 import ramble.error
 from ramble.util.logger import logger
 
@@ -138,8 +136,6 @@ class Spec:
         self.name = None
         self.namespace = None
 
-        self._application = None
-        self._application_class = None
         self.workloads = {}
 
         if isinstance(spec_like, str):
@@ -277,29 +273,6 @@ class Spec:
             if self.namespace
             else (self.name if self.name else "")
         )
-
-    @property
-    def application(self):
-        if not self._application:
-            app_type = ramble.repository.ObjectTypes.applications
-            self._application = ramble.repository.paths[app_type].get(self)
-        return self._application
-
-    @property
-    def application_class(self):
-        if not self._application_class:
-            app_type = ramble.repository.ObjectTypes.applications
-            self._application_class = ramble.repository.paths[app_type].get_obj_class(
-                self.fullname
-            )
-        return self._application_class
-
-    @property
-    def application_file_path(self):
-        app_type = ramble.repository.ObjectTypes.applications
-        file_dir = ramble.repository.paths[app_type].dirname_for_object_name(self.fullname)
-        app_file = ramble.repository.paths[app_type].filename_for_object_name(self.fullname)
-        return os.path.join(file_dir, app_file)
 
 
 def parse(string):

--- a/lib/ramble/ramble/test/cmd/mirror.py
+++ b/lib/ramble/ramble/test/cmd/mirror.py
@@ -15,7 +15,8 @@ import llnl.util.filesystem as fs
 
 import ramble.config
 import ramble.workspace
-from ramble.main import RambleCommand, RambleCommandError
+from ramble.main import RambleCommand
+from ramble.error import RambleCommandError
 import spack.util.url
 
 mirror = RambleCommand("mirror")

--- a/lib/ramble/ramble/test/cmd/software_definitions.py
+++ b/lib/ramble/ramble/test/cmd/software_definitions.py
@@ -6,7 +6,8 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-from ramble.main import RambleCommand, RambleCommandError
+from ramble.main import RambleCommand
+from ramble.error import RambleCommandError
 
 software_defs = RambleCommand("software-definitions")
 

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -15,7 +15,8 @@ import llnl.util.filesystem as fs
 
 import ramble.application
 import ramble.workspace
-from ramble.main import RambleCommand, RambleCommandError
+from ramble.main import RambleCommand
+from ramble.error import RambleCommandError
 from ramble.test.dry_run_helpers import search_files_for_string
 from ramble.namespace import namespace
 import ramble.config

--- a/lib/ramble/ramble/test/commands.py
+++ b/lib/ramble/ramble/test/commands.py
@@ -8,7 +8,8 @@
 
 import pytest
 
-from ramble.main import RambleCommand, RambleCommandError
+from ramble.main import RambleCommand
+from ramble.error import RambleCommandError
 from ramble.util.logger import logger  # noqa:  F401
 
 

--- a/lib/ramble/ramble/test/end_to_end/missing_required_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/missing_required_dry_run.py
@@ -13,7 +13,8 @@ import pytest
 import ramble.workspace
 import ramble.config
 import ramble.software_environments
-from ramble.main import RambleCommand, RambleCommandError
+from ramble.main import RambleCommand
+from ramble.error import RambleCommandError
 
 
 # everything here uses the mock_workspace_path

--- a/lib/ramble/ramble/test/end_to_end/test_target_shells.py
+++ b/lib/ramble/ramble/test/end_to_end/test_target_shells.py
@@ -11,7 +11,8 @@ import os
 import pytest
 
 import ramble.workspace
-from ramble.main import RambleCommand, RambleCommandError
+from ramble.main import RambleCommand
+from ramble.error import RambleCommandError
 
 pytestmark = pytest.mark.usefixtures(
     "mutable_config",

--- a/lib/ramble/ramble/test/workspace_hashing/unsetup_workspace_cannot_analyze.py
+++ b/lib/ramble/ramble/test/workspace_hashing/unsetup_workspace_cannot_analyze.py
@@ -14,7 +14,8 @@ import ramble.application
 import ramble.workspace
 import ramble.config
 import ramble.software_environments
-from ramble.main import RambleCommand, RambleCommandError
+from ramble.main import RambleCommand
+from ramble.error import RambleCommandError
 
 
 # everything here uses the mock_workspace_path

--- a/lib/ramble/ramble/util/version.py
+++ b/lib/ramble/ramble/util/version.py
@@ -1,0 +1,59 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+import re
+
+import ramble
+import ramble.paths
+
+
+def get_version():
+    """Get a descriptive version of this instance of Ramble.
+
+    Outputs '<PEP440 version> (<git commit sha>)'.
+
+    The commit sha is only added when available.
+    """
+    version = ramble.ramble_version
+    git_hash = get_git_hash(path=ramble.paths.prefix)
+
+    if git_hash:
+        version += f" ({git_hash})"
+
+    return version
+
+
+def get_git_hash(path=ramble.paths.prefix):
+    """Get get hash from a path
+
+    Outputs '<git commit sha>'.
+    """
+    import spack.util.git
+
+    git_path = os.path.join(path, ".git")
+    if os.path.exists(git_path):
+        git = spack.util.git.git()
+        if not git:
+            return
+        rev = git(
+            "-C",
+            path,
+            "rev-parse",
+            "HEAD",
+            output=str,
+            error=os.devnull,
+            fail_on_error=False,
+        )
+        if git.returncode != 0:
+            return
+        match = re.match(r"[a-f\d]{7,}$", rev)
+        if match:
+            return match.group(0)
+
+    return

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -52,6 +52,7 @@ import ramble.util.matrices
 import ramble.util.env
 from ramble.util.logger import logger
 from ramble.util.conversions import list_str_to_list
+import ramble.util.version
 
 #: Environment variable used to indicate the active workspace
 ramble_workspace_var = "RAMBLE_WORKSPACE"
@@ -435,14 +436,12 @@ class Workspace:
         self.software_environments = None
         self.metadata = syaml.syaml_dict()
         self.hash_inventory = {"experiments": [], "versions": []}
-
-        from ramble.main import get_version
-
+        version = ramble.util.version.get_version()
         self.hash_inventory["versions"].append(
             {
                 "name": "ramble",
-                "version": get_version(),
-                "digest": ramble.util.hashing.hash_string(get_version()),
+                "version": version,
+                "digest": ramble.util.hashing.hash_string(version),
             }
         )
 

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
@@ -616,7 +616,7 @@ class SpackRunner(CommandRunner):
 
     def get_version(self):
         """Get spack's version"""
-        from ramble.main import get_git_hash
+        from ramble.util.version import get_git_hash
         import importlib.util
 
         version_spec = importlib.util.spec_from_file_location(


### PR DESCRIPTION
The list is generated via:

```
pylint --disable=all --enable=R0401 lib/ramble/ramble/*
```

Changes included:

* Pull out some utils from `ramble.main` (`RambleCommandError` and utils around `get_version`)
* Remove a bunch of unused code in `ramble.mirror` and `ramble.spec`, to avoid the circular deps between `ramble.repository` and `ramble.spec`
* Move the `load_results` util from `ramble.reports` into `ramble.cmd.results`
* Remove a few unused imports