### PR TITLE
feat: update lammps reaxff to use newer builds

### DIFF
--- a/examples/apptainer/lammps-reaxff.yaml
+++ b/examples/apptainer/lammps-reaxff.yaml
@@ -1,0 +1,51 @@
+# Copyright 2022-2025 The Ramble Authors
+
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+ramble:
+  modifiers:
+  - name: apptainer
+  env_vars:
+    set:
+      OMP_NUM_THREADS: '{n_threads}'
+  variables:
+    mpi_command: ''
+    container_uri: docker://ghcr.io/converged-computing/metric-lammps-cpu:libfabric-zen4-reax
+    container_name: lammps-reax
+    batch_submit: '{execute_experiment}'
+    processes_per_node: 1
+    gpus_per_node: 0
+    # This is how you can add flags
+    # apptainer_run_args: --nv --bind {container_mounts} --writable-tmpfs
+  applications:
+    lammps: # Application name
+      workloads:
+        hns-reaxff: # Workload name from application
+          experiments:
+            strong_scale: # Arbitrary experiment name
+              variables:
+                env_name: apptainer
+                n_nodes: 1
+                lammps_path: /usr
+                # Add other lammps flags
+                lammps_flags: "-nocite"
+                # This is the release that is downloaded
+                input_stage: stable_29Aug2024_update1
+                # The input file used for lammps from the input_path directory
+                input_file: in.reaxff.hns
+                # Problem size dimensions for lammps
+                xx: 2
+                yy: 2
+                zz: 2
+  software:
+    packages:
+      apptainer:
+        pkg_spec: apptainer
+    environments:
+      lammps:
+        packages:
+        - apptainer

--- a/var/ramble/repos/builtin/applications/lammps/application.py
+++ b/var/ramble/repos/builtin/applications/lammps/application.py
@@ -72,12 +72,10 @@ class Lammps(ExecutableApplication):
 
     input_file(
         "lammps-stage",
-        url="https://github.com/lammps/lammps/archive/refs/tags/stable_23Jun2022_update3.tar.gz",
-        target_dir="{application_input_dir}/stable_23Jun2022_update3",
-        description="Stage of lammps source from 20220623.3 release",
-        sha256="8a276a01b50d37eecfe6eb36f420f354cde51936d20aca7944dea60d3c098c89",
+        url="https://github.com/lammps/lammps/archive/refs/tags/{input_stage}.tar.gz",
+        target_dir="{application_input_dir}/lammps-input-stage",
+        description="Stage of lammps source from release",
     )
-
     executable(
         "copy",
         template=["cp {input_path} {experiment_run_dir}/input.txt"],
@@ -276,11 +274,19 @@ class Lammps(ExecutableApplication):
     )
 
     workload_variable(
+        "input_stage",
+        default="stable_23Jun2022_update3.tar.gz",
+        description="Stage name of LAMMPS input archive",
+        workloads=["hns-reaxff"],
+    )
+
+    workload_variable(
         "input_file",
         default="in.reaxc.hns",
         description="hns-reaxff input file name",
         workloads=["hns-reaxff"],
     )
+
     workload_variable(
         "input_path",
         default=os.path.join(f"{intel_test_path}"),


### PR DESCRIPTION
Problem: we want to run apptainer with lammps, and not require any spack or previous software installed. This adds an example, and also a new variable that exposes the version of lammps to download.

@douglasjacobsen this successfully runs our lammps container with ramble, with the updated problem (and I figured out what I needed to in order to get it to work, thanks for the help!)

I added a new directory to examples that can explicitly be for apptainer, the reason because I think some users will want to skip spack, etc. and jump straight to that. 

## Questions

I have questions about usability too (and sorry if I missed these in the docs).

- I noticed on the first run I did that the input.txt file, even when I specified a new input_file and ran setup again, did not update. I had to manually remove the experiment directory and then setup again and rerun for the change to propagate. **Could that be a bug or is there a different command I need to run in order to properly cleanup?**
- I'd like to be able to do `ramble on` and see the output stream to the terminal (right now it doesn't, it runs silently and I have to cat the output file) - **is there a flag or command to stream output to the terminal**?
- **Is there a programmatic way to create the workspace from the file** instead of manually copy pasting into the `ramble workspace edit --config`? We will need that for automated runs.
- **Where do I specify a number of iterations for an experiment?**
- **Is there a command to cleanup a ramble workspace (not delete it, just remove the experiment results to do again)?**
- For top level variables, I'm wondering why `mpi_command` and `batch_submit` need to be set, when they are basically using defaults (an empty string and `{execute_command}`. It added some confusion for my first try because I had no idea what they means.
- I'm guessing that for some run with a workload manager, I'd set the `batch_submit` to something with my workload manager (e.g., flux)? And would I put the nodes / tasks in there as well?

Thanks for answering my questions! When I know about the above, I'll probably next test this running from inside a container with a lammps executable directly, and then with flux. 