### PR TITLE
Permit errors when concretizing workspace

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -905,10 +905,14 @@ class ApplicationBase(metaclass=ApplicationMeta):
                 self.expander.add_no_expand_var(var)
                 mod_inst.expander.add_no_expand_var(var)
 
-    def validate_experiment(self):
+    def validate_experiment(self, warn_validation=True, die_on_validate_error=True):
         # Validate the new modifiers variables exist
         # (note: the base ramble variables are checked earlier too)
-        self.keywords.check_required_keys(self.variables)
+        self.keywords.check_required_keys(
+            self.variables,
+            warn_validation=warn_validation,
+            die_on_validate_error=die_on_validate_error,
+        )
         self._check_object_validators()
 
     def _check_object_validators(self):

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -139,7 +139,7 @@ class ExperimentSet:
 
         self._set_context(self._contexts.workload, workload_context)
 
-    def set_experiment_context(self, experiment_context):
+    def set_experiment_context(self, experiment_context, die_on_validate_error=True):
         """Set up current experiment context"""
 
         try:
@@ -149,7 +149,7 @@ class ExperimentSet:
             raise RambleVariableDefinitionError(f"In experiment {namespace}: {e}")
 
         self._set_context(self._contexts.experiment, experiment_context)
-        self._ingest_experiments()
+        self._ingest_experiments(die_on_validate_error=die_on_validate_error)
 
     @property
     def application_namespace(self):
@@ -254,7 +254,15 @@ class ExperimentSet:
         if not n_threads:
             variables[self.keywords.n_threads] = 1
 
-    def _prepare_experiment(self, exp_template_name, variables, context, repeats):
+    def _prepare_experiment(
+        self,
+        exp_template_name,
+        variables,
+        context,
+        repeats,
+        die_on_validate_error=True,
+        warn_validation=True,
+    ):
         """Prepare an experiment instance
 
         Create an experiment instance based on the input variables, context,
@@ -269,6 +277,7 @@ class ExperimentSet:
         Returns:
             (Application): Instance of an application class for this experiment
         """
+
         experiment_suffix = ""
         # After generating the base experiment, append the index to repeat experiments
         if repeats.repeat_index:
@@ -349,14 +358,9 @@ class ExperimentSet:
         app_inst.add_expand_vars(self._workspace)
         app_inst.read_status()
 
-        try:
-            app_inst.validate_experiment()
-        except ramble.keywords.RambleKeywordError as e:
-            raise RambleVariableDefinitionError(str(e))
-
         return app_inst
 
-    def _ingest_experiments(self):
+    def _ingest_experiments(self, die_on_validate_error=True):
         """Ingest experiments based on the current context.
 
         Merge all contexts, and render individual experiments. Track these
@@ -464,7 +468,12 @@ class ExperimentSet:
             tracking_group, exclude_where=exclude_where, ignore_used=False, fatal=False
         ):
             app_inst = self._prepare_experiment(
-                experiment_template_name, tracking_vars, final_context, repeats
+                experiment_template_name,
+                tracking_vars,
+                final_context,
+                repeats,
+                warn_validation=False,
+                die_on_validate_error=die_on_validate_error,
             )
 
             final_exp_name = app_inst.expander.expand_var_name(self.keywords.experiment_namespace)
@@ -478,7 +487,12 @@ class ExperimentSet:
             render_group, exclude_where=exclude_where
         ):
             app_inst = self._prepare_experiment(
-                experiment_template_name, experiment_vars, final_context, repeats
+                experiment_template_name,
+                experiment_vars,
+                final_context,
+                repeats,
+                warn_validation=False,
+                die_on_validate_error=die_on_validate_error,
             )
 
             final_exp_name = app_inst.expander.expand_var_name(self.keywords.experiment_name)
@@ -527,11 +541,15 @@ class ExperimentSet:
                     logger.die(f"Experiment {final_exp_namespace} is not unique.")
 
                 try:
-                    self.keywords.check_required_keys(experiment_vars)
-                except ramble.keywords.RambleKeywordError as e:
-                    raise RambleVariableDefinitionError(
-                        f"In experiment {final_exp_namespace}: {e}"
+                    app_inst.validate_experiment(
+                        warn_validation=True, die_on_validate_error=die_on_validate_error
                     )
+                except ramble.keywords.RambleKeywordError as e:
+                    if die_on_validate_error:
+                        raise RambleVariableDefinitionError(
+                            f"In experiment {final_exp_namespace}: {e}"
+                        )
+                    pass
 
                 rendered_experiments.add(final_exp_namespace)
                 self.experiments[final_exp_namespace] = app_inst

--- a/lib/ramble/ramble/keywords.py
+++ b/lib/ramble/ramble/keywords.py
@@ -168,7 +168,7 @@ class Keywords:
                     f'Keyword "{definition}" has been defined, ' + "but is reserved by ramble."
                 )
 
-    def check_required_keys(self, definitions):
+    def check_required_keys(self, definitions, warn_validation=True, die_on_validate_error=True):
         """Check a dictionary of variable definitions for all required keywords"""
         if not definitions:
             return
@@ -183,11 +183,14 @@ class Keywords:
                 required_set.remove(definition)
 
         if len(required_set) > 0:
-            for key in required_set:
-                logger.warn(f'Required key "{key}" is not defined')
-            raise RambleKeywordError(
-                "One or more required keys " + "are not defined within an experiment."
-            )
+            if warn_validation:
+                for key in required_set:
+                    logger.warn(f'Required key "{key}" is not defined')
+
+            if die_on_validate_error:
+                raise RambleKeywordError(
+                    "One or more required keys " + "are not defined within an experiment."
+                )
 
 
 class RambleKeywordError(ramble.error.RambleError):

--- a/lib/ramble/ramble/modkit.py
+++ b/lib/ramble/ramble/modkit.py
@@ -7,8 +7,7 @@
 # except according to those terms.
 
 # flake8: noqa: F401
-"""modkit is a set of useful modules to import when writing modifiers
-"""
+"""modkit is a set of useful modules to import when writing modifiers"""
 
 import llnl.util.filesystem
 from llnl.util.filesystem import *

--- a/lib/ramble/ramble/pkgmankit.py
+++ b/lib/ramble/ramble/pkgmankit.py
@@ -7,8 +7,7 @@
 # except according to those terms.
 
 # flake8: noqa: F401
-"""pkgmankit is a set of useful modules to import when writing package managers
-"""
+"""pkgmankit is a set of useful modules to import when writing package managers"""
 
 import os
 

--- a/lib/ramble/ramble/test/concretize_builtin.py
+++ b/lib/ramble/ramble/test/concretize_builtin.py
@@ -16,6 +16,7 @@ from ramble.main import RambleCommand
 # everything here uses the mock_workspace_path
 pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_path")
 
+config = RambleCommand("config")
 workspace = RambleCommand("workspace")
 
 
@@ -97,3 +98,45 @@ ramble:
                     req_test = False
                     break
             assert req_test
+
+
+def test_concretize_allows_invalid_experiment(
+    mutable_config, mutable_mock_workspace_path, request
+):
+    ws_name = request.node.name
+
+    global_args = ["-w", ws_name]
+
+    with ramble.workspace.create(ws_name) as ws:
+
+        workspace(
+            "manage",
+            "experiments",
+            "gromacs",
+            "--wf",
+            "water_bare",
+            "-p",
+            "spack",
+            global_args=global_args,
+        )
+
+        # Remove variables, to create an invalid experiment
+        config(
+            "rm",
+            "applications:gromacs:workloads:water_bare:experiments:generated:n_ranks",
+            global_args=global_args,
+        )
+        config(
+            "rm",
+            "applications:gromacs:workloads:water_bare:experiments:generated:n_nodes",
+            global_args=global_args,
+        )
+
+        ws._re_read()
+
+        workspace("concretize")
+
+        with open(ws.config_file_path) as f:
+            data = f.read()
+
+            assert "spack_gromacs" in data

--- a/lib/ramble/ramble/wmkit.py
+++ b/lib/ramble/ramble/wmkit.py
@@ -7,8 +7,7 @@
 # except according to those terms.
 
 # flake8: noqa: F401
-"""wmkit is a set of useful modules to import when writing workflow managers
-"""
+"""wmkit is a set of useful modules to import when writing workflow managers"""
 
 from ramble.language.shared_language import *
 from ramble.language.workflow_manager_language import *

--- a/lib/ramble/ramble/workspace/__init__.py
+++ b/lib/ramble/ramble/workspace/__init__.py
@@ -6,8 +6,7 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-"""This package implements Ramble workspaces.
-"""
+"""This package implements Ramble workspaces."""
 
 from .workspace import (
     RambleActiveWorkspaceError,

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -844,7 +844,7 @@ ramble:
     def all_experiments_path(self):
         return os.path.join(self.root, workspace_all_experiments_file)
 
-    def build_experiment_set(self):
+    def build_experiment_set(self, die_on_validate_error=True):
         """Create an experiment set representing this workspace"""
 
         experiment_set = ramble.experiment_set.ExperimentSet(self)
@@ -858,7 +858,9 @@ ramble:
                 experiment_set.set_workload_context(workload_context)
 
                 for _, experiment_context in self.all_experiments(experiments):
-                    experiment_set.set_experiment_context(experiment_context)
+                    experiment_set.set_experiment_context(
+                        experiment_context, die_on_validate_error=die_on_validate_error
+                    )
 
         experiment_set.build_experiment_chains()
 
@@ -1395,7 +1397,7 @@ ramble:
 
         self.software_environments = ramble.software_environments.SoftwareEnvironments(self)
 
-        experiment_set = self.build_experiment_set()
+        experiment_set = self.build_experiment_set(die_on_validate_error=False)
 
         for _, app_inst, _ in experiment_set.all_experiments():
             app_inst.build_modifier_instances()


### PR DESCRIPTION
This merge allows the experiment set to permit errors when concretizing software. In this way, invalid experiments (i.e. those without `n_ranks`, `processes_per_node`, and `n_nodes`) can still fill out their software without having to be completely valid first.