### PR TITLE
Allow env-var names to be expanded

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -1365,7 +1365,9 @@ class ApplicationBase(metaclass=ApplicationMeta):
                 app_licenses = license_conf[self.name] if self.name in license_conf else {}
 
                 for action, conf in app_licenses.items():
-                    (env_cmds, var_set) = action_funcs[action](conf, var_set, shell=shell)
+                    (env_cmds, var_set) = action_funcs[action](
+                        conf, self.expander, var_set, shell=shell
+                    )
 
                     lock = lk.Lock(os.path.join(self.license_path, ".ramble-license"))
                     with lk.WriteTransaction(lock):
@@ -2299,7 +2301,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
         # Process environment variable actions
         for env_var_set in self._env_variable_sets:
             for action, conf in env_var_set.items():
-                (env_cmds, _) = action_funcs[action](conf, set(), shell=shell)
+                (env_cmds, _) = action_funcs[action](conf, self.expander, set(), shell=shell)
 
                 for cmd in env_cmds:
                     if cmd:
@@ -2307,7 +2309,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
 
         for mod_inst in self._modifier_instances:
             for action, conf in mod_inst.all_env_var_modifications():
-                (env_cmds, _) = action_funcs[action](conf, set(), shell=shell)
+                (env_cmds, _) = action_funcs[action](conf, self.expander, set(), shell=shell)
 
                 for cmd in env_cmds:
                     if cmd:

--- a/lib/ramble/ramble/test/util/env.py
+++ b/lib/ramble/ramble/test/util/env.py
@@ -8,14 +8,19 @@
 """Perform tests of the util/env functions"""
 
 import ramble.util.env
+from ramble.expander import Expander
 
 
 def test_env_var_set_command_gen(mutable_mock_apps_repo):
-    tests = {"var1": "val1", "var2": "val2"}
+    tests = {"var1": "val1", "var2": "val2", "{test_exp}": "bar"}
 
-    answer = ["export var1=val1;", "export var2=val2;"]
+    answer = ["export var1=val1;", "export var2=val2;", "export foo=bar;"]
 
-    out_cmds, _ = ramble.util.env.action_funcs["set"](tests, set())
+    exp_vars = {"test_exp": "foo"}
+
+    expander = Expander(exp_vars, None)
+
+    out_cmds, _ = ramble.util.env.action_funcs["set"](tests, expander, set())
     for cmd in answer:
         assert cmd in out_cmds
 
@@ -24,7 +29,7 @@ def test_env_var_append_command_gen(mutable_mock_apps_repo):
     tests = [
         {
             "var-separator": ",",
-            "vars": {"var1": "val1", "var2": "val2"},
+            "vars": {"var1": "val1", "var2": "val2", "{test_exp}": "bar"},
             "paths": {"path1": "path1", "path2": "path2"},
         },
         {
@@ -36,33 +41,49 @@ def test_env_var_append_command_gen(mutable_mock_apps_repo):
     answer = [
         'export var1="${var1},val1,val2";',
         'export var2="${var2},val2,val1";',
+        'export foo="${foo},bar";',
         'export path1="${path1}:path1";',
         'export path2="${path2}:path2";',
     ]
 
-    out_cmds, _ = ramble.util.env.action_funcs["append"](tests, set())
+    exp_vars = {"test_exp": "foo"}
+    expander = Expander(exp_vars, None)
+
+    out_cmds, _ = ramble.util.env.action_funcs["append"](tests, expander, set())
     for cmd in answer:
         assert cmd in out_cmds
 
 
 def test_env_var_prepend_command_gen(mutable_mock_apps_repo):
     tests = [
-        {"paths": {"path1": "path1", "path2": "path2"}},
-        {"paths": {"path1": "path2", "path2": "path1"}},
+        {"paths": {"path1": "path1", "path2": "path2", "{test_exp}": "bar"}},
+        {"paths": {"path1": "path2", "path2": "path1", "{test_exp}": "bar"}},
     ]
 
-    answer = ['export path1="path2:path1:${path1}";', 'export path2="path1:path2:${path2}";']
+    answer = [
+        'export path1="path2:path1:${path1}";',
+        'export path2="path1:path2:${path2}";',
+        'export foo="bar:bar:${foo}";',
+    ]
 
-    out_cmds, _ = ramble.util.env.action_funcs["prepend"](tests, set())
+    exp_vars = {"test_exp": "foo"}
+
+    expander = Expander(exp_vars, None)
+
+    out_cmds, _ = ramble.util.env.action_funcs["prepend"](tests, expander, set())
     for cmd in answer:
         assert cmd in out_cmds
 
 
 def test_env_var_unset_command_gen(mutable_mock_apps_repo):
-    tests = ["var1", "var2"]
+    tests = ["var1", "var2", "{test_exp}"]
 
-    answer = ["unset var1;", "unset var2;"]
+    answer = ["unset var1;", "unset var2;", "unset foo;"]
 
-    out_cmds, _ = ramble.util.env.action_funcs["unset"](tests, set())
+    exp_vars = {"test_exp": "foo"}
+
+    expander = Expander(exp_vars, None)
+
+    out_cmds, _ = ramble.util.env.action_funcs["unset"](tests, expander, set())
     for cmd in answer:
         assert cmd in out_cmds


### PR DESCRIPTION
This merge enables environment variable names to be references to variables, which will be expanded.

Multiple variables that expand to the same name would cause the last value to be set.