### PR TITLE
Allow templates in nested directories inside configs

### DIFF
--- a/lib/ramble/docs/workspace_config.rst
+++ b/lib/ramble/docs/workspace_config.rst
@@ -989,6 +989,11 @@ Ramble automatically generates definitions for the following variables:
   ``$workspace_root/configs`` have a variable generated that resolves to the
   absolute path to: ``{experiment_run_dir}/<template_name>`` where
   ``<template_name>`` is the filename of the template, without the extension.
+  If the template file is in a nested directory inside of
+  ``$workspace_root/configs`` the variable name will contain the path relative
+  to the ``configs`` directory. For example:
+  ``$workspace_root/configs/templates/foo.tpl`` would create a variable named
+  ``templates/foo``.
 * ``unformatted_command`` - A multi-line string with the command for running
   the experiment. Unformatted so it can be formatted for various experiments.
 * ``unformatted_command_without_logs`` - The same as ``unformatted_command`` but

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -1458,6 +1458,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
             for template_name, template_conf in workspace.all_templates():
                 expand_path = os.path.join(experiment_run_dir, template_name)
                 logger.msg(f"Writing template {template_name} to {expand_path}")
+                fs.mkdirp(os.path.dirname(expand_path))
 
                 with open(expand_path, "w+") as f:
                     f.write(

--- a/lib/ramble/ramble/test/end_to_end/nested_config_templates.py
+++ b/lib/ramble/ramble/test/end_to_end/nested_config_templates.py
@@ -1,0 +1,65 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+import llnl.util.filesystem as fs
+import pytest
+
+import ramble.workspace
+from ramble.main import RambleCommand
+
+pytestmark = pytest.mark.usefixtures(
+    "mutable_config", "mutable_mock_workspace_path", "mutable_mock_apps_repo"
+)
+
+workspace = RambleCommand("workspace")
+
+
+def test_nested_config_templates(request):
+    test_config = """
+ramble:
+  variables:
+    mpi_command: mpirun -n {n_ranks}
+    batch_submit: 'batch_submit {execute_experiment}'
+    processes_per_node: 1
+  applications:
+    basic:
+      workloads:
+        test_wl:
+          experiments:
+            test:
+              variables:
+                n_nodes: 1
+"""
+    workspace_name = request.node.name
+    ws = ramble.workspace.create(workspace_name)
+    ws.write()
+    config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+    with open(config_path, "w+") as f:
+        f.write(test_config)
+    new_template_path = os.path.join(ws.config_dir, "templates", "test_template.tpl")
+    fs.mkdirp(os.path.dirname(new_template_path))
+    with open(new_template_path, "w+") as f:
+        f.write("{templates/test_template}")
+    ws._re_read()
+
+    workspace("setup", "--dry-run", global_args=["-w", workspace_name])
+    run_dir = os.path.join(ws.experiment_dir, "basic/test_wl/test/")
+    script_path = os.path.join(run_dir, "templates", "test_template")
+    assert os.path.isfile(script_path)
+    with open(script_path) as f:
+        data = f.read()
+        assert "basic/test_wl/test/templates/test_template" in data
+
+    # Test template archival
+    workspace("archive", global_args=["-w", workspace_name])
+    exp_archive_path = os.path.join(
+        ws.latest_archive_path, "experiments", "basic", "test_wl", "test"
+    )
+    files = os.listdir(exp_archive_path)
+    assert "test_template" in files


### PR DESCRIPTION
This merge enables templates within the configs directory to be in nested directories. The directories are then created within the resulting experiment directories, and the variables that contain their paths are named "{directory_name/template_name}".