### PR TITLE
Update default semantics for variants in new workspaces

### DIFF
--- a/etc/ramble/defaults/variants.yaml
+++ b/etc/ramble/defaults/variants.yaml
@@ -1,2 +1,3 @@
 variants:
   package_manager: user-managed
+  workflow_manager: null

--- a/lib/ramble/ramble/test/end_to_end/variant_propagation.py
+++ b/lib/ramble/ramble/test/end_to_end/variant_propagation.py
@@ -1,0 +1,36 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import pytest
+
+import ramble.workspace
+import ramble.config
+from ramble.main import RambleCommand
+
+
+# everything here uses the mock_workspace_path
+pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_path")
+
+workspace = RambleCommand("workspace")
+
+
+def test_variant_propagation_in_new_workspace(
+    mutable_config, mutable_mock_workspace_path, request
+):
+    ws_name = request.node.name
+    ramble.config.add("variants:package_manager:spack")
+    ramble.config.add("variants:workflow_manager:slurm")
+    with ramble.workspace.create(ws_name) as ws1:
+        ws1.write()
+
+        config_path = ws1.config_file_path
+
+        with open(config_path) as f:
+            data = f.read()
+            assert "package_manager: spack" in data
+            assert "workflow_manager: slurm" in data

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -576,7 +576,21 @@ cd "{experiment_run_dir}"
 
     @classmethod
     def _default_config_yaml(self):
-        return """\
+
+        # Construct string for default variants
+        variant_string = ""
+        variant_dict = ramble.config.get("variants")
+        variant_defs = []
+
+        for var, val in variant_dict.items():
+            variant_defs.append(f"    {var}: {val}")
+
+        if variant_defs:
+            merged_string = "\n".join(variant_defs)
+            variant_string = f"""  variants:
+{merged_string}"""
+
+        return f"""\
 # This is a ramble workspace config file.
 #
 # It describes the experiments, the software stack
@@ -594,20 +608,21 @@ cd "{experiment_run_dir}"
 #         experiments:
 #           single_node: # Arbitrary experiment name
 #             variables:
-#               n_ranks: '{processes_per_node}'
+#               n_ranks: '{{processes_per_node}}'
 
 ramble:
   env_vars:
     set:
-      OMP_NUM_THREADS: '{n_threads}'
+      OMP_NUM_THREADS: '{{n_threads}}'
+{variant_string}
   variables:
-    mpi_command: mpirun -n {n_ranks}
-    batch_submit: '{execute_experiment}'
+    mpi_command: mpirun -n {{n_ranks}}
+    batch_submit: '{{execute_experiment}}'
     processes_per_node: 1
-  applications: {}
+  applications: {{}}
   software:
-    packages: {}
-    environments: {}
+    packages: {{}}
+    environments: {{}}
 """
 
     def _read_application_config(self, path, f, raw_yaml=None):


### PR DESCRIPTION
This merge updates the semantics around variants within newly created workspaces. Previously, externally defined variants would not show up within a workspace. This merge updates this behavior so now any variants that are defined outside of workspaces are propagated into the workspace when it is created.

This is primarily as a mechanism to communicate to users who create new workspaces what is defined within their workspace and to help allow them to change this more easily.