### PR TITLE
Front-end commands for managing workspace includes.

### DIFF
--- a/lib/ramble/ramble/namespace.py
+++ b/lib/ramble/ramble/namespace.py
@@ -65,3 +65,4 @@ class namespace:
     workflow_manager = "workflow_manager"
 
     metadata = "metadata"
+    include = "include"

--- a/lib/ramble/ramble/test/end_to_end/workspace_includes.py
+++ b/lib/ramble/ramble/test/end_to_end/workspace_includes.py
@@ -1,0 +1,141 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.workspace
+import ramble.config
+import ramble.software_environments
+from ramble.main import RambleCommand
+
+
+# everything here uses the mock_workspace_path
+pytestmark = pytest.mark.usefixtures(
+    "mutable_config",
+    "mutable_mock_workspace_path",
+)
+
+workspace = RambleCommand("workspace")
+
+
+def test_workspace_add_includes(request):
+    workspace_name = request.node.name
+    ws = ramble.workspace.create(workspace_name)
+    global_args = ["-w", workspace_name]
+
+    ws.write()
+
+    output = workspace("manage", "includes", "--list", global_args=global_args)
+
+    assert "Workspace contains no includes." in output
+
+    workspace(
+        "manage",
+        "includes",
+        "--add",
+        "$workspace_configs/auxiliary_software_files",
+        global_args=global_args,
+    )
+
+    ws._re_read()
+
+    config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+
+    with open(config_path) as f:
+        data = f.read()
+        assert "- $workspace_configs/auxiliary_software_files" in data
+
+
+def test_workspace_remove_includes_index(request):
+    workspace_name = request.node.name
+    ws = ramble.workspace.create(workspace_name)
+    global_args = ["-w", workspace_name]
+
+    ws.write()
+
+    output = workspace("manage", "includes", "--list", global_args=global_args)
+
+    assert "Workspace contains no includes." in output
+
+    workspace(
+        "manage",
+        "includes",
+        "--add",
+        "$workspace_configs/auxiliary_software_files",
+        global_args=global_args,
+    )
+
+    ws._re_read()
+
+    config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+
+    output = workspace("manage", "includes", "--list", global_args=global_args)
+
+    assert "0: $workspace_configs/auxiliary_software_files" in output
+
+    with open(config_path) as f:
+        data = f.read()
+        assert "- $workspace_configs/auxiliary_software_files" in data
+
+    workspace("manage", "includes", "--remove-index", "0", global_args=global_args)
+
+    ws._re_read()
+
+    output = workspace("manage", "includes", "--list", global_args=global_args)
+
+    assert "Workspace contains no includes." in output
+
+    with open(config_path) as f:
+        data = f.read()
+        assert "- $workspace_configs/auxiliary_software_files" not in data
+
+
+def test_workspace_remove_includes_pattern(request):
+    workspace_name = request.node.name
+    ws = ramble.workspace.create(workspace_name)
+    global_args = ["-w", workspace_name]
+
+    ws.write()
+
+    output = workspace("manage", "includes", "--list", global_args=global_args)
+
+    assert "Workspace contains no includes." in output
+
+    workspace(
+        "manage",
+        "includes",
+        "--add",
+        "$workspace_configs/auxiliary_software_files",
+        global_args=global_args,
+    )
+
+    ws._re_read()
+
+    config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+
+    output = workspace("manage", "includes", "--list", global_args=global_args)
+
+    assert "0: $workspace_configs/auxiliary_software_files" in output
+
+    with open(config_path) as f:
+        data = f.read()
+        assert "- $workspace_configs/auxiliary_software_files" in data
+
+    workspace("manage", "includes", "--remove", "*aux*", global_args=global_args)
+
+    ws._re_read()
+
+    output = workspace("manage", "includes", "--list", global_args=global_args)
+
+    assert "Workspace contains no includes." in output
+
+    with open(config_path) as f:
+        data = f.read()
+        assert "- $workspace_configs/auxiliary_software_files" not in data

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1891,6 +1891,52 @@ ramble:
 
         return self._workspace_path_replacements
 
+    def add_include(self, new_include):
+        """Add a new include to this workspace"""
+
+        if namespace.include not in self.config_sections["workspace"]["yaml"][namespace.ramble]:
+            self.config_sections["workspace"]["yaml"][namespace.ramble][namespace.include] = []
+        includes = self.config_sections["workspace"]["yaml"][namespace.ramble][namespace.include]
+        includes.append(new_include)
+        self._write_config(config_section)
+
+    def remove_include(self, index=None, pattern=None):
+        """Remove one or more includes from this workspace.
+
+        Args:
+            index (optional): Numerical position of include to remove
+            pattern (optional): String or pattern of include to remove.
+                                Removes all matching includes.
+        """
+
+        if namespace.include not in self.config_sections["workspace"]["yaml"][namespace.ramble]:
+            return
+
+        includes = self.config_sections["workspace"]["yaml"][namespace.ramble][namespace.include]
+        changed = False
+
+        if index is not None:
+            if index < 0 or index >= len(includes):
+                logger.die(
+                    f"Requested index {index} " "is outside of the range of existing includes."
+                )
+            includes.pop(index)
+            changed = True
+
+        if pattern is not None:
+            remove_indices = []
+            for idx, include in enumerate(includes):
+                if fnmatch.fnmatch(include, pattern):
+                    remove_indices.append(idx)
+
+            for remove_idx in reversed(remove_indices):
+                if remove_idx >= 0 and remove_idx < len(includes):
+                    includes.pop(remove_idx)
+                    changed = True
+
+        if changed:
+            self._write_config(config_section)
+
     def included_config_scopes(self):
         """List of included configuration scopes from the environment.
 

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -747,7 +747,7 @@ _ramble_workspace_manage() {
     then
         RAMBLE_COMPREPLY="-h --help"
     else
-        RAMBLE_COMPREPLY="experiments software"
+        RAMBLE_COMPREPLY="experiments software includes"
     fi
 }
 
@@ -762,4 +762,8 @@ _ramble_workspace_manage_experiments() {
 
 _ramble_workspace_manage_software() {
     RAMBLE_COMPREPLY="-h --help --environment-name --env --environment-packages --external-env --package-name --pkg --package-spec --pkg-spec --spec --compiler-package --compiler-pkg --compiler --compiler-spec --package-manager-prefix --prefix --remove --delete --overwrite -o --dry-run --print"
+}
+
+_ramble_workspace_manage_includes() {
+    RAMBLE_COMPREPLY="-h --help --list -l --remove -r --remove-index --add -a"
 }


### PR DESCRIPTION
This merge adds front-end commands for managing workspace includes.

These fall under the sub-command `ramble workspace manage includes`. Functionality includes listing includes, removing includes by index or pattern, and adding new includes.