### PR TITLE
Minor cleanups

### DIFF
--- a/lib/ramble/ramble/cmd/unit_test.py
+++ b/lib/ramble/ramble/cmd/unit_test.py
@@ -66,11 +66,6 @@ def setup_parser(subparser):
         help="list full names of all tests",
     )
 
-    # use tests for extension
-    subparser.add_argument(
-        "--extension", default=None, help="run test for a given ramble extension"
-    )
-
     # spell out some common pytest arguments, so they'll show up in help
     pytest_group = subparser.add_argument_group(
         "common pytest arguments (ramble unit-test --pytest-help for more)"
@@ -200,13 +195,7 @@ def unit_test(parser, args, unknown_args):
     # add back any parsed pytest args we need to pass to pytest
     pytest_args = add_back_pytest_args(args, unknown_args)
 
-    # The default is to test the core of Ramble. If the option `--extension`
-    # has been used, then test that extension.
     pytest_root = ramble.paths.ramble_root
-    if args.extension:
-        target = args.extension
-        extensions = ramble.config.get("config:extensions")
-        pytest_root = ramble.extensions.path_for_extension(target, *extensions)
 
     # pytest.ini lives in the root of the ramble repository.
     with working_dir(pytest_root):

--- a/lib/ramble/ramble/util/command_runner.py
+++ b/lib/ramble/ramble/util/command_runner.py
@@ -129,6 +129,7 @@ class CommandRunner:
         error = False
 
         self._cmd_start(executable, args)
+        out_str = None
         try:
             if active_stream is None:
                 if return_output:
@@ -155,7 +156,7 @@ class CommandRunner:
 
         self._cmd_end(executable, args)
 
-        if return_output:
+        if out_str is not None:
             return out_str
         return
 

--- a/lib/ramble/ramble/util/stats.py
+++ b/lib/ramble/ramble/util/stats.py
@@ -31,6 +31,7 @@ def max_decimal_places(list):
 
 class StatsBase:
     min_count = 1
+    name = ""
 
     def compute(self, values):
         pass

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -634,7 +634,7 @@ _ramble_style() {
 _ramble_unit_test() {
     if $list_options
     then
-        RAMBLE_COMPREPLY="-h --help -H --pytest-help -l --list -L --list-long -N --list-names --extension -s -k --showlocals"
+        RAMBLE_COMPREPLY="-h --help -H --pytest-help -l --list -L --list-long -N --list-names -s -k --showlocals"
     else
         _tests
     fi


### PR DESCRIPTION
* A couple tweaks to get rid of pylint errors
* Remove the `--extension` support in `unit-test`, which doesn't actually work