### PR TITLE
Update format specifier extraction to be more robust

### DIFF
--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -211,11 +211,6 @@ class ExpansionNode:
                     self.value = "{}"
                     return
 
-                # TODO:
-                # - Make sure there's only one format specifier
-                # - Detect it from the end backwards
-                # - Do not format broken format specifiers
-
                 keyword = replaced_contents[1:-1]
                 format_match = format_spec_regex.search(keyword)
                 required_passthrough = False

--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -262,9 +262,9 @@ class ExpansionNode:
                         )
                         required_passthrough = False
                     except ValueError:
-                        self.value += f":{format_spec}"
+                        self.value = replaced_contents
                     except KeyError:
-                        self.value += f":{format_spec}"
+                        self.value = replaced_contents
 
                 if required_passthrough:
                     self.value = f"{{{self.value}}}"

--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -10,6 +10,7 @@ import ast
 import math
 import operator
 import random
+import re
 import string
 from typing import Dict
 
@@ -79,6 +80,9 @@ supported_scalar_function_pointers = {
     "simplify_str": spack.util.naming.simplify_name,
     "re_search": _re_search,
 }
+
+# Format Spec Regex:
+format_spec_regex = re.compile(r"(?P<kw>.*):(?P<format_spec>\S+)$")
 
 # Functions that need to be supplied with the expander
 supported_scalar_function_with_self_arg_pointers = {
@@ -207,39 +211,49 @@ class ExpansionNode:
                     self.value = "{}"
                     return
 
-                format_kw = replaced_contents[1:-1]
-                kw_parts = format_kw.split(":")
+                # TODO:
+                # - Make sure there's only one format specifier
+                # - Detect it from the end backwards
+                # - Do not format broken format specifiers
+
+                keyword = replaced_contents[1:-1]
+                format_match = format_spec_regex.search(keyword)
                 required_passthrough = False
 
-                if kw_parts[0] in expansion_dict:
-                    used_vars.add(kw_parts[0])
+                if format_match:
+                    keyword = format_match.group("kw")
+                    format_spec = format_match.group("format_spec")
+
+                if keyword in expansion_dict:
+                    used_vars.add(keyword)
                     # Exit expansion for variables defined as no_expand
-                    if kw_parts[0] in no_expand_vars:
-                        self.value = expansion_dict[kw_parts[0]]
+                    if keyword in no_expand_vars:
+                        self.value = expansion_dict[keyword]
                         return
                     else:
                         self.value = expansion_func(
                             expansion_dict,
-                            expansion_dict[kw_parts[0]],
+                            expansion_dict[keyword],
                             allow_passthrough=allow_passthrough,
                         )
                 else:
-                    self.value = kw_parts[0]
+                    self.value = keyword
                     required_passthrough = True
 
                 # Evaluation should go here
                 try:
                     old_value = self.value
                     self.value = evaluation_func(self.value)
+                    logger.debug(f"  Expanded: {old_value} -> {self.value}")
                     if old_value != self.value:
                         required_passthrough = False
                 except SyntaxError:
                     pass
 
                 # If we had a format spec, add it
-                if len(kw_parts) > 1:
+                if format_match:
                     kw_dict = {"value": self.value}
-                    format_str = f"value:{kw_parts[1]}"
+                    format_str = f"value:{format_spec}"
                     try:
                         self.value = formatter.vformat(
                             VformatDelimiter.left + format_str + VformatDelimiter.right,
@@ -248,9 +262,9 @@ class ExpansionNode:
                         )
                         required_passthrough = False
                     except ValueError:
-                        self.value += f":{kw_parts[1]}"
+                        self.value += f":{format_spec}"
                     except KeyError:
-                        self.value += f":{kw_parts[1]}"
+                        self.value += f":{format_spec}"
 
                 if required_passthrough:
                     self.value = f"{{{self.value}}}"

--- a/lib/ramble/ramble/test/expander.py
+++ b/lib/ramble/ramble/test/expander.py
@@ -95,6 +95,8 @@ def exp_dict():
         ("maybe(not_a_var, foo)", "foo", set(), 1),
         ("maybe(not_a_var)", "", set(), 1),
         ("2.1.a", "2.1.a", set(), 1),
+        ("{'key1': 'val1'}", "{'key1': 'val1'}", set(), 1),
+        ("{'key1': 'val1', 'key2': 'val2'}", "{'key1': 'val1', 'key2': 'val2'}", set(), 1),
     ],
 )
 def test_expansions(input, output, no_expand_vars, passes):

--- a/lib/ramble/ramble/test/expander.py
+++ b/lib/ramble/ramble/test/expander.py
@@ -95,6 +95,7 @@ def exp_dict():
         ("maybe(not_a_var, foo)", "foo", set(), 1),
         ("maybe(not_a_var)", "", set(), 1),
         ("2.1.a", "2.1.a", set(), 1),
+        ("{'key1':'val1'}", "{'key1':'val1'}", set(), 1),
         ("{'key1': 'val1'}", "{'key1': 'val1'}", set(), 1),
         ("{'key1': 'val1', 'key2': 'val2'}", "{'key1': 'val1', 'key2': 'val2'}", set(), 1),
     ],


### PR DESCRIPTION
This merge updates the way the expander extracts format specifiers. Previously, it would split the input string on colons, and had a hard coded assumption that there would only be two portions to this split. After splitting, it would try to use the first as the keyword, and the second as the format specifier (then throwing everything after that away).

When the input string is a formatted dictionary, this breaks and results in improperly formatted output.

This merge changes this behavior to use regular expression to detect the format specifier (if one exists), and then attempts to apply it to the detected keyword.

Tests are added for this case.