### PR TITLE
Add a `maybe` function to expander

### DIFF
--- a/lib/ramble/docs/workspace_config.rst
+++ b/lib/ramble/docs/workspace_config.rst
@@ -175,6 +175,7 @@ Supported functions are:
 * ``randrange`` (from `random.randrange`)
 * ``randint`` (from `random.randint`)
 * ``re_search(regex, str)`` (determine if ``str`` contains pattern ``regex``, based on ``re.search``)
+* ``maybe(var_name, default="")`` (returns the expanded ``var_name`` if it is defined, otherwise returns ``default``)
 
 String slicing is supported:
 

--- a/lib/ramble/ramble/test/expander.py
+++ b/lib/ramble/ramble/test/expander.py
@@ -91,6 +91,9 @@ def exp_dict():
         ("{test_dict['test_key2']}", "test_val2", set(), 1),
         ("{test_dict['missing_key']}", "{test_dict['missing_key']}", set(), 1),
         ("{test_dict[None]}", "{test_dict[None]}", set(), 1),
+        ("maybe(env_name, foo)", "spack_foo.bar", set(), 1),
+        ("maybe(not_a_var, foo)", "foo", set(), 1),
+        ("maybe(not_a_var)", "", set(), 1),
     ],
 )
 def test_expansions(input, output, no_expand_vars, passes):


### PR DESCRIPTION
The motivation is to enable filtering using variables that are only defined for a subset of the experiments.

For instance, for the following workspace config:

```
ramble:
  variables:
    mpi_command: ''
    batch_submit: '{execute_experiment}'
    processes_per_node: 1
    n_nodes: 1
  applications:
    hostname:
      workloads:
        local:
          experiments:
            test_{local_var}:
              variables:
                local_var: ["l1", "l2"]
        parallel:
          experiments:
            test_parallel: {}
```

Filter done with the `local_var`:

```
$ ramble workspace info --where 'maybe(local_var) == "l2"'
Workspace: wl-name

Location: /usr/local/google/home/linsword/hpc-dev/ramble/var/ramble/workspaces/wl-name

Experiments:
  Application: hostname
    Workload: local
      Experiment 2: hostname.local.test_l2
```