### PR TITLE
Fix attribute reference expansion

### DIFF
--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -783,7 +783,9 @@ class Expander:
         elif isinstance(node.value, ast.Name):
             base = self._ast_name(node.value)
         else:
-            self.__raise_syntax_error(node)
+            self.__dbg_syntax_error(
+                " Unknown attribute syntax used.\nreturning unexpanded string", node
+            )
 
         val = f"{base}.{node.attr}"
         return val

--- a/lib/ramble/ramble/test/expander.py
+++ b/lib/ramble/ramble/test/expander.py
@@ -94,6 +94,7 @@ def exp_dict():
         ("maybe(env_name, foo)", "spack_foo.bar", set(), 1),
         ("maybe(not_a_var, foo)", "foo", set(), 1),
         ("maybe(not_a_var)", "", set(), 1),
+        ("2.1.a", "2.1.a", set(), 1),
     ],
 )
 def test_expansions(input, output, no_expand_vars, passes):


### PR DESCRIPTION
Previously, Ramble wouldn't handle unknown formats of attributes (i.e. `'2.3.a'`). These would raise an error that would cause Ramble to fail when trying to expand the input string.

This merge adds a test that previously failed, and fixes this by allowing unknown attribute formats to pass through the expander without error.