### PR TITLE
Add env-var passthrough option

### DIFF
--- a/etc/ramble/defaults/config.yaml
+++ b/etc/ramble/defaults/config.yaml
@@ -24,6 +24,7 @@ config:
   workspace_dirs: $ramble/var/ramble/workspaces
   report_dirs: ~/.ramble/reports
   include_phase_dependencies: false
+  resolve_variables_in_subprocesses: false
   spack:
     install:
       flags: --reuse

--- a/lib/ramble/ramble/main.py
+++ b/lib/ramble/ramble/main.py
@@ -442,6 +442,12 @@ def make_argument_parser(**kwargs):
     )
 
     parser.add_argument(
+        "--resolve-variables-in-subprocesses",
+        action="store_true",
+        help="Allow resolution of environment variables when launching subprocesses",
+    )
+
+    parser.add_argument(
         "-k",
         "--insecure",
         action="store_true",
@@ -611,6 +617,10 @@ def setup_main_options(args):
     if args.insecure:
         logger.warn("You asked for --insecure. Will NOT check SSL certificates.")
         ramble.config.set("config:verify_ssl", False, scope="command_line")
+
+    # If the user asked for it allow env-vars to resolve in subprocess calls
+    if args.resolve_variables_in_subprocesses:
+        ramble.config.set("config:resolve_variables_in_subprocesses", True, scope="command_line")
 
     # Use the ramble config command to handle parsing the config strings
     for config_var in args.config_vars or []:

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -555,6 +555,8 @@ class ExecutePipeline(Pipeline):
     def _execute(self):
         super()._execute()
 
+        resolve_env_vars = ramble.config.get("config:resolve_variables_in_subprocesses", False)
+
         if not self.suppress_run_header:
             logger.all_msg("Running executors...")
 
@@ -568,6 +570,8 @@ class ExecutePipeline(Pipeline):
 
             app_inst.add_expand_vars(self.workspace)
             exec_str = app_inst.expander.expand_var(self.executor)
+            if resolve_env_vars:
+                exec_str = os.path.expandvars(exec_str)
             exec_parts = shlex.split(exec_str)
             exec_name = exec_parts[0]
             exec_args = exec_parts[1:]

--- a/lib/ramble/ramble/schema/config.py
+++ b/lib/ramble/ramble/schema/config.py
@@ -116,6 +116,11 @@ properties["config"]["spack"] = {
             },
             "additionalProperties": False,
         },
+        "resolve_variables_in_subprocesses": {
+            "type": "boolean",
+            "default": False,
+            "additionalProperties": False,
+        },
     },
     "additionalProperties": False,
 }

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -264,7 +264,7 @@ complete -o bashdefault -o default -F _bash_completion_ramble ramble
 _ramble() {
     if $list_options
     then
-        RAMBLE_COMPREPLY="-h --help -H --all-help --color -c --config -C --config-scope -d --debug --disable-passthrough -N --disable-logger -P --disable-progress-bar --timestamp --pdb -w --workspace -D --workspace-dir -W --no-workspace --use-workspace-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock --mock-applications --mock-modifiers --mock-package-managers --mock-workflow-managers --mock-base-applications --mock-base-modifiers --mock-base-package-managers --mock-base-workflow-managers -p --profile --sorted-profile --lines --profile-restrictions -v --verbose --stacktrace -V --version --print-shell-vars"
+        RAMBLE_COMPREPLY="-h --help -H --all-help --color -c --config -C --config-scope -d --debug --disable-passthrough -N --disable-logger -P --disable-progress-bar --timestamp --pdb -w --workspace -D --workspace-dir -W --no-workspace --use-workspace-repo --resolve-variables-in-subprocesses -k --insecure -l --enable-locks -L --disable-locks -m --mock --mock-applications --mock-modifiers --mock-package-managers --mock-workflow-managers --mock-base-applications --mock-base-modifiers --mock-base-package-managers --mock-base-workflow-managers -p --profile --sorted-profile --lines --profile-restrictions -v --verbose --stacktrace -V --version --print-shell-vars"
     else
         RAMBLE_COMPREPLY="attributes clean commands config debug deployment docs edit help info license list mirror on python repo results software-definitions style unit-test workspace"
     fi


### PR DESCRIPTION
This merge adds a config option to allow environment variables to passthrough from the user environment into the execution environment when using `ramble on`.