### PR TITLE
Fix Command Reference in docs

### DIFF
--- a/lib/ramble/docs/command_index.in
+++ b/lib/ramble/docs/command_index.in
@@ -1,0 +1,6 @@
+=================
+Command Reference
+=================
+
+This is a reference for all commands in the Ramble command line interface.
+The same information is available through :ref:`ramble-help`.

--- a/lib/ramble/docs/conf.py
+++ b/lib/ramble/docs/conf.py
@@ -53,6 +53,7 @@ subprocess.call(
         "ramble",
         "commands",
         "--format=rst",
+        "--header=command_index.in",
         "--update=command_index.rst",
     ]
     + glob("*rst")


### PR DESCRIPTION
Adds a header with title to Command Reference page so it can be added to table of contents by readthedocs