### PR TITLE
Ensure dependency indicators are ignored in spack provenance strings

### DIFF
--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
@@ -1354,7 +1354,13 @@ class SpackRunner(CommandRunner):
             ).replace('"', "")
 
             if all_info:
-                for info in all_info.split("\n"):
+                for info_line in all_info.split("\n"):
+                    pkg_parts = info_line.split(" ")
+                    if len(pkg_parts) == 1:
+                        info = pkg_parts[0]
+                    else:
+                        info = " ".join(pkg_parts[1:])
+
                     info_dict = self._package_dict_from_str(info)
 
                     if info_dict:


### PR DESCRIPTION
This merge updates the spack package manager's provenance extraction logic to handle a more recent spack change that omits dependency and external indicators along with package data in the output of `spack find`.

This previously broke provenance extraction, as Ramble would end up tracking the indicators incorrectly.