### PR TITLE
Better error message for malformed ramble.yaml

### DIFF
--- a/lib/ramble/ramble/config.py
+++ b/lib/ramble/ramble/config.py
@@ -169,7 +169,7 @@ def first_existing(dictionary, keys):
     try:
         return next(k for k in keys if k in dictionary)
     except StopIteration:
-        raise KeyError("None of %s is in dict!" % keys)
+        raise KeyError(f"None of {keys} is in dict!")
 
 
 class ConfigScope:

--- a/lib/ramble/ramble/test/end_to_end/malformed_config.py
+++ b/lib/ramble/ramble/test/end_to_end/malformed_config.py
@@ -1,0 +1,57 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import pytest
+import os
+
+import ramble.workspace
+import ramble.config
+import ramble.software_environments
+from ramble.main import RambleCommand
+
+
+# everything here uses the mock_workspace_path
+pytestmark = pytest.mark.usefixtures(
+    "mutable_config",
+    "mutable_mock_workspace_path",
+)
+
+workspace = RambleCommand("workspace")
+
+
+def test_missing_config_keys():
+    test_config = """
+amble:
+  variables:
+    mpi_command: ''
+    batch_submit: 'batch_submit {execute_experiment}'
+    processes_per_node: 1
+    n_nodes: 1
+  applications:
+    hostname:
+      workloads:
+        local:
+          experiments:
+            test: {}
+"""
+    ws_name = "test_missing_config_keys"
+    ws = ramble.workspace.create(ws_name)
+    ws.write()
+
+    config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+
+    with open(config_path, "w+") as f:
+        f.write(test_config)
+
+    ws._re_read()
+
+    with pytest.raises(
+        ramble.workspace.RambleActiveWorkspaceError,
+        match="ramble.yaml needs to contain at least one of the required keys",
+    ):
+        workspace("info", global_args=["-w", ws_name])

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -327,8 +327,14 @@ def create(name, read_default_template=True):
 
 def config_dict(yaml_data):
     """Get the configuration scope section out of a ramble.yaml"""
-    key = ramble.config.first_existing(yaml_data, ramble.schema.workspace.keys)
-    return yaml_data[key]
+    try:
+        key = ramble.config.first_existing(yaml_data, ramble.schema.workspace.keys)
+        return yaml_data[key]
+    except KeyError:
+        raise RambleActiveWorkspaceError(
+            "ramble.yaml needs to contain at least one of the "
+            f"required keys {ramble.schema.workspace.keys}"
+        )
 
 
 def get_workspace(args, cmd_name, required=False):


### PR DESCRIPTION
Before the fix:

```
$ ramble workspace create -a typo-test
$ ramble workspace manage experiments hostname
$ sed -i '0,/ramble:/{s/ramble:/amble:/}' $RAMBLE_WORKSPACE/configs/ramble.yaml # create a malformed config
$ ramble workspace info
==> Error: not all arguments converted during string formatting
```

With the fix (also allows `workspace edit` to open and fix up the file):

```
$ ramble workspace info
==> Error while reading workspace config. In some cases this can be avoided by passing `-W` to ramble or by running
`ramble workspace deactivate`
==> Error: ramble.yaml needs to contain at least one of the required keys ('ramble', 'workspace')
```