### PR TITLE
Create a user-managed package manager, update None package manager

### DIFF
--- a/etc/ramble/defaults/variants.yaml
+++ b/etc/ramble/defaults/variants.yaml
@@ -1,0 +1,2 @@
+variants:
+  package_manager: user-managed

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -273,18 +273,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
                         "\tramble list --type package_managers"
                     )
 
-        # Mark required package variables appropriately
-        if self.package_manager is None:
-            for pkgname, _ in self.required_packages.items():
-                self.keywords.update_keys(
-                    {
-                        f"{pkgname}_path": {
-                            "type": ramble.keywords.key_type.required,
-                            "level": ramble.keywords.output_level.variable,
-                        }
-                    }
-                )
-        else:
+        if self.package_manager is not None:
             for pkgname, config in self.required_packages.items():
                 if fnmatch.fnmatch(self.package_manager.name, config["package_manager"]):
                     self.keywords.update_keys(

--- a/lib/ramble/ramble/test/end_to_end/known_applications.py
+++ b/lib/ramble/ramble/test/end_to_end/known_applications.py
@@ -50,7 +50,7 @@ def test_known_applications(application, package_manager, mock_file_auto_create)
             "-w",
             "test_workload",
         ]
-        if package_manager == "None":
+        if package_manager == "user-managed":
             app_inst = ramble.repository.get(application)
             for pkg in app_inst.required_packages.keys():
                 args.append("-v")

--- a/var/ramble/repos/builtin/package_managers/user-managed/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/user-managed/package_manager.py
@@ -1,0 +1,56 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.pkgmankit import *  # noqa: F403
+
+
+class UserManaged(PackageManagerBase):
+    """Package manager representing a user managed environment.
+
+    This package manager is used when the software required for the experiments
+    is manually installed outside of Ramble. Generally, a user will need to
+    convey the paths to these installed packages to Ramble through specific
+    variable definitions.
+    """
+
+    name = "user-managed"
+
+    _spec_prefix = "user_managed"
+
+    register_phase(
+        "define_requirements",
+        pipeline="setup",
+        run_before=["get_inputs"],
+    )
+
+    def _define_requirements(self, workspace, app_inst=None):
+        """Define requirements for user managed software stack
+
+        Extracts all required packages from experiments and modifiers, then
+        creates required variables to convey the installation locations to
+        Ramble.
+        """
+
+        package_objects = [app_inst]
+        package_objects.append(self)
+        if app_inst.workflow_manager is not None:
+            package_objects.append(app_inst.workflow_manager)
+        package_objects.extend(app_inst._modifier_instances)
+
+        for obj in package_objects:
+            for pkgname, _ in obj.required_packages.items():
+                app_inst.keywords.update_keys(
+                    {
+                        f"{pkgname}_path": {
+                            "type": ramble.keywords.key_type.required,
+                            "level": ramble.keywords.output_level.variable,
+                        }
+                    }
+                )
+
+        app_inst.validate_experiment()

--- a/var/ramble/repos/builtin/package_managers/user-managed/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/user-managed/package_manager.py
@@ -36,14 +36,13 @@ class UserManaged(PackageManagerBase):
         Ramble.
         """
 
-        package_objects = [app_inst]
-        package_objects.append(self)
-        if app_inst.workflow_manager is not None:
-            package_objects.append(app_inst.workflow_manager)
-        package_objects.extend(app_inst._modifier_instances)
+        if app_inst is None:
+            package_objects = [(None, self)]
+        else:
+            package_objects = app_inst._objects()
 
-        for obj in package_objects:
-            for pkgname, _ in obj.required_packages.items():
+        for _, obj in package_objects:
+            for pkgname in obj.required_packages.keys():
                 app_inst.keywords.update_keys(
                     {
                         f"{pkgname}_path": {


### PR DESCRIPTION
This merge creates a user-managed package manager that behaves as the previous None package manager was.

Additionally, the None package manager has been converted to not do anything. Paths are no longer required to be defined when using a None package manager anymore. The default package manager is updated to be `user-managed`.