### PR TITLE
Print additional slurm job info from the query script

### DIFF
--- a/var/ramble/repos/builtin/workflow_managers/slurm/batch_query.tpl
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/batch_query.tpl
@@ -17,11 +17,15 @@ if [ ! -z "$status" ]; then
         status=${status_map["$status"]}
     fi
 fi
-echo "job {job_name} with id ${job_id} has status: $status"
+
+saved="{experiment_run_dir}/.slurm_job_info"
+
+echo "job {job_name} with id ${job_id} has status: $status" | tee $saved
 
 # Print also the nodelist, start and end times of the job
-echo "additional job info:"
+echo "additional job info:" | tee -a $saved
 paste -d ":" \
   <(echo "nodes start end" | xargs -n1) \
   <(sacct -j "${job_id}" -o 'nodelist%80,start,end' -X -n | xargs -n1) \
-  | sed "s/^/  /"
+  | sed "s/^/  /" \
+  | tee -a $saved

--- a/var/ramble/repos/builtin/workflow_managers/slurm/batch_query.tpl
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/batch_query.tpl
@@ -18,3 +18,10 @@ if [ ! -z "$status" ]; then
     fi
 fi
 echo "job {job_name} with id ${job_id} has status: $status"
+
+# Print also the nodelist, start and end times of the job
+echo "additional job info:"
+paste -d ":" \
+  <(echo "nodes start end" | xargs -n1) \
+  <(sacct -j "${job_id}" -o 'nodelist%80,start,end' -X -n | xargs -n1) \
+  | sed "s/^/  /"

--- a/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
@@ -19,11 +19,16 @@ _STATUS_MAP = {
     "PD": "SUBMITTED",
     "R": "RUNNING",
     "CF": "SETUP",
+    # Regard completing as complete
     "CG": "COMPLETE",
+    "COMPLETING": "COMPLETE",
+    "CA": "COMPLETE",
     "COMPLETED": "COMPLETE",
     "CANCELLED": "CANCELLED",
     "CANCELLED+": "CANCELLED",
+    "F": "FAILED",
     "FAILED": "FAILED",
+    "TO": "TIMEOUT",
     "TIMEOUT": "TIMEOUT",
 }
 


### PR DESCRIPTION
These info can be useful for various purpose, such as debugging.

Example output:

```
job foo with id 1934 has status: COMPLETE
additional job info:
  nodes:nodeset-[11,29]
  start:2025-03-09T06:45:22
  end:2025-03-09T06:55:40
```

Also add in a few job status mappings.