### PR TITLE
Guard appending results when no results exist

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -1812,7 +1812,8 @@ class ApplicationBase(metaclass=ApplicationMeta):
         so when the workspace dumps results they are included.
         """
 
-        workspace.append_result(self.result.to_dict())
+        if hasattr(self, "result") and self.result is not None:
+            workspace.append_result(self.result.to_dict())
 
     def calculate_statistics(self, workspace):
         """Calculate statistics for results of repeated experiments


### PR DESCRIPTION
This merge adds a guarding check when trying to append results to a workspace. Previously, if results were not found in an experiment, analysis of a workspace would fail. This change allows these issues to be gracefully ignored.