### PR TITLE
Add missing join_separator to formatted executable language

### DIFF
--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -546,7 +546,9 @@ def register_template(
 
 
 @shared_directive("formatted_executables")
-def formatted_executable(name: str, prefix: str, indentation: int, commands: list):
+def formatted_executable(
+    name: str, commands: list, prefix: str = "", indentation: int = 0, join_separator: str = "\n"
+):
     """Define a new formatted execution for this object
 
     Args:
@@ -560,6 +562,7 @@ def formatted_executable(name: str, prefix: str, indentation: int, commands: lis
         obj.formatted_executables[name] = {
             "prefix": prefix,
             "indentation": indentation,
+            "join_separator": join_separator,
             "commands": commands.copy(),
         }
 


### PR DESCRIPTION
This merge adds a missing argument to the language for `formatted_executables`.