### PR TITLE
Tolerate some "none-looking" names in variant setting

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -51,6 +51,7 @@ from ramble.error import RambleError
 from ramble.experiment_result import ExperimentResult
 from ramble.language.application_language import ApplicationMeta
 from ramble.language.shared_language import SharedMeta, register_builtin, register_phase
+from ramble.util import conversions
 from ramble.util.foms import FomType
 from ramble.util.logger import logger
 from ramble.util.naming import NS_SEPARATOR
@@ -59,7 +60,6 @@ from ramble.util.shell_utils import source_str
 from ramble.workspace import namespace
 
 import spack.util.compression
-import spack.util.environment
 import spack.util.executable
 import spack.util.spack_json
 
@@ -280,8 +280,8 @@ class ApplicationBase(metaclass=ApplicationMeta):
 
     def _set_package_manager(self):
         if namespace.package_manager in self.variants:
-            pkgman_name = self.expander.expand_var(
-                self.variants[namespace.package_manager], typed=True
+            pkgman_name = conversions.canonical_none(
+                self.expander.expand_var(self.variants[namespace.package_manager], typed=True)
             )
 
             if pkgman_name is not None:
@@ -310,18 +310,18 @@ class ApplicationBase(metaclass=ApplicationMeta):
 
     def _set_workflow_manager(self):
         if namespace.workflow_manager in self.variants:
-            workflow_name = self.expander.expand_var(
-                self.variants[namespace.workflow_manager], typed=True
+            wm_name = conversions.canonical_none(
+                self.expander.expand_var(self.variants[namespace.workflow_manager], typed=True)
             )
 
-            if workflow_name is not None:
+            if wm_name is not None:
                 try:
                     wfman_type = ramble.repository.ObjectTypes.workflow_managers
-                    self.workflow_manager = ramble.repository.get(workflow_name, wfman_type).copy()
+                    self.workflow_manager = ramble.repository.get(wm_name, wfman_type).copy()
                     self.workflow_manager.set_application(self)
                 except ramble.repository.UnknownObjectError:
                     logger.die(
-                        f"{workflow_name} is not a valid workflow manager. "
+                        f"{wm_name} is not a valid workflow manager. "
                         "Valid workflow managers can be listed via:\n"
                         "\tramble list --type workflow_managers"
                     )

--- a/lib/ramble/ramble/test/package_manager_functionality/package_manager_general.py
+++ b/lib/ramble/ramble/test/package_manager_functionality/package_manager_general.py
@@ -1,0 +1,62 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.workspace
+from ramble.main import RambleCommand, RambleCommandError
+
+workspace = RambleCommand("workspace")
+
+pytestmark = pytest.mark.usefixtures(
+    "mutable_config",
+    "mutable_mock_workspace_path",
+)
+
+
+@pytest.mark.maybeslow
+@pytest.mark.parametrize(
+    "pkgman_name,expect_success_setup",
+    [
+        ("none", True),
+        (None, True),
+        ("", True),
+        ("spack", True),
+        ("non-existent-pkgman", False),
+    ],
+)
+def test_package_manager_names(pkgman_name, expect_success_setup):
+    ws_name = f"test-{pkgman_name}"
+    ws = ramble.workspace.create(ws_name)
+    workspace(
+        "manage",
+        "experiments",
+        "hostname",
+        "-p",
+        pkgman_name,
+        "--wf",
+        "local",
+        "-v",
+        "n_nodes=1",
+        "-v",
+        "processes_per_node=1",
+        "-v",
+        "mpi_command=''",
+        "-v",
+        "batch_submit=''",
+        global_args=["-w", ws_name],
+    )
+    ws._re_read()
+    if expect_success_setup:
+        workspace("setup", "--dry-run", global_args=["-D", ws.root])
+        assert os.path.isfile(os.path.join(ws.log_dir, "setup.latest.out"))
+    else:
+        with pytest.raises(RambleCommandError):
+            workspace("setup", "--dry-run", global_args=["-D", ws.root])

--- a/lib/ramble/ramble/test/util/conversions.py
+++ b/lib/ramble/ramble/test/util/conversions.py
@@ -1,0 +1,36 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import pytest
+
+from ramble.util import conversions
+
+
+@pytest.mark.parametrize(
+    "input,expect",
+    [
+        ("not-a-list", "not-a-list"),
+        ("[1,2, 3, a, b, c]", ["1", "2", "3", "a", "b", "c"]),
+    ],
+)
+def test_list_str_to_list(input, expect):
+    assert conversions.list_str_to_list(input) == expect
+
+
+@pytest.mark.parametrize(
+    "input,expect",
+    [
+        (None, None),
+        ("none", None),
+        ("None", None),
+        ("", None),
+        ("other", "other"),
+    ],
+)
+def test_canonical_none(input, expect):
+    assert conversions.canonical_none(input) == expect

--- a/lib/ramble/ramble/util/conversions.py
+++ b/lib/ramble/ramble/util/conversions.py
@@ -28,3 +28,12 @@ def list_str_to_list(in_str):
         else:
             out_value.append(part)
     return out_value
+
+
+def canonical_none(maybe_none):
+    """Convert a small set of "none-looking" inputs to None"""
+    if maybe_none == "":
+        return None
+    if isinstance(maybe_none, str) and maybe_none.lower() == "none":
+        return None
+    return maybe_none


### PR DESCRIPTION
With the change, all the following would point to the None pkgman:

```
package_manager: null
package_manager: None
package_manager: ''
package_manager: 'None'
package_manager: 'none'
```