### PR TITLE
Update RAMBLE_PYTHON logic to use _RAMBLE_PYTHON

### DIFF
--- a/bin/ramble
+++ b/bin/ramble
@@ -17,10 +17,10 @@
 # prefer python3, then python, then python2
 ## prefer RAMBLE_PYTHON environment variable, python3, python, then python2
 RAMBLE_PREFERRED_PYTHONS="python3 python python2 /usr/libexec/platform-python"
-for cmd in "${RAMBLE_PYTHON:-}" ${RAMBLE_PREFERRED_PYTHONS}; do
+for cmd in "${_RAMBLE_PYTHON}" "${RAMBLE_PYTHON:-}" ${RAMBLE_PREFERRED_PYTHONS}; do
     if command -v > /dev/null "$cmd"; then
-        export RAMBLE_PYTHON="$(command -v "$cmd")"
-        exec "${RAMBLE_PYTHON}" "$0" "$@"
+        export _RAMBLE_PYTHON="$(command -v "$cmd")"
+        exec "${_RAMBLE_PYTHON}" "$0" "$@"
     fi
 done
 

--- a/share/ramble/setup-env.csh
+++ b/share/ramble/setup-env.csh
@@ -61,13 +61,25 @@ alias ramble          'set _rmb_args = (\!*); source $_ramble_share_dir/csh/ramb
 alias _ramble_pathadd 'set _pa_args = (\!*) && source $_ramble_share_dir/csh/pathadd.csh'
 
 # Identify and lock the python interpreter
+if ($?RAMBLE_PYTHON) then
+    echo "The RAMBLE_PYTHON environment variable is set to $RAMBLE_PYTHON"
+    echo "Will pin the python binary ramble uses to this value".
+endif
+
 if (! $?RAMBLE_PYTHON) then
     setenv RAMBLE_PYTHON ""
 endif
+
+if ($?_RAMBLE_PYTHON && "$RAMBLE_PYTHON" != "$_RAMBLE_PYTHON") then
+    echo "WARNING: Ramble was previously pinned to use $_RAMBLE_PYTHON"
+    echo "         If this is not what you want, set the correct python"
+    echo "         in RAMBLE_PYTHON and re-source this file"
+endif
+
 foreach cmd ("$RAMBLE_PYTHON" python3 python python2)
     command -v "$cmd" >& /dev/null
     if ($status == 0) then
-        setenv RAMBLE_PYTHON `command -v "$cmd"`
+        setenv _RAMBLE_PYTHON `command -v "$cmd"`
         break
     endif
 end

--- a/share/ramble/setup-env.fish
+++ b/share/ramble/setup-env.fish
@@ -638,10 +638,20 @@ set -l rmb_source_file (status -f)  # name of current file
 #
 # Identify and lock the python interpreter
 #
+if test -n "$RAMBLE_PYTHON"
+  echo "The RAMBLE_PYTHON environment variable is set to $RAMBLE_PYTHON"
+  echo "Will pin the python binary ramble uses to this value".
+
+  if test -n "$_RAMBLE_PYTHON" -a  "$RAMBLE_PYTHON" !=  "$_RAMBLE_PYTHON"
+    echo "WARNING: Ramble was previously pinned to use $_RAMBLE_PYTHON"
+    echo "         If this is not what you want, set the correct python"
+    echo "         in RAMBLE_PYTHON and re-source this file"
+  end
+end
 for cmd in "$RAMBLE_PYTHON" python3 python python2
     set -l _rmb_python (command -v "$cmd")
     if test $status -eq 0
-        set -x RAMBLE_PYTHON $_rmb_python
+        set -x _RAMBLE_PYTHON $_rmb_python
         break
     end
 end

--- a/share/ramble/setup-env.sh
+++ b/share/ramble/setup-env.sh
@@ -309,9 +309,21 @@ if [ "$_rmb_shell" = bash ]; then
 fi
 
 # Identify and lock the python interpreter
+if [ -n "$RAMBLE_PYTHON" ]; then
+  echo "The RAMBLE_PYTHON environment variable is set to $RAMBLE_PYTHON"
+  echo "Will pin the python binary ramble uses to this value".
+  if [ -n "$_RAMBLE_PYTHON" ]; then
+    if [ "$RAMBLE_PYTHON" != "$_RAMBLE_PYTHON" ]; then
+      echo "WARNING: Ramble was previously pinned to use $_RAMBLE_PYTHON"
+      echo "         If this is not what you want, set the correct python"
+      echo "         in RAMBLE_PYTHON and re-source this file"
+    fi
+  fi
+fi
+
 for cmd in "${RAMBLE_PYTHON:-}" python3 python python2; do
     if command -v > /dev/null "$cmd"; then
-        export RAMBLE_PYTHON="$(command -v "$cmd")"
+        export _RAMBLE_PYTHON="$(command -v "$cmd")"
         break
     fi
 done


### PR DESCRIPTION
This merge updates the logic around the RAMBLE_PYTHON environment variable.

Previously, ramble set the RAMBLE_PYTHON env-var as a way to set which python would be used when executing ramble. This merge migrates that logic to use _RAMBLE_PYTHON, while the RAMBLE_PYTHON environment can still be used by users to control which python (if a different one should be used than would be found by `which`) is used.

A warning message is also added in this merge to help convey to users which python is being used.

One of the main benefits of this change is subsequently sourcing the same setup script will update the python thati s used.