### PR TITLE
Make sure to terminate script upon missing job-id

### DIFF
--- a/var/ramble/repos/builtin/workflow_managers/slurm/batch_cancel.tpl
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/batch_cancel.tpl
@@ -2,6 +2,6 @@
 
 . {batch_helpers}
 
-job_id=$(get_job_id)
+job_id=$(get_job_id) || exit 0
 
 scancel ${job_id}

--- a/var/ramble/repos/builtin/workflow_managers/slurm/batch_query.tpl
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/batch_query.tpl
@@ -2,7 +2,7 @@
 
 . {batch_helpers}
 
-job_id=$(get_job_id)
+job_id=$(get_job_id) || exit 0
 
 # Set up the status_map mapping between
 # sacct/squeue status to ramble counterpart

--- a/var/ramble/repos/builtin/workflow_managers/slurm/batch_wait.tpl
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/batch_wait.tpl
@@ -2,7 +2,7 @@
 
 . {batch_helpers}
 
-job_id=$(get_job_id)
+job_id=$(get_job_id) || exit 0
 
 echo "Waiting for job {job_name} with id ${job_id} to complete..."
 


### PR DESCRIPTION
Previously the exit only happens in a subshell, but the main script will continue and generate undesirable outputs.

Return with zero as we don't want the script to terminate the whole execution.