### PR TITLE
Tiny up printing around software packages

### DIFF
--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1557,6 +1557,16 @@ ramble:
 
         create_symlink(out_file, latest_file)
 
+    def write_software_info(self, f, exp):
+        f.write("  Software definitions:\n")
+        for package_manager, packages in exp["SOFTWARE"].items():
+            f.write(f"    {package_manager} packages:\n")
+            if not packages:
+                f.write("      None\n")
+            else:
+                for pkg in packages:
+                    f.write(f"      {pkg['name']} @{pkg['version']}\n")
+
     def dump_results(self, output_formats=None, print_results=False, summary_only=False):
         """
         Write out result file in desired format
@@ -1600,6 +1610,8 @@ ramble:
                         if "TAGS" in exp:
                             f.write(f'  Tags = {exp["TAGS"]}\n')
 
+                        software_key = ramble.experiment_result._OUTPUT_MAPPING["software"]
+
                         if exp["N_REPEATS"] > 0:  # this is a base exp with summary of repeats
                             for context in exp["CONTEXTS"]:
                                 f.write(f'  {context["display_name"]} figures of merit:\n')
@@ -1621,13 +1633,8 @@ ramble:
                                     for fom_val in fom_val_list:
                                         f.write(f"      {fom_val.strip()}\n")
 
-                            # Print software section if it contains info
-                            if "SOFTWARE" in exp and exp["SOFTWARE"]:
-                                f.write("  Software definitions:\n")
-                                for package_manager, packages in exp["SOFTWARE"].items():
-                                    f.write(f"    {package_manager} packages:\n")
-                                    for pkg in packages:
-                                        f.write(f"      {pkg['name']} @{pkg['version']}\n")
+                            if software_key in exp and exp[software_key]:
+                                self.write_software_info(f, exp)
 
                         else:
                             for context in exp["CONTEXTS"]:
@@ -1642,13 +1649,8 @@ ramble:
                                     output = "{} = {} {}".format(name, fom["value"], fom["units"])
                                     f.write("    %s\n" % (output.strip()))
 
-                            # Print software section if it contains info
-                            if "SOFTWARE" in exp and exp["SOFTWARE"]:
-                                f.write("  Software definitions:\n")
-                                for package_manager, packages in exp["SOFTWARE"].items():
-                                    f.write(f"    {package_manager} packages:\n")
-                                    for pkg in packages:
-                                        f.write(f"      {pkg['name']} @{pkg['version']}\n")
+                            if software_key in exp and exp[software_key]:
+                                self.write_software_info(f, exp)
 
                 else:
                     logger.msg("No results to write")


### PR DESCRIPTION
This PR fixes two things:

1. Duplicated code in workspace that outputs software info
2. Adds code to handle the case where packages are empty