### PR TITLE
Avoid unnecessary repeated expansion

### DIFF
--- a/lib/ramble/ramble/success_criteria.py
+++ b/lib/ramble/ramble/success_criteria.py
@@ -203,10 +203,10 @@ class SuccessCriteria:
                 )
                 return False
 
+            fom_name_glob = app_inst.expander.expand_var(self.fom_name)
+
             for context in contexts:
-                fom_names = fnmatch.filter(
-                    fom_values[context].keys(), app_inst.expander.expand_var(self.fom_name)
-                )
+                fom_names = fnmatch.filter(fom_values[context].keys(), fom_name_glob)
 
                 for fom_name in fom_names:
                     comparison_vars = {

--- a/lib/ramble/ramble/test/success_criteria_functionality/always_print_foms.py
+++ b/lib/ramble/ramble/test/success_criteria_functionality/always_print_foms.py
@@ -10,8 +10,6 @@ import os
 
 import pytest
 
-import ramble.config
-import ramble.software_environments
 import ramble.workspace
 from ramble.main import RambleCommand
 

--- a/lib/ramble/ramble/test/success_criteria_functionality/repeat_success_strict.py
+++ b/lib/ramble/ramble/test/success_criteria_functionality/repeat_success_strict.py
@@ -10,8 +10,6 @@ import os
 
 import pytest
 
-import ramble.config
-import ramble.software_environments
 import ramble.workspace
 from ramble.main import RambleCommand
 

--- a/lib/ramble/ramble/test/success_criteria_functionality/success_fom_comparison.py
+++ b/lib/ramble/ramble/test/success_criteria_functionality/success_fom_comparison.py
@@ -10,9 +10,6 @@ import os
 
 import pytest
 
-import ramble.config
-import ramble.namespace
-import ramble.software_environments
 import ramble.workspace
 from ramble.main import RambleCommand
 from ramble.test.dry_run_helpers import SCOPES, dry_run_config

--- a/lib/ramble/ramble/test/success_criteria_functionality/success_fom_globbing.py
+++ b/lib/ramble/ramble/test/success_criteria_functionality/success_fom_globbing.py
@@ -10,9 +10,6 @@ import os
 
 import pytest
 
-import ramble.config
-import ramble.namespace
-import ramble.software_environments
 import ramble.workspace
 from ramble.main import RambleCommand
 from ramble.test.dry_run_helpers import SCOPES, dry_run_config

--- a/lib/ramble/ramble/test/success_criteria_functionality/success_functions.py
+++ b/lib/ramble/ramble/test/success_criteria_functionality/success_functions.py
@@ -10,8 +10,6 @@ import os
 
 import pytest
 
-import ramble.config
-import ramble.software_environments
 import ramble.workspace
 from ramble.main import RambleCommand
 

--- a/lib/ramble/ramble/test/success_criteria_functionality/success_variable_fom_comparison.py
+++ b/lib/ramble/ramble/test/success_criteria_functionality/success_variable_fom_comparison.py
@@ -10,9 +10,6 @@ import os
 
 import pytest
 
-import ramble.config
-import ramble.namespace
-import ramble.software_environments
 import ramble.workspace
 from ramble.main import RambleCommand
 from ramble.test.dry_run_helpers import SCOPES, dry_run_config


### PR DESCRIPTION
It'd be even better to do the expansion upon `add_criteria`. However the expander isn't available at the workspace level. And the fom_comparison isn't tied to a file so incurs much less overhead than file_foms.

Incidentally remove some unused imports in the tests.