### PR TITLE
Change the organization of deployed repos

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -2355,12 +2355,48 @@ class ApplicationBase(metaclass=ApplicationMeta):
     register_phase("deploy_artifacts", pipeline="pushdeployment")
 
     def _deploy_artifacts(self, workspace, app_inst=None):
+        """Copy all relevant ramble objects to the deployment directory.
 
-        def _copy_files(obj_inst, obj_type, repo_root):
+        All the ramble objects are grouped under a "ramble" directory, and
+        further organized based on the object's original repo namespace.
+
+        Package manager (like Spack) may also create its own repos.
+
+        An example:
+
+        object_repos/
+        ├── ramble
+        │   ├── builtin
+        │   │   ├── modifiers
+        │   │   │   ├── gcp-metadata
+        │   │   │   │   └── modifier.py
+        │   │   ├── package_managers
+        │   │   │   ├── spack
+        │   │   │   │   └── package_manager.py
+        │   │   │   └── spack-lightweight
+        │   │   │       └── package_manager.py
+        │   │   ├── repo.yaml
+        │   └── googleaux
+        │       ├── applications
+        │       │   ├── base-app
+        │       │   │   └── application.py
+        │       │   └── derived-app
+        │       │       └── application.py
+        │       └── repo.yaml
+        └── spack
+            └── obj_repo
+                ├── packages
+                │   └── my-package
+                │       └── package.py
+                └── repo.yaml
+        """
+
+        def _copy_files(obj_inst, obj_type, root_path):
             flist = ramble.repository.list_object_files(obj_inst, obj_type)
-            for type_dir_name, obj_path in flist:
+            for type_dir_name, obj_path, repo_namespace in flist:
                 obj_src_dir_path = os.path.dirname(obj_path)
                 obj_dir_name = os.path.basename(obj_src_dir_path)
+                repo_root = os.path.join(root_path, "ramble", repo_namespace)
                 obj_dest_dir = os.path.join(repo_root, type_dir_name, obj_dir_name)
                 shutil.rmtree(obj_dest_dir, ignore_errors=True)
                 shutil.copytree(
@@ -2368,10 +2404,15 @@ class ApplicationBase(metaclass=ApplicationMeta):
                     obj_dest_dir,
                     ignore=shutil.ignore_patterns("*.pyc", "__pycache__"),
                 )
+                config_path = os.path.join(repo_root, ramble.repository.unified_config)
+                if not os.path.exists(config_path):
+                    with open(config_path, "w+") as f:
+                        f.write("repo:\n")
+                        f.write(f"  namespace: {repo_namespace}\n")
 
-        repo_path = os.path.join(workspace.named_deployment, "object_repo")
+        repo_path = workspace.deployment_repos_dir
 
-        repo_lock = lk.Lock(os.path.join(repo_path, ".ramble-obj-repo.lock"))
+        repo_lock = lk.Lock(os.path.join(repo_path, ".ramble-obj-repos.lock"))
 
         with lk.WriteTransaction(repo_lock):
             for obj_type, obj in self._objects():

--- a/lib/ramble/ramble/cmd/deployment.py
+++ b/lib/ramble/ramble/cmd/deployment.py
@@ -16,6 +16,7 @@ import ramble.config
 import ramble.fetch_strategy
 import ramble.filters
 import ramble.pipeline
+import ramble.repository
 import ramble.stage
 import ramble.util.path
 import ramble.workspace
@@ -152,12 +153,23 @@ def deployment_pull(args):
                     "Deployment may be corrupt or incomplete."
                 )
 
-        obj_repo_path = os.path.join(
-            ws.root, ramble.pipeline.PushDeploymentPipeline.object_repo_name
+        legacy_obj_repo_path = os.path.join(
+            ws.root, ramble.pipeline.PushDeploymentPipeline.legacy_object_repo_name
         )
-        if os.path.exists(obj_repo_path):
+        # Read in legacy deployment repo if it exists
+        if os.path.exists(legacy_obj_repo_path):
             repo_cmd = RambleCommand("repo")
-            repo_cmd("add", obj_repo_path, global_args=["-D", ws.root])
+            repo_cmd("add", legacy_obj_repo_path, global_args=["-D", ws.root])
+
+        ramble_repos_path = os.path.join(ws.root, "object_repos", "ramble")
+        if os.path.exists(ramble_repos_path):
+            repo_cmd = RambleCommand("repo")
+            for maybe_repo in os.listdir(ramble_repos_path):
+                maybe_repo_dir = os.path.join(ramble_repos_path, maybe_repo)
+                if os.path.isdir(maybe_repo_dir) and os.path.exists(
+                    os.path.join(maybe_repo_dir, ramble.repository.unified_config)
+                ):
+                    repo_cmd("add", maybe_repo_dir, global_args=["-D", ws.root])
 
 
 def deployment_run_pipeline(args, pipeline):

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -657,7 +657,7 @@ class PushDeploymentPipeline(Pipeline):
     index_filename = "index.json"
     index_namespace = "deployment_files"
     tar_extension = ".tar.gz"
-    object_repo_name = "object_repo"
+    legacy_object_repo_name = "object_repo"
 
     def __init__(
         self, workspace, filters, create_tar=False, upload_url=None, deployment_name=None
@@ -693,15 +693,6 @@ class PushDeploymentPipeline(Pipeline):
 
         aux_software_dir = os.path.join(configs_dir, ramble.workspace.auxiliary_software_dir_name)
         fs.mkdirp(aux_software_dir)
-
-        repo_path = os.path.join(self.workspace.named_deployment, self.object_repo_name)
-        for object_type_def in ramble.repository.type_definitions.values():
-            fs.mkdirp(os.path.join(repo_path, object_type_def["dir_name"]))
-
-        # Write out only to the unified repo.yaml
-        with open(os.path.join(repo_path, ramble.repository.unified_config), "w+") as f:
-            f.write("repo:\n")
-            f.write(f"  namespace: deployment_{self.deployment_name}\n")
 
         super()._execute()
 

--- a/lib/ramble/ramble/repository.py
+++ b/lib/ramble/ramble/repository.py
@@ -214,6 +214,10 @@ def _gen_path(repo_dirs=None, obj_type=default_type):
     return path
 
 
+def _get_repo_namespace(repo_path, obj_name):
+    return repo_path.repo_for_obj(obj_name).namespace
+
+
 def list_object_files(obj_inst, object_type):
     """List object file paths of the given object along the inheritance chain.
 
@@ -227,9 +231,15 @@ def list_object_files(obj_inst, object_type):
     repo_path = paths[object_type]
     base_repo_path = paths[base_type]
     obj_file = obj_inst._file_path
-    result = []
-    if repo_path.in_path(obj_file) or base_repo_path.in_path(obj_file):
-        result = [(type_def["dir_name"], obj_file)]
+    obj_name = os.path.basename(os.path.dirname(obj_file))
+    if repo_path.in_path(obj_file):
+        result = [(type_def["dir_name"], obj_file, _get_repo_namespace(repo_path, obj_name))]
+    elif base_repo_path.in_path(obj_file):
+        result = [
+            (base_type_def["dir_name"], obj_file, _get_repo_namespace(base_repo_path, obj_name))
+        ]
+    else:
+        result = []
     base_chain = obj_inst.__class__.__mro__[1:]
 
     for cls in base_chain:
@@ -240,10 +250,13 @@ def list_object_files(obj_inst, object_type):
             break
 
         basename = os.path.basename(path)
+        cls_name = os.path.basename(os.path.dirname(path))
         if basename == type_def["file_name"]:
-            result.append((type_def["dir_name"], path))
+            result.append((type_def["dir_name"], path, _get_repo_namespace(repo_path, cls_name)))
         elif basename == base_type_def["file_name"]:
-            result.append((base_type_def["dir_name"], path))
+            result.append(
+                (base_type_def["dir_name"], path, _get_repo_namespace(base_repo_path, cls_name))
+            )
         else:
             break
     return result

--- a/lib/ramble/ramble/test/cmd/deployment.py
+++ b/lib/ramble/ramble/test/cmd/deployment.py
@@ -31,14 +31,15 @@ def check_deployment_files(root, app_name):
     tpl = os.path.join(configs_dir, "execute_experiment.tpl")
     yaml = os.path.join(configs_dir, "ramble.yaml")
 
-    object_dir = os.path.join(root, "object_repo")
+    ramble_object_dir = os.path.join(root, "object_repos", "ramble", "builtin")
     spack_pm = os.path.join(
-        object_dir, "package_managers", "spack-lightweight", "package_manager.py"
+        ramble_object_dir, "package_managers", "spack-lightweight", "package_manager.py"
     )
-    app = os.path.join(object_dir, "applications", app_name, "application.py")
-    pkg = os.path.join(object_dir, "packages", app_name, "package.py")
+    app = os.path.join(ramble_object_dir, "applications", app_name, "application.py")
+    spack_object_dir = os.path.join(root, "object_repos", "spack", "obj_repo")
+    pkg = os.path.join(spack_object_dir, "packages", app_name, "package.py")
 
-    dir_list = [root, root, configs_dir, object_dir]
+    dir_list = [root, configs_dir, ramble_object_dir, spack_object_dir]
     for d in dir_list:
         assert os.path.isdir(d)
 

--- a/lib/ramble/ramble/test/repository.py
+++ b/lib/ramble/ramble/test/repository.py
@@ -69,23 +69,23 @@ def test_repo_unknown_app(mutable_mock_apps_repo):
             "openfoam-org",
             ramble.repository.ObjectTypes.applications,
             [
-                ("applications", "openfoam-org/application.py"),
-                ("base_applications", "openfoam/base_application.py"),
+                ("applications", "openfoam-org/application.py", "builtin"),
+                ("base_applications", "openfoam/base_application.py", "builtin"),
             ],
         ),
         (
             "lscpu",
             ramble.repository.ObjectTypes.modifiers,
             [
-                ("modifiers", "lscpu/modifier.py"),
+                ("modifiers", "lscpu/modifier.py", "builtin"),
             ],
         ),
         (
             "spack",
             ramble.repository.ObjectTypes.package_managers,
             [
-                ("package_managers", "spack/package_manager.py"),
-                ("package_managers", "spack-lightweight/package_manager.py"),
+                ("package_managers", "spack/package_manager.py", "builtin"),
+                ("package_managers", "spack-lightweight/package_manager.py", "builtin"),
             ],
         ),
     ],
@@ -108,8 +108,10 @@ def test_list_object_files(
     actual = ramble.repository.list_object_files(obj_inst, obj_type)
     assert len(expected) == len(actual)
     for i in range(len(expected)):
+        assert len(expected[i]) == len(actual[i])
         assert expected[i][0] == actual[i][0]
         assert actual[i][1].endswith(expected[i][1])
+        assert expected[i][2] == actual[i][2]
 
 
 #

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1931,6 +1931,11 @@ ramble:
         return os.path.join(self.deployments_dir, self.deployment_name)
 
     @property
+    def deployment_repos_dir(self):
+        """Path to the specific deployment directory that contains all the repos"""
+        return os.path.join(self.named_deployment, "object_repos")
+
+    @property
     def shared_license_dir(self):
         """Path to the shared license directory"""
         return os.path.join(self.shared_dir, workspace_shared_license_path)

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
@@ -452,11 +452,19 @@ class SpackLightweight(PackageManagerBase):
             self.runner.set_env(env_path)
             self.runner.activate()
 
-            repo_path = os.path.join(workspace.named_deployment, "object_repo")
+            # Hard-code a repo.yaml for spack packages
+            # TODO: Put spack packages based on their original namespaces
+            repo_root = os.path.join(
+                workspace.deployment_repos_dir, "spack", "obj_repo"
+            )
+            fs.mkdirp(repo_root)
+            with open(os.path.join(repo_root, "repo.yaml"), "w+") as f:
+                f.write("repo:\n")
+                f.write("  namespace: obj_repo\n")
 
-            for pkg, pkg_def in self.runner.package_definitions():
+            for _, pkg_def in self.runner.package_definitions():
                 pkg_dir_name = os.path.basename(os.path.dirname(pkg_def))
-                pkg_dir = os.path.join(repo_path, "packages", pkg_dir_name)
+                pkg_dir = os.path.join(repo_root, "packages", pkg_dir_name)
                 fs.mkdirp(pkg_dir)
                 shutil.copyfile(pkg_def, os.path.join(pkg_dir, "package.py"))
 


### PR DESCRIPTION
The motiviation is that using the original repo namespace helps with object inheritance (as it references the repo namespace when import.)

The downside is that there are now duplicate repo namespaces, but it seems to OK from my testing.

An example of the updated deployment repo organization:

```
object_repos/
├── ramble
│   ├── builtin
│   │   ├── modifiers
│   │   │   ├── gcp-metadata
│   │   │   │   └── modifier.py
│   │   ├── package_managers
│   │   │   ├── spack
│   │   │   │   └── package_manager.py
│   │   │   └── spack-lightweight
│   │   │       └── package_manager.py
│   │   ├── repo.yaml
│   └── googleaux
│       ├── applications
│       │   ├── base-app
│       │   │   └── application.py
│       │   └── derived-app
│       │       └── application.py
│       └── repo.yaml
└── spack
    └── obj_repo
        ├── packages
        │   └── my-package
        │       └── package.py
        └── repo.yaml
```