### PR TITLE
Enable checks by default on nccl-tests to match default behavior

### DIFF
--- a/var/ramble/repos/builtin/applications/nccl-tests/application.py
+++ b/var/ramble/repos/builtin/applications/nccl-tests/application.py
@@ -112,7 +112,7 @@ class NcclTests(ExecutableApplication):
     )
     workload_variable(
         "result_check",
-        default="0",
+        default="1",
         description="0 to skip checking, 1 to enable checking",
         workloads=all_workloads,
     )


### PR DESCRIPTION
OSS nccl-tests has checks enabled by default, we should do the same here.