### PR TITLE
Add default variable to define likely hostfile path

### DIFF
--- a/lib/ramble/ramble/workflow_manager.py
+++ b/lib/ramble/ramble/workflow_manager.py
@@ -56,6 +56,10 @@ class WorkflowManagerBase(metaclass=WorkflowManagerMeta):
         description="Hostfile command to apply within execution templates for the workflow",
     )
 
+    workflow_manager_variable(
+        "hostfile", default="{experiment_run_dir}/hostfile", description="Default hostfile path"
+    )
+
     def __init__(self, file_path):
         super().__init__()
 

--- a/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
@@ -271,4 +271,4 @@ class SlurmRunner:
         }
 
     def get_hostfile_cmd(self):
-        return "scontrol show hostnames > {experiment_run_dir}/hostfile"
+        return "scontrol show hostnames > {hostfile}"


### PR DESCRIPTION
This allows users to do something like `    mpi_command: mpirun -n {n_ranks} --hostfile {hostfile}` without having to know where the hostfile lives explicitly 