### PR TITLE
Preserve formatting on multi-line yaml strings

### DIFF
--- a/lib/ramble/ramble/test/cmd/config.py
+++ b/lib/ramble/ramble/test/cmd/config.py
@@ -704,6 +704,46 @@ ramble:  # comment
     assert output == expected
 
 
+def test_config_add_to_workspace_preserve_multiline_str(
+    mutable_empty_config, mutable_mock_workspace_path, tmpdir
+):
+    workspace = ramble.workspace.Workspace(str(tmpdir))
+    workspace.write()
+    filepath = ramble.workspace.config_file(workspace.root)
+    contents = """# comment
+ramble:  # comment
+  # comment
+  variables:
+    test_multi_line: |
+      my test
+      string with
+      multiple lines
+  applications:
+    hostname: # comment
+      workloads:
+        basic:
+          experiments:
+            test: # Single node
+              variables:
+                n_ranks: '1'
+                n_nodes: '1'
+                processes_per_node: '1'
+"""
+    with open(filepath, "w") as f:
+        f.write(contents)
+
+    with workspace:
+        config("add", "variables:foo:bar")
+        output = config("get")
+
+    expected = """    test_multi_line: |
+      my test
+      string with
+      multiple lines"""
+
+    assert expected in output
+
+
 def test_config_remove_from_workspace(mutable_empty_config, mutable_mock_workspace_path):
     import io
 

--- a/lib/ramble/spack/util/spack_yaml.py
+++ b/lib/ramble/spack/util/spack_yaml.py
@@ -186,6 +186,8 @@ class OrderedLineDumper(RoundTripDumper):
     def represent_str(self, data):
         if hasattr(data, 'override') and data.override:
             data = data + ':'
+        if len(data.splitlines()) > 1:
+            return super(OrderedLineDumper, self).represent_scalar('tag:yaml.org,2002:str', data, style='|')
         return super(OrderedLineDumper, self).represent_str(data)
 
 


### PR DESCRIPTION
This merge updates the way config dumps multi-line strings to style them with `"|"` instead of None, which allows their formatting to remain the same as it was before modifying a configuration file.