### PR TITLE
Reset success criteria before evaluating each experiment

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -546,7 +546,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
         criteria_list = workspace.success_list
         for criteria in criteria_list.all_criteria():
             if criteria.mode == "fom_comparison":
-                self.expander.expand_var(criteria.formula)
+                self.expander.expand_var(criteria.fom_formula)
                 self.expander.expand_var(criteria.fom_name)
                 self.expander.expand_var(criteria.fom_context)
             elif criteria.mode == "application_function":
@@ -1668,6 +1668,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
         fom_values = {}
 
         criteria_list = workspace.success_list
+        criteria_list.reset()
 
         files, contexts, foms = self._analysis_dicts(criteria_list)
 

--- a/lib/ramble/ramble/success_criteria.py
+++ b/lib/ramble/ramble/success_criteria.py
@@ -49,6 +49,11 @@ class ScopedCriteriaList:
         for scope in self._valid_scopes:
             self.criteria[scope] = []
 
+    def reset(self):
+        for scope in self._valid_scopes:
+            for criteria in self.criteria[scope]:
+                criteria.reset()
+
     def validate_scope(self, scope):
         if scope not in self._valid_scopes:
             logger.die(
@@ -156,7 +161,7 @@ class SuccessCriteria:
                     f'Success criteria with mode="{mode}" '
                     'require a "fom_name" and "formula" attribute.'
                 )
-            self.formula = formula
+            self.fom_formula = formula
             self.fom_name = fom_name
             self.fom_context = fom_context
 
@@ -210,7 +215,7 @@ class SuccessCriteria:
 
                     comparison_tested = True
                     result = app_inst.expander.evaluate_predicate(
-                        self.formula, extra_vars=comparison_vars
+                        self.fom_formula, extra_vars=comparison_vars
                     )
 
             # If fom doesn't match any fom names, fail the comparison


### PR DESCRIPTION
This merge updates success criteria to reset the state of each criteria before trying to evaluate the experiment's status.