### PR TITLE
Fix bug with trailing space in executable template

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -1168,7 +1168,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
                         expanded_cmd = self.expander.expand_var(command_part, exec_vars)
                         suffix_cmd = self.expander.expand_var(suffix_part, exec_vars).lstrip()
 
-                        self._command_list.append(expanded_cmd + " " + suffix_cmd)
+                        self._command_list.append((expanded_cmd + " " + suffix_cmd).rstrip())
                         self._command_list_without_logs.append(expanded_cmd)
 
             else:  # All Builtins

--- a/lib/ramble/ramble/test/end_to_end/test_template.py
+++ b/lib/ramble/ramble/test/end_to_end/test_template.py
@@ -116,3 +116,40 @@ ramble:
 
     script_path = os.path.join(ws.shared_dir, "script.sh")
     assert os.path.isfile(script_path)
+
+
+def test_executable_templates_no_trailing_spaces(mutable_mock_apps_repo):
+    test_config = """
+ramble:
+  variables:
+    mpi_command: mpirun -n {n_ranks}
+    batch_submit: 'batch_submit {execute_experiment}'
+    processes_per_node: 1
+  applications:
+    basic:
+      workloads:
+        template_wl:
+          experiments:
+            test:
+              variables:
+                n_ranks: '1'
+  software:
+    packages: {}
+    environments: {}
+"""
+    workspace_name = "test_executable_templates_no_trailing_spaces"
+    ws = ramble.workspace.create(workspace_name)
+    ws.write()
+    config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+    with open(config_path, "w+") as f:
+        f.write(test_config)
+    ws._re_read()
+
+    workspace("setup", "--dry-run", global_args=["-w", workspace_name])
+    run_dir = os.path.join(ws.experiment_dir, "basic/template_wl/test/")
+    execute_path = os.path.join(run_dir, "execute_experiment")
+
+    with open(execute_path) as f:
+        content = f.read()
+        assert "EOF" in content
+        assert "EOF " not in content

--- a/var/ramble/repos/builtin.mock/applications/basic/application.py
+++ b/var/ramble/repos/builtin.mock/applications/basic/application.py
@@ -15,6 +15,12 @@ class Basic(ExecutableApplication):
     executable("foo", "bar", use_mpi=False)
     executable("bar", "baz", use_mpi=True)
     executable("echo", 'echo "0.25 seconds"', use_mpi=False)
+    executable(
+        "template",
+        template=["cat <<EOF> filename", "command", "EOF"],
+        redirect="",
+        output_capture="",
+    )
 
     input_file(
         "input",
@@ -26,6 +32,7 @@ class Basic(ExecutableApplication):
     workload("test_wl", executable="foo", input="input")
     workload("test_wl2", executable="bar", input="input")
     workload("working_wl", executable="echo")
+    workload("template_wl", executable="template")
 
     workload_variable(
         "my_base_var",


### PR DESCRIPTION
Fixes a bug that caused `cat <<EOF> filename ... EOF` in an execute script to break by inserting a trailing space on each line. An application.py used the template argument in an executable to generate contents of a local file that the execute_experiment script would then write.