### PR TITLE
promote upload print to be more visible

### DIFF
--- a/lib/ramble/ramble/experimental/uploader.py
+++ b/lib/ramble/ramble/experimental/uploader.py
@@ -146,7 +146,7 @@ def upload_results(results):
         logger.warn("No data to upload")
         return
 
-    logger.msg(f"Uploading results to {uri} with {uploader_type} uploader")
+    logger.all_msg(f"Uploading results to {uri} with {uploader_type} uploader")
     if uploader_type == uploader_types.BigQuery:
         uploader = BigQueryUploader()
     else:


### PR DESCRIPTION
Better matches the `logger.all_msg("Results are written to:")` we have for analyze output