### PR TITLE
Add archival of requirements to pip package manager

### DIFF
--- a/var/ramble/repos/builtin/package_managers/pip/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/pip/package_manager.py
@@ -33,6 +33,9 @@ class Pip(PackageManagerBase):
 
     _spec_prefix = "pip"
 
+    archive_pattern(os.path.join("{env_path}", "requirements.txt"))
+    archive_pattern(os.path.join("{env_path}", "requirements.lock"))
+
     def __init__(self, file_path):
         super().__init__(file_path)
 


### PR DESCRIPTION
This merge adds archival of the requirements files for a pip venv to the ramble archive.