### PR TITLE
Add Google Batch workflow manager, and formatted executables directive

### DIFF
--- a/lib/ramble/docs/workspace_config.rst
+++ b/lib/ramble/docs/workspace_config.rst
@@ -989,6 +989,10 @@ Ramble automatically generates definitions for the following variables:
   ``$workspace_root/configs`` have a variable generated that resolves to the
   absolute path to: ``{experiment_run_dir}/<template_name>`` where
   ``<template_name>`` is the filename of the template, without the extension.
+* ``unformatted_command`` - A multi-line string with the command for running
+  the experiment. Unformatted so it can be formatted for various experiments.
+* ``unformatted_command_without_logs`` - The same as ``unformatted_command`` but
+  has no log removal, creation, or redirection.
 
 """"""""""""""""""""""""""""""""""""""""""""
 Package Manager Specific Generated Variables

--- a/lib/ramble/ramble/keywords.py
+++ b/lib/ramble/ramble/keywords.py
@@ -50,6 +50,10 @@ default_keys = {
     "mpi_command": {"type": key_type.required, "level": output_level.variable},
     "experiment_template_name": {"type": key_type.reserved, "level": output_level.key},
     "unformatted_command": {"type": key_type.reserved, "level": output_level.variable},
+    "unformatted_command_without_logs": {
+        "type": key_type.reserved,
+        "level": output_level.variable,
+    },
 }
 
 

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -543,3 +543,24 @@ def register_template(
         }
 
     return _define_template
+
+
+@shared_directive("formatted_executables")
+def formatted_executable(name: str, prefix: str, indentation: int, commands: list):
+    """Define a new formatted execution for this object
+
+    Args:
+        name: Name of the new formatted executable
+        prefix: Prefix for each line of the formatted executable
+        indentation: Number of spaces to indent before the prefix of each line
+        commands: List of commands to expand when generating the formatted executable
+    """
+
+    def _define_formatted_executable(obj):
+        obj.formatted_executables[name] = {
+            "prefix": prefix,
+            "indentation": indentation,
+            "commands": commands.copy(),
+        }
+
+    return _define_formatted_executable

--- a/lib/ramble/ramble/test/workflow_manager_functionality/google_batch_workflow_manager.py
+++ b/lib/ramble/ramble/test/workflow_manager_functionality/google_batch_workflow_manager.py
@@ -1,0 +1,79 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.workspace
+import ramble.config
+from ramble.namespace import namespace
+from ramble.main import RambleCommand
+
+workspace = RambleCommand("workspace")
+
+pytestmark = pytest.mark.usefixtures(
+    "mutable_config",
+    "mutable_mock_workspace_path",
+)
+
+
+def test_google_batch_workflow_default(request):
+    workspace_name = request.node.name
+
+    global_args = ["-w", workspace_name]
+
+    variants_conf = r"""
+variants:
+  workflow_manager: google-batch
+"""
+
+    ws = ramble.workspace.create(workspace_name)
+
+    ws.write()
+
+    variants_path = os.path.join(ws.config_dir, "variants.yaml")
+
+    with open(variants_path, "w+") as f:
+        f.write(variants_conf)
+
+    workspace(
+        "manage",
+        "experiments",
+        "hostname",
+        "--wf",
+        "local",
+        "-v",
+        "n_ranks=1",
+        "-v",
+        "n_nodes=1",
+        global_args=global_args,
+    )
+
+    ws._re_read()
+
+    # Remove batch submit definition
+    ws_vars = ws.get_workspace_vars()
+    if "batch_submit" in ws_vars:
+        del ws_vars["batch_submit"]
+    ramble.config.config.update_config(
+        namespace.variables, ws_vars, scope=ws.ws_file_config_scope_name()
+    )
+    ws.write()
+
+    ws._re_read()
+
+    workspace("setup", "--dry-run", global_args=global_args)
+
+    exp_dir = os.path.join(ws.experiment_dir, "hostname", "local", "generated")
+    files = [f for f in os.listdir(exp_dir) if os.path.isfile(os.path.join(exp_dir, f))]
+    assert "batch_submit" in files
+    assert "batch_query" in files
+    assert "batch_cancel" in files
+    assert "batch_wait" in files
+    assert "batch_config.yaml" in files

--- a/var/ramble/repos/builtin.mock/modifiers/formatted-exec-mod/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/formatted-exec-mod/modifier.py
@@ -1,0 +1,30 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.modkit import *  # noqa: F403
+
+
+class FormattedExecMod(BasicModifier):
+    """Define a modifier for testing formatted executables
+
+    This modifier is just a test of the formatted executable language.
+    """
+
+    name = "formatted-exec-mod"
+
+    tags("test")
+
+    mode("test", description="This is a test mode")
+    default_mode("test")
+
+    formatted_executable(
+        "mod_formatted_exec",
+        prefix="FROM_MOD ",
+        indentation="4",
+        commands=['echo "Test formatted exec"'],
+    )

--- a/var/ramble/repos/builtin/workflow_managers/google-batch/batch_cancel.tpl
+++ b/var/ramble/repos/builtin/workflow_managers/google-batch/batch_cancel.tpl
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+BATCH_FILE={experiment_run_dir}/.batch_job.yaml
+
+. {batch_helpers}
+
+has_job_file
+if [ $? == 0 ]; then
+  exit 0
+fi
+
+job_in_list
+if [ $? == 1 ]; then
+  JOB_NAME=$(get_job_name)
+  
+  gcloud batch jobs delete --project {batch_project} --location {batch_job_region} $JOB_NAME
+fi

--- a/var/ramble/repos/builtin/workflow_managers/google-batch/batch_clean.tpl
+++ b/var/ramble/repos/builtin/workflow_managers/google-batch/batch_clean.tpl
@@ -1,0 +1,29 @@
+#!/bin/bash
+. {batch_helpers}
+
+has_job_file
+if [ $? == 1 ]; then
+  JOB_NAME=$(get_job_name)
+
+  if [ ! -z "$JOB_NAME" ]; then
+    job_in_list
+    LIST_CHECK=$?
+    if [ $LIST_CHECK == 1 ]; then
+      echo "Experiment {experiment_namespace} is still in the queue for Google Batch. Skipping clean..."
+    fi
+
+    if [ $LIST_CHECK == 0 ]; then
+      echo "Removing stale batch job files for experiment {experiment_namespace}"
+      rm -f $BATCH_FILE
+
+      if [ -f $BATCH_LIST_FILE ]; then
+        rm -f $BATCH_LIST_FILE
+      fi
+    fi
+  fi
+
+  if [ -z "$JOB_NAME" ]; then
+    rm -f $BATCH_FILE
+    rm -f $BATCH_LIST_FILE
+  fi
+fi

--- a/var/ramble/repos/builtin/workflow_managers/google-batch/batch_config.yaml.tpl
+++ b/var/ramble/repos/builtin/workflow_managers/google-batch/batch_config.yaml.tpl
@@ -1,0 +1,23 @@
+taskGroups:
+  - taskSpec:
+      runnables:
+        - script:
+            text: |
+{batch_formatted_command}
+    task_count: {n_nodes}
+    task_count_per_node: 1
+    require_hosts_file: true
+    permissive_ssh: true
+allocation_policy:
+  instances:
+    - policy:
+        machine_type: {batch_machine_type}
+        boot_disk:
+          image: {batch_machine_image}
+          size_gb: {batch_disk_size}
+  location:
+    allowed_locations:
+      - regions/{batch_job_region}
+      - zones/{batch_job_zone}
+logs_policy:
+  destination: CLOUD_LOGGING

--- a/var/ramble/repos/builtin/workflow_managers/google-batch/batch_fetch_logs.tpl
+++ b/var/ramble/repos/builtin/workflow_managers/google-batch/batch_fetch_logs.tpl
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+. {batch_helpers}
+
+has_job_file
+if [ $? == 0 ]; then
+  exit 0
+fi
+
+BATCH_UID=$(get_job_uid)
+
+gcloud logging read --project {batch_project} labels.job_uid=$BATCH_UID &> {experiment_run_dir}/batch_job_log

--- a/var/ramble/repos/builtin/workflow_managers/google-batch/batch_helpers.tpl
+++ b/var/ramble/repos/builtin/workflow_managers/google-batch/batch_helpers.tpl
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+STATUS_FILE={experiment_run_dir}/ramble_status.json
+BATCH_FILE={experiment_run_dir}/.batch_job.yaml
+BATCH_LIST_FILE={experiment_run_dir}/.batch_job_list
+{declare_status_map}
+
+job_in_list() {
+  local JOB_NAME=$(get_job_name)
+
+  local JOB_LIST=
+  if [ ! -z "$JOB_NAME" ]; then
+    gcloud batch jobs list --project {batch_project} --location {batch_job_region} > $BATCH_LIST_FILE 2> /dev/null
+  fi
+
+  if [ -f $BATCH_LIST_FILE ]; then
+    cat $BATCH_LIST_FILE | grep "$JOB_NAME" &> /dev/null
+    local LIST_CHECK=$?
+    if [ $LIST_CHECK == 0 ]; then
+      return 1
+    fi
+  fi
+
+  return 0
+}
+
+has_job_file() {
+  if [ -f $BATCH_FILE ]; then
+    return 1
+  fi
+  return 0
+}
+
+get_job_name() {
+  local BATCH_NAME=""
+  if [ -f $BATCH_FILE ]; then
+    local BATCH_NAME=`grep "^name:" $BATCH_FILE | awk '{print $2}'`
+  fi
+  echo $BATCH_NAME
+}
+
+get_job_uid() {
+  local BATCH_UID=""
+  if [ -f $BATCH_FILE ]; then
+    local BATCH_UID=`grep "uid: " $BATCH_FILE | awk '{print $2}'`
+  fi
+  echo $BATCH_UID
+}
+
+update_job_description() {
+  local JOB_NAME=
+  if [ -f $BATCH_FILE ]; then
+    local JOB_NAME=`grep "name: " $BATCH_FILE | head -n 1 | awk '{print $2}'`
+  fi
+
+  if [ ! -z "$JOB_NAME" ]; then
+    gcloud batch jobs describe --project {batch_project} --location {batch_job_region} $JOB_NAME &> $BATCH_FILE
+  fi
+}
+
+get_job_status() {
+  local l_status
+  local l_status="UNQUEUED"
+
+  if [ -f $STATUS_FILE ]; then
+    local l_status=`grep "experient_status" $STATUS_FILE | awk '{print $2}' | sed 's|"||g'`
+  fi
+
+  job_in_list
+  local l_list_check=$?
+  if [ $l_list_check == 0 ]; then
+    local l_status="UNQUEUED"
+  fi
+
+  if [ $l_list_check == 1 -a -f $BATCH_FILE ]; then
+    update_job_description
+
+    local l_status=`grep " state: " $BATCH_FILE | head -n 1 | awk '{print $2}'` &> /dev/null
+    if [ -z "$l_status" ]; then
+      l_status="UNRESOLVED"
+    fi
+
+    if [ ! -z "$l_status" ]; then
+      if [ -v status_map["$l_status"] ]; then
+        local l_status=${status_map["$l_status"]}
+      fi
+    fi
+  fi
+
+  echo $l_status
+}
+
+is_job_complete() {
+  local JOB_STATUS=$(get_job_status)
+
+  if [ "$JOB_STATUS" == "UNQUEUED" ]; then
+      return 1
+  fi
+  if [ "$JOB_STATUS" == "COMPLETE" ]; then
+      return 1
+  fi
+  if [ "$JOB_STATUS" == "FAILED" ]; then
+      return 1
+  fi
+  if [ "$JOB_STATUS" == "UNRESOLVED" ]; then
+      return 1
+  fi
+  return 0
+}

--- a/var/ramble/repos/builtin/workflow_managers/google-batch/batch_query.tpl
+++ b/var/ramble/repos/builtin/workflow_managers/google-batch/batch_query.tpl
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+. {batch_helpers}
+
+has_job_file
+if [ $? == 0 ]; then
+  exit 0
+fi
+
+BATCH_NAME=$(get_job_name)
+
+BATCH_STATUS=$(get_job_status)
+
+echo "Experiment {experiment_namespace} with id $BATCH_NAME has status: $BATCH_STATUS"

--- a/var/ramble/repos/builtin/workflow_managers/google-batch/batch_submit.tpl
+++ b/var/ramble/repos/builtin/workflow_managers/google-batch/batch_submit.tpl
@@ -1,0 +1,35 @@
+#!/bin/bash
+. {batch_helpers}
+
+has_job_file
+if [ $? == 1 ]; then
+  JOB_NAME=$(get_job_name)
+
+  job_in_list
+  if [ $? == 1 ]; then
+    echo "Previous job ${JOB_NAME} is still in batch queue. Will not resubmit."
+    exit 0
+  fi
+
+  echo 'Stale job file found for experiment {experiment_namespace}. Remove with `ramble on --executor="\{batch_clean\}"`. Will not submit.'
+  exit 0
+fi
+
+{batch_submit_cmd} > $BATCH_FILE 2> {experiment_run_dir}/.batch_submit_err
+
+has_job_file
+FILE_EXISTS=$?
+if [ $FILE_EXISTS == 1 ]; then
+  JOB_NAME=$(get_job_name)
+
+  if [ ! -z "$JOB_NAME" ]; then
+    echo "Job $JOB_NAME was submitted successfully"
+  fi
+  if [ -z "$JOB_NAME" ]; then
+    echo "Error submitting experiment {experiment_namespace} to Google Batch."
+    exit 1
+  fi
+fi
+if [ $FILE_EXISTS == 0 ]; then
+  echo "Experiment {experiment_namespace} failed to submit."
+fi

--- a/var/ramble/repos/builtin/workflow_managers/google-batch/batch_wait.tpl
+++ b/var/ramble/repos/builtin/workflow_managers/google-batch/batch_wait.tpl
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+. {batch_helpers}
+
+has_job_file
+if [ $? == 0 ]; then
+  exit 0
+fi
+
+JOB_NAME=$(get_job_name)
+
+echo "Waiting for experiment {experiment_namespace} with id ${JOB_NAME} to complete..."
+
+is_job_complete
+END_LOOP=$?
+while [ $END_LOOP == 0 ]; do
+  sleep 10
+  is_job_complete
+  END_LOOP=$?
+done

--- a/var/ramble/repos/builtin/workflow_managers/google-batch/workflow_manager.py
+++ b/var/ramble/repos/builtin/workflow_managers/google-batch/workflow_manager.py
@@ -1,0 +1,307 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+import yaml
+
+from ramble.wmkit import *
+from ramble.application import experiment_status
+
+from spack.util.executable import ProcessError
+
+# Mapping from batch status to Ramble status
+_STATUS_MAP = {
+    "UNRESOLVED": "UNRESOLVED",
+    "UNQUEUED": "UNQUEUED",
+    "QUEUED": "SUBMITTED",
+    "SCHEDULED": "SUBMITTED",
+    "FAILED": "FAILED",
+    "RUNNING": "RUNNING",
+    "SUCCEEDED": "COMPLETE",
+    "DELETION_IN_PROGRESS": "CANCELLED",
+}
+
+
+def _declare_status_map():
+    """A utility to convert the `_STATUS_MAP` into a bash array"""
+    entries = ["declare -A status_map"]
+    for k, v in _STATUS_MAP.items():
+        entries.append(f'status_map["{k}"]="{v}"')
+    return "\n".join(entries)
+
+
+class GoogleBatch(WorkflowManagerBase):
+    """Google Batch workflow manager"""
+
+    name = "google-batch"
+
+    maintainers("douglasjacobsen")
+
+    tags("workflow", "google", "batch")
+
+    def __init__(self, file_path):
+        super().__init__(file_path)
+
+        self.runner = GcloudRunner()
+
+    workflow_manager_variable(
+        "workflow_banner",
+        default="""# ****************************************************
+# * Workflow manager: google-batch
+# * Submission command is: {batch_submit_cmd}
+# * If this file is not part of the above path, it is unlikely that this file
+# * is used when `ramble on` executes experiments.
+# ****************************************************
+""",
+        description="Banner to describe the workflow within execution templates",
+    )
+
+    workflow_manager_variable(
+        name="job_name",
+        default='{simplify_str("{experiment_namespace}")}',
+        description="Batch job name",
+    )
+
+    workflow_manager_variable(
+        name="hostlist",
+        default="`hostname`",
+        description="hostlist variable used by various modifiers",
+    )
+
+    workflow_manager_variable(
+        name="mpi_command",
+        default="srun {srun_args}",
+        description="mpirun prefix, mostly served as an overridable default",
+    )
+
+    workflow_manager_variable(
+        name="batch_machine_type",
+        default="n2-standard-8",
+        description="Default machine type for batch jobs.",
+    )
+
+    workflow_manager_variable(
+        name="batch_machine_image",
+        default="batch-hpc-rocky",
+        values=["batch-cos", "batch-debian", "batch-hpc-rocky"],
+        description="Default machine image for batch jobs.",
+    )
+
+    workflow_manager_variable(
+        name="batch_disk_size",
+        default="30",
+        description="Default machine size in GB for batch jobs.",
+    )
+
+    workflow_manager_variable(
+        name="batch_job_zone",
+        default="us-central1-a",
+        description="Default zone for batch jobs.",
+    )
+
+    workflow_manager_variable(
+        name="batch_job_region",
+        default="us-central1",
+        description="Default region for batch jobs.",
+    )
+
+    workflow_manager_variable(
+        name="unformatted_batch_command",
+        default="{unformatted_command_without_logs}",
+        description="Command to expand and format for batch execution",
+    )
+
+    workflow_manager_variable(
+        name="batch_project",
+        default="",
+        description="Google Cloud Platform Project to run batch job within.",
+    )
+
+    template_path = os.path.join("{experiment_run_dir}", "batch_config.yaml")
+
+    default_submit_command = (
+        "gcloud batch jobs submit --project {batch_project} "
+        "--config " + template_path + " "
+        "--location {batch_job_region} "
+        "{job_name}"
+    )
+
+    workflow_manager_variable(
+        name="batch_submit_cmd",
+        default=default_submit_command,
+        description="Command to submit batch job",
+    )
+
+    formatted_executable(
+        "batch_formatted_command",
+        prefix="",
+        indentation="14",
+        commands=["{unformatted_batch_command}"],
+    )
+
+    workflow_manager_variable(
+        name="batch_submit_template_path",
+        default="batch_config.yaml.tpl",
+        description="Path to the custom template for generating the slurm sbatch job script. "
+        "For a relative path, it is searched under the workflow manager's source directory. "
+        "The path can contain workspace path variables such as $workspace_config.",
+    )
+
+    register_template(
+        name="batch_config",
+        src_path="batch_config.yaml.tpl",
+        dest_path="batch_config.yaml",
+    )
+
+    register_template(
+        name="batch_submit",
+        src_path="batch_submit.tpl",
+        dest_path="batch_submit",
+        extra_vars_func="batch_submit_vars",
+    )
+
+    def _batch_submit_vars(self):
+        vars = self.app_inst.variables
+        old_var_name = "_old_batch_submit"
+        if old_var_name in vars:
+            batch_submit_cmd = vars[old_var_name]
+            if "gcloud" not in batch_submit_cmd:
+                logger.warn(
+                    "`gcloud` is missing in the given `batch_submit` command"
+                )
+        else:
+            batch_submit_cmd = self.default_submit_command
+
+        return {
+            "batch_submit_cmd": batch_submit_cmd,
+        }
+
+    register_template(
+        name="batch_helpers",
+        src_path="batch_helpers.tpl",
+        dest_path="batch_helpers",
+        extra_vars={"declare_status_map": _declare_status_map()},
+    )
+
+    register_template(
+        name="batch_fetch_logs",
+        src_path="batch_fetch_logs.tpl",
+        dest_path="batch_fetch_logs",
+    )
+
+    register_template(
+        name="batch_query",
+        src_path="batch_query.tpl",
+        dest_path="batch_query",
+        extra_vars={"declare_status_map": _declare_status_map()},
+    )
+
+    register_template(
+        name="batch_cancel",
+        src_path="batch_cancel.tpl",
+        dest_path="batch_cancel",
+    )
+
+    register_template(
+        name="batch_clean",
+        src_path="batch_clean.tpl",
+        dest_path="batch_clean",
+    )
+
+    register_template(
+        name="batch_wait",
+        src_path="batch_wait.tpl",
+        dest_path="batch_wait",
+    )
+
+    def get_status(self, workspace):
+        expander = self.app_inst.expander
+        run_dir = expander.expand_var_name("experiment_run_dir")
+        job_file = os.path.join(run_dir, ".batch_job.yaml")
+        status = experiment_status.UNRESOLVED
+        if not os.path.isfile(job_file):
+            logger.warn(
+                f"{self.name} job file is missing in experiment {expander.experiment_namespace}"
+            )
+            return status
+
+        with open(job_file) as f:
+            job_data = yaml.safe_load(f)
+
+        job_name = job_data["name"]
+
+        self.runner.set_dry_run(workspace.dry_run)
+        project = expander.expand_var_name("batch_project")
+        location = expander.expand_var_name("batch_job_region")
+        wm_status_raw = self.runner.get_status(project, location, job_name)
+        wm_status = _STATUS_MAP.get(wm_status_raw)
+        if wm_status is not None and hasattr(experiment_status, wm_status):
+            status = getattr(experiment_status, wm_status)
+        if status == experiment_status.UNRESOLVED:
+            logger.warn(
+                f"The {self.name} workflow manager failed to resolve the status of job {job_name}.\n "
+                "Enable debug mode (`ramble -d`) for more detailed error messages."
+            )
+        return status
+
+
+class GcloudRunner:
+    """Runner for executing gcloud commands"""
+
+    def __init__(self, dry_run=False):
+        self.dry_run = dry_run
+        self.gcloud_runner = None
+        self.run_dir = None
+
+    def _ensure_runner(self, runner_name: str):
+        attr = f"{runner_name}_runner"
+        if getattr(self, attr) is None:
+            setattr(
+                self,
+                attr,
+                CommandRunner(name=runner_name, command=runner_name),
+            )
+
+    def set_dry_run(self, dry_run=False):
+        """
+        Set the dry_run state of this runner
+        """
+        self.dry_run = dry_run
+
+    def get_status(self, project, location, job_name):
+        if self.dry_run:
+            return None
+        self._ensure_runner("gcloud")
+        status_args = [
+            "batch",
+            "jobs",
+            "describe",
+            "--project",
+            project,
+            "--location",
+            location,
+            job_name,
+        ]
+        try:
+            status_out = self.gcloud_runner.command(
+                *status_args, output=str, error=os.devnull
+            )
+        except ProcessError as e:
+            status_out = ""
+            logger.debug(
+                f"`gcloud batch jobs describe` returns error {e}. This is normal if the job has already been completed."
+            )
+
+        yaml_status = yaml.safe_load(status_out)
+        if (
+            yaml_status
+            and "status" in yaml_status
+            and "state" in yaml_status["status"]
+        ):
+            return yaml_status["status"]["state"]
+        return "UNRESOLVED"


### PR DESCRIPTION
This merge adds functionality for two major things, along with a minor change.

The first is the addition of the Google Batch workflow manager. This allows experiments to be submitted to Google Batch directly, and provides functionality for managing and inspecting the jobs.

The second major addition is a formatted_executables directive. This allows objects to define their own formatted executables that can be used within templates or workflows.

The minor addition is the definition of `unformatted_command_sans_logs` which contains the same content as `unformatted_command` but omits any log removal, creation, and redirection.