### PR TITLE
Fix variants in chained experiments

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -738,8 +738,8 @@ class ApplicationBase(metaclass=ApplicationMeta):
                 if "order" in cur_exp_def:
                     order = cur_exp_def["order"]
 
-                chained_name = f"{chain_idx}.{cur_exp_name}"
-                new_name = f"{parent_namespace}.chain.{chained_name}"
+                chained_name = f"chain.{chain_idx}.{cur_exp_name}"
+                new_name = f"{parent_namespace}.{chained_name}"
 
                 new_run_dir = os.path.join(
                     parent_run_dir, namespace.chained_experiments, chained_name

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -229,6 +229,8 @@ class ApplicationBase(metaclass=ApplicationMeta):
         new_copy.set_template(False)
         new_copy.repeats.set_repeats(False, 0)
         new_copy.set_chained_experiments(None)
+        if self.variants:
+            new_copy.set_variants(self.variants)
 
         return new_copy
 

--- a/lib/ramble/ramble/test/end_to_end/chained_experiment_variant_propagation.py
+++ b/lib/ramble/ramble/test/end_to_end/chained_experiment_variant_propagation.py
@@ -24,7 +24,7 @@ pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_p
 workspace = RambleCommand("workspace")
 
 
-def test_chained_experiment_variable_inheritance(request):
+def test_chained_experiment_variant_propagation(request):
     test_config = r"""
 ramble:
   variants:
@@ -158,4 +158,6 @@ ramble:
             assert chained_script in parent_script_data
 
             with open(chained_script) as f:
-                assert "mpirun -n 20 -ppn 10" in f.read()
+                data = f.read()
+                assert "spack env activate" in data
+                assert "mpirun -n 20 -ppn 10" in data

--- a/lib/ramble/ramble/test/end_to_end/dryrun_chained_experiments.py
+++ b/lib/ramble/ramble/test/end_to_end/dryrun_chained_experiments.py
@@ -150,7 +150,7 @@ ramble:
             chained_script = os.path.join(
                 parent_dir,
                 "chained_experiments",
-                f"{chain_idx}" + r".intel-mpi-benchmarks.collective.collective_chain",
+                rf"chain.{chain_idx}.intel-mpi-benchmarks.collective.collective_chain",
                 "execute_experiment",
             )
             assert os.path.exists(chained_script)
@@ -178,12 +178,12 @@ ramble:
                     expected_order.pop(0)
 
         # Ensure results contain chain information, and properly extract figures of merit
-        chain_exp_name = r"3.intel-mpi-benchmarks.collective.collective_chain"
+        chain_exp_name = r"chain.3.intel-mpi-benchmarks.collective.collective_chain"
         output_path_3 = os.path.join(
             parent_dir,
             "chained_experiments",
             chain_exp_name,
-            f"gromacs.water_bare.parent_test.chain.{chain_exp_name}.out",
+            f"gromacs.water_bare.parent_test.{chain_exp_name}.out",
         )
 
         with open(output_path_3, "w+") as f:

--- a/lib/ramble/ramble/test/end_to_end/experiment_templates.py
+++ b/lib/ramble/ramble/test/end_to_end/experiment_templates.py
@@ -68,8 +68,8 @@ ramble:
         ]
 
         expected_chained_experiments = [
-            "0.hostname.serial.used_template",
-            "1.hostname.serial.template_false",
+            "chain.0.hostname.serial.used_template",
+            "chain.1.hostname.serial.template_false",
         ]
 
         unexpected_experiments = ["unused_template", "used_template"]

--- a/lib/ramble/ramble/test/experiment_set.py
+++ b/lib/ramble/ramble/test/experiment_set.py
@@ -981,7 +981,7 @@ def test_chained_experiment_has_correct_directory(mutable_mock_workspace_path, c
 
         parent_name = "basic.test_wl.series2_4"
         chained_name = "basic.test_wl.series2_4.chain.0.basic.test_wl.test1"
-        chained_dir = "0.basic.test_wl.test1"
+        chained_dir = "chain.0.basic.test_wl.test1"
         assert parent_name in exp_set.experiments
         assert chained_name in exp_set.chained_experiments
 


### PR DESCRIPTION
This merge fixes two issues with chained experiments.

First, it updates the name of the chained experiments to avoid a warning about invalid decimal literals.

Second, it propagates variants into chained experiments, to make sure things like package managers and workflow managers are setup properly.

Tests are added for this as well.