### PR TITLE
Cache template file read

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -2471,8 +2471,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
         for obj, tpl_config in self._object_templates(workspace):
             extra_vars = extra_vars_origin.copy()
             src_path = tpl_config["src_path"]
-            with open(src_path) as f_in:
-                content = f_in.read()
+            content = workspace.read_file_content(src_path)
             extra_vars_dict = tpl_config.get("extra_vars")
             if extra_vars_dict is not None:
                 extra_vars.update(extra_vars_dict)

--- a/lib/ramble/ramble/test/workspace_tests.py
+++ b/lib/ramble/ramble/test/workspace_tests.py
@@ -30,3 +30,16 @@ def test_re_read(tmpdir):
         test_workspace = ramble.workspace.Workspace(os.getcwd(), True)
         test_workspace.clear()
         test_workspace._re_read()
+
+
+def test_read_file_content(tmpdir):
+    with tmpdir.as_cwd():
+        test_workspace = ramble.workspace.Workspace(os.getcwd(), True)
+        fname = "test.tpl"
+        with open(fname, "w+") as f:
+            f.write("test content read")
+        assert test_workspace.read_file_content(fname) == "test content read"
+        with open(fname, "w") as f:
+            f.write("test content read modified")
+        # The read is cached and does not reflect the latest content
+        assert test_workspace.read_file_content(fname) == "test content read"

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -464,6 +464,10 @@ class Workspace:
         # This can be re-used by all experiments of the workspace.
         self.pkg_path_cache = defaultdict(dict)
 
+        # A simple dict mapping a file's src_path to its content.
+        # This is currently used as a cache for reading per-object template contents.
+        self._inmem_file_cache = {}
+
         self.results = self.default_results()
 
         self.success_list = ramble.success_criteria.ScopedCriteriaList()
@@ -1787,6 +1791,19 @@ ramble:
     def date_string(self):
         now = datetime.datetime.now()
         return now.strftime("%Y-%m-%d_%H.%M.%S")
+
+    def read_file_content(self, file_path):
+        """Read and cache the file content
+
+        This should only be used on files that are not modified during the lifetime of the
+        workspace command execution.
+        """
+        if file_path in self._inmem_file_cache:
+            return self._inmem_file_cache[file_path]
+        with open(file_path) as f:
+            content = f.read()
+        self._inmem_file_cache[file_path] = content
+        return content
 
     @property
     def internal(self):


### PR DESCRIPTION
This brings in a modest speedup when a workspace needs to repeatedly read in the same template files (like when using slurm workflow manager for a large number of experiments.)

Here's a per-line-profile comparison for the speed up (for a workspace with a dozen experiments):

```
 # before
2477        72       5333.2     74.1      1.5              with open(src_path) as f_in:
2478        72       1003.1     13.9      0.3                  content = f_in.read()

 # after
2477        72       2535.7     35.2      0.8              content = workspace.read_file_content(src_path)
```