### PR TITLE
Add support for variants, a when clause, and the default_args clause

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -46,6 +46,7 @@ import ramble.util.hashing
 import ramble.util.lock as lk
 import ramble.util.path
 import ramble.util.stats
+import ramble.variants
 import ramble.workflow_manager
 from ramble.error import RambleError
 from ramble.experiment_result import ExperimentResult
@@ -57,7 +58,6 @@ from ramble.util.logger import logger
 from ramble.util.naming import NS_SEPARATOR
 from ramble.util.output_capture import output_mapper
 from ramble.util.shell_utils import source_str
-import ramble.variants
 from ramble.workspace import namespace
 
 import spack.util.compression

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -57,6 +57,7 @@ from ramble.util.logger import logger
 from ramble.util.naming import NS_SEPARATOR
 from ramble.util.output_capture import output_mapper
 from ramble.util.shell_utils import source_str
+import ramble.variants
 from ramble.workspace import namespace
 
 import spack.util.compression
@@ -132,6 +133,7 @@ def _get_phase_func_wrapper(workspace, phase_func, phase_name):
 
 class ApplicationBase(metaclass=ApplicationMeta):
     name = None
+    object_variants = None
     _builtin_name = NS_SEPARATOR.join(("builtin", "{name}"))
     _builtin_required_key = "required"
     _inventory_file_name = "ramble_inventory.json"
@@ -157,6 +159,9 @@ class ApplicationBase(metaclass=ApplicationMeta):
 
     def __init__(self, file_path):
         super().__init__()
+
+        if self.object_variants is None:
+            self.object_variants = ramble.variants.VariantSet()
 
         ramble.util.class_attributes.convert_class_attributes(self)
 
@@ -274,31 +279,45 @@ class ApplicationBase(metaclass=ApplicationMeta):
             variants (dict): Dictionary of variant controls for this
                              experiment.
         """
+
         self.variants = variants.copy()
+        for _, obj in self._objects(exclude_types=[ramble.repository.ObjectTypes.applications]):
+            obj_variants = getattr(obj, "object_variants", None)
+            if obj_variants is not None:
+                self.object_variants.merge_default_variants(getattr(obj, "object_variants"))
+
+        for name, value in variants.items():
+            expanded_value = self.expander.expand_var(value, typed=True)
+            self.object_variants.experiment_variant(name, expanded_value)
+
         self._set_package_manager()
         self._set_workflow_manager()
 
-    def _set_package_manager(self):
-        if namespace.package_manager in self.variants:
-            pkgman_name = conversions.canonical_none(
-                self.expander.expand_var(self.variants[namespace.package_manager], typed=True)
-            )
+        for _, obj in self._objects(exclude_types=[ramble.repository.ObjectTypes.applications]):
+            obj_variants = getattr(obj, "object_variants", None)
+            if obj_variants is not None:
+                self.object_variants.merge_multi_value_variants(getattr(obj, "object_variants"))
 
-            if pkgman_name is not None:
-                try:
-                    pkgman_type = ramble.repository.ObjectTypes.package_managers
-                    self.package_manager = ramble.repository.get(pkgman_name, pkgman_type).copy()
-                    self.package_manager.set_application(self)
-                except ramble.repository.UnknownObjectError:
-                    logger.die(
-                        f"{pkgman_name} is not a valid package manager. "
-                        "Valid package managers can be listed via:\n"
-                        "\tramble list --type package_managers"
-                    )
+    def _set_package_manager(self):
+        pkgman_name = conversions.canonical_none(
+            self.object_variants.value(namespace.package_manager)
+        )
+
+        if pkgman_name is not None:
+            try:
+                pkgman_type = ramble.repository.ObjectTypes.package_managers
+                self.package_manager = ramble.repository.get(pkgman_name, pkgman_type).copy()
+                self.package_manager.set_application(self)
+            except ramble.repository.UnknownObjectError:
+                logger.die(
+                    f"{pkgman_name} is not a valid package manager. "
+                    "Valid package managers can be listed via:\n"
+                    "\tramble list --type package_managers"
+                )
 
         if self.package_manager is not None:
             for pkgname, config in self.required_packages.items():
-                if fnmatch.fnmatch(self.package_manager.name, config["package_manager"]):
+                if self.expander.satisfies(config["when"], variant_set=self.object_variants):
                     self.keywords.update_keys(
                         {
                             f"{pkgname}_path": {
@@ -309,22 +328,22 @@ class ApplicationBase(metaclass=ApplicationMeta):
                     )
 
     def _set_workflow_manager(self):
-        if namespace.workflow_manager in self.variants:
-            wm_name = conversions.canonical_none(
-                self.expander.expand_var(self.variants[namespace.workflow_manager], typed=True)
-            )
+        workflow_name = conversions.canonical_none(
+            self.object_variants.value(namespace.workflow_manager)
+        )
 
-            if wm_name is not None:
-                try:
-                    wfman_type = ramble.repository.ObjectTypes.workflow_managers
-                    self.workflow_manager = ramble.repository.get(wm_name, wfman_type).copy()
-                    self.workflow_manager.set_application(self)
-                except ramble.repository.UnknownObjectError:
-                    logger.die(
-                        f"{wm_name} is not a valid workflow manager. "
-                        "Valid workflow managers can be listed via:\n"
-                        "\tramble list --type workflow_managers"
-                    )
+        if workflow_name is not None:
+            try:
+                wfman_type = ramble.repository.ObjectTypes.workflow_managers
+                self.workflow_manager = ramble.repository.get(workflow_name, wfman_type).copy()
+                self.workflow_manager.set_application(self)
+            except ramble.repository.UnknownObjectError:
+                logger.die(
+                    f"{workflow_name} is not a valid workflow manager. "
+                    "Valid workflow managers can be listed via:\n"
+                    "\tramble list --type workflow_managers"
+                )
+
         if self.workflow_manager is None:
             base_path = os.path.join(ramble.paths.module_path, "workflow_manager.py")
             self.workflow_manager = ramble.workflow_manager.WorkflowManagerBase(base_path)

--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -650,12 +650,16 @@ class Expander:
             )
 
     def satisfies(
-        self, reqs: List = None, variant_set=None, extra_vars=None, merge_used_stage: bool = True
+        self,
+        reqs: List[str] = None,
+        variant_set=None,
+        extra_vars=None,
+        merge_used_stage: bool = True,
     ):
         """Determine an experiment's variants satisfy a query
 
         Args:
-            req: requirement to check if experiment satisfies
+            reqs: List of string requirements to check if experiment satisfies
             extra_vars: Variable definitions to use with highest precedence
             merged_used_stage: Whether used variables are merged into the
                                set of used variables or not.
@@ -927,12 +931,7 @@ class Expander:
 
             found = False
             for comp in node.comparators:
-                if isinstance(comp, ast.List):
-                    for elt in comp.elts:
-                        rhs_value = self.eval_math(elt)
-                        if lhs_value == rhs_value:
-                            found = True
-                elif isinstance(comp, ast.Set):
+                if isinstance(comp, (ast.List, ast.Set)):
                     for elt in comp.elts:
                         rhs_value = self.eval_math(elt)
                         if lhs_value == rhs_value:

--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -11,7 +11,7 @@ import math
 import operator
 import random
 import string
-from typing import Dict
+from typing import Dict, List
 
 import ramble.error
 import ramble.keywords
@@ -649,6 +649,37 @@ class Expander:
                 f'a non-boolean string: "{evaluated}"'
             )
 
+    def satisfies(
+        self, reqs: List = None, variant_set=None, extra_vars=None, merge_used_stage: bool = True
+    ):
+        """Determine an experiment's variants satisfy a query
+
+        Args:
+            req: requirement to check if experiment satisfies
+            extra_vars: Variable definitions to use with highest precedence
+            merged_used_stage: Whether used variables are merged into the
+                               set of used variables or not.
+
+        Returns:
+            boolean: True or False, based if the experiment's variants satisfy
+                     the input requirement.
+        """
+
+        if variant_set is not None:
+            variant_definitions = variant_set.as_set()
+        else:
+            variant_definitions = set()
+
+        satisfied = True
+        if reqs is not None:
+            for req in reqs:
+                exp_req = self.expand_var(
+                    req, extra_vars=extra_vars, merge_used_stage=merge_used_stage
+                )
+
+                satisfied = satisfied and exp_req in variant_definitions
+        return satisfied
+
     @staticmethod
     def expansion_str(in_str):
         return f"{ExpansionDelimiter.left}{in_str}{ExpansionDelimiter.right}"
@@ -897,6 +928,11 @@ class Expander:
             found = False
             for comp in node.comparators:
                 if isinstance(comp, ast.List):
+                    for elt in comp.elts:
+                        rhs_value = self.eval_math(elt)
+                        if lhs_value == rhs_value:
+                            found = True
+                elif isinstance(comp, ast.Set):
                     for elt in comp.elts:
                         rhs_value = self.eval_math(elt)
                         if lhs_value == rhs_value:

--- a/lib/ramble/ramble/language/language_base.py
+++ b/lib/ramble/ramble/language/language_base.py
@@ -10,9 +10,9 @@
 directives, which are to allow functions to be invoked at class level
 """
 
-from typing import List, Dict, Any
 import functools
 from collections.abc import Sequence  # novm
+from typing import Any, Dict, List
 
 import llnl.util.lang
 import llnl.util.tty.color

--- a/lib/ramble/ramble/language/language_base.py
+++ b/lib/ramble/ramble/language/language_base.py
@@ -10,6 +10,7 @@
 directives, which are to allow functions to be invoked at class level
 """
 
+from typing import List, Dict, Any
 import functools
 from collections.abc import Sequence  # novm
 
@@ -47,6 +48,8 @@ class DirectiveMeta(type):
     _directives_to_be_executed = []
     _directive_functions = {}
     _directive_classes = {}
+    _when_constraints_from_context = []
+    _default_args: List[dict] = []
 
     def __new__(cls, name, bases, attr_dict):
         # Initialize the attribute containing the list of directives
@@ -78,6 +81,22 @@ class DirectiveMeta(type):
             DirectiveMeta._directives_to_be_executed = []
 
         return super().__new__(cls, name, bases, attr_dict)
+
+    @staticmethod
+    def push_to_context(when_condition: str) -> None:
+        DirectiveMeta._when_constraints_from_context.append(when_condition)
+
+    @staticmethod
+    def pop_from_context() -> str:
+        return DirectiveMeta._when_constraints_from_context.pop()
+
+    @staticmethod
+    def push_default_args(default_args: Dict[str, Any]) -> None:
+        DirectiveMeta._default_args.append(default_args)
+
+    @staticmethod
+    def pop_default_args() -> dict:
+        return DirectiveMeta._default_args.pop()
 
     def __init__(cls, name, bases, attr_dict):
         # The instance is being initialized: if it is a package we must ensure
@@ -174,7 +193,33 @@ class DirectiveMeta(type):
         # This decorator just returns the directive functions
         def _decorator(decorated_function):
             @functools.wraps(decorated_function)
-            def _wrapper(*args, **kwargs):
+            def _wrapper(*args, **_kwargs):
+                # First merge default args with kwargs
+                kwargs = dict()
+                for default_args in DirectiveMeta._default_args:
+                    kwargs.update(default_args)
+                kwargs.update(_kwargs)
+
+                # Inject when arguments from the context
+                if DirectiveMeta._when_constraints_from_context:
+                    # Check that directives not yet supporting the when= argument
+                    # are not used inside the context manager
+                    if decorated_function.__name__ == "version":
+                        msg = (
+                            'directive "{0}" cannot be used within a "when"'
+                            ' context since it does not support a "when=" '
+                            "argument"
+                        )
+                        msg = msg.format(decorated_function.__name__)
+                        raise DirectiveError(msg)
+
+                    when_constraints = DirectiveMeta._when_constraints_from_context.copy()
+
+                    if kwargs.get("when"):
+                        when_constraints.extend(kwargs["when"])
+
+                    kwargs["when"] = when_constraints.copy()
+
                 # If any of the arguments are executors returned by a
                 # directive passed as an argument, don't execute them
                 # lazily. Instead, let the called directive handle them.

--- a/lib/ramble/ramble/language/language_base.py
+++ b/lib/ramble/ramble/language/language_base.py
@@ -38,6 +38,22 @@ namespaces = [
 ]
 
 
+def _push_to_context(when_condition: str) -> None:
+    DirectiveMeta._when_constraints_from_context.append(when_condition)
+
+
+def _pop_from_context() -> str:
+    return DirectiveMeta._when_constraints_from_context.pop()
+
+
+def _push_default_args(default_args: Dict[str, Any]) -> None:
+    DirectiveMeta._default_args.append(default_args)
+
+
+def _pop_default_args() -> dict:
+    return DirectiveMeta._default_args.pop()
+
+
 class DirectiveMeta(type):
     """Flushes the directives that were temporarily stored in the staging
     area into the package.
@@ -50,6 +66,11 @@ class DirectiveMeta(type):
     _directive_classes = {}
     _when_constraints_from_context = []
     _default_args: List[dict] = []
+
+    push_to_context = _push_to_context
+    pop_from_context = _pop_from_context
+    push_default_args = _push_default_args
+    pop_default_args = _pop_default_args
 
     def __new__(cls, name, bases, attr_dict):
         # Initialize the attribute containing the list of directives
@@ -81,22 +102,6 @@ class DirectiveMeta(type):
             DirectiveMeta._directives_to_be_executed = []
 
         return super().__new__(cls, name, bases, attr_dict)
-
-    @staticmethod
-    def push_to_context(when_condition: str) -> None:
-        DirectiveMeta._when_constraints_from_context.append(when_condition)
-
-    @staticmethod
-    def pop_from_context() -> str:
-        return DirectiveMeta._when_constraints_from_context.pop()
-
-    @staticmethod
-    def push_default_args(default_args: Dict[str, Any]) -> None:
-        DirectiveMeta._default_args.append(default_args)
-
-    @staticmethod
-    def pop_default_args() -> dict:
-        return DirectiveMeta._default_args.pop()
 
     def __init__(cls, name, bases, attr_dict):
         # The instance is being initialized: if it is a package we must ensure
@@ -204,7 +209,12 @@ class DirectiveMeta(type):
                 if DirectiveMeta._when_constraints_from_context:
                     # Check that directives not yet supporting the when= argument
                     # are not used inside the context manager
-                    if decorated_function.__name__ == "version":
+                    if decorated_function.__name__ not in [
+                        "software_spec",
+                        "required_package",
+                        "define_compiler",
+                        "package_manager_config",
+                    ]:
                         msg = (
                             'directive "{0}" cannot be used within a "when"'
                             ' context since it does not support a "when=" '

--- a/lib/ramble/ramble/language/language_helpers.py
+++ b/lib/ramble/ramble/language/language_helpers.py
@@ -8,6 +8,8 @@
 
 import fnmatch
 
+from typing import List, Any
+
 from ramble.language.language_base import DirectiveError
 
 
@@ -153,3 +155,33 @@ def expand_patterns(multiple_type: list, multiple_pattern_match: list):
             expanded_patterns.append(input)
 
     return expanded_patterns
+
+
+def build_when_list(
+    when_arg: List[str], obj: Any, directive_id: str, directive_name: str
+) -> List[str]:
+    """Construct list of when conditions based on a directives input argument
+    Also, validate that when is passed in with the right type.
+
+    Args:
+        when_arg (list(str)): List of string conditions that were input into
+                              the calling directive.
+        obj: A ramble object (i.e. application, modifier, etc..)
+        directive_id (str): Directive identifier. The calling directive can
+                            define what is used here, but it should be
+                            something that can help users identify where errors
+                            from this method originate from.
+        directive_name (str): Name of the calling directive
+
+    Returns:
+        List of strings, for all of the when conditions.
+    """
+    when_list = []
+    if when_arg is not None:
+        if not isinstance(when_arg, list):
+            raise DirectiveError(
+                f"Object {obj.name} calls directive {directive_name} {directive_id} "
+                f"with an invalid `when` argument. The `when` argument must be input as a list."
+            )
+        when_list.extend(when_arg)
+    return when_list

--- a/lib/ramble/ramble/language/language_helpers.py
+++ b/lib/ramble/ramble/language/language_helpers.py
@@ -7,8 +7,7 @@
 # except according to those terms.
 
 import fnmatch
-
-from typing import List, Any
+from typing import Any, List
 
 from ramble.language.language_base import DirectiveError
 

--- a/lib/ramble/ramble/language/package_manager_language.py
+++ b/lib/ramble/ramble/language/package_manager_language.py
@@ -52,3 +52,18 @@ def package_manager_variable(
         )
 
     return _define_package_manager_variable
+
+
+@package_manager_directive(dicts=())
+def package_manager_family(*names: str):
+    """Add a new family to this package manager
+
+    Args:
+        name (str): Name of family to apply to this package manager
+    """
+
+    def _define_package_manager_family(pm):
+        families_from_base = getattr(pm, "families", [])
+        pm.families = list(sorted(set(families_from_base + list(names))))
+
+    return _define_package_manager_family

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -6,6 +6,7 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+import contextlib
 from typing import Optional
 
 import ramble.language.language_base
@@ -590,3 +591,21 @@ def register_validator(name: str, predicate: str, message: str, fail_on_invalid:
         }
 
     return _define_validator
+
+
+@contextlib.contextmanager
+def when(condition):
+    from ramble.language.language_base import DirectiveMeta
+
+    DirectiveMeta.push_to_context(condition)
+    yield
+    DirectiveMeta.pop_from_context()
+
+
+@contextlib.contextmanager
+def default_args(**kwargs):
+    from ramble.language.language_base import DirectiveMeta
+
+    DirectiveMeta.push_default_args(kwargs)
+    yield
+    DirectiveMeta.pop_default_args()

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -7,8 +7,10 @@
 # except according to those terms.
 
 import contextlib
-from typing import Optional
+import collections
+from typing import Optional, Any, Union, Callable
 
+import ramble.variants
 import ramble.language.language_base
 import ramble.language.language_helpers
 import ramble.success_criteria
@@ -24,7 +26,7 @@ definition to modify the object, for example:
 
       class Gromacs(ExecutableApplication):
           # Required package directive
-          required_package("gromacs", package_manager="spack")
+          required_package("gromacs", when=["package_manager_family=spack"])
 
 In the above example, "required_package" is a ramble directive
 
@@ -120,7 +122,9 @@ def figure_of_merit(
 
 
 @shared_directive("compilers")
-def define_compiler(name, pkg_spec, compiler_spec=None, compiler=None, package_manager="*"):
+def define_compiler(
+    name, pkg_spec, compiler_spec=None, compiler=None, package_manager=None, when=None
+):
     """Defines the compiler that will be used with this object
 
     Adds a new compiler spec to this object. Software specs should
@@ -136,23 +140,35 @@ def define_compiler(name, pkg_spec, compiler_spec=None, compiler=None, package_m
     """
 
     def _execute_define_compiler(obj):
+        when_list = ramble.language.language_helpers.build_when_list(
+            when, obj, name, "define_compiler"
+        )
+
+        if package_manager is not None:
+            logger.warn(
+                "The `package_manager` argument of the define_compiler "
+                f"directive in object {obj.name} is depreacated. Please "
+                "transition this to use the `when` argument instead."
+            )
+
         obj.compilers[name] = {
             "pkg_spec": pkg_spec,
             "compiler_spec": compiler_spec,
             "compiler": compiler,
-            "package_manager": package_manager,
+            "when": when_list,
         }
 
     return _execute_define_compiler
 
 
 @shared_directive("software_specs")
-def software_spec(name, pkg_spec, compiler_spec=None, compiler=None, package_manager="*"):
+def software_spec(
+    name, pkg_spec, compiler_spec=None, compiler=None, package_manager=None, when=None
+):
     """Defines a new software spec needed for this object.
 
     Adds a new software spec (for spack to use) that this object
     needs to execute properly.
-
     Only adds specs to object that use spack.
 
     Specs can be described as an mpi spec, which means they
@@ -170,19 +186,30 @@ def software_spec(name, pkg_spec, compiler_spec=None, compiler=None, package_man
     """
 
     def _execute_software_spec(obj):
+        when_list = ramble.language.language_helpers.build_when_list(
+            when, obj, name, "software_spec"
+        )
+
+        if package_manager is not None:
+            logger.warn(
+                "The `package_manager` argument of the define_compiler "
+                f"directive in object {obj.name} is depreacated. Please "
+                "transition this to use the `when` argument instead."
+            )
+
         # Define the spec
         obj.software_specs[name] = {
             "pkg_spec": pkg_spec,
             "compiler_spec": compiler_spec,
             "compiler": compiler,
-            "package_manager": package_manager,
+            "when": when_list,
         }
 
     return _execute_software_spec
 
 
 @shared_directive("package_manager_configs")
-def package_manager_config(name, config, package_manager="*", **kwargs):
+def package_manager_config(name, config, package_manager=None, when=None, **kwargs):
     """Defines a config option to set within a package manager
 
     Define a new config which will be passed to a package manager. The
@@ -196,16 +223,27 @@ def package_manager_config(name, config, package_manager="*", **kwargs):
     """
 
     def _execute_package_manager_config(obj):
+        when_list = ramble.language.language_helpers.build_when_list(
+            when, obj, name, "package_manager_config"
+        )
+
+        if package_manager is not None:
+            logger.warn(
+                "The `package_manager` argument of the package_manager_config "
+                f"directive in object {obj.name} is depreacated. Please "
+                "transition this to use the `when` argument instead."
+            )
+
         obj.package_manager_configs[name] = {
             "config": config,
-            "package_manager": package_manager,
+            "when": when_list,
         }
 
     return _execute_package_manager_config
 
 
 @shared_directive("required_packages")
-def required_package(name, package_manager="*"):
+def required_package(name, package_manager=None, when=None):
     """Defines a new spack package that is required for this object
     to function properly.
 
@@ -215,9 +253,18 @@ def required_package(name, package_manager="*"):
     """
 
     def _execute_required_package(obj):
-        obj.required_packages[name] = {
-            "package_manager": package_manager,
-        }
+        when_list = ramble.language.language_helpers.build_when_list(
+            when, obj, name, "package_manager_config"
+        )
+
+        if package_manager is not None:
+            logger.warn(
+                "The `package_manager` argument of the required_package "
+                f"directive in object {obj.name} is depreacated. Please "
+                "transition this to use the `when` argument instead."
+            )
+
+        obj.required_packages[name] = {"when": when_list}
 
     return _execute_required_package
 
@@ -591,6 +638,36 @@ def register_validator(name: str, predicate: str, message: str, fail_on_invalid:
         }
 
     return _define_validator
+
+
+@shared_directive(dicts=())
+def variant(
+    name: str,
+    default: Optional[Any] = None,
+    description: str = "",
+    values: Optional[Union[collections.abc.Sequence, Callable[[Any], bool]]] = None,
+):
+
+    def _define_variant(obj):
+        """Define a new variant in the input object
+
+        Args:
+            obj: Input ramble object to define variant inside.
+            name (str): Name of variant to define
+            default: Default value of the new variant
+            description (str): Description of the variant
+            values: Values for variant.
+        """
+        ramble.variants.validate_variant(name)
+
+        if obj.object_variants is None:
+            obj.object_variants = ramble.variants.VariantSet()
+
+        obj.object_variants.default_variant(
+            name, default=default, description=description, values=values
+        )
+
+    return _define_variant
 
 
 @contextlib.contextmanager

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -6,14 +6,14 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-import contextlib
 import collections
-from typing import Optional, Any, Union, Callable
+import contextlib
+from typing import Any, Callable, Optional, Union
 
-import ramble.variants
 import ramble.language.language_base
 import ramble.language.language_helpers
 import ramble.success_criteria
+import ramble.variants
 from ramble.util.foms import FomType
 from ramble.util.logger import logger
 

--- a/lib/ramble/ramble/language/workflow_manager_language.py
+++ b/lib/ramble/ramble/language/workflow_manager_language.py
@@ -45,3 +45,18 @@ def workflow_manager_variable(
         )
 
     return _define_wm_variable
+
+
+@workflow_manager_directive(dicts=())
+def workflow_manager_family(*names: str):
+    """Add a new family to this workflow manager
+
+    Args:
+        name (str): Name of family to apply to this workflow manager
+    """
+
+    def _define_workflow_manager_family(pm):
+        families_from_base = getattr(pm, "families", [])
+        pm.families = list(sorted(set(families_from_base + list(names))))
+
+    return _define_workflow_manager_family

--- a/lib/ramble/ramble/language/workflow_manager_language.py
+++ b/lib/ramble/ramble/language/workflow_manager_language.py
@@ -55,8 +55,8 @@ def workflow_manager_family(*names: str):
         name (str): Name of family to apply to this workflow manager
     """
 
-    def _define_workflow_manager_family(pm):
-        families_from_base = getattr(pm, "families", [])
-        pm.families = list(sorted(set(families_from_base + list(names))))
+    def _define_workflow_manager_family(wm):
+        families_from_base = getattr(wm, "families", [])
+        wm.families = list(sorted(set(families_from_base + list(names))))
 
     return _define_workflow_manager_family

--- a/lib/ramble/ramble/modifier.py
+++ b/lib/ramble/ramble/modifier.py
@@ -20,10 +20,12 @@ from ramble.language.modifier_language import ModifierMeta, mode
 from ramble.language.shared_language import SharedMeta
 from ramble.util.logger import logger
 from ramble.util.naming import NS_SEPARATOR
+import ramble.variants
 
 
 class ModifierBase(metaclass=ModifierMeta):
     name = None
+    object_variants = None
     _builtin_name = NS_SEPARATOR.join(("modifier_builtin", "{obj_name}", "{name}"))
     _mod_prefix_builtin = f"modifier_builtin{NS_SEPARATOR}"
     _language_classes = [ModifierMeta, SharedMeta]
@@ -42,6 +44,9 @@ class ModifierBase(metaclass=ModifierMeta):
 
     def __init__(self, file_path):
         super().__init__()
+
+        if self.object_variants is None:
+            self.object_variants = ramble.variants.VariantSet()
 
         ramble.util.class_attributes.convert_class_attributes(self)
 

--- a/lib/ramble/ramble/modifier.py
+++ b/lib/ramble/ramble/modifier.py
@@ -15,12 +15,12 @@ from typing import List
 
 import ramble.util.class_attributes
 import ramble.util.directives
+import ramble.variants
 from ramble.error import RambleError
 from ramble.language.modifier_language import ModifierMeta, mode
 from ramble.language.shared_language import SharedMeta
 from ramble.util.logger import logger
 from ramble.util.naming import NS_SEPARATOR
-import ramble.variants
 
 
 class ModifierBase(metaclass=ModifierMeta):

--- a/lib/ramble/ramble/modkit.py
+++ b/lib/ramble/ramble/modkit.py
@@ -7,8 +7,7 @@
 # except according to those terms.
 
 # flake8: noqa: F401
-"""modkit is a set of useful modules to import when writing modifiers
-"""
+"""modkit is a set of useful modules to import when writing modifiers"""
 
 import llnl.util.filesystem
 from llnl.util.filesystem import *

--- a/lib/ramble/ramble/package_manager.py
+++ b/lib/ramble/ramble/package_manager.py
@@ -7,7 +7,6 @@
 # except according to those terms.
 """Define base classes for package manager definitions"""
 
-import fnmatch
 import io
 import os
 import re
@@ -16,11 +15,11 @@ from typing import List
 
 import ramble.util.class_attributes
 import ramble.util.directives
+import ramble.variants
 from ramble.error import RambleError
 from ramble.language.package_manager_language import PackageManagerMeta
 from ramble.language.shared_language import SharedMeta, register_phase
 from ramble.util.naming import NS_SEPARATOR
-import ramble.variants
 
 import spack.util.naming
 

--- a/lib/ramble/ramble/package_manager.py
+++ b/lib/ramble/ramble/package_manager.py
@@ -20,12 +20,14 @@ from ramble.error import RambleError
 from ramble.language.package_manager_language import PackageManagerMeta
 from ramble.language.shared_language import SharedMeta, register_phase
 from ramble.util.naming import NS_SEPARATOR
+import ramble.variants
 
 import spack.util.naming
 
 
 class PackageManagerBase(metaclass=PackageManagerMeta):
     name = None
+    object_variants = None
     _builtin_name = NS_SEPARATOR.join(("package_manager_builtin", "{obj_name}", "{name}"))
     _language_classes = [PackageManagerMeta, SharedMeta]
     _pipelines = [
@@ -53,9 +55,13 @@ class PackageManagerBase(metaclass=PackageManagerMeta):
     #: Do not include @ here in order not to unnecessarily ping the users.
     maintainers: List[str] = []
     tags: List[str] = []
+    families: List[str] = []
 
     def __init__(self, file_path):
         super().__init__()
+
+        if self.object_variants is None:
+            self.object_variants = ramble.variants.VariantSet()
 
         ramble.util.class_attributes.convert_class_attributes(self)
 
@@ -68,6 +74,18 @@ class PackageManagerBase(metaclass=PackageManagerMeta):
         self.keywords = None
 
         ramble.util.directives.define_directive_methods(self)
+
+        self.object_variants.default_variant(
+            "package_manager",
+            default=self.name,
+            description="Name of package manager for an experiment",
+        )
+
+        for family in self.families:
+            self.object_variants.multi_value_variant(
+                "package_manager_family",
+                value=family,
+            )
 
     def copy(self):
         """Deep copy a package manager instance"""
@@ -92,7 +110,9 @@ class PackageManagerBase(metaclass=PackageManagerMeta):
         app_inst = self.app_inst
         if hasattr(app_inst, "software_specs"):
             for info in app_inst.software_specs.values():
-                if fnmatch.fnmatch(self.name, info["package_manager"]):
+                if self.app_inst.expander.satisfies(
+                    info["when"], variant_set=self.object_variants
+                ):
                     return True
 
         return False

--- a/lib/ramble/ramble/pkgmankit.py
+++ b/lib/ramble/ramble/pkgmankit.py
@@ -7,8 +7,7 @@
 # except according to those terms.
 
 # flake8: noqa: F401
-"""pkgmankit is a set of useful modules to import when writing package managers
-"""
+"""pkgmankit is a set of useful modules to import when writing package managers"""
 
 import os
 

--- a/lib/ramble/ramble/test/expander.py
+++ b/lib/ramble/ramble/test/expander.py
@@ -9,6 +9,7 @@
 import pytest
 
 import ramble.expander
+import ramble.variants
 
 
 def exp_dict():
@@ -34,6 +35,29 @@ def exp_dict():
         "max_len": 9,
         "test_dict": {"test_key1": "test_val1", "test_key2": "test_val2"},
     }
+
+
+def build_variant_set():
+    variant_set = ramble.variants.VariantSet()
+
+    variants = {
+        "test_variant": "defined",
+        "package_manager": "spack",
+        "workflow_manager": "slurm",
+    }
+
+    multi_value_variants = [
+        ("package_manager_family", "spack"),
+        ("workflow_manager_family", "slurm"),
+    ]
+
+    for name, value in variants.items():
+        variant_set.default_variant(name, value)
+
+    for name, value in multi_value_variants:
+        variant_set.multi_value_variant(name, value)
+
+    return variant_set
 
 
 @pytest.mark.parametrize(
@@ -197,3 +221,25 @@ def test_expansion_namespaces():
     assert expander.application_namespace == "foo"
     assert expander.workload_namespace == "foo.bar"
     assert expander.experiment_namespace == "foo.bar.baz"
+
+
+@pytest.mark.parametrize(
+    "input_list,output",
+    [
+        (["package_manager=spack"], True),
+        (["test_variant=defined", "package_manager=spack"], True),
+        (["test_variant=undefined", "package_manager=spack"], False),
+        (["test_variant=undefined", "package_manager=spack", "workflow_manager=slurm"], False),
+        (["test_variant=defined", "package_manager=spack", "workflow_manager=slurm"], True),
+    ],
+)
+def test_satisfies_works(input_list, output):
+    variants = build_variant_set()
+
+    expansion_vars = exp_dict()
+
+    expander = ramble.expander.Expander(expansion_vars, None)
+
+    satisfied = expander.satisfies(input_list, variant_set=variants)
+
+    assert satisfied == output

--- a/lib/ramble/ramble/test/variant_tests.py
+++ b/lib/ramble/ramble/test/variant_tests.py
@@ -1,0 +1,198 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+import pytest
+
+import ramble.variants
+import ramble.workspace
+from ramble.main import RambleCommand
+
+pytestmark = pytest.mark.usefixtures(
+    "mutable_config", "mutable_mock_workspace_path", "mutable_mock_apps_repo"
+)
+
+config = RambleCommand("config")
+workspace = RambleCommand("workspace")
+
+
+def test_default_arg_works(request):
+    ws_name = request.node.name
+
+    global_args = ["-w", ws_name]
+
+    with ramble.workspace.create(ws_name) as ws:
+        workspace(
+            "manage",
+            "experiments",
+            "when-variants",
+            "--wf",
+            "test_wl",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "processes_per_node=1",
+            "-p",
+            "spack",
+            global_args=global_args,
+        )
+
+        ws._re_read()
+        workspace("concretize", global_args=global_args)
+        workspace("setup", "--dry-run", global_args=global_args)
+
+        with open(ws.config_file_path) as f:
+            data = f.read()
+
+            assert "zlib@1.2.11" not in data
+            assert "zlib@1.2.12" in data
+
+        script_path = os.path.join(
+            ws.experiment_dir, "when-variants", "test_wl", "generated", "execute_experiment"
+        )
+
+        with open(script_path) as f:
+            data = f.read()
+
+            assert "echo 'Test'" in data
+
+
+def test_default_variant_value_works_with_when(request):
+    ws_name = request.node.name
+
+    global_args = ["-w", ws_name]
+
+    with ramble.workspace.create(ws_name) as ws:
+        workspace(
+            "manage",
+            "experiments",
+            "when-variants",
+            "--wf",
+            "test_wl",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "processes_per_node=1",
+            "-p",
+            "spack",
+            global_args=global_args,
+        )
+
+        ws._re_read()
+        workspace("concretize", global_args=global_args)
+
+        with open(ws.config_file_path) as f:
+            data = f.read()
+
+            assert "zlib@1.2.11" not in data
+            assert "zlib@1.2.12" in data
+
+
+def test_changed_variant_value_works_with_when(request):
+    ws_name = request.node.name
+
+    global_args = ["-w", ws_name]
+
+    with ramble.workspace.create(ws_name) as ws:
+        workspace(
+            "manage",
+            "experiments",
+            "when-variants",
+            "--wf",
+            "test_wl",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "processes_per_node=1",
+            "-p",
+            "spack",
+            global_args=global_args,
+        )
+
+        config("add", "variants:zlib_type:testing", global_args=global_args)
+
+        ws._re_read()
+        workspace("concretize", global_args=global_args)
+
+        with open(ws.config_file_path) as f:
+            data = f.read()
+
+            assert "zlib@1.2.11" in data
+            assert "zlib@1.2.12" not in data
+
+
+def test_invalid_variant_value_errors(request):
+    ws_name = request.node.name
+
+    global_args = ["-w", ws_name]
+
+    with ramble.workspace.create(ws_name) as ws:
+        workspace(
+            "manage",
+            "experiments",
+            "when-variants",
+            "--wf",
+            "test_wl",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "processes_per_node=1",
+            "-p",
+            "spack",
+            global_args=global_args,
+        )
+
+        config("add", "variants:zlib_type:invalid", global_args=global_args)
+
+        ws._re_read()
+
+        with pytest.raises(ramble.variants.RambleVariantError):
+            workspace("concretize", global_args=global_args)
+
+
+def test_boolean_variants(request):
+    ws_name = request.node.name
+
+    global_args = ["-w", ws_name]
+
+    with ramble.workspace.create(ws_name) as ws:
+        workspace(
+            "manage",
+            "experiments",
+            "when-variants",
+            "--wf",
+            "test_wl",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "processes_per_node=1",
+            "-p",
+            "spack",
+            global_args=global_args,
+        )
+
+        config("add", "variants:inc_zlib:false", global_args=global_args)
+
+        ws._re_read()
+        workspace("concretize", global_args=global_args)
+
+        with open(ws.config_file_path) as f:
+            data = f.read()
+
+            assert "zlib@1.2.11" not in data
+            assert "zlib@1.2.12" not in data

--- a/lib/ramble/ramble/test/variant_tests.py
+++ b/lib/ramble/ramble/test/variant_tests.py
@@ -7,6 +7,7 @@
 # except according to those terms.
 
 import os
+
 import pytest
 
 import ramble.variants

--- a/lib/ramble/ramble/test/variant_tests.py
+++ b/lib/ramble/ramble/test/variant_tests.py
@@ -197,3 +197,35 @@ def test_boolean_variants(request):
 
             assert "zlib@1.2.11" not in data
             assert "zlib@1.2.12" not in data
+
+
+def test_non_matched_variants_are_ignored(request):
+    ws_name = request.node.name
+
+    global_args = ["-w", ws_name]
+
+    with ramble.workspace.create(ws_name) as ws:
+        workspace(
+            "manage",
+            "experiments",
+            "when-variants",
+            "--wf",
+            "test_wl",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "processes_per_node=1",
+            "-p",
+            "pip",
+            global_args=global_args,
+        )
+
+        ws._re_read()
+        workspace("concretize", global_args=global_args)
+
+        with open(ws.config_file_path) as f:
+            data = f.read()
+
+            assert "zlib" not in data

--- a/lib/ramble/ramble/util/spec_utils.py
+++ b/lib/ramble/ramble/util/spec_utils.py
@@ -25,6 +25,9 @@ def specs_equiv(spec1, spec2):
     if "package_manager" in all_keys:
         all_keys.remove("package_manager")
 
+    if "when" in all_keys:
+        all_keys.remove("when")
+
     for key in all_keys:
         if key not in spec1:
             return False

--- a/lib/ramble/ramble/variants.py
+++ b/lib/ramble/ramble/variants.py
@@ -6,7 +6,7 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-import collections.abc
+from collections.abc import Sequence
 from enum import Enum
 from typing import Any, Callable, Optional, Union
 
@@ -75,7 +75,7 @@ class VariantSet:
         name: str,
         default: Optional[Any] = None,
         description: str = "",
-        values: Optional[Union[collections.abc.Sequence, Callable[[Any], bool]]] = None,
+        values: Optional[Union[Sequence, Callable[[Any], bool]]] = None,
     ):
         """Define a new default variant within this set.
 
@@ -148,7 +148,7 @@ class VariantSet:
         variant_type: int,
         default: Optional[Any] = None,
         description: str = "",
-        values: Optional[Union[collections.abc.Sequence, Callable[[Any], bool]]] = None,
+        values: Optional[Union[Sequence, Callable[[Any], bool]]] = None,
     ):
         """Define a variant within this set.
 
@@ -240,7 +240,7 @@ class Variant:
         name: str,
         default: Optional[Any] = None,
         description: str = "",
-        values: Optional[Union[collections.abc.Sequence, Callable[[Any], bool]]] = None,
+        values: Optional[Union[Sequence, Callable[[Any], bool]]] = None,
     ):
         self.name = name
         self.default = default

--- a/lib/ramble/ramble/variants.py
+++ b/lib/ramble/ramble/variants.py
@@ -6,9 +6,10 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-from enum import Enum
 import collections.abc
-from typing import Optional, Any, Union, Callable
+from enum import Enum
+from typing import Any, Callable, Optional, Union
+
 import ramble.error
 
 reserved_variants = {"package_manager", "package_manager_prefix", "workflow_manager", "version"}

--- a/lib/ramble/ramble/variants.py
+++ b/lib/ramble/ramble/variants.py
@@ -1,0 +1,312 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from enum import Enum
+import collections.abc
+from typing import Optional, Any, Union, Callable
+import ramble.error
+
+reserved_variants = {"package_manager", "package_manager_prefix", "workflow_manager", "version"}
+
+variant_types = Enum("variant_types", ["default", "experiment"])
+
+
+class VariantSet:
+    """A custom set for housing multiple types of variants, and encapsulating
+    the logic of merging them together."""
+
+    def __init__(self):
+        self.default_variants = {}
+        self.multi_value_variants = {}
+        self.experiment_variants = {}
+        self._set_cache = None
+
+    def copy(self):
+        new_set = VariantSet()
+
+        set_attrs = ["default_variants", "experiment_variants"]
+        for set_attr in set_attrs:
+            src_attr_set = getattr(self, set_attr)
+            dest_attr_set = getattr(new_set, set_attr)
+            for name, variant in src_attr_set.items():
+                dest_attr_set[name] = variant.copy()
+
+        for name, var_list in self.multi_value_variants.items():
+            new_set.multi_value_variants[name] = []
+            for variant in var_list:
+                new_set.multi_value_variants[name].append(variant.copy())
+
+        return new_set
+
+    def merge_default_variants(self, in_set):
+        """Merge another variant set's default variants into this variant set.
+
+        Args:
+            in_set: VariantSet to merge into self
+        """
+
+        self._set_cache = None
+        for name, variant in in_set.default_variants.items():
+            if name not in self.default_variants:
+                self.default_variants[name] = variant.copy()
+
+    def merge_multi_value_variants(self, in_set):
+        """Merge another variant set's multi value variants into this variant set.
+
+        Args:
+            in_set: VariantSet to merge into self
+        """
+
+        self._set_cache = None
+        for name, variant_list in in_set.multi_value_variants.items():
+            if name not in self.multi_value_variants:
+                self.multi_value_variants[name] = []
+            for variant in variant_list:
+                self.multi_value_variants[name].append(variant.copy())
+
+    def default_variant(
+        self,
+        name: str,
+        default: Optional[Any] = None,
+        description: str = "",
+        values: Optional[Union[collections.abc.Sequence, Callable[[Any], bool]]] = None,
+    ):
+        """Define a new default variant within this set.
+
+        Default variants are variants defined by directives in an object. These
+        are used to define the defaults, and provide documentation for users.
+
+        Args:
+            name: Name of variant
+            default: Default value of the variant
+            description: Description of the variant, and what it's used for
+            values: Set of valid values for the variant
+        """
+
+        self._define_variant(
+            name,
+            variant_type=variant_types.default,
+            default=default,
+            description=description,
+            values=values,
+        )
+
+    def experiment_variant(self, name: str, value: Any):
+        """Define a new experiment variant within this set.
+
+        Experiment variants are variants defined within a workspace's configuration file.
+        These are expected to be user defined values that will override the defaults of the object.
+
+        Experiment variants should always be defined after default variants (as
+        defaults come from object directives, and experiment variants come from
+        yaml). As a result, we only define experiment variants that have a
+        corresponding default variant with the same name.
+
+        Args:
+            name: Name of variant
+            value: The value the variant should take.
+        """
+        if name in self.default_variants:
+            if value not in self.default_variants[name].values:
+                raise RambleVariantError(
+                    f"When defining variant {name} the value {value} is not valid.\n"
+                    f"   Valid values include: {self.default_variants[name].values}"
+                )
+
+            self._define_variant(
+                name,
+                variant_type=variant_types.experiment,
+                default=value,
+                description=None,
+                values=None,
+            )
+        elif name in reserved_variants:
+            self._define_variant(
+                name,
+                variant_type=variant_types.experiment,
+                default=value,
+                description=None,
+                values=None,
+            )
+
+    def multi_value_variant(self, name: str, value: Any):
+        self._set_cache = None
+        if name not in self.multi_value_variants:
+            self.multi_value_variants[name] = []
+
+        self.multi_value_variants[name].append(Variant(name, default=value))
+
+    def _define_variant(
+        self,
+        name: str,
+        variant_type: int,
+        default: Optional[Any] = None,
+        description: str = "",
+        values: Optional[Union[collections.abc.Sequence, Callable[[Any], bool]]] = None,
+    ):
+        """Define a variant within this set.
+
+        This is an abstract method intended to construct a new default or
+        experiment variant based on the calling signature.
+
+        Args:
+            name: Name of variant
+            variant_type: Type of variant (as defined in the variant_types enum) of this variant
+            default: Default value of the variant
+            description: Description of the variant, and what it's used for
+            values: Set of valid values for the variant
+        """
+
+        self._set_cache = None
+        variant_dict = None
+        if variant_type == variant_types.experiment:
+            variant_dict = self.experiment_variants
+
+        elif variant_type == variant_types.default:
+            variant_dict = self.default_variants
+
+        else:
+            raise RambleVariantError(
+                f"Cannot define variant {name} with unknown variant type of {variant_type}"
+            )
+
+        variant_dict[name] = Variant(
+            name=name, default=default, description=description, values=values
+        )
+
+    def value(self, name: str):
+        """Extract the value of a variant by name
+
+        Args:
+            name: Name of variant to determine value for
+
+        Returns:
+            Value of variant if found, otherwise None.
+        """
+
+        if name in self.experiment_variants:
+            return self.experiment_variants[name].default
+
+        if name in self.default_variants:
+            return self.default_variants[name].default
+
+        return None
+
+    def as_set(self):
+        """Construct a set of definitions for this variant set
+
+        The set of variant definitions will be used to determine if a when
+        clause is valid or not.
+
+        Returns:
+            set: A set consisting of strings with the variant definitions
+        """
+        if self._set_cache is not None:
+            return self._set_cache
+
+        defined_variants = set()
+        out_set = set()
+
+        # Define default variants after experiment variants so we only define
+        # undefined variants.
+        variant_sets = [self.experiment_variants, self.default_variants]
+
+        for variant_set in variant_sets:
+            for name, variant in variant_set.items():
+                if name not in defined_variants:
+                    out_set.add(variant.as_definition())
+                    defined_variants.add(name)
+
+        for name, variant_list in self.multi_value_variants.items():
+            for variant in variant_list:
+                out_set.add(variant.as_definition())
+
+        self._set_cache = out_set
+        return out_set
+
+
+class Variant:
+    """A custom set for housing multiple types of variants, and encapsulating
+    the logic of merging them together."""
+
+    def __init__(
+        self,
+        name: str,
+        default: Optional[Any] = None,
+        description: str = "",
+        values: Optional[Union[collections.abc.Sequence, Callable[[Any], bool]]] = None,
+    ):
+        self.name = name
+        self.default = default
+        self.description = description
+        self.values = values
+
+    def copy(self):
+        return Variant(
+            name=self.name, default=self.default, description=self.description, values=self.values
+        )
+
+    def as_definition(self):
+        """Build a definition for this variant
+
+        Format the variant as a string which can be used to test against when
+        clauses.
+
+        Returns:
+            str: String definition for this variant
+        """
+
+        if isinstance(self.default, bool):
+            if self.default:
+                return f"+{self.name}"
+            else:
+                return f"~{self.name}"
+        return f"{self.name}={str(self.default)}"
+
+    def as_str(self, indent=0):
+        """String documentation of this variant
+
+        Returns:
+            str: String for information of this variant
+        """
+        indentation = " " * indent
+        out_str = f"{indentation}Variant: {self.name}\n"
+        attrs = [
+            ("Description", "description"),
+            ("Default", "default"),
+            ("Values", "values"),
+        ]
+        for print_name, attr_name in attrs:
+            if hasattr(self, attr_name):
+                value = getattr(self, attr_name, None)
+                if value is not None:
+                    out_str += f"{indentation}  {print_name}: {value}"
+        return out_str
+
+    def __str__(self):
+        return self.as_str(indent=0)
+
+
+def validate_variant(variant: str):
+    """Check if a variant name is valid or not
+
+    If the input variant name is not valid, this function will raise an
+    exception. Otherwise this function will not perform any actions.
+
+    Args:
+        variant (str): Variant name to test
+    """
+
+    if variant in reserved_variants:
+        raise RambleVariantError(
+            f"Variant {variant} is invalid, as this name is reserved by ramble"
+        )
+
+
+class RambleVariantError(ramble.error.RambleError):
+    """Class representing errors with variants"""

--- a/lib/ramble/ramble/wmkit.py
+++ b/lib/ramble/ramble/wmkit.py
@@ -7,8 +7,7 @@
 # except according to those terms.
 
 # flake8: noqa: F401
-"""wmkit is a set of useful modules to import when writing workflow managers
-"""
+"""wmkit is a set of useful modules to import when writing workflow managers"""
 
 from ramble.language.shared_language import *
 from ramble.language.workflow_manager_language import *

--- a/lib/ramble/ramble/workflow_manager.py
+++ b/lib/ramble/ramble/workflow_manager.py
@@ -11,6 +11,7 @@ from typing import List
 
 import ramble.util.class_attributes
 import ramble.util.directives
+import ramble.variants
 from ramble.expander import ExpanderError
 from ramble.language.shared_language import SharedMeta
 from ramble.language.workflow_manager_language import (
@@ -18,7 +19,6 @@ from ramble.language.workflow_manager_language import (
     workflow_manager_variable,
 )
 from ramble.util.naming import NS_SEPARATOR
-import ramble.variants
 
 
 class WorkflowManagerBase(metaclass=WorkflowManagerMeta):

--- a/lib/ramble/ramble/workflow_manager.py
+++ b/lib/ramble/ramble/workflow_manager.py
@@ -18,10 +18,12 @@ from ramble.language.workflow_manager_language import (
     workflow_manager_variable,
 )
 from ramble.util.naming import NS_SEPARATOR
+import ramble.variants
 
 
 class WorkflowManagerBase(metaclass=WorkflowManagerMeta):
     name = None
+    object_variants = None
     _builtin_name = NS_SEPARATOR.join(("workflow_manager_builtin", "{obj_name}", "{name}"))
     _language_classes = [WorkflowManagerMeta, SharedMeta]
     _pipelines = [
@@ -31,6 +33,7 @@ class WorkflowManagerBase(metaclass=WorkflowManagerMeta):
     ]
     maintainers: List[str] = []
     tags: List[str] = []
+    families: List[str] = []
 
     workflow_manager_variable(
         "workflow_banner",
@@ -63,11 +66,20 @@ class WorkflowManagerBase(metaclass=WorkflowManagerMeta):
     def __init__(self, file_path):
         super().__init__()
 
+        if self.object_variants is None:
+            self.object_variants = ramble.variants.VariantSet()
+
         ramble.util.class_attributes.convert_class_attributes(self)
 
         self._file_path = file_path
 
         ramble.util.directives.define_directive_methods(self)
+
+        self.object_variants.default_variant(
+            "workflow_manager",
+            default=self.name,
+            description="Name of workflow manager for an experiment",
+        )
 
         self.app_inst = None
         self.runner = None

--- a/lib/ramble/ramble/workspace/__init__.py
+++ b/lib/ramble/ramble/workspace/__init__.py
@@ -6,8 +6,7 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-"""This package implements Ramble workspaces.
-"""
+"""This package implements Ramble workspaces."""
 
 from .workspace import (
     RambleActiveWorkspaceError,

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1399,6 +1399,7 @@ ramble:
 
         for _, app_inst, _ in experiment_set.all_experiments():
             app_inst.build_modifier_instances()
+            app_inst.add_expand_vars(self)
             env_name_str = app_inst.expander.expansion_str(ramble.keywords.keywords.env_name)
             env_name = app_inst.expander.expand_var(env_name_str)
 
@@ -1411,7 +1412,10 @@ ramble:
 
             for compiler_dict in compiler_dicts:
                 for comp, info in compiler_dict.items():
-                    if fnmatch.fnmatch(app_inst.package_manager.name, info["package_manager"]):
+                    keep_comp = app_inst.expander.satisfies(
+                        info["when"], variant_set=app_inst.object_variants
+                    )
+                    if keep_comp:
                         if comp not in packages_dict or force:
                             packages_dict[comp] = syaml.syaml_dict()
                             packages_dict[comp]["pkg_spec"] = info["pkg_spec"]
@@ -1455,7 +1459,10 @@ ramble:
 
             for software_dict in software_dicts:
                 for spec_name, info in software_dict.items():
-                    if fnmatch.fnmatch(app_inst.package_manager.name, info["package_manager"]):
+                    keep_pkg = app_inst.expander.satisfies(
+                        info["when"], variant_set=app_inst.object_variants
+                    )
+                    if keep_pkg:
                         logger.debug(f"    Found spec: {spec_name}")
                         if spec_name not in packages_dict or force:
                             packages_dict[spec_name] = syaml.syaml_dict()

--- a/var/ramble/repos/builtin.mock/applications/when-variants/application.py
+++ b/var/ramble/repos/builtin.mock/applications/when-variants/application.py
@@ -37,12 +37,11 @@ class WhenVariants(ExecutableApplication):
         description="Test boolean variant",
     )
 
-    with when("package_manager_family=spack"):
-        with when("+inc_zlib"):
-            with when("zlib_type=preferred"):
-                software_spec("zlib-pref", pkg_spec="zlib@1.2.12")
+    with default_args(when=["package_manager_family=spack", "+inc_zlib"]):
+        with when("zlib_type=preferred"):
+            software_spec("zlib-pref", pkg_spec="zlib@1.2.12")
 
-            with when("zlib_type=testing"):
-                software_spec("zlib-test", pkg_spec="zlib@1.2.11")
+        with when("zlib_type=testing"):
+            software_spec("zlib-test", pkg_spec="zlib@1.2.11")
 
-            required_package("zlib")
+        required_package("zlib")

--- a/var/ramble/repos/builtin.mock/applications/when-variants/application.py
+++ b/var/ramble/repos/builtin.mock/applications/when-variants/application.py
@@ -1,0 +1,48 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.appkit import *
+
+
+class WhenVariants(ExecutableApplication):
+    name = "when-variants"
+
+    executable("test_exec", "echo '{test_variable}'", use_mpi=False)
+
+    workload("test_wl", executable="test_exec")
+
+    with default_args(workload="test_wl"):
+        workload_variable(
+            "test_variable",
+            default="Test",
+            description="Variable to print for testing",
+        )
+
+    variant(
+        "zlib_type",
+        default="preferred",
+        values=["preferred", "testing"],
+        description="Type of zlib to use",
+    )
+
+    variant(
+        "inc_zlib",
+        default=True,
+        values=[True, False],
+        description="Test boolean variant",
+    )
+
+    with when("package_manager_family=spack"):
+        with when("+inc_zlib"):
+            with when("zlib_type=preferred"):
+                software_spec("zlib-pref", pkg_spec="zlib@1.2.12")
+
+            with when("zlib_type=testing"):
+                software_spec("zlib-test", pkg_spec="zlib@1.2.11")
+
+            required_package("zlib")

--- a/var/ramble/repos/builtin.mock/applications/zlib-configs/application.py
+++ b/var/ramble/repos/builtin.mock/applications/zlib-configs/application.py
@@ -12,15 +12,14 @@ from ramble.appkit import *
 class ZlibConfigs(ExecutableApplication):
     name = "zlib-configs"
 
-    software_spec("zlib", pkg_spec="zlib", package_manager="spack*")
+    with when("package_manager_family=spack"):
+        software_spec("zlib", pkg_spec="zlib")
+
+        package_manager_config("enable_debug", "config:debug:true")
 
     executable("list_lib", "ls {zlib_path}/lib", use_mpi=False)
 
     workload("ensure_installed", executable="list_lib")
-
-    package_manager_config(
-        "enable_debug", "config:debug:true", package_manager="spack*"
-    )
 
     figure_of_merit(
         "zlib_installed",

--- a/var/ramble/repos/builtin.mock/applications/zlib/application.py
+++ b/var/ramble/repos/builtin.mock/applications/zlib/application.py
@@ -12,7 +12,9 @@ from ramble.appkit import *
 class Zlib(ExecutableApplication):
     name = "zlib"
 
-    software_spec("zlib", pkg_spec="zlib", package_manager="spack*")
+    software_spec(
+        "zlib", pkg_spec="zlib", when=["package_manager_family=spack"]
+    )
 
     executable("list_lib", "ls {zlib_path}/lib", use_mpi=False)
 

--- a/var/ramble/repos/builtin.mock/modifiers/spack-failed-reqs/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/spack-failed-reqs/modifier.py
@@ -21,26 +21,24 @@ class SpackFailedReqs(BasicModifier):
         description="This is the default mode for the spack-failed-reqs modifier",
     )
 
-    define_compiler(
-        "mod_compiler",
-        pkg_spec="mod_compiler@1.1 target=x86_64",
-        compiler_spec="mod_compiler@1.1",
-        package_manager="spack*",
-    )
+    with when("package_manager_family=spack"):
+        define_compiler(
+            "mod_compiler",
+            pkg_spec="mod_compiler@1.1 target=x86_64",
+            compiler_spec="mod_compiler@1.1",
+        )
 
-    software_spec(
-        "mod_package1",
-        pkg_spec="mod_package1@1.1",
-        compiler="mod_compiler",
-        package_manager="spack*",
-    )
+        software_spec(
+            "mod_package1",
+            pkg_spec="mod_package1@1.1",
+            compiler="mod_compiler",
+        )
 
-    software_spec(
-        "mod_package2",
-        pkg_spec="mod_package2@1.1",
-        compiler="mod_compiler",
-        package_manager="spack*",
-    )
+        software_spec(
+            "mod_package2",
+            pkg_spec="mod_package2@1.1",
+            compiler="mod_compiler",
+        )
 
     package_manager_requirement(
         "list not-a-package", validation_type="not_empty", modes=["default"]

--- a/var/ramble/repos/builtin.mock/modifiers/spack-mod/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/spack-mod/modifier.py
@@ -18,30 +18,26 @@ class SpackMod(BasicModifier):
 
     mode("default", description="This is the default mode for the spack-mod")
 
-    package_manager_config(
-        "enable_debug", "config:debug:true", package_manager="spack*"
-    )
+    with when("package_manager_family=spack"):
+        package_manager_config("enable_debug", "config:debug:true")
 
-    define_compiler(
-        "mod_compiler",
-        pkg_spec="mod_compiler@1.1 target=x86_64",
-        compiler_spec="mod_compiler@1.1",
-        package_manager="spack*",
-    )
+        define_compiler(
+            "mod_compiler",
+            pkg_spec="mod_compiler@1.1 target=x86_64",
+            compiler_spec="mod_compiler@1.1",
+        )
 
-    software_spec(
-        "mod_package1",
-        pkg_spec="mod_package1@1.1",
-        compiler="mod_compiler",
-        package_manager="spack*",
-    )
+        software_spec(
+            "mod_package1",
+            pkg_spec="mod_package1@1.1",
+            compiler="mod_compiler",
+        )
 
-    software_spec(
-        "mod_package2",
-        pkg_spec="mod_package2@1.1",
-        compiler="mod_compiler",
-        package_manager="spack*",
-    )
+        software_spec(
+            "mod_package2",
+            pkg_spec="mod_package2@1.1",
+            compiler="mod_compiler",
+        )
 
     package_manager_requirement(
         "list not-a-package", validation_type="empty", modes=["default"]

--- a/var/ramble/repos/builtin.mock/modifiers/test-mod/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/test-mod/modifier.py
@@ -54,7 +54,9 @@ class TestMod(BasicModifier):
     )
 
     software_spec(
-        "analysis_spec", pkg_spec="analysis_pkg@1.1", package_manager="spack*"
+        "analysis_spec",
+        pkg_spec="analysis_pkg@1.1",
+        when=["package_manager_family=spack"],
     )
 
     fom_regex = r"(?P<context>fom_context)(?P<fom>.*)"

--- a/var/ramble/repos/builtin/applications/babelstream/application.py
+++ b/var/ramble/repos/builtin/applications/babelstream/application.py
@@ -23,14 +23,14 @@ class Babelstream(ExecutableApplication):
 
     maintainers("rfbgo", "kaanolgu", "douglasjacobsen", "tomdeakin")
 
-    define_compiler("gcc12", pkg_spec="gcc@12.2.0", package_manager="spack*")
+    with when("package_manager_family=spack"):
+        define_compiler("gcc12", pkg_spec="gcc@12.2.0")
 
-    software_spec(
-        "babelstream",
-        pkg_spec="babelstream@5.0",
-        compiler="gcc12",
-        package_manager="spack*",
-    )
+        software_spec(
+            "babelstream",
+            pkg_spec="babelstream@5.0",
+            compiler="gcc12",
+        )
     executable(
         "get_bin",
         template=[

--- a/var/ramble/repos/builtin/applications/cloverleaf/application.py
+++ b/var/ramble/repos/builtin/applications/cloverleaf/application.py
@@ -30,22 +30,21 @@ class Cloverleaf(ExecutableApplication):
         "mini-benchmark",
     )
 
-    define_compiler("gcc12", pkg_spec="gcc@12.2.0", package_manager="spack*")
+    with when("package_manager_family=spack"):
+        define_compiler("gcc12", pkg_spec="gcc@12.2.0")
 
-    software_spec(
-        "ompi414",
-        pkg_spec="openmpi@4.1.4 +legacylaunchers +cxx",
-        compiler="gcc12",
-        package_manager="spack*",
-    )
-    software_spec(
-        "cloverleaf",
-        pkg_spec="cloverleaf@1.1 build=ref",
-        compiler="gcc12",
-        package_manager="spack*",
-    )
+        software_spec(
+            "ompi414",
+            pkg_spec="openmpi@4.1.4 +legacylaunchers +cxx",
+            compiler="gcc12",
+        )
+        software_spec(
+            "cloverleaf",
+            pkg_spec="cloverleaf@1.1 build=ref",
+            compiler="gcc12",
+        )
 
-    required_package("cloverleaf", package_manager="spack*")
+        required_package("cloverleaf")
 
     executable("execute", "clover_leaf", use_mpi=True)
 

--- a/var/ramble/repos/builtin/applications/gromacs/application.py
+++ b/var/ramble/repos/builtin/applications/gromacs/application.py
@@ -21,21 +21,24 @@ class Gromacs(ExecutableApplication):
 
     tags("molecular-dynamics")
 
-    define_compiler("gcc9", pkg_spec="gcc@9.3.0", package_manager="spack*")
-    software_spec(
-        "impi2018", pkg_spec="intel-mpi@2018.4.274", package_manager="spack*"
-    )
-    software_spec(
-        "spack_gromacs",
-        pkg_spec="gromacs@2020.5",
-        compiler="gcc9",
-        package_manager="spack*",
-    )
+    with when("package_manager_family=spack"):
+        define_compiler("gcc9", pkg_spec="gcc@9.3.0")
+
+        software_spec(
+            "impi2018",
+            pkg_spec="intel-mpi@2018.4.274",
+        )
+
+        with default_args(compiler="gcc9"):
+            software_spec(
+                "spack_gromacs",
+                pkg_spec="gromacs@2020.5",
+            )
 
     software_spec(
         "eessi_gromacs",
         pkg_spec="GROMACS/2024.1-foss-2023b",
-        package_manager="eessi",
+        when=["package_manager_family=eessi"],
     )
 
     executable(

--- a/var/ramble/repos/builtin/applications/hmmer/application.py
+++ b/var/ramble/repos/builtin/applications/hmmer/application.py
@@ -29,18 +29,16 @@ class Hmmer(ExecutableApplication):
 
     tags("molecular-dynamics", "hidden-markov-models", "bio-molecule")
 
-    define_compiler("gcc9", pkg_spec="gcc@9.3.0", package_manager="spack*")
+    with when("package_manager_family=spack"):
+        define_compiler("gcc9", pkg_spec="gcc@9.3.0")
 
-    software_spec(
-        "impi_2018", pkg_spec="intel-mpi@2018.4.274", package_manager="spack*"
-    )
+        software_spec("impi_2018", pkg_spec="intel-mpi@2018.4.274")
 
-    software_spec(
-        "hmmer",
-        pkg_spec="hmmer@3.3.2",
-        compiler="gcc9",
-        package_manager="spack*",
-    )
+        software_spec(
+            "hmmer",
+            pkg_spec="hmmer@3.3.2",
+            compiler="gcc9",
+        )
 
     # This would ideally not use the current_release, as the package will need to be manually updated per release
     # Here current_release == 'Pfam36.0'

--- a/var/ramble/repos/builtin/applications/hp2p/application.py
+++ b/var/ramble/repos/builtin/applications/hp2p/application.py
@@ -19,10 +19,9 @@ class Hp2p(ExecutableApplication):
     tags("benchmark", "mpi")
     maintainers("rfbgo")
 
-    software_spec("hp2p", pkg_spec="hp2p@4.1", package_manager="spack*")
-    software_spec(
-        "openmpi412", pkg_spec="openmpi@4.1.2", package_manager="spack*"
-    )
+    with when("package_manager_family=spack"):
+        software_spec("hp2p", pkg_spec="hp2p@4.1")
+        software_spec("openmpi412", pkg_spec="openmpi@4.1.2")
 
     executable(
         "execute",

--- a/var/ramble/repos/builtin/applications/hpcc/application.py
+++ b/var/ramble/repos/builtin/applications/hpcc/application.py
@@ -29,20 +29,18 @@ class Hpcc(ExecutableApplication):
 
     tags("benchmark-app", "mini-app", "benchmark", "DGEMM")
 
-    define_compiler("gcc9", pkg_spec="gcc@9.3.0", package_manager="spack*")
+    with when("package_manager_family=spack"):
+        define_compiler("gcc9", pkg_spec="gcc@9.3.0")
 
-    software_spec(
-        "impi2018", pkg_spec="intel-mpi@2018.4.274", package_manager="spack*"
-    )
+        software_spec("impi2018", pkg_spec="intel-mpi@2018.4.274")
 
-    software_spec(
-        "hpcc",
-        pkg_spec="hpcc@1.5.0",
-        compiler="gcc9",
-        package_manager="spack*",
-    )
+        software_spec(
+            "hpcc",
+            pkg_spec="hpcc@1.5.0",
+            compiler="gcc9",
+        )
 
-    required_package("hpcc", package_manager="spack*")
+        required_package("hpcc")
 
     input_file(
         "hpccinf",

--- a/var/ramble/repos/builtin/applications/hpcg/application.py
+++ b/var/ramble/repos/builtin/applications/hpcg/application.py
@@ -26,20 +26,18 @@ class Hpcg(BaseHpcg):
 
     maintainers("douglasjacobsen")
 
-    define_compiler("gcc9", pkg_spec="gcc@9.3.0", package_manager="spack*")
+    with when("package_manager_family=spack"):
+        define_compiler("gcc9", pkg_spec="gcc@9.3.0")
 
-    software_spec(
-        "impi2018", pkg_spec="intel-mpi@2018.4.274", package_manager="spack*"
-    )
+        software_spec("impi2018", pkg_spec="intel-mpi@2018.4.274")
 
-    software_spec(
-        "hpcg",
-        pkg_spec="hpcg@3.1 +openmp",
-        compiler="gcc9",
-        package_manager="spack*",
-    )
+        software_spec(
+            "hpcg",
+            pkg_spec="hpcg@3.1 +openmp",
+            compiler="gcc9",
+        )
 
-    required_package("hpcg", package_manager="spack*")
+        required_package("hpcg")
 
     workload("standard", executables=["execute", "move-log"])
 

--- a/var/ramble/repos/builtin/applications/hpl/application.py
+++ b/var/ramble/repos/builtin/applications/hpl/application.py
@@ -19,20 +19,18 @@ class Hpl(HplBase):
 
     tags("benchmark-app", "benchmark", "linpack")
 
-    define_compiler("gcc9", pkg_spec="gcc@9.3.0", package_manager="spack*")
+    with when("package_manager_family=spack"):
+        define_compiler("gcc9", pkg_spec="gcc@9.3.0")
 
-    software_spec(
-        "impi_2018", pkg_spec="intel-mpi@2018.4.274", package_manager="spack*"
-    )
+        software_spec("impi_2018", pkg_spec="intel-mpi@2018.4.274")
 
-    software_spec(
-        "hpl",
-        pkg_spec="hpl@2.3 +openmp",
-        compiler="gcc9",
-        package_manager="spack*",
-    )
+        software_spec(
+            "hpl",
+            pkg_spec="hpl@2.3 +openmp",
+            compiler="gcc9",
+        )
 
-    required_package("hpl", package_manager="spack*")
+        required_package("hpl")
 
     executable("execute", "xhpl", use_mpi=True)
 

--- a/var/ramble/repos/builtin/applications/intel-hpl/application.py
+++ b/var/ramble/repos/builtin/applications/intel-hpl/application.py
@@ -19,20 +19,19 @@ class IntelHpl(HplBase):
 
     tags("benchmark-app", "benchmark", "linpack", "optimized", "intel", "mkl")
 
-    define_compiler("gcc13p2", pkg_spec="gcc@13.2.0", package_manager="spack*")
-    software_spec(
-        "imkl_2024p2",
-        pkg_spec="intel-oneapi-mkl@2024.2.0 threads=openmp",
-        compiler="gcc13p2",
-        package_manager="spack*",
-    )
-    software_spec(
-        "impi2021p11",
-        pkg_spec="intel-oneapi-mpi@2021.11.0",
-        package_manager="spack*",
-    )
+    with when("package_manager_family=spack"):
+        define_compiler("gcc13p2", pkg_spec="gcc@13.2.0")
+        software_spec(
+            "imkl_2024p2",
+            pkg_spec="intel-oneapi-mkl@2024.2.0 threads=openmp",
+            compiler="gcc13p2",
+        )
+        software_spec(
+            "impi2021p11",
+            pkg_spec="intel-oneapi-mpi@2021.11.0",
+        )
 
-    required_package("intel-oneapi-mkl", package_manager="spack*")
+        required_package("intel-oneapi-mkl")
 
     # This step does a few things:
     # - Prepare calling for the script runme_intel64_prv

--- a/var/ramble/repos/builtin/applications/intel-mpi-benchmarks/application.py
+++ b/var/ramble/repos/builtin/applications/intel-mpi-benchmarks/application.py
@@ -30,18 +30,16 @@ class IntelMpiBenchmarks(ExecutableApplication):
 
     tags("micro-benchmark", "benchmark", "mpi")
 
-    define_compiler("gcc9", pkg_spec="gcc@9.3.0", package_manager="spack*")
-    software_spec(
-        "impi2018", pkg_spec="intel-mpi@2018.4.274", package_manager="spack*"
-    )
-    software_spec(
-        "intel-mpi-benchmarks",
-        pkg_spec="intel-mpi-benchmarks@2019.6",
-        compiler="gcc9",
-        package_manager="spack*",
-    )
+    with when("package_manager_family"):
+        define_compiler("gcc9", pkg_spec="gcc@9.3.0")
+        software_spec("impi2018", pkg_spec="intel-mpi@2018.4.274")
+        software_spec(
+            "intel-mpi-benchmarks",
+            pkg_spec="intel-mpi-benchmarks@2019.6",
+            compiler="gcc9",
+        )
 
-    required_package("intel-mpi-benchmarks", package_manager="spack*")
+        required_package("intel-mpi-benchmarks")
 
     executable(
         "pingpong",

--- a/var/ramble/repos/builtin/applications/ior/application.py
+++ b/var/ramble/repos/builtin/applications/ior/application.py
@@ -19,13 +19,12 @@ class Ior(ExecutableApplication):
 
     tags("synthetic-benchmarks", "IO")
 
-    define_compiler("gcc", pkg_spec="gcc", package_manager="spack*")
-    software_spec("openmpi", pkg_spec="openmpi", package_manager="spack*")
-    software_spec(
-        "ior", pkg_spec="ior", compiler="gcc", package_manager="spack*"
-    )
+    with when("package_manager_family=spack"):
+        define_compiler("gcc", pkg_spec="gcc")
+        software_spec("openmpi", pkg_spec="openmpi")
+        software_spec("ior", pkg_spec="ior", compiler="gcc")
 
-    required_package("ior", package_manager="spack*")
+        required_package("ior")
 
     workload("multi-file", executable="ior")
 

--- a/var/ramble/repos/builtin/applications/iperf2/application.py
+++ b/var/ramble/repos/builtin/applications/iperf2/application.py
@@ -21,14 +21,14 @@ class Iperf2(ExecutableApplication):
 
     define_compiler("gcc9", pkg_spec="gcc@9.3.0")
 
-    software_spec(
-        "iperf2",
-        pkg_spec="iperf2@2.0.12",
-        compiler="gcc9",
-        package_manager="spack*",
-    )
+    with when("package_manager_family=spack"):
+        software_spec(
+            "iperf2",
+            pkg_spec="iperf2@2.0.12",
+            compiler="gcc9",
+        )
 
-    required_package("iperf2", package_manager="spack*")
+        required_package("iperf2")
 
     # Need to support these use cases:
     # iperf -s // set up server

--- a/var/ramble/repos/builtin/applications/lammps/application.py
+++ b/var/ramble/repos/builtin/applications/lammps/application.py
@@ -22,18 +22,16 @@ class Lammps(ExecutableApplication):
 
     define_compiler("gcc9", pkg_spec="gcc@9.3.0")
 
-    software_spec(
-        "impi2018", pkg_spec="intel-mpi@2018.4.274", package_manager="spack*"
-    )
+    with when("package_manager_family=spack"):
+        software_spec("impi2018", pkg_spec="intel-mpi@2018.4.274")
 
-    software_spec(
-        "lammps",
-        pkg_spec="lammps@20220623.4 +opt+manybody+molecule+kspace+rigid+openmp+openmp-package+asphere+dpd-basic+dpd-meso+dpd-react+dpd-smooth",
-        compiler="gcc9",
-        package_manager="spack*",
-    )
+        software_spec(
+            "lammps",
+            pkg_spec="lammps@20220623.4 +opt+manybody+molecule+kspace+rigid+openmp+openmp-package+asphere+dpd-basic+dpd-meso+dpd-react+dpd-smooth",
+            compiler="gcc9",
+        )
 
-    required_package("lammps", package_manager="spack*")
+        required_package("lammps")
 
     input_file(
         "leonard-jones",

--- a/var/ramble/repos/builtin/applications/lulesh/application.py
+++ b/var/ramble/repos/builtin/applications/lulesh/application.py
@@ -21,20 +21,18 @@ class Lulesh(ExecutableApplication):
 
     tags("proxy-app", "mini-app")
 
-    define_compiler("gcc13", pkg_spec="gcc@13.1.0", package_manager="spack*")
+    with when("package_manager_family"):
+        define_compiler("gcc13", pkg_spec="gcc@13.1.0")
 
-    software_spec(
-        "impi2018", pkg_spec="intel-mpi@2018.4.274", package_manager="spack*"
-    )
+        software_spec("impi2018", pkg_spec="intel-mpi@2018.4.274")
 
-    software_spec(
-        "lulesh",
-        pkg_spec="lulesh@2.0.3 +openmp",
-        compiler="gcc13",
-        package_manager="spack*",
-    )
+        software_spec(
+            "lulesh",
+            pkg_spec="lulesh@2.0.3 +openmp",
+            compiler="gcc13",
+        )
 
-    required_package("lulesh", package_manager="spack*")
+        required_package("lulesh")
 
     executable("execute", "lulesh2.0 {flags}", use_mpi=True)
 

--- a/var/ramble/repos/builtin/applications/md-test/application.py
+++ b/var/ramble/repos/builtin/applications/md-test/application.py
@@ -19,16 +19,15 @@ class MdTest(ExecutableApplication):
 
     tags("synthetic-benchmarks", "IO")
 
-    define_compiler("gcc", pkg_spec="gcc", package_manager="spack*")
-    software_spec("openmpi", pkg_spec="openmpi", package_manager="spack*")
+    with when("package_manager_family=spack"):
+        define_compiler("gcc", pkg_spec="gcc")
+        software_spec("openmpi", pkg_spec="openmpi")
 
-    # The IOR spack package also includes MDTest, but we implement it as a
-    # separate application in ramble
-    software_spec(
-        "ior", pkg_spec="ior", compiler="gcc", package_manager="spack*"
-    )
+        # The IOR spack package also includes MDTest, but we implement it as a
+        # separate application in ramble
+        software_spec("ior", pkg_spec="ior", compiler="gcc")
 
-    required_package("ior", package_manager="spack*")
+        required_package("ior")
 
     workload("multi-file", executable="ior")
 

--- a/var/ramble/repos/builtin/applications/minixyce/application.py
+++ b/var/ramble/repos/builtin/applications/minixyce/application.py
@@ -27,23 +27,22 @@ class Minixyce(ExecutableApplication):
         "mini-benchmark",
     )
 
-    define_compiler("gcc12", pkg_spec="gcc@12.2.0", package_manager="spack*")
+    with when("package_manager_family=spack"):
+        define_compiler("gcc12", pkg_spec="gcc@12.2.0")
 
-    software_spec(
-        "ompi415cxx",
-        pkg_spec="openmpi@4.1.5 +legacylaunchers +cxx",
-        compiler="gcc12",
-        package_manager="spack*",
-    )
+        software_spec(
+            "ompi415cxx",
+            pkg_spec="openmpi@4.1.5 +legacylaunchers +cxx",
+            compiler="gcc12",
+        )
 
-    software_spec(
-        "minixyce",
-        pkg_spec="minixyce@1.0 +mpi",
-        compiler="gcc12",
-        package_manager="spack*",
-    )
+        software_spec(
+            "minixyce",
+            pkg_spec="minixyce@1.0 +mpi",
+            compiler="gcc12",
+        )
 
-    required_package("minixyce", package_manager="spack*")
+        required_package("minixyce")
 
     executable(
         "execute",

--- a/var/ramble/repos/builtin/applications/namd/application.py
+++ b/var/ramble/repos/builtin/applications/namd/application.py
@@ -23,29 +23,27 @@ class Namd(ExecutableApplication):
 
     tags("molecular-dynamics", "charm++", "task-parallelism")
 
-    define_compiler("gcc12", pkg_spec="gcc@12.2.0", package_manager="spack*")
+    with when("package_manager_family=spack"):
+        define_compiler("gcc12", pkg_spec="gcc@12.2.0")
 
-    software_spec(
-        "impi2021p8",
-        pkg_spec="intel-oneapi-mpi@2021.8.0",
-        package_manager="spack*",
-    )
+        software_spec(
+            "impi2021p8",
+            pkg_spec="intel-oneapi-mpi@2021.8.0",
+        )
 
-    software_spec(
-        "charmpp",
-        pkg_spec="charmpp backend=mpi build-target=charm++",
-        compiler="gcc12",
-        package_manager="spack*",
-    )
+        software_spec(
+            "charmpp",
+            pkg_spec="charmpp backend=mpi build-target=charm++",
+            compiler="gcc12",
+        )
 
-    software_spec(
-        "namd",
-        pkg_spec="namd@2.14 interface=tcl",
-        compiler="gcc12",
-        package_manager="spack*",
-    )
+        software_spec(
+            "namd",
+            pkg_spec="namd@2.14 interface=tcl",
+            compiler="gcc12",
+        )
 
-    required_package("namd", package_manager="spack*")
+        required_package("namd")
 
     input_file(
         "stmv",

--- a/var/ramble/repos/builtin/applications/nccl-tests/application.py
+++ b/var/ramble/repos/builtin/applications/nccl-tests/application.py
@@ -65,8 +65,12 @@ class NcclTests(ExecutableApplication):
         "send-recv",
     ]
 
-    software_spec("nccl-test", pkg_spec="nccl-tests", package_manager="spack*")
-    required_package("nccl-tests")
+    software_spec(
+        "nccl-test",
+        pkg_spec="nccl-tests",
+        when=["package_manager_family=spack"],
+    )
+    required_package("nccl-tests", when=["package_manager_family=spack"])
 
     workload_variable(
         "num_gpus_per_task",

--- a/var/ramble/repos/builtin/applications/nvbandwidth/application.py
+++ b/var/ramble/repos/builtin/applications/nvbandwidth/application.py
@@ -18,11 +18,10 @@ class Nvbandwidth(ExecutableApplication):
 
     tags("synthetic-benchmarks")
 
-    software_spec(
-        "nvbandwidth", pkg_spec="nvbandwidth", package_manager="spack*"
-    )
+    with when("package_manager_family=spack"):
+        software_spec("nvbandwidth", pkg_spec="nvbandwidth")
 
-    required_package("nvbandwidth", package_manager="spack*")
+        required_package("nvbandwidth")
 
     workload("all_benchmarks", executable="nvbandwidth")
 

--- a/var/ramble/repos/builtin/applications/openfoam-org/application.py
+++ b/var/ramble/repos/builtin/applications/openfoam-org/application.py
@@ -19,20 +19,18 @@ class OpenfoamOrg(OpenfoamBase):
 
     tags("cfd", "fluid", "dynamics")
 
-    define_compiler("gcc9", pkg_spec="gcc@9.3.0", package_manager="spack*")
+    with when("package_manager_family=spack"):
+        define_compiler("gcc9", pkg_spec="gcc@9.3.0")
 
-    software_spec(
-        "impi2018", pkg_spec="intel-mpi@2018.4.274", package_manager="spack*"
-    )
+        software_spec("impi2018", pkg_spec="intel-mpi@2018.4.274")
 
-    software_spec(
-        "openfoam-org",
-        pkg_spec="openfoam-org@10",
-        compiler="gcc9",
-        package_manager="spack*",
-    )
+        software_spec(
+            "openfoam-org",
+            pkg_spec="openfoam-org@10",
+            compiler="gcc9",
+        )
 
-    required_package("openfoam-org", package_manager="spack*")
+        required_package("openfoam-org")
 
     executable(
         "get_inputs",

--- a/var/ramble/repos/builtin/applications/openfoam/application.py
+++ b/var/ramble/repos/builtin/applications/openfoam/application.py
@@ -17,20 +17,18 @@ class Openfoam(OpenfoamBase):
 
     maintainers("douglasjacobsen")
 
-    define_compiler("gcc9", pkg_spec="gcc@9.3.0", package_manager="spack*")
+    with when("package_manager_family=spack"):
+        define_compiler("gcc9", pkg_spec="gcc@9.3.0")
 
-    software_spec(
-        "impi2018", pkg_spec="intel-mpi@2018.4.274", package_manager="spack*"
-    )
+        software_spec("impi2018", pkg_spec="intel-mpi@2018.4.274")
 
-    software_spec(
-        "openfoam",
-        pkg_spec="openfoam@2312",
-        compiler="gcc9",
-        package_manager="spack*",
-    )
+        software_spec(
+            "openfoam",
+            pkg_spec="openfoam@2312",
+            compiler="gcc9",
+        )
 
-    required_package("openfoam", package_manager="spack*")
+        required_package("openfoam")
 
     executable(
         "surfaceFeatures",

--- a/var/ramble/repos/builtin/applications/orca/application.py
+++ b/var/ramble/repos/builtin/applications/orca/application.py
@@ -21,10 +21,9 @@ class Orca(ExecutableApplication):
 
     tags = ["quantum chemistry"]
 
-    software_spec("orca", pkg_spec="orca@5.0.4", package_manager="spack*")
-    software_spec(
-        "openmpi412", pkg_spec="openmpi@4.1.2", package_manager="spack*"
-    )
+    with when("package_manager_family=spack"):
+        software_spec("orca", pkg_spec="orca@5.0.4")
+        software_spec("openmpi412", pkg_spec="openmpi@4.1.2")
 
     input_file(
         "orca_in",

--- a/var/ramble/repos/builtin/applications/osu-micro-benchmarks/application.py
+++ b/var/ramble/repos/builtin/applications/osu-micro-benchmarks/application.py
@@ -23,16 +23,16 @@ class OsuMicroBenchmarks(ExecutableApplication):
 
     tags("synthetic-benchmarks")
 
-    define_compiler("gcc", pkg_spec="gcc", package_manager="spack*")
-    software_spec("openmpi", pkg_spec="openmpi", package_manager="spack*")
-    software_spec(
-        "osu-micro-benchmarks",
-        pkg_spec="osu-micro-benchmarks",
-        compiler="gcc",
-        package_manager="spack*",
-    )
+    with when("package_manager_family=spack"):
+        define_compiler("gcc", pkg_spec="gcc")
+        software_spec("openmpi", pkg_spec="openmpi")
+        software_spec(
+            "osu-micro-benchmarks",
+            pkg_spec="osu-micro-benchmarks",
+            compiler="gcc",
+        )
 
-    required_package("osu-micro-benchmarks", package_manager="spack*")
+        required_package("osu-micro-benchmarks")
 
     all_workloads = [
         "osu_bibw",

--- a/var/ramble/repos/builtin/applications/pip-test/application.py
+++ b/var/ramble/repos/builtin/applications/pip-test/application.py
@@ -16,19 +16,18 @@ class PipTest(ExecutableApplication):
 
     tags("test-app")
 
-    software_spec(
-        "requests",
-        pkg_spec="requests>=2.31.0",
-        package_manager="pip",
-    )
+    with when("package_manager_family=pip"):
+        software_spec(
+            "requests",
+            pkg_spec="requests>=2.31.0",
+        )
 
-    software_spec(
-        "semver",
-        pkg_spec="semver",
-        package_manager="pip",
-    )
+        software_spec(
+            "semver",
+            pkg_spec="semver",
+        )
 
-    required_package("semver", package_manager="pip")
+        required_package("semver")
 
     executable(
         "import",

--- a/var/ramble/repos/builtin/applications/quantum-espresso/application.py
+++ b/var/ramble/repos/builtin/applications/quantum-espresso/application.py
@@ -28,21 +28,20 @@ class QuantumEspresso(ExecutableApplication):
         "pseudopotentials",
     )
 
-    define_compiler("gcc13", pkg_spec="gcc@13.1.0", package_manager="spack*")
+    with when("package_manager_family=spack"):
+        define_compiler("gcc13", pkg_spec="gcc@13.1.0")
 
-    software_spec(
-        "impi2021p8",
-        pkg_spec="intel-oneapi-mpi@2021.8.0",
-        package_manager="spack*",
-    )
-    software_spec(
-        "quantum-espresso",
-        pkg_spec="quantum-espresso@7.1",
-        compiler="gcc13",
-        package_manager="spack*",
-    )
+        software_spec(
+            "impi2021p8",
+            pkg_spec="intel-oneapi-mpi@2021.8.0",
+        )
+        software_spec(
+            "quantum-espresso",
+            pkg_spec="quantum-espresso@7.1",
+            compiler="gcc13",
+        )
 
-    required_package("quantum-espresso", package_manager="spack*")
+        required_package("quantum-espresso")
 
     input_file(
         "AUSURF112",

--- a/var/ramble/repos/builtin/applications/roms/application.py
+++ b/var/ramble/repos/builtin/applications/roms/application.py
@@ -25,10 +25,9 @@ class Roms(ExecutableApplication):
 
     tags("ocean")
 
-    software_spec("roms", pkg_spec="roms@4.1", package_manager="spack*")
-    software_spec(
-        "openmpi412", pkg_spec="openmpi@4.1.2", package_manager="spack*"
-    )
+    with when("package_manager_family=spack"):
+        software_spec("roms", pkg_spec="roms@4.1")
+        software_spec("openmpi412", pkg_spec="openmpi@4.1.2")
 
     input_file(
         "bm1",

--- a/var/ramble/repos/builtin/applications/streamc/application.py
+++ b/var/ramble/repos/builtin/applications/streamc/application.py
@@ -26,16 +26,16 @@ class Streamc(ExecutableApplication):
         "micro-benchmark",
     )
 
-    define_compiler("gcc12", pkg_spec="gcc@12.2.0", package_manager="spack*")
+    with when("package_manager_family=spack"):
+        define_compiler("gcc12", pkg_spec="gcc@12.2.0")
 
-    software_spec(
-        "streamc",
-        pkg_spec='stream@5.10 +openmp cflags="-O3 -DSTREAM_ARRAY_SIZE=80000000 -DNTIMES=20"',
-        compiler="gcc12",
-        package_manager="spack*",
-    )
+        software_spec(
+            "streamc",
+            pkg_spec='stream@5.10 +openmp cflags="-O3 -DSTREAM_ARRAY_SIZE=80000000 -DNTIMES=20"',
+            compiler="gcc12",
+        )
 
-    required_package("stream", package_manager="spack*")
+        required_package("stream")
 
     executable("execute_c", "stream_c.exe")
 

--- a/var/ramble/repos/builtin/applications/ufs-weather-model/application.py
+++ b/var/ramble/repos/builtin/applications/ufs-weather-model/application.py
@@ -21,36 +21,33 @@ class UfsWeatherModel(ExecutableApplication):
 
     tags("nwp", "weather")
 
-    define_compiler("gcc9", pkg_spec="gcc@9.3.0", package_manager="spack*")
+    with when("package_manager_family=spack"):
+        define_compiler("gcc9", pkg_spec="gcc@9.3.0")
 
-    software_spec(
-        "ompi415",
-        pkg_spec="openmpi@4.1.5",
-        compiler="gcc9",
-        package_manager="spack*",
-    )
+        software_spec(
+            "ompi415",
+            pkg_spec="openmpi@4.1.5",
+            compiler="gcc9",
+        )
 
-    software_spec(
-        "python39",
-        pkg_spec="python@3.9.15",
-        compiler="gcc9",
-        package_manager="spack*",
-    )
-    software_spec(
-        "esmf",
-        pkg_spec="esmf@8.0.1",
-        compiler="gcc9",
-        package_manager="spack*",
-    )
+        software_spec(
+            "python39",
+            pkg_spec="python@3.9.15",
+            compiler="gcc9",
+        )
+        software_spec(
+            "esmf",
+            pkg_spec="esmf@8.0.1",
+            compiler="gcc9",
+        )
 
-    software_spec(
-        "ufs-weather-model",
-        pkg_spec="ufs-weather-model@2.0.0 +avx2 +openmp",
-        compiler="gcc9",
-        package_manager="spack*",
-    )
+        software_spec(
+            "ufs-weather-model",
+            pkg_spec="ufs-weather-model@2.0.0 +avx2 +openmp",
+            compiler="gcc9",
+        )
 
-    required_package("ufs-weather-model", package_manager="spack*")
+        required_package("ufs-weather-model")
 
     input_file(
         "simple_test_case",

--- a/var/ramble/repos/builtin/applications/wrfv3/application.py
+++ b/var/ramble/repos/builtin/applications/wrfv3/application.py
@@ -21,20 +21,18 @@ class Wrfv3(ExecutableApplication):
 
     tags("nwp", "weather")
 
-    define_compiler("gcc8", pkg_spec="gcc@8.2.0", package_manager="spack*")
+    with when("package_manager_family=spack"):
+        define_compiler("gcc8", pkg_spec="gcc@8.2.0")
 
-    software_spec(
-        "impi2018", pkg_spec="intel-mpi@2018.4.274", package_manager="spack*"
-    )
+        software_spec("impi2018", pkg_spec="intel-mpi@2018.4.274")
 
-    software_spec(
-        "wrfv3",
-        pkg_spec="wrf@3.9.1.1 build_type=dm+sm compile_type=em_real nesting=basic ~pnetcdf",
-        compiler="gcc8",
-        package_manager="spack*",
-    )
+        software_spec(
+            "wrfv3",
+            pkg_spec="wrf@3.9.1.1 build_type=dm+sm compile_type=em_real nesting=basic ~pnetcdf",
+            compiler="gcc8",
+        )
 
-    required_package("wrf", package_manager="spack*")
+        required_package("wrf")
 
     input_file(
         "CONUS_2p5km",

--- a/var/ramble/repos/builtin/applications/wrfv4/application.py
+++ b/var/ramble/repos/builtin/applications/wrfv4/application.py
@@ -21,23 +21,22 @@ class Wrfv4(ExecutableApplication):
 
     tags("nwp", "weather")
 
-    define_compiler("gcc9", pkg_spec="gcc@9.3.0", package_manager="spack*")
+    with when("package_manager_family=spack"):
+        define_compiler("gcc9", pkg_spec="gcc@9.3.0")
 
-    software_spec(
-        "intel-mpi",
-        pkg_spec="intel-mpi@2018.4.274",
-        compiler="gcc9",
-        package_manager="spack*",
-    )
+        software_spec(
+            "intel-mpi",
+            pkg_spec="intel-mpi@2018.4.274",
+            compiler="gcc9",
+        )
 
-    software_spec(
-        "wrfv4",
-        pkg_spec="wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf",
-        compiler="gcc9",
-        package_manager="spack*",
-    )
+        software_spec(
+            "wrfv4",
+            pkg_spec="wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf",
+            compiler="gcc9",
+        )
 
-    required_package("wrf", package_manager="spack*")
+        required_package("wrf")
 
     input_file(
         "CONUS_2p5km",

--- a/var/ramble/repos/builtin/modifiers/ethtool/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/ethtool/modifier.py
@@ -69,7 +69,9 @@ class Ethtool(BasicModifier):
         mode="standard",
     )
 
-    software_spec("pdsh", pkg_spec="pdsh", package_manager="spack*")
+    software_spec(
+        "pdsh", pkg_spec="pdsh", when=["package_manager_family=spack"]
+    )
 
     register_builtin("run_ethtool")
 

--- a/var/ramble/repos/builtin/modifiers/gcp-metadata/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/gcp-metadata/modifier.py
@@ -32,7 +32,9 @@ class GcpMetadata(BasicModifier):
     )
     default_mode("standard")
 
-    software_spec("pdsh", pkg_spec="pdsh", package_manager="spack*")
+    software_spec(
+        "pdsh", pkg_spec="pdsh", when=["package_manager_family=spack"]
+    )
 
     required_variable("hostlist", modes=["standard"])
 

--- a/var/ramble/repos/builtin/modifiers/intel-aps/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/intel-aps/modifier.py
@@ -107,13 +107,13 @@ class IntelAps(BasicModifier):
 
     archive_pattern("aps_*_results_dir/*")
 
-    software_spec(
-        "intel-oneapi-vtune",
-        pkg_spec="intel-oneapi-vtune",
-        package_manager="spack*",
-    )
+    with when("package_manager_family=spack"):
+        software_spec(
+            "intel-oneapi-vtune",
+            pkg_spec="intel-oneapi-vtune",
+        )
 
-    required_package("intel-oneapi-vtune", package_manager="spack*")
+        required_package("intel-oneapi-vtune")
 
     executable_modifier("aps_summary")
 

--- a/var/ramble/repos/builtin/modifiers/sys-stat/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/sys-stat/modifier.py
@@ -61,13 +61,13 @@ class SysStat(BasicModifier):
     default_mode("custom")
 
     # sysstat contains common tools such as mpstat and iostat
-    software_spec(
-        "sysstat",
-        pkg_spec="sysstat",
-        package_manager="spack*",
-    )
+    with when("package_manager_family=spack"):
+        software_spec(
+            "sysstat",
+            pkg_spec="sysstat",
+        )
 
-    required_package("sysstat", package_manager="spack*")
+        required_package("sysstat")
 
     archive_pattern("{experiment_run_dir}/sampler_*")
 

--- a/var/ramble/repos/builtin/modifiers/tuned-adm/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/tuned-adm/modifier.py
@@ -28,7 +28,9 @@ class TunedAdm(BasicModifier):
 
     mode("standard", description="Standard execution mode for tuned-adm")
 
-    software_spec("pdsh", pkg_spec="pdsh", package_manager="spack*")
+    software_spec(
+        "pdsh", pkg_spec="pdsh", when=["package_manager_family=spack"]
+    )
 
     required_variable("hostlist")
 

--- a/var/ramble/repos/builtin/package_managers/eessi/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/eessi/package_manager.py
@@ -32,6 +32,8 @@ class Eessi(EnvironmentModules):
         description="Version of EESSI to use",
     )
 
+    package_manager_family("eessi")
+
     register_builtin("eessi_init")
 
     def eessi_init(self):

--- a/var/ramble/repos/builtin/package_managers/environment-modules/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/environment-modules/package_manager.py
@@ -33,6 +33,8 @@ class EnvironmentModules(PackageManagerBase):
 
     _list_file = ".environment_modules_list"
 
+    package_manager_family("environment-modules")
+
     register_phase(
         "write_module_commands",
         pipeline="setup",

--- a/var/ramble/repos/builtin/package_managers/pip/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/pip/package_manager.py
@@ -33,6 +33,8 @@ class Pip(PackageManagerBase):
 
     _spec_prefix = "pip"
 
+    package_manager_family("pip")
+
     archive_pattern(os.path.join("{env_path}", "requirements.txt"))
     archive_pattern(os.path.join("{env_path}", "requirements.lock"))
 
@@ -125,8 +127,13 @@ class Pip(PackageManagerBase):
             self.runner.install()
 
             installed_pkgs = self.runner.installed_packages()
-            for pkg in self.app_inst.required_packages.keys():
-                if pkg not in installed_pkgs:
+            for pkg, conf in self.app_inst.required_packages.items():
+                if (
+                    app_inst.expander.satisfies(
+                        conf["when"], variant_set=app_inst.object_variants
+                    )
+                    and pkg not in installed_pkgs
+                ):
                     logger.die(
                         f"Package {pkg} is not installed "
                         f"in environment {env_context}, but is "
@@ -135,8 +142,13 @@ class Pip(PackageManagerBase):
                     )
 
             for mod_inst in self.app_inst._modifier_instances:
-                for pkg in mod_inst.required_packages.keys():
-                    if pkg not in installed_pkgs:
+                for pkg, conf in mod_inst.required_packages.items():
+                    if (
+                        app_inst.expander.satisfies(
+                            conf["when"], variant_set=app_inst.object_variants
+                        )
+                        and pkg not in installed_pkgs
+                    ):
                         logger.die(
                             f"Package {pkg} is not installed "
                             f"in environment {env_context}, but is "

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
@@ -6,7 +6,6 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-import fnmatch
 import os
 import re
 import shlex

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
@@ -39,6 +39,8 @@ class SpackLightweight(PackageManagerBase):
 
     _spec_prefix = "spack"
 
+    package_manager_family("spack")
+
     def __init__(self, file_path):
         super().__init__(file_path)
 
@@ -127,7 +129,10 @@ class SpackLightweight(PackageManagerBase):
 
         for config_dict in package_manager_config_dicts:
             for _, config in config_dict.items():
-                if fnmatch.fnmatch(self.name, config["package_manager"]):
+                keep_config = app_inst.expander.satisfies(
+                    config["when"], variant_set=app_inst.object_variants
+                )
+                if keep_config:
                     self.runner.add_config(config["config"])
 
         try:
@@ -175,8 +180,14 @@ class SpackLightweight(PackageManagerBase):
                     self.runner.generate_env_file()
 
                 added_packages = set(self.runner.added_packages())
-                for pkg in self.app_inst.required_packages.keys():
-                    if pkg not in added_packages:
+                for pkg, conf in self.app_inst.required_packages.items():
+
+                    if (
+                        app_inst.expander.satisfies(
+                            conf["when"], variant_set=app_inst.object_variants
+                        )
+                        and pkg not in added_packages
+                    ):
                         logger.die(
                             f"Software spec {pkg} is not defined "
                             f"in environment {env_context}, but is "
@@ -185,8 +196,14 @@ class SpackLightweight(PackageManagerBase):
                         )
 
                 for mod_inst in self.app_inst._modifier_instances:
-                    for pkg in mod_inst.required_packages.keys():
-                        if pkg not in added_packages:
+                    for pkg, conf in mod_inst.required_packages.items():
+                        if (
+                            app_inst.expander.satisfies(
+                                conf["when"],
+                                variant_set=app_inst.object_variants,
+                            )
+                            and pkg not in added_packages
+                        ):
                             logger.die(
                                 f"Software spec {pkg} is not defined "
                                 f"in environment {env_context}, but is "

--- a/var/ramble/repos/builtin/workflow_managers/google-batch/workflow_manager.py
+++ b/var/ramble/repos/builtin/workflow_managers/google-batch/workflow_manager.py
@@ -38,6 +38,8 @@ class GoogleBatch(WorkflowManagerBase):
 
     tags("workflow", "google", "batch")
 
+    workflow_manager_family("google-batch")
+
     def __init__(self, file_path):
         super().__init__(file_path)
 

--- a/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
@@ -42,6 +42,8 @@ class Slurm(WorkflowManagerBase):
 
     tags("workflow", "slurm")
 
+    workflow_manager_family("slurm")
+
     def __init__(self, file_path):
         super().__init__(file_path)
 


### PR DESCRIPTION
This merge adds support for variants and two new directives.

Variants can be defined within object definitions to give them default values and allow experiments to define them.

The two new directives that are added are `when` and `default_args`. These were backported from Spack's implementation, and allow default definitions for shared arguments to be passed through with blocks.