### PR TITLE
Enable push to cache to push compilers

### DIFF
--- a/lib/ramble/ramble/util/command_runner.py
+++ b/lib/ramble/ramble/util/command_runner.py
@@ -51,7 +51,9 @@ class CommandRunner:
         """
         self.dry_run = dry_run
 
-    def execute(self, executable, args: List[str], return_output: bool = False):
+    def execute(
+        self, executable, args: List[str], allow_failure: bool = False, return_output: bool = False
+    ):
         """Wrapper around execution of a command
 
         Handles execution of a command when the execution path is dependent on
@@ -63,7 +65,9 @@ class CommandRunner:
             return_output (bool): Whether the output of the command should be returned or not
         """
         if not self.dry_run:
-            return self._run_command(executable, args, return_output=return_output)
+            return self._run_command(
+                executable, args, allow_failure=allow_failure, return_output=return_output
+            )
         else:
             return self._dry_run_print(executable, args, return_output=return_output)
 
@@ -115,12 +119,13 @@ class CommandRunner:
         logger.msg(banner)
         logger.msg("")
 
-    def _run_command(self, executable, args, return_output=False):
+    def _run_command(self, executable, args, allow_failure=False, return_output=False):
         """Perform execution of executable with args, and optionally return the output
 
         Args:
             executable (spack.util.executable.Executable): Executable to run with arguments
             args (list(str)): List of string arguments to pass into executable
+            allow_failure (bool): Whether a failure in the command should be tolerated
             return_output (bool): Whether the output of the command should be returned or not
 
         Returns:
@@ -144,8 +149,9 @@ class CommandRunner:
                 else:
                     executable(*args, output=active_stream, error=active_stream)
         except ProcessError as e:
-            logger.error(e)
-            error = True
+            if not allow_failure:
+                logger.error(e)
+                error = True
             pass
 
         if error:

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
@@ -344,8 +344,23 @@ class SpackLightweight(PackageManagerBase):
             self.runner.set_env(env_path, require_exists=env_required)
             self.runner.activate()
 
-            self.runner.push_to_spack_cache(workspace.spack_cache_path)
+            app_context = self.app_inst.expander.expand_var_name(
+                self.keywords.env_name
+            )
+            software_envs = workspace.software_environments
+            require_env = self.environment_required()
+            software_env = software_envs.render_environment(
+                app_context, self.app_inst.expander, self, require=require_env
+            )
+            compiler_specs = software_envs.compiler_specs_for_environment(
+                software_env
+            )
 
+            self.runner.push_to_spack_cache(
+                workspace.spack_cache_path, compiler_specs
+            )
+
+            # push_to_spack_cache deactivates env, this is here for safety.
             self.runner.deactivate()
         except RunnerError as e:
             if self.environment_required():
@@ -1190,28 +1205,39 @@ class SpackRunner(CommandRunner):
         )
         return output
 
-    def push_to_spack_cache(self, spack_cache_path):
+    def push_to_spack_cache(self, spack_cache_path, compiler_specs):
         """Push packages for a given env to the spack cache"""
         self._check_active()
 
         hash_list = self.get_env_hash_list()
 
-        args = ["buildcache", "push"]
+        base_args = ["buildcache", "push"]
         user_flags = ramble.config.get(f"{self.buildcache_config_name}:flags")
 
         logger.debug(f"Running with user flags: {user_flags}")
 
         if user_flags is not None:
-            args.extend(shlex.split(user_flags))
+            base_args.extend(shlex.split(user_flags))
 
-        args.extend([spack_cache_path, hash_list])
+        base_args.extend([spack_cache_path])
 
-        out_str = self.execute(self.spack, args, return_output=True)
+        args = base_args.copy()
+        args.extend([hash_list])
 
-        if out_str is None:
-            out_str = "None"
+        self.execute(self.spack, args, return_output=True)
 
-        return out_str.strip()
+        # Attempt to push compilers too
+        self.deactivate()  # need to not be in env to find the user compiler
+
+        for compiler_spec in compiler_specs:
+            tty.debug("Pushing " + compiler_spec)
+            args = base_args.copy()
+            args.append(compiler_spec)
+
+            # We cannot push system/extern compilers, so this call must tolerate failures
+            self.execute(
+                self.spack, args, allow_failure=True, return_output=True
+            )
 
     def validate_command(
         self,


### PR DESCRIPTION
This also changes functionality around running external commands to allow failures and avoid calling `logger.die`

```
self._run_command(executable, args, allow_failure=allow_failure,
```

It's possible this should generally be re-written to throw exceptions not call `logger.die` intstead