### PR TITLE
wrfv4: Change executable order

### DIFF
--- a/var/ramble/repos/builtin/applications/wrfv4/application.py
+++ b/var/ramble/repos/builtin/applications/wrfv4/application.py
@@ -80,13 +80,13 @@ class Wrfv4(ExecutableApplication):
 
     workload(
         "CONUS_2p5km",
-        executables=["cleanup", "copy", "execute"],
+        executables=["copy", "cleanup", "execute"],
         input="CONUS_2p5km",
     )
 
     workload(
         "CONUS_12km",
-        executables=["cleanup", "copy", "fix_12km", "execute"],
+        executables=["copy", "cleanup", "fix_12km", "execute"],
         input="CONUS_12km",
     )
 


### PR DESCRIPTION
This merge moves the cleanup executable further in the workload executable list, to ensure rsl files are purged before executing the experiment.