### PR TITLE
Update workflow managers to have an execution banner

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -39,6 +39,8 @@ import ramble.repository
 import ramble.modifier
 import ramble.modifier_types.disabled
 import ramble.success_criteria
+import ramble.workflow_manager
+import ramble.paths
 import ramble.util.executable
 import ramble.util.colors as rucolor
 import ramble.util.hashing
@@ -311,6 +313,10 @@ class ApplicationBase(metaclass=ApplicationMeta):
                         "Valid workflow managers can be listed via:\n"
                         "\tramble list --type workflow_managers"
                     )
+        if self.workflow_manager is None:
+            base_path = os.path.join(ramble.paths.module_path, "workflow_manager.py")
+            self.workflow_manager = ramble.workflow_manager.WorkflowManagerBase(base_path)
+            self.workflow_manager.set_application(self)
 
     def build_phase_order(self):
         if self._pipeline_graphs is not None:
@@ -1768,7 +1774,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
         # When workflow_manager is present, only use app_status when workflow is completed.
         if self.workflow_manager is not None:
             wm_status = self.workflow_manager.get_status(workspace)
-            if not wm_status == experiment_status.COMPLETE:
+            if not (wm_status == experiment_status.COMPLETE or wm_status is None):
                 status = wm_status
         self.set_status(status)
 

--- a/lib/ramble/ramble/language/language_base.py
+++ b/lib/ramble/ramble/language/language_base.py
@@ -27,7 +27,16 @@ __all__ = ["DirectiveMeta", "DirectiveError"]
 #: them
 reserved_names = []
 
-namespaces = ["ramble.app", "ramble.mod", "ramble.pkg_man", "ramble.package_manager", "ramble.wm"]
+namespaces = [
+    "ramble.app",
+    "ramble.mod",
+    "ramble.pkg_man",
+    "ramble.package_manager",
+    "ramble.wm",
+    "ramble.workflow_manager",
+    "ramble.application",
+    "ramble.modifier",
+]
 
 
 class DirectiveMeta(type):

--- a/lib/ramble/ramble/repository.py
+++ b/lib/ramble/ramble/repository.py
@@ -228,7 +228,9 @@ def list_object_files(obj_inst, object_type):
     repo_path = paths[object_type]
     base_repo_path = paths[base_type]
     obj_file = obj_inst._file_path
-    result = [(type_def["dir_name"], obj_file)]
+    result = []
+    if repo_path.in_path(obj_file) or base_repo_path.in_path(obj_file):
+        result = [(type_def["dir_name"], obj_file)]
     base_chain = obj_inst.__class__.__mro__[1:]
 
     for cls in base_chain:
@@ -245,6 +247,7 @@ def list_object_files(obj_inst, object_type):
             result.append((base_type_def["dir_name"], path))
         else:
             break
+    logger.all_msg(f" Deployment files: {result}")
     return result
 
 

--- a/lib/ramble/ramble/workflow_manager.py
+++ b/lib/ramble/ramble/workflow_manager.py
@@ -9,7 +9,10 @@
 
 from typing import List
 
-from ramble.language.workflow_manager_language import WorkflowManagerMeta
+from ramble.language.workflow_manager_language import (
+    WorkflowManagerMeta,
+    workflow_manager_variable,
+)
 from ramble.language.shared_language import SharedMeta
 from ramble.util.naming import NS_SEPARATOR
 import ramble.util.class_attributes
@@ -28,6 +31,30 @@ class WorkflowManagerBase(metaclass=WorkflowManagerMeta):
     ]
     maintainers: List[str] = []
     tags: List[str] = []
+
+    workflow_manager_variable(
+        "workflow_banner",
+        default="""# ****************************************************
+# * No workflow is used with this experiment
+# * Execution command: {batch_submit}
+# * If this file is not the same as the above path, it is unlikely that this script
+# * is used when `ramble on` executes experiments.
+# ****************************************************
+""",
+        description="Banner to describe the workflow within execution templates",
+    )
+
+    workflow_manager_variable(
+        "workflow_pragmas",
+        default="",
+        description="Pragmas to apply within execution templates for the workflow",
+    )
+
+    workflow_manager_variable(
+        "workflow_hostfile_cmd",
+        default="",
+        description="Hostfile command to apply within execution templates for the workflow",
+    )
 
     def __init__(self, file_path):
         super().__init__()
@@ -74,7 +101,7 @@ class WorkflowManagerBase(metaclass=WorkflowManagerMeta):
 
     def template_render_vars(self):
         """Define variables to be used in template rendering"""
-        return {"workflow_pragmas": "", "workflow_hostfile_cmd": ""}
+        return {}
 
     def copy(self):
         """Deep copy a workflow manager instance"""

--- a/lib/ramble/ramble/workflow_manager.py
+++ b/lib/ramble/ramble/workflow_manager.py
@@ -74,9 +74,7 @@ class WorkflowManagerBase(metaclass=WorkflowManagerMeta):
 
     def get_status(self, workspace):
         """Return status of a given job"""
-        raise NotImplementedError(
-            f"The workflow manager {self.name} does not support `get_status`"
-        )
+        return None
 
     def conditional_expand(self, templates):
         """Return a (potentially empty) list of expanded strings

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -564,6 +564,8 @@ class Workspace:
 #   - n_nodes (Will be replaced with the required number of nodes)
 #   Any experiment parameters will be available as variables as well.
 
+{workflow_banner}
+
 cd "{experiment_run_dir}"
 
 {command}

--- a/var/ramble/repos/builtin/workflow_managers/slurm/slurm_experiment_sbatch.tpl
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/slurm_experiment_sbatch.tpl
@@ -1,6 +1,8 @@
 #!/bin/bash
 {workflow_pragmas}
 
+{workflow_banner}
+
 cd {experiment_run_dir}
 
 {workflow_hostfile_cmd}

--- a/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
@@ -48,6 +48,18 @@ class Slurm(WorkflowManagerBase):
         self.runner = SlurmRunner()
 
     workflow_manager_variable(
+        "workflow_banner",
+        default="""# ****************************************************
+# * Workflow manager: slurm
+# * Execution script is: {slurm_experiment_sbatch}
+# * If this file is not the same as the above path, it is unlikely that this script
+# * is used when `ramble on` executes experiments.
+# ****************************************************
+""",
+        description="Banner to describe the workflow within execution templates",
+    )
+
+    workflow_manager_variable(
         name="job_name",
         default="{application_name}_{workload_name}_{experiment_name}",
         description="Slurm job name",
@@ -139,7 +151,7 @@ class Slurm(WorkflowManagerBase):
     )
 
     def template_render_vars(self):
-        vars = super().template_render_vars()
+        vars = {}
         expander = self.app_inst.expander
         # Adding pre-defined and custom headers
         pragmas = [


### PR DESCRIPTION
This merge adds a banner variable definition to workflow managers. The goal of this is to help users identify if a script (that they are potentially editing) is related to the execution of the experiment or not.