### PR TITLE
Make fom regex less greedy

### DIFF
--- a/var/ramble/repos/builtin/applications/architecture-check/application.py
+++ b/var/ramble/repos/builtin/applications/architecture-check/application.py
@@ -74,7 +74,7 @@ fi
 
     workload_group("all_workloads", workloads=["standard"])
 
-    spack_regex = r"Spack tuple: (?P<platform>\S+)-(?P<os>\S+)-(?P<arch>\S+)"
+    spack_regex = r"Spack tuple: (?P<platform>\S+?)-(?P<os>\S+?)-(?P<arch>\S+)"
 
     figure_of_merit(
         "Spack Platform",

--- a/var/ramble/repos/builtin/applications/elk/application.py
+++ b/var/ramble/repos/builtin/applications/elk/application.py
@@ -69,7 +69,7 @@ class Elk(ExecutableApplication):
     success_criteria(
         "prints_done",
         mode="string",
-        match=r".*Elk code stopped.*",
+        match=r".*?Elk code stopped",
         file="{experiment_run_dir}/{experiment_name}.out",
     )
 
@@ -88,7 +88,7 @@ class Elk(ExecutableApplication):
         figure_of_merit(
             metric,
             log_file=output_file,
-            fom_regex=rf"\s*(?P<metric>{metric})\s+:\s+(?P<value>[0-9]+\.[0-9]*).*",
+            fom_regex=rf"\s*(?P<metric>{metric})\s+:\s+(?P<value>[0-9]+\.[0-9]*)",
             group_name="value",
             units="s",
         )

--- a/var/ramble/repos/builtin/applications/gromacs/application.py
+++ b/var/ramble/repos/builtin/applications/gromacs/application.py
@@ -392,7 +392,7 @@ class Gromacs(ExecutableApplication):
     figure_of_merit(
         "Core Time",
         log_file=log_str,
-        fom_regex=r"\s+Time:\s+(?P<core_time>[0-9]+\.[0-9]+).*",
+        fom_regex=r"\s+Time:\s+(?P<core_time>[0-9]+\.[0-9]+)",
         group_name="core_time",
         units="s",
         fom_type=FomType.TIME,
@@ -402,7 +402,7 @@ class Gromacs(ExecutableApplication):
         "Wall Time",
         log_file=log_str,
         fom_regex=r"\s+Time:\s+[0-9]+\.[0-9]+\s+"
-        + r"(?P<wall_time>[0-9]+\.[0-9]+).*",
+        + r"(?P<wall_time>[0-9]+\.[0-9]+)",
         group_name="wall_time",
         units="s",
         fom_type=FomType.TIME,
@@ -412,7 +412,7 @@ class Gromacs(ExecutableApplication):
         "Percent Core Time",
         log_file=log_str,
         fom_regex=r"\s+Time:\s+[0-9]+\.[0-9]+\s+[0-9]+\.[0-9]+\s+"
-        + r"(?P<perc_core_time>[0-9]+\.[0-9]+).*",
+        + r"(?P<perc_core_time>[0-9]+\.[0-9]+)",
         group_name="perc_core_time",
         units="%",
         fom_type=FomType.MEASURE,
@@ -421,7 +421,7 @@ class Gromacs(ExecutableApplication):
     figure_of_merit(
         "Nanosecs per day",
         log_file=log_str,
-        fom_regex=r"Performance:\s+" + r"(?P<ns_per_day>[0-9]+\.[0-9]+).*",
+        fom_regex=r"Performance:\s+" + r"(?P<ns_per_day>[0-9]+\.[0-9]+)",
         group_name="ns_per_day",
         units="ns/day",
         fom_type=FomType.THROUGHPUT,
@@ -431,7 +431,7 @@ class Gromacs(ExecutableApplication):
         "Hours per nanosec",
         log_file=log_str,
         fom_regex=r"Performance:\s+[0-9]+\.[0-9]+\s+"
-        + r"(?P<hours_per_ns>[0-9]+\.[0-9]+).*",
+        + r"(?P<hours_per_ns>[0-9]+\.[0-9]+)",
         group_name="hours_per_ns",
         units="hours/ns",
         fom_type=FomType.INFO,

--- a/var/ramble/repos/builtin/applications/hmmer/application.py
+++ b/var/ramble/repos/builtin/applications/hmmer/application.py
@@ -97,7 +97,7 @@ class Hmmer(ExecutableApplication):
 
     figure_of_merit(
         "Elapsed time",
-        fom_regex=r"# CPU.*Elapsed:\s+(?P<elapsed_time>[0-9]+:[0-9]+:[0-9]+\.*[0-9]*)\s*$",
+        fom_regex=r"# CPU.*?Elapsed:\s+(?P<elapsed_time>[0-9]+:[0-9]+:[0-9]+\.*[0-9]*)\s*$",
         group_name="elapsed_time",
         log_file=out_file,
         units="hms",

--- a/var/ramble/repos/builtin/applications/hostname/application.py
+++ b/var/ramble/repos/builtin/applications/hostname/application.py
@@ -57,7 +57,7 @@ class Hostname(ExecutableApplication):
 
     figure_of_merit(
         "possible hostname",
-        fom_regex=r"(?P<hostname>\S+)\s*",
+        fom_regex=r"(?P<hostname>\S+)",
         group_name="hostname",
         units="",
     )

--- a/var/ramble/repos/builtin/applications/intel-mpi-benchmarks/application.py
+++ b/var/ramble/repos/builtin/applications/intel-mpi-benchmarks/application.py
@@ -273,5 +273,5 @@ class IntelMpiBenchmarks(ExecutableApplication):
     success_criteria(
         "run_to_completion",
         mode="string",
-        match=r".*All processes entering MPI_Finalize",
+        match=r".*?All processes entering MPI_Finalize",
     )

--- a/var/ramble/repos/builtin/applications/iperf2/application.py
+++ b/var/ramble/repos/builtin/applications/iperf2/application.py
@@ -106,7 +106,7 @@ class Iperf2(ExecutableApplication):
     figure_of_merit(
         "Total BW",
         log_file=log_str,
-        fom_regex=r"\[SUM\]\s.*sec\s.*GBytes\s(?P<bw>.*)\sGbits/sec.*",
+        fom_regex=r"\[SUM\]\s.*?sec\s.*?GBytes\s(?P<bw>.*)\sGbits/sec",
         group_name="bw",
         units="Gbits/sec",
     )

--- a/var/ramble/repos/builtin/applications/lammps/application.py
+++ b/var/ramble/repos/builtin/applications/lammps/application.py
@@ -316,21 +316,21 @@ class Lammps(ExecutableApplication):
     )
     figure_of_merit(
         "Nanoseconds per day",
-        fom_regex=r"Performance.*\s+(?P<nspd>[0-9\.]+) (ns|tau)/day",
+        fom_regex=r"Performance.*?\s+(?P<nspd>[0-9\.]+) (ns|tau)/day",
         group_name="nspd",
         units="ns/day",
         fom_type=FomType.THROUGHPUT,
     )
     figure_of_merit(
         "Hours per nanosecond",
-        fom_regex=r"Performance.*\s+(?P<hpns>[0-9\.]+) hours/ns",
+        fom_regex=r"Performance.*?\s+(?P<hpns>[0-9\.]+) hours/ns",
         group_name="hpns",
         units="hours/ns",
         fom_type=FomType.TIME,
     )
     figure_of_merit(
         "Timesteps per second",
-        fom_regex=r"Performance.*\s+(?P<tsps>[0-9\.]+) timesteps/s",
+        fom_regex=r"Performance.*?\s+(?P<tsps>[0-9\.]+) timesteps/s",
         group_name="tsps",
         units="timesteps/s",
         fom_type=FomType.THROUGHPUT,

--- a/var/ramble/repos/builtin/applications/lulesh/application.py
+++ b/var/ramble/repos/builtin/applications/lulesh/application.py
@@ -68,7 +68,7 @@ class Lulesh(ExecutableApplication):
     figure_of_merit(
         "Time",
         log_file=log_str,
-        fom_regex=r"\s*Elapsed time\s+=\s+(?P<time>[0-9]+\.[0-9]+).*",
+        fom_regex=r"\s*Elapsed time\s+=\s+(?P<time>[0-9]+\.[0-9]+)",
         group_name="time",
         units="s",
     )
@@ -76,7 +76,7 @@ class Lulesh(ExecutableApplication):
     figure_of_merit(
         "FOM",
         log_file=log_str,
-        fom_regex=r"\s*FOM\s+=\s+(?P<fom>[0-9]+\.[0-9]+).*",
+        fom_regex=r"\s*FOM\s+=\s+(?P<fom>[0-9]+\.[0-9]+)",
         group_name="fom",
         units="z/s",
     )
@@ -92,7 +92,7 @@ class Lulesh(ExecutableApplication):
     figure_of_merit(
         "Grind Time",
         log_file=log_str,
-        fom_regex=r"\s*Grind time \(us/z/c\)\s+=\s+(?P<grind>[0-9]+\.[0-9]+).*",
+        fom_regex=r"\s*Grind time \(us/z/c\)\s+=\s+(?P<grind>[0-9]+\.[0-9]+)",
         group_name="grind",
         units="s/element",
     )

--- a/var/ramble/repos/builtin/applications/minixyce/application.py
+++ b/var/ramble/repos/builtin/applications/minixyce/application.py
@@ -153,7 +153,7 @@ class Minixyce(ExecutableApplication):
     floating_point_regex = r"\d+\.\d+"
     scientific_number_regex = r"[\+\-]*\d+\.\d+[eE][\+\-]*\d+"
 
-    success_regex = r"^\s*TIME.*num_GMRES_iters\s*num_GMRES_restarts"
+    success_regex = r"^\s*TIME.*?num_GMRES_iters\s*num_GMRES_restarts"
     success_criteria("valid", mode="string", match=success_regex, file=log_str)
 
     figure_of_merit(

--- a/var/ramble/repos/builtin/applications/namd/application.py
+++ b/var/ramble/repos/builtin/applications/namd/application.py
@@ -166,7 +166,7 @@ class Namd(ExecutableApplication):
     success_criteria(
         "Completion",
         mode="string",
-        match=r".*End of program.*",
+        match=r".*?End of program",
         file=log_file_str,
     )
 
@@ -174,7 +174,7 @@ class Namd(ExecutableApplication):
     timing_regex = (
         r"TIMING:\s+(?P<itr>[0-9]+)\s+CPU:\s+(?P<cpu>[0-9]+\.[0-9]+),\s+(?P<cpu_per_step>[0-9]+\.[0-9]+)/step\s+"
         + r"Wall:\s+(?P<wall>[0-9]+\.[0-9]+),\s+(?P<wall_per_step>[0-9]+\.[0-9]+)/step,\s+(?P<remaining>[0-9]+\.*[0-9]*)\s+"
-        + r"hours\s+remaining,\s+(?P<mem>[0-9]+\.[0-9]+)\s+MB.*"
+        + r"hours\s+remaining,\s+(?P<mem>[0-9]+\.[0-9]+)\s+MB"
     )
     figure_of_merit_context(
         "Perf iteration",

--- a/var/ramble/repos/builtin/applications/nvidia-hpl/application.py
+++ b/var/ramble/repos/builtin/applications/nvidia-hpl/application.py
@@ -302,7 +302,7 @@ class NvidiaHpl(HplBase, NvidiaHPCBase):
 
     figure_of_merit(
         "Per GPU GFlops",
-        fom_regex=r".*\s+(?P<N>[0-9]+)\s+(?P<NB>[0-9]+)\s+(?P<P>[0-9]+)"
+        fom_regex=r".*?\s+(?P<N>[0-9]+)\s+(?P<NB>[0-9]+)\s+(?P<P>[0-9]+)"
         + r"\s+(?P<Q>[0-9]+)\s+(?P<time>[0-9]+\.[0-9]+)\s+"
         + r"(?P<gflops>\S+)\s+\(\s+(?P<per_gpu_gflops>\S+)\)",
         group_name="per_gpu_gflops",

--- a/var/ramble/repos/builtin/applications/orca/application.py
+++ b/var/ramble/repos/builtin/applications/orca/application.py
@@ -109,10 +109,10 @@ class Orca(ExecutableApplication):
     success_criteria(
         "Error free",
         mode="string",
-        anti_match=r".*Error:.*",
+        anti_match=r".*?Error:",
     )
     success_criteria(
         "Normal termination",
         mode="string",
-        match=r".*ORCA TERMINATED NORMALLY.*",
+        match=r".*?ORCA TERMINATED NORMALLY",
     )

--- a/var/ramble/repos/builtin/applications/pip-test/application.py
+++ b/var/ramble/repos/builtin/applications/pip-test/application.py
@@ -40,7 +40,7 @@ class PipTest(ExecutableApplication):
 
     figure_of_merit(
         "return_code",
-        fom_regex=r"return code is (?P<code>[0-9]+)\s*",
+        fom_regex=r"return code is (?P<code>[0-9]+)",
         group_name="code",
         units="",
     )

--- a/var/ramble/repos/builtin/applications/py-cosmoflow/application.py
+++ b/var/ramble/repos/builtin/applications/py-cosmoflow/application.py
@@ -184,63 +184,63 @@ class PyCosmoflow(ExecutableApplication):
 
     figure_of_merit(
         "Best Epoch",
-        fom_regex=r".*INFO\s+epoch: (?P<idx>[0-9]+)",
+        fom_regex=r".*?INFO\s+epoch: (?P<idx>[0-9]+)",
         group_name="idx",
         units="",
     )
 
     figure_of_merit(
         "Best Epoch Loss",
-        fom_regex=r".*INFO\s+loss: (?P<loss>[0-9\.]+)",
+        fom_regex=r".*?INFO\s+loss: (?P<loss>[0-9\.]+)",
         group_name="loss",
         units="",
     )
 
     figure_of_merit(
         "Best Epoch LR",
-        fom_regex=r".*INFO\s+lr: (?P<lr>[0-9\.]+)",
+        fom_regex=r".*?INFO\s+lr: (?P<lr>[0-9\.]+)",
         group_name="lr",
         units="",
     )
 
     figure_of_merit(
         "Best Epoch Mean Absolute Error",
-        fom_regex=r".*INFO\s+mean_absolute_error: (?P<abs_err>[0-9\.]+)",
+        fom_regex=r".*?INFO\s+mean_absolute_error: (?P<abs_err>[0-9\.]+)",
         group_name="abs_err",
         units="",
     )
 
     figure_of_merit(
         "Best Epoch Time",
-        fom_regex=r".*INFO\s+time: (?P<time>[0-9\.]+)",
+        fom_regex=r".*?INFO\s+time: (?P<time>[0-9\.]+)",
         group_name="time",
         units="s",
     )
 
     figure_of_merit(
         "Best Epoch Val Loss",
-        fom_regex=r".*INFO\s+val_loss: (?P<val_loss>[0-9\.]+)",
+        fom_regex=r".*?INFO\s+val_loss: (?P<val_loss>[0-9\.]+)",
         group_name="val_loss",
         units="",
     )
 
     figure_of_merit(
         "Best Epoch Val Mean Absolute Error",
-        fom_regex=r".*INFO\s+val_mean_absolute_error: (?P<val_error>[0-9\.]+)",
+        fom_regex=r".*?INFO\s+val_mean_absolute_error: (?P<val_error>[0-9\.]+)",
         group_name="val_error",
         units="",
     )
 
     figure_of_merit(
         "Total epoch time",
-        fom_regex=r".*INFO\s+Total epoch time: (?P<total_time>[0-9\.]+)",
+        fom_regex=r".*?INFO\s+Total epoch time: (?P<total_time>[0-9\.]+)",
         group_name="total_time",
         units="s",
     )
 
     figure_of_merit(
         "Mean epoch time",
-        fom_regex=r".*INFO\s+Mean epoch time: (?P<mean_time>[0-9\.]+)",
+        fom_regex=r".*?INFO\s+Mean epoch time: (?P<mean_time>[0-9\.]+)",
         group_name="mean_time",
         units="s",
     )

--- a/var/ramble/repos/builtin/applications/py-nemo-2/application.py
+++ b/var/ramble/repos/builtin/applications/py-nemo-2/application.py
@@ -273,35 +273,35 @@ class PyNemo2(ExecutableApplication):
     )
     figure_of_merit(
         "v_num",
-        fom_regex=r"Epoch.*v_num=(?P<v_num>\S+)[,\]]",
+        fom_regex=r"Epoch.*?v_num=(?P<v_num>\S+)[,\]]",
         group_name="v_num",
         log_file="{processed_log_file}",
         contexts=[epoch_context_name],
     )
     figure_of_merit(
         "reduced_train_loss",
-        fom_regex=r"Epoch.*reduced_train_loss=(?P<reduced_train_loss>[0-9\.]+)[,\]]",
+        fom_regex=r"Epoch.*?reduced_train_loss=(?P<reduced_train_loss>[0-9\.]+)[,\]]",
         group_name="reduced_train_loss",
         log_file="{processed_log_file}",
         contexts=[epoch_context_name],
     )
     figure_of_merit(
         "global_step",
-        fom_regex=r"Epoch.*global_step=(?P<global_step>[0-9\.]+)[,\]]",
+        fom_regex=r"Epoch.*?global_step=(?P<global_step>[0-9\.]+)[,\]]",
         group_name="global_step",
         log_file="{processed_log_file}",
         contexts=[epoch_context_name],
     )
     figure_of_merit(
         "consumed_samples",
-        fom_regex=r"Epoch.*consumed_samples=(?P<consumed_samples>[0-9\.]+)[,\]]",
+        fom_regex=r"Epoch.*?consumed_samples=(?P<consumed_samples>[0-9\.]+)[,\]]",
         group_name="consumed_samples",
         log_file="{processed_log_file}",
         contexts=[epoch_context_name],
     )
     figure_of_merit(
         "train_step_timing",
-        fom_regex=r"Epoch.*train_step_timing in s=(?P<train_step_time>[0-9\.]+)[,\]]",
+        fom_regex=r"Epoch.*?train_step_timing in s=(?P<train_step_time>[0-9\.]+)[,\]]",
         group_name="train_step_time",
         units="s",
         log_file="{processed_log_file}",
@@ -311,7 +311,7 @@ class PyNemo2(ExecutableApplication):
     success_criteria(
         "training-complete",
         mode="string",
-        match=".*`Trainer.fit` stopped: `max_steps=.*` reached.",
+        match=".*?`Trainer.fit` stopped: `max_steps=.*?` reached.",
         file="{processed_log_file}",
     )
 

--- a/var/ramble/repos/builtin/applications/py-nemo/application.py
+++ b/var/ramble/repos/builtin/applications/py-nemo/application.py
@@ -430,35 +430,35 @@ class PyNemo(ExecutableApplication):
     )
     figure_of_merit(
         "v_num",
-        fom_regex=r"Epoch.*v_num=(?P<v_num>\S+)[,\]]",
+        fom_regex=r"Epoch.*?v_num=(?P<v_num>\S+)[,\]]",
         group_name="v_num",
         log_file="{processed_log_file}",
         contexts=[epoch_context_name],
     )
     figure_of_merit(
         "reduced_train_loss",
-        fom_regex=r"Epoch.*reduced_train_loss=(?P<reduced_train_loss>[0-9\.]+)[,\]]",
+        fom_regex=r"Epoch.*?reduced_train_loss=(?P<reduced_train_loss>[0-9\.]+)[,\]]",
         group_name="reduced_train_loss",
         log_file="{processed_log_file}",
         contexts=[epoch_context_name],
     )
     figure_of_merit(
         "global_step",
-        fom_regex=r"Epoch.*global_step=(?P<global_step>[0-9\.]+)[,\]]",
+        fom_regex=r"Epoch.*?global_step=(?P<global_step>[0-9\.]+)[,\]]",
         group_name="global_step",
         log_file="{processed_log_file}",
         contexts=[epoch_context_name],
     )
     figure_of_merit(
         "consumed_samples",
-        fom_regex=r"Epoch.*consumed_samples=(?P<consumed_samples>[0-9\.]+)[,\]]",
+        fom_regex=r"Epoch.*?consumed_samples=(?P<consumed_samples>[0-9\.]+)[,\]]",
         group_name="consumed_samples",
         log_file="{processed_log_file}",
         contexts=[epoch_context_name],
     )
     figure_of_merit(
         "train_step_timing",
-        fom_regex=r"Epoch.*train_step_timing in s=(?P<train_step_time>[0-9\.]+)[,\]]",
+        fom_regex=r"Epoch.*?train_step_timing in s=(?P<train_step_time>[0-9\.]+)[,\]]",
         group_name="train_step_time",
         units="s",
         log_file="{processed_log_file}",
@@ -468,7 +468,7 @@ class PyNemo(ExecutableApplication):
     success_criteria(
         "training-complete",
         mode="string",
-        match=".*`Trainer.fit` stopped: `max_steps=.*` reached.",
+        match=".*?`Trainer.fit` stopped: `max_steps=.*?` reached.",
         file="{processed_log_file}",
     )
 

--- a/var/ramble/repos/builtin/applications/quantum-espresso/application.py
+++ b/var/ramble/repos/builtin/applications/quantum-espresso/application.py
@@ -194,7 +194,7 @@ class QuantumEspresso(ExecutableApplication):
     log_str = Expander.expansion_str("log_file")
     figure_of_merit(
         "Total CPU time",
-        fom_regex=r"\s*total cpu time spent up to now is\s+(?P<time>[0-9]+\.[0-9]+).*",
+        fom_regex=r"\s*total cpu time spent up to now is\s+(?P<time>[0-9]+\.[0-9]+)",
         group_name="time",
         log_file=log_str,
         units="s",
@@ -202,7 +202,7 @@ class QuantumEspresso(ExecutableApplication):
 
     figure_of_merit(
         "Estimated SCF accuracy",
-        fom_regex=r"\s*estimated scf accuracy\s+<\s+(?P<energy>[0-9]+\.[0-9]+).*",
+        fom_regex=r"\s*estimated scf accuracy\s+<\s+(?P<energy>[0-9]+\.[0-9]+)",
         group_name="energy",
         log_file=log_str,
         units="Ry",
@@ -210,7 +210,7 @@ class QuantumEspresso(ExecutableApplication):
 
     profile_regex = (
         r"\s+(?P<section>[\w:]+)\s+:\s+(?P<cpu>[0-9]+\.[0-9]+)s CPU\s+"
-        + r"(?P<wall>[0-9]+\.[0-9]+)s WALL \(\s+(?P<calls>[0-9]+) calls\).*"
+        + r"(?P<wall>[0-9]+\.[0-9]+)s WALL \(\s+(?P<calls>[0-9]+) calls\)"
     )
     figure_of_merit_context(
         "Profile section", regex=profile_regex, output_format="{section}"
@@ -244,5 +244,5 @@ class QuantumEspresso(ExecutableApplication):
     )
 
     success_criteria(
-        "job_done", mode="string", match=r".*JOB DONE\..*", file=log_str
+        "job_done", mode="string", match=r".*?JOB DONE\.", file=log_str
     )

--- a/var/ramble/repos/builtin/applications/roms/application.py
+++ b/var/ramble/repos/builtin/applications/roms/application.py
@@ -81,12 +81,12 @@ class Roms(ExecutableApplication):
     success_criteria(
         "prints_done",
         mode="string",
-        match=r".*ROMS/TOMS: DONE.*",
+        match=r".*?ROMS/TOMS: DONE",
     )
 
     figure_of_merit(
         "Total Time",
-        fom_regex=r"\s*All percentages are with respect to total time =\s+(?P<time>\d+\.\d+).*",
+        fom_regex=r"\s*All percentages are with respect to total time =\s+(?P<time>\d+\.\d+)",
         group_name="time",
         units="s",
     )

--- a/var/ramble/repos/builtin/applications/sleep/application.py
+++ b/var/ramble/repos/builtin/applications/sleep/application.py
@@ -66,35 +66,35 @@ class Sleep(ExecutableApplication):
         workloads=["rand_sleep"],
     )
 
-    echo_regex = r".*Sleep for (?P<time>[0-9]+) seconds.*"
+    echo_regex = r"Sleep for (?P<time>[0-9]+) seconds"
     figure_of_merit(
         "Sleep time", fom_regex=echo_regex, group_name="time", units="s"
     )
 
     figure_of_merit(
         "User time",
-        fom_regex=r"(?P<user_time>[0-9]+\.[0-9]+)user.*",
+        fom_regex=r"(?P<user_time>[0-9]+\.[0-9]+)user",
         group_name="user_time",
         units="s",
     )
 
     figure_of_merit(
         "Elapsed minutes",
-        fom_regex=r".*(?P<mins>[0-9]+):(?P<secs>[0-9]+)\.(?P<millisecs>[0-9]+)elapsed.*",
+        fom_regex=r".*?(?P<mins>[0-9]+):(?P<secs>[0-9]+)\.(?P<millisecs>[0-9]+)elapsed",
         group_name="mins",
         units="minutes",
     )
 
     figure_of_merit(
         "Elapsed seconds",
-        fom_regex=r".*(?P<mins>[0-9]+):(?P<secs>[0-9]+)\.(?P<millisecs>[0-9]+)elapsed.*",
+        fom_regex=r".*?(?P<mins>[0-9]+):(?P<secs>[0-9]+)\.(?P<millisecs>[0-9]+)elapsed",
         group_name="secs",
         units="s",
     )
 
     figure_of_merit(
         "Elapsed milliseconds",
-        fom_regex=r".*(?P<mins>[0-9]+):(?P<secs>[0-9]+)\.(?P<millisecs>[0-9]+)elapsed.*",
+        fom_regex=r".*?(?P<mins>[0-9]+):(?P<secs>[0-9]+)\.(?P<millisecs>[0-9]+)elapsed",
         group_name="millisecs",
         units="ms",
     )

--- a/var/ramble/repos/builtin/applications/spack-stack/application.py
+++ b/var/ramble/repos/builtin/applications/spack-stack/application.py
@@ -103,21 +103,21 @@ class SpackStack(ExecutableApplication):
     )
 
     success_criteria(
-        "view-updated", mode="string", match=r".*==> Updating view at.*"
+        "view-updated", mode="string", match=r".*?==> Updating view at"
     )
 
-    pkg_regex = r"\s*==\> (?P<name>.*) Successfully installed (?P<spec>.*)"
+    pkg_regex = r"\s*==\> (?P<name>.*?) Successfully installed (?P<spec>.*)"
 
     figure_of_merit(
         "Previously installed packages",
-        fom_regex=r"\s*==\> (?P<quant>.*) of the packages are already installed",
+        fom_regex=r"\s*==\> (?P<quant>.*?) of the packages are already installed",
         group_name="quant",
         units="",
     )
 
     figure_of_merit(
         "{pkg_name} installed",
-        fom_regex=r"\s*==\> (?P<pkg_name>.*): Successfully installed (?P<spec>.*)",
+        fom_regex=r"\s*==\> (?P<pkg_name>.*?): Successfully installed (?P<spec>.*)",
         group_name="spec",
         units="",
     )
@@ -139,7 +139,7 @@ class SpackStack(ExecutableApplication):
         "Total",
     ]
     for i, fom_part in enumerate(fom_parts):
-        full_regex = r".*\s*" + fom_part + r":\s+(?P<fom>[0-9\.]+)s.*"
+        full_regex = r".*?\s*" + fom_part + r":\s+(?P<fom>[0-9\.]+)s"
         figure_of_merit(
             fom_part,
             fom_regex=full_regex,

--- a/var/ramble/repos/builtin/applications/ufs-weather-model/application.py
+++ b/var/ramble/repos/builtin/applications/ufs-weather-model/application.py
@@ -88,7 +88,7 @@ class UfsWeatherModel(ExecutableApplication):
         "Total wall clock time",
         fom_regex=(
             r"^\s*The total amount of wall time\s+=\s+"
-            r"(?P<walltime>[0-9]+\.[0-9]+).*"
+            r"(?P<walltime>[0-9]+\.[0-9]+)"
         ),
         group_name="walltime",
         log_file=log_str,
@@ -99,7 +99,7 @@ class UfsWeatherModel(ExecutableApplication):
         "Total user mode time",
         fom_regex=(
             r"^\s*The total amount of time in user mode\s+=\s+"
-            r"(?P<usertime>[0-9]+\.[0-9]+).*"
+            r"(?P<usertime>[0-9]+\.[0-9]+)"
         ),
         group_name="usertime",
         log_file=log_str,
@@ -110,7 +110,7 @@ class UfsWeatherModel(ExecutableApplication):
         "Total sys mode time",
         fom_regex=(
             r"^\s*The total amount of time in sys mode\s+=\s+"
-            r"(?P<systime>[0-9]+\.[0-9]+).*"
+            r"(?P<systime>[0-9]+\.[0-9]+)"
         ),
         group_name="systime",
         log_file=log_str,
@@ -120,8 +120,8 @@ class UfsWeatherModel(ExecutableApplication):
     figure_of_merit(
         "Maximum resident set size",
         fom_regex=(
-            r"^\s*The maximum resident set size.*\s+=\s+"
-            r"(?P<res_set_size>[0-9]+).*"
+            r"^\s*The maximum resident set size.*?\s+=\s+"
+            r"(?P<res_set_size>[0-9]+)"
         ),
         group_name="res_set_size",
         log_file=log_str,
@@ -131,8 +131,8 @@ class UfsWeatherModel(ExecutableApplication):
     figure_of_merit(
         "Mean specific humidity above 75mb",
         fom_regex=(
-            r"^\s*Mean specific humidity.*=\s+"
-            r"(?P<mean_sp_hum>[0-9]+\.[0-9]+).*"
+            r"^\s*Mean specific humidity.*?=\s+"
+            r"(?P<mean_sp_hum>[0-9]+\.[0-9]+)"
         ),
         group_name="mean_sp_hum",
         log_file=log_str,
@@ -142,8 +142,8 @@ class UfsWeatherModel(ExecutableApplication):
     figure_of_merit(
         "Total surface pressure",
         fom_regex=(
-            r"^\s*Total surface pressure.*=\s+"
-            r"(?P<tot_surf_press>[0-9]+\.[0-9]+).*"
+            r"^\s*Total surface pressure.*?=\s+"
+            r"(?P<tot_surf_press>[0-9]+\.[0-9]+)"
         ),
         group_name="tot_surf_press",
         log_file=log_str,
@@ -153,10 +153,10 @@ class UfsWeatherModel(ExecutableApplication):
     figure_of_merit(
         "mean dry surface pressure",
         fom_regex=(
-            r"^\s*mean dry surface pressure.*=\s+"
+            r"^\s*mean dry surface pressure.*?=\s+"
             r"(?P<mean_dry_surf_press>"
             r"[\+\-]*[0-9]*\.*[0-9]+E*[\+\-]*[0-9]*"
-            r").*"
+            r")"
         ),
         group_name="mean_dry_surf_press",
         log_file=log_str,
@@ -166,10 +166,10 @@ class UfsWeatherModel(ExecutableApplication):
     figure_of_merit(
         "Total water vapor",
         fom_regex=(
-            r"^\s*Total Water Vapor.*=\s+"
+            r"^\s*Total Water Vapor.*?=\s+"
             r"(?P<tot_h2o_vapor>"
             r"[\+\-]*[0-9]*\.*[0-9]+E*[\+\-]*[0-9]*"
-            r").*"
+            r")"
         ),
         group_name="tot_h2o_vapor",
         log_file=log_str,
@@ -179,10 +179,10 @@ class UfsWeatherModel(ExecutableApplication):
     figure_of_merit(
         "Total cloud water",
         fom_regex=(
-            r"^\s*Total cloud water.*=\s+"
+            r"^\s*Total cloud water.*?=\s+"
             r"(?P<tot_cloud_h2o>"
             r"[\+\-]*[0-9]*\.*[0-9]+E*[\+\-]*[0-9]*"
-            r").*"
+            r")"
         ),
         group_name="tot_cloud_h2o",
         log_file=log_str,
@@ -192,10 +192,10 @@ class UfsWeatherModel(ExecutableApplication):
     figure_of_merit(
         "Total rain water",
         fom_regex=(
-            r"^\s*Total rain water.*=\s+"
+            r"^\s*Total rain water.*?=\s+"
             r"(?P<tot_rain_h2o>"
             r"[\+\-]*[0-9]*\.*[0-9]+E*[\+\-]*[0-9]*"
-            r").*"
+            r")"
         ),
         group_name="tot_rain_h2o",
         log_file=log_str,
@@ -205,10 +205,10 @@ class UfsWeatherModel(ExecutableApplication):
     figure_of_merit(
         "Total snow",
         fom_regex=(
-            r"^\s*Total snow.*=\s+"
+            r"^\s*Total snow.*?=\s+"
             r"(?P<tot_snow>"
             r"[\+\-]*[0-9]*\.*[0-9]+E*[\+\-]*[0-9]*"
-            r").*"
+            r")"
         ),
         group_name="tot_snow",
         log_file=log_str,
@@ -218,10 +218,10 @@ class UfsWeatherModel(ExecutableApplication):
     figure_of_merit(
         "Total graupel",
         fom_regex=(
-            r"^\s*Total graupel.*=\s+"
+            r"^\s*Total graupel.*?=\s+"
             r"(?P<tot_graupel>"
             r"[\+\-]*[0-9]*\.*[0-9]+E*[\+\-]*[0-9]*"
-            r").*"
+            r")"
         ),
         group_name="tot_graupel",
         log_file=log_str,
@@ -231,6 +231,6 @@ class UfsWeatherModel(ExecutableApplication):
     success_criteria(
         "program_ended",
         mode="string",
-        match=r"^\s+PROGRAM.*HAS ENDED\..*",
+        match=r"^\s+PROGRAM.*?HAS ENDED\.",
         file=log_str,
     )

--- a/var/ramble/repos/builtin/applications/wrfv3/application.py
+++ b/var/ramble/repos/builtin/applications/wrfv3/application.py
@@ -99,7 +99,7 @@ class Wrfv3(ExecutableApplication):
     figure_of_merit(
         "Average Timestep Time",
         log_file=log_str,
-        fom_regex=r"Average time:\s+(?P<avg_time>[0-9]+\.[0-9]*).*",
+        fom_regex=r"Average time:\s+(?P<avg_time>[0-9]+\.[0-9]*)",
         group_name="avg_time",
         units="s",
         fom_type=FomType.TIME,
@@ -108,7 +108,7 @@ class Wrfv3(ExecutableApplication):
     figure_of_merit(
         "Cumulative Timestep Time",
         log_file=log_str,
-        fom_regex=r"Cumulative time:\s+(?P<total_time>[0-9]+\.[0-9]*).*",
+        fom_regex=r"Cumulative time:\s+(?P<total_time>[0-9]+\.[0-9]*)",
         group_name="total_time",
         units="s",
         fom_type=FomType.TIME,
@@ -117,7 +117,7 @@ class Wrfv3(ExecutableApplication):
     figure_of_merit(
         "Minimum Timestep Time",
         log_file=log_str,
-        fom_regex=r"Min time:\s+(?P<min_time>[0-9]+\.[0-9]*).*",
+        fom_regex=r"Min time:\s+(?P<min_time>[0-9]+\.[0-9]*)",
         group_name="min_time",
         units="s",
         fom_type=FomType.TIME,
@@ -126,7 +126,7 @@ class Wrfv3(ExecutableApplication):
     figure_of_merit(
         "Maximum Timestep Time",
         log_file=log_str,
-        fom_regex=r"Max time:\s+(?P<max_time>[0-9]+\.[0-9]*).*",
+        fom_regex=r"Max time:\s+(?P<max_time>[0-9]+\.[0-9]*)",
         group_name="max_time",
         units="s",
         fom_type=FomType.TIME,
@@ -144,7 +144,7 @@ class Wrfv3(ExecutableApplication):
     figure_of_merit(
         "Avg. Max Ratio Time",
         log_file=log_str,
-        fom_regex=r"Avg time / Max time:\s+(?P<avg_max_ratio>[0-9]+\.[0-9]*).*",
+        fom_regex=r"Avg time / Max time:\s+(?P<avg_max_ratio>[0-9]+\.[0-9]*)",
         group_name="avg_max_ratio",
         units="",
         fom_type=FomType.MEASURE,
@@ -153,7 +153,7 @@ class Wrfv3(ExecutableApplication):
     success_criteria(
         "Complete",
         mode="string",
-        match=r".*wrf: SUCCESS COMPLETE WRF.*",
+        match=r".*?wrf: SUCCESS COMPLETE WRF",
         file="{experiment_run_dir}/rsl.out.0000",
     )
 

--- a/var/ramble/repos/builtin/applications/wrfv4/application.py
+++ b/var/ramble/repos/builtin/applications/wrfv4/application.py
@@ -111,7 +111,7 @@ class Wrfv4(ExecutableApplication):
     figure_of_merit(
         "Average Timestep Time",
         log_file=log_str,
-        fom_regex=r"Average time:\s+(?P<avg_time>[0-9]+\.[0-9]*).*",
+        fom_regex=r"Average time:\s+(?P<avg_time>[0-9]+\.[0-9]*)",
         group_name="avg_time",
         units="s",
         fom_type=FomType.TIME,
@@ -120,7 +120,7 @@ class Wrfv4(ExecutableApplication):
     figure_of_merit(
         "Cumulative Timestep Time",
         log_file=log_str,
-        fom_regex=r"Cumulative time:\s+(?P<total_time>[0-9]+\.[0-9]*).*",
+        fom_regex=r"Cumulative time:\s+(?P<total_time>[0-9]+\.[0-9]*)",
         group_name="total_time",
         units="s",
         fom_type=FomType.TIME,
@@ -129,7 +129,7 @@ class Wrfv4(ExecutableApplication):
     figure_of_merit(
         "Minimum Timestep Time",
         log_file=log_str,
-        fom_regex=r"Min time:\s+(?P<min_time>[0-9]+\.[0-9]*).*",
+        fom_regex=r"Min time:\s+(?P<min_time>[0-9]+\.[0-9]*)",
         group_name="min_time",
         units="s",
         fom_type=FomType.TIME,
@@ -138,7 +138,7 @@ class Wrfv4(ExecutableApplication):
     figure_of_merit(
         "Maximum Timestep Time",
         log_file=log_str,
-        fom_regex=r"Max time:\s+(?P<max_time>[0-9]+\.[0-9]*).*",
+        fom_regex=r"Max time:\s+(?P<max_time>[0-9]+\.[0-9]*)",
         group_name="max_time",
         units="s",
         fom_type=FomType.TIME,
@@ -156,7 +156,7 @@ class Wrfv4(ExecutableApplication):
     figure_of_merit(
         "Avg. Max Ratio Time",
         log_file=log_str,
-        fom_regex=r"Avg time / Max time:\s+(?P<avg_max_ratio>[0-9]+\.[0-9]*).*",
+        fom_regex=r"Avg time / Max time:\s+(?P<avg_max_ratio>[0-9]+\.[0-9]*)",
         group_name="avg_max_ratio",
         units="",
         fom_type=FomType.MEASURE,
@@ -165,7 +165,7 @@ class Wrfv4(ExecutableApplication):
     success_criteria(
         "Complete",
         mode="string",
-        match=r".*wrf: SUCCESS COMPLETE WRF.*",
+        match=r".*?wrf: SUCCESS COMPLETE WRF",
         file="{experiment_run_dir}/rsl.out.0000",
     )
 

--- a/var/ramble/repos/builtin/base_applications/hpcg/base_application.py
+++ b/var/ramble/repos/builtin/base_applications/hpcg/base_application.py
@@ -78,7 +78,7 @@ class Hpcg(ExecutableApplication):
     figure_of_merit(
         "Time",
         log_file=out_file,
-        fom_regex=r"Final Summary::Results are.* execution time.*is=(?P<exec_time>[0-9\.]*)",
+        fom_regex=r"Final Summary::Results are.*? execution time.*?is=(?P<exec_time>[0-9\.]*)",
         group_name="exec_time",
         units="s",
         fom_type=FomType.TIME,
@@ -87,7 +87,7 @@ class Hpcg(ExecutableApplication):
     figure_of_merit(
         "ComputeDotProductMsg",
         log_file=out_file,
-        fom_regex=r"Final Summary::Reference version of ComputeDotProduct used.*=(?P<msg>.*)",
+        fom_regex=r"Final Summary::Reference version of ComputeDotProduct used.*?=(?P<msg>.*)",
         group_name="msg",
         units="",
     )
@@ -95,7 +95,7 @@ class Hpcg(ExecutableApplication):
     figure_of_merit(
         "ComputeSPMVMsg",
         log_file=out_file,
-        fom_regex=r"Final Summary::Reference version of ComputeSPMV used.*=(?P<msg>.*)",
+        fom_regex=r"Final Summary::Reference version of ComputeSPMV used.*?=(?P<msg>.*)",
         group_name="msg",
         units="",
     )
@@ -103,7 +103,7 @@ class Hpcg(ExecutableApplication):
     figure_of_merit(
         "ComputeMGMsg",
         log_file=out_file,
-        fom_regex=r"Final Summary::Reference version of ComputeMG used.*=(?P<msg>.*)",
+        fom_regex=r"Final Summary::Reference version of ComputeMG used.*?=(?P<msg>.*)",
         group_name="msg",
         units="",
     )
@@ -111,7 +111,7 @@ class Hpcg(ExecutableApplication):
     figure_of_merit(
         "ComputeWAXPBYMsg",
         log_file=out_file,
-        fom_regex=r"Final Summary::Reference version of ComputeWAXPBY used.*=(?P<msg>.*)",
+        fom_regex=r"Final Summary::Reference version of ComputeWAXPBY used.*?=(?P<msg>.*)",
         group_name="msg",
         units="",
     )
@@ -119,7 +119,7 @@ class Hpcg(ExecutableApplication):
     figure_of_merit(
         "HPCG 2.4 Rating",
         log_file=out_file,
-        fom_regex=r"Final Summary::HPCG 2\.4 rating.*=(?P<rating>[0-9\.]+)",
+        fom_regex=r"Final Summary::HPCG 2\.4 rating.*?=(?P<rating>[0-9\.]+)",
         group_name="rating",
         units="",
         fom_type=FomType.THROUGHPUT,

--- a/var/ramble/repos/builtin/base_applications/hpl/base_application.py
+++ b/var/ramble/repos/builtin/base_applications/hpl/base_application.py
@@ -272,7 +272,7 @@ class Hpl(ExecutableApplication):
     # FOMs:
     figure_of_merit(
         "Time",
-        fom_regex=r".*\s+(?P<N>[0-9]+)\s+(?P<NB>[0-9]+)\s+(?P<P>[0-9]+)\s+(?P<Q>[0-9]+)\s+(?P<time>[0-9]+\.[0-9]+)\s+(?P<gflops>\S+)",
+        fom_regex=r".*?\s+(?P<N>[0-9]+)\s+(?P<NB>[0-9]+)\s+(?P<P>[0-9]+)\s+(?P<Q>[0-9]+)\s+(?P<time>[0-9]+\.[0-9]+)\s+(?P<gflops>\S+)",
         group_name="time",
         units="s",
         contexts=["problem-name"],
@@ -281,7 +281,7 @@ class Hpl(ExecutableApplication):
 
     figure_of_merit(
         "GFlops",
-        fom_regex=r".*\s+(?P<N>[0-9]+)\s+(?P<NB>[0-9]+)\s+(?P<P>[0-9]+)\s+(?P<Q>[0-9]+)\s+(?P<time>[0-9]+\.[0-9]+)\s+(?P<gflops>\S+)",
+        fom_regex=r".*?\s+(?P<N>[0-9]+)\s+(?P<NB>[0-9]+)\s+(?P<P>[0-9]+)\s+(?P<Q>[0-9]+)\s+(?P<time>[0-9]+\.[0-9]+)\s+(?P<gflops>\S+)",
         group_name="gflops",
         units="GFLOP/s",
         contexts=["problem-name"],
@@ -290,7 +290,7 @@ class Hpl(ExecutableApplication):
 
     figure_of_merit_context(
         "problem-name",
-        regex=r".*\s+(?P<N>[0-9]+)\s+(?P<NB>[0-9]+)\s+(?P<P>[0-9]+)\s+(?P<Q>[0-9]+)\s+(?P<time>[0-9]+\.[0-9]+)\s+(?P<gflops>\S+)",
+        regex=r".*?\s+(?P<N>[0-9]+)\s+(?P<NB>[0-9]+)\s+(?P<P>[0-9]+)\s+(?P<Q>[0-9]+)\s+(?P<time>[0-9]+\.[0-9]+)\s+(?P<gflops>\S+)",
         output_format="N-NB-P-Q = {N}-{NB}-{P}-{Q}",
     )
 

--- a/var/ramble/repos/builtin/base_applications/openfoam/base_application.py
+++ b/var/ramble/repos/builtin/base_applications/openfoam/base_application.py
@@ -390,7 +390,7 @@ class Openfoam(ExecutableApplication):
     figure_of_merit(
         "Number of cells",
         log_file=(log_prefix + "snappyHexMesh"),
-        fom_regex=r"Layer mesh\s+:\s+cells:(?P<ncells>[0-9]+)\s+.*",
+        fom_regex=r"Layer mesh\s+:\s+cells:(?P<ncells>[0-9]+)\s+",
         group_name="ncells",
         units="",
     )
@@ -398,7 +398,7 @@ class Openfoam(ExecutableApplication):
     figure_of_merit(
         "snappyHexMesh Time",
         log_file=(log_prefix + "snappyHexMesh"),
-        fom_regex=r"Finished meshing in = (?P<mesh_time>[0-9]+\.?[0-9]*).*",
+        fom_regex=r"Finished meshing in = (?P<mesh_time>[0-9]+\.?[0-9]*)",
         group_name="mesh_time",
         units="s",
     )
@@ -414,7 +414,7 @@ class Openfoam(ExecutableApplication):
     figure_of_merit(
         "simpleFoam Time",
         log_file=(log_prefix + "simpleFoam"),
-        fom_regex=r"\s*ExecutionTime = (?P<foam_time>[0-9]+\.?[0-9]*).*",
+        fom_regex=r"\s*ExecutionTime = (?P<foam_time>[0-9]+\.?[0-9]*)",
         group_name="foam_time",
         units="s",
     )
@@ -422,7 +422,7 @@ class Openfoam(ExecutableApplication):
     figure_of_merit(
         "simpleFoam Time",
         log_file=(log_prefix + "simpleFoam"),
-        fom_regex=r"\s*ExecutionTime = (?P<foam_time>[0-9]+\.?[0-9]*).*",
+        fom_regex=r"\s*ExecutionTime = (?P<foam_time>[0-9]+\.?[0-9]*)",
         group_name="foam_time",
         units="s",
     )
@@ -438,7 +438,7 @@ class Openfoam(ExecutableApplication):
     figure_of_merit(
         "potentialFoam Time",
         log_file=(log_prefix + "potentialFoam"),
-        fom_regex=r"\s*ExecutionTime = (?P<foam_time>[0-9]+\.?[0-9]*).*",
+        fom_regex=r"\s*ExecutionTime = (?P<foam_time>[0-9]+\.?[0-9]*)",
         group_name="foam_time",
         units="s",
     )

--- a/var/ramble/repos/builtin/modifiers/conditional-psm3/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/conditional-psm3/modifier.py
@@ -145,7 +145,7 @@ class ConditionalPsm3(BasicModifier):
 
         return pre_cmds, post_cmds
 
-    psm3_build_info_regex = r".*\sPSM3_IDENTIFY PSM3\s+(?P<version>v[\d.]+)\s+built for\s+(?P<target>.*)$"
+    psm3_build_info_regex = r".*?\sPSM3_IDENTIFY PSM3\s+(?P<version>v[\d.]+)\s+built for\s+(?P<target>.*)$"
 
     figure_of_merit(
         "PSM3 version",

--- a/var/ramble/repos/builtin/modifiers/ethtool/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/ethtool/modifier.py
@@ -190,7 +190,7 @@ class Ethtool(BasicModifier):
 
     figure_of_merit(
         "adaptive_tx",
-        fom_regex=r"Adaptive RX:.*TX:\s*(?P<adaptive_tx>off|on)",
+        fom_regex=r"Adaptive RX:.*?TX:\s*(?P<adaptive_tx>off|on)",
         log_file="{experiment_run_dir}/ethtool_out",
         group_name="adaptive_tx",
         units="",

--- a/var/ramble/repos/builtin/modifiers/exit-code/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/exit-code/modifier.py
@@ -112,7 +112,9 @@ class ExitCode(BasicModifier):
 
         return pre_exec, post_exec
 
-    exit_code_regex = r"Exit code for (?P<exec_name>.*): (?P<exit_code>[0-9]+)"
+    exit_code_regex = (
+        r"Exit code for (?P<exec_name>.*?): (?P<exit_code>[0-9]+)"
+    )
 
     figure_of_merit_context(
         "Executable Exit Code",

--- a/var/ramble/repos/builtin/modifiers/gcp-metadata/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/gcp-metadata/modifier.py
@@ -237,14 +237,14 @@ class GcpMetadata(BasicModifier):
 
     figure_of_merit(
         "machine-type",
-        fom_regex=r".*machineTypes/(?P<machine>.*)",
+        fom_regex=r".*?machineTypes/(?P<machine>.*)",
         group_name="machine",
         log_file="{experiment_run_dir}/gcp-metadata.machine-type.log",
         fom_type=FomType.INFO,
     )
     figure_of_merit(
         "image",
-        fom_regex=r"(?P<image>.*global/images.*)",
+        fom_regex=r"(?P<image>.*?global/images.*)",
         group_name="image",
         log_file="{experiment_run_dir}/gcp-metadata.image.log",
         fom_type=FomType.INFO,
@@ -253,7 +253,7 @@ class GcpMetadata(BasicModifier):
     # This is intentionally left singular, to get the hostname of the "parent" or "root" process
     figure_of_merit(
         "ghostname",
-        fom_regex=r"(?P<ghostname>.*internal)",
+        fom_regex=r"(?P<ghostname>.*?internal)",
         group_name="ghostname",
         log_file="{experiment_run_dir}/gcp-metadata.hostname.log",
         fom_type=FomType.INFO,


### PR DESCRIPTION
From informal testing, making it less greedy can improve the regex matching perf by about 5-7%. Also remove some redundant end-of-string match using `.*`, as we use `re.match` for finding the match.