### PR TITLE
Allow package managers to ignore defined software environments

### DIFF
--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -723,7 +723,10 @@ def workspace_info(args):
 
                 for exp_name, _, _ in print_experiment_set.filtered_experiments(filters):
                     app_inst = experiment_set.get_experiment(exp_name)
-                    if app_inst.package_manager is not None:
+                    if (
+                        app_inst.package_manager is not None
+                        and app_inst.package_manager.uses_software_environment
+                    ):
                         software_environments.render_environment(
                             app_inst.expander.expand_var("{env_name}"),
                             app_inst.expander,

--- a/lib/ramble/ramble/package_manager.py
+++ b/lib/ramble/ramble/package_manager.py
@@ -47,6 +47,7 @@ class PackageManagerBase(metaclass=PackageManagerMeta):
     _spec_prefix = ""
 
     package_manager_class = "PackageManagerBase"
+    uses_software_environment = True
 
     #: Lists of strings which contains GitHub usernames of attributes.
     #: Do not include @ here in order not to unnecessarily ping the users.
@@ -178,12 +179,13 @@ class PackageManagerBase(metaclass=PackageManagerMeta):
         Returns:
             (set): All variable names used by this experiment.
         """
-        app_context = self.app_inst.expander.expand_var_name(self.keywords.env_name)
+        if self.uses_software_environment:
+            app_context = self.app_inst.expander.expand_var_name(self.keywords.env_name)
 
-        software_environments = workspace.software_environments
-        software_environments.render_environment(
-            app_context, self.app_inst.expander, self, require=False
-        )
+            software_environments = workspace.software_environments
+            software_environments.render_environment(
+                app_context, self.app_inst.expander, self, require=False
+            )
 
         return self.app_inst.expander._used_variables
 

--- a/var/ramble/repos/builtin/package_managers/user-managed/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/user-managed/package_manager.py
@@ -22,6 +22,8 @@ class UserManaged(PackageManagerBase):
 
     _spec_prefix = "user_managed"
 
+    uses_software_environment = False
+
     register_phase(
         "define_requirements",
         pipeline="setup",


### PR DESCRIPTION
This merge fixes an issue where the `user-managed` package required an environment to be used, when it doesn't actually consume it.

Package managers now have a `uses_software_environments` attribute that can be used to prevent them from requiring a software environment.