### PR TITLE
Add FOM support for workflow manager

### DIFF
--- a/lib/ramble/ramble/test/workflow_manager_functionality/workflow_manager_foms.py
+++ b/lib/ramble/ramble/test/workflow_manager_functionality/workflow_manager_foms.py
@@ -1,0 +1,54 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.workspace
+from ramble.main import RambleCommand
+
+workspace = RambleCommand("workspace")
+
+pytestmark = pytest.mark.usefixtures(
+    "mutable_config",
+    "mutable_mock_workspace_path",
+)
+
+
+@pytest.mark.maybeslow
+def test_workflow_manager_foms(mutable_mock_wms_repo):
+    workspace_name = "test_workflow_manager_foms"
+    test_config = """
+ramble:
+  variants:
+    workflow_manager: wm-with-foms
+  variables:
+    mpi_command: ""
+    batch_submit: "{execute_experiment}"
+    processes_per_node: 1
+    n_nodes: 1
+  applications:
+    hostname:
+      workloads:
+        local:
+          experiments:
+            test: {}
+"""
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+        config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+        with open(config_path, "w+") as f:
+            f.write(test_config)
+        ws._re_read()
+        workspace("setup", "--dry-run", global_args=["-D", ws.root])
+
+        workspace("analyze", "-p", global_args=["-D", ws.root])
+        result_file = os.path.join(ws.root, "results.latest.txt")
+        with open(result_file) as f:
+            assert "job-status = RUNNING" in f.read()

--- a/lib/ramble/ramble/workflow_manager.py
+++ b/lib/ramble/ramble/workflow_manager.py
@@ -105,6 +105,24 @@ class WorkflowManagerBase(metaclass=WorkflowManagerMeta):
         """Define variables to be used in template rendering"""
         return {}
 
+    def run_phase_hook(self, workspace, pipeline, hook_name):
+        """Run a workflow manager hook.
+
+        This follows the idea of `run_phase_hook` from modifiers.
+
+        It allows a workflow manager to hook into phases defined by
+        the application.
+        """
+        if pipeline in self.phase_definitions:
+            if hook_name in self.phase_definitions[pipeline]:
+                return
+
+        hook_func_name = f"_{hook_name}"
+        if hasattr(self, hook_func_name):
+            phase_func = getattr(self, hook_func_name)
+
+            phase_func(workspace)
+
     def copy(self):
         """Deep copy a workflow manager instance"""
         new_copy = type(self)(self._file_path)

--- a/var/ramble/repos/builtin.mock/workflow_managers/wm-with-foms/workflow_manager.py
+++ b/var/ramble/repos/builtin.mock/workflow_managers/wm-with-foms/workflow_manager.py
@@ -1,0 +1,34 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.wmkit import *
+
+
+class WmWithFoms(WorkflowManagerBase):
+    """A workflow manager for testing FOMs"""
+
+    name = "wm-with-foms"
+
+    tags("workflow", "test")
+
+    _fom_file = "{experiment_run_dir}/.wm_job_info"
+
+    def _prepare_analysis(self, workspace):
+        del workspace
+        expander = self.app_inst.expander
+        path = expander.expand_var(self._fom_file)
+        with open(path, "w+") as f:
+            f.write("job_status: RUNNING")
+
+    figure_of_merit(
+        "job-status",
+        fom_regex=r"\s*job_status:\s*(?P<val>.*)",
+        group_name="val",
+        log_file="{experiment_run_dir}/.wm_job_info",
+        fom_type=FomType.INFO,
+    )

--- a/var/ramble/repos/builtin/workflow_managers/slurm/batch_query.tpl
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/batch_query.tpl
@@ -22,10 +22,14 @@ saved="{experiment_run_dir}/.slurm_job_info"
 
 echo "job {job_name} with id ${job_id} has status: $status" | tee $saved
 
-# Print also the nodelist, start and end times of the job
-echo "additional job info:" | tee -a $saved
+# Print out various info about the job
+echo "job info:" | tee -a $saved
+echo "  job_id: ${job_id}" | tee -a $saved
+echo "  job_name: {job_name}" | tee -a $saved
+echo "  job_status: $status" | tee -a $saved
+
 paste -d ":" \
-  <(echo "nodes start end" | xargs -n1) \
+  <(echo "job_nodes job_start job_end" | xargs -n1) \
   <(sacct -j "${job_id}" -o 'nodelist%80,start,end' -X -n | xargs -n1) \
   | sed "s/^/  /" \
   | tee -a $saved


### PR DESCRIPTION
The use case is to add some slurm-specific FOMs for every experiment that uses the slurm workflow manager.

Example output:

```
Experiment hostname.local.generated figures of merit:
  Status = SUCCESS
  Tags = ['test-app']
  default (null) context figures of merit:
    possible hostname = nodeset-2
    job-id = 2105
    job-status = COMPLETE
    job-nodes = nodeset-2
    job-start = 2025-03-11T05:56:54
    job-end = 2025-03-11T05:56:55
  Software definitions:
    spack packages:
```