### PR TITLE
decouple meaning of RAMBLE_STATUS and experiment_status

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -2309,19 +2309,29 @@ class ApplicationBase(metaclass=ApplicationMeta):
             with lk.ReadTransaction(exp_lock):
                 with open(status_path) as f:
                     status_data = spack.util.spack_json.load(f)
-                self.variables[self.keywords.experiment_status] = ExperimentStatus(
-                    status_data[self.keywords.experiment_status]
-                )
+                    self.set_status(ExperimentStatus(status_data[self.keywords.experiment_status]))
         else:
             self.set_status(ExperimentStatus.UNKNOWN)
 
     def set_status(self, status=ExperimentStatus.UNKNOWN):
         """Set the status of this experiment"""
         self.variables[self.keywords.experiment_status] = status
+        self.set_ramble_status(status)
 
     def get_status(self):
         """Get the status of this experiment"""
         return self.variables[self.keywords.experiment_status]
+
+    def get_ramble_status(self):
+        """Get the RAMBLE_STATUS of this experiment (boolifyied status)"""
+        return self.variables[self.keywords.RAMBLE_STATUS]
+
+    def set_ramble_status(self, status):
+        """Set the RAMBLE_STATUS (boolifyied status) of this experiment"""
+
+        self.variables[self.keywords.RAMBLE_STATUS] = status
+        if status != ExperimentStatus.SUCCESS:
+            self.variables[self.keywords.RAMBLE_STATUS] = ExperimentStatus.FAILED
 
     register_phase("write_status", pipeline="analyze", run_after=["analyze_experiments"])
     register_phase("write_status", pipeline="setup", run_after=["make_experiments"])

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -2027,9 +2027,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
                             repeat_foms[context_name][fom_key]["fom_values"].append(fom["value"])
 
         # Iterate through the aggregated foms, calculate stats, and insert into results
-        print(repeat_foms)
         for context, fom_dict in repeat_foms.items():
-            print(fom_dict)
             if not fom_dict:
                 continue
 
@@ -2054,7 +2052,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
                 summary_foms.append(n_total_dict)
 
                 n_success = exp_status_list.count(ExperimentStatus.SUCCESS)
-                print(n_success)
+
                 n_success_dict = {
                     "value": n_success,
                     "units": "repeats",
@@ -2306,9 +2304,9 @@ class ApplicationBase(metaclass=ApplicationMeta):
             with lk.ReadTransaction(exp_lock):
                 with open(status_path) as f:
                     status_data = spack.util.spack_json.load(f)
-                self.variables[self.keywords.experiment_status] = status_data[
-                    self.keywords.experiment_status
-                ]
+                self.variables[self.keywords.experiment_status] = ExperimentStatus(
+                    status_data[self.keywords.experiment_status]
+                )
         else:
             self.set_status(ExperimentStatus.UNKNOWN)
 

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -17,7 +17,6 @@ import stat
 import string
 import textwrap
 import time
-from enum import Enum
 from typing import List
 
 import llnl.util.filesystem as fs
@@ -47,7 +46,7 @@ import ramble.util.stats
 import ramble.variants
 import ramble.workflow_manager
 from ramble.error import RambleError
-from ramble.experiment_result import ExperimentResult
+from ramble.experiment_result import ExperimentResult, ExperimentStatus
 from ramble.language.application_language import ApplicationMeta
 from ramble.language.shared_language import SharedMeta, register_builtin, register_phase
 from ramble.util import conversions
@@ -61,24 +60,6 @@ from ramble.workspace import namespace
 import spack.util.compression
 import spack.util.executable
 import spack.util.spack_json
-
-experiment_status = Enum(
-    "experiment_status",
-    [
-        "UNKNOWN",
-        "UNQUEUED",
-        # unresolved means the status is not fetched successfully
-        "UNRESOLVED",
-        "SETUP",
-        "SUBMITTED",
-        "RUNNING",
-        "COMPLETE",
-        "SUCCESS",
-        "FAILED",
-        "CANCELLED",
-        "TIMEOUT",
-    ],
-)
 
 _NULL_CONTEXT = "null"
 
@@ -1498,7 +1479,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
             experiment_script = workspace.experiments_script
             experiment_script.write(self.expander.expand_var("{batch_submit}\n"))
 
-        self.set_status(status=experiment_status.SETUP)
+        self.set_status(status=ExperimentStatus.SETUP)
 
     def _clean_hash_variables(self, workspace, variables):
         """Cleanup variables to hash before computing the hash
@@ -1730,7 +1711,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
         injected in a workspace config.
         """
 
-        if self.get_status() == experiment_status.UNKNOWN.name and not workspace.dry_run:
+        if self.get_status() == ExperimentStatus.UNKNOWN and not workspace.dry_run:
             logger.warn(f"Experiment has status {self.get_status()}. Skipping analysis..\n")
             return
 
@@ -1856,16 +1837,17 @@ class ApplicationBase(metaclass=ApplicationMeta):
                     success = True
         success = success and criteria_list.passed()
 
-        status = experiment_status.SUCCESS if success else experiment_status.FAILED
+        status = ExperimentStatus.SUCCESS if success else self.get_status()
         # When workflow_manager is present, only use app_status when workflow is completed or
         # unresolved.
         if self.workflow_manager is not None:
             wm_status = self.workflow_manager.get_status(workspace)
             if not (
                 wm_status is None
-                or wm_status in [experiment_status.COMPLETE, experiment_status.UNRESOLVED]
+                or wm_status in [ExperimentStatus.COMPLETE, ExperimentStatus.UNRESOLVED]
             ):
                 status = wm_status
+
         self.set_status(status)
 
         self._init_result()
@@ -1975,20 +1957,20 @@ class ApplicationBase(metaclass=ApplicationMeta):
             exp_status_list.append(exp_inst.get_status())
 
         if workspace.repeat_success_strict:
-            if experiment_status.FAILED.name in exp_status_list:
+            if ExperimentStatus.FAILED in exp_status_list:
                 repeat_success = False
             else:
                 repeat_success = True
         else:
-            if experiment_status.SUCCESS.name in exp_status_list:
+            if ExperimentStatus.SUCCESS in exp_status_list:
                 repeat_success = True
             else:
                 repeat_success = False
 
         if repeat_success:
-            self.set_status(status=experiment_status.SUCCESS)
+            self.set_status(status=ExperimentStatus.SUCCESS)
         else:
-            self.set_status(status=experiment_status.FAILED)
+            self.set_status(status=ExperimentStatus.FAILED)
 
         self._init_result()
 
@@ -2008,7 +1990,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
                 continue
 
             # When strict success is off for repeats (loose success), skip failed exps
-            if exp_inst.result.status == experiment_status.FAILED.name:
+            if exp_inst.result.status == ExperimentStatus.FAILED:
                 continue
 
             if exp_inst.result.contexts:
@@ -2045,7 +2027,9 @@ class ApplicationBase(metaclass=ApplicationMeta):
                             repeat_foms[context_name][fom_key]["fom_values"].append(fom["value"])
 
         # Iterate through the aggregated foms, calculate stats, and insert into results
+        print(repeat_foms)
         for context, fom_dict in repeat_foms.items():
+            print(fom_dict)
             if not fom_dict:
                 continue
 
@@ -2069,7 +2053,8 @@ class ApplicationBase(metaclass=ApplicationMeta):
                 }
                 summary_foms.append(n_total_dict)
 
-                n_success = exp_status_list.count(experiment_status.SUCCESS.name)
+                n_success = exp_status_list.count(ExperimentStatus.SUCCESS)
+                print(n_success)
                 n_success_dict = {
                     "value": n_success,
                     "units": "repeats",
@@ -2310,7 +2295,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
 
         Set this experiment's status based on the status file in the experiment
         run directory, if it exists. If it doesn't exist, set its status to
-        experiment_status.UNKNOWN
+        ExperimentStatus.UNKNOWN
         """
         status_path = os.path.join(
             self.expander.expand_var_name(self.keywords.experiment_run_dir), self._status_file_name
@@ -2325,11 +2310,11 @@ class ApplicationBase(metaclass=ApplicationMeta):
                     self.keywords.experiment_status
                 ]
         else:
-            self.set_status(experiment_status.UNKNOWN)
+            self.set_status(ExperimentStatus.UNKNOWN)
 
-    def set_status(self, status=experiment_status.UNKNOWN):
+    def set_status(self, status=ExperimentStatus.UNKNOWN):
         """Set the status of this experiment"""
-        self.variables[self.keywords.experiment_status] = status.name
+        self.variables[self.keywords.experiment_status] = status
 
     def get_status(self):
         """Get the status of this experiment"""

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -1837,7 +1837,12 @@ class ApplicationBase(metaclass=ApplicationMeta):
                     success = True
         success = success and criteria_list.passed()
 
-        status = ExperimentStatus.SUCCESS if success else self.get_status()
+        status = self.get_status()
+        if status == ExperimentStatus.SUCCESS and not success:
+            status = ExperimentStatus.FAILED
+        elif success:
+            status = ExperimentStatus.SUCCESS
+
         # When workflow_manager is present, only use app_status when workflow is completed or
         # unresolved.
         if self.workflow_manager is not None:

--- a/lib/ramble/ramble/experiment_result.py
+++ b/lib/ramble/ramble/experiment_result.py
@@ -6,7 +6,25 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+from enum import Enum
+
 from ramble.namespace import namespace
+
+
+# Can use auto() once we're at >= python 3.11
+class ExperimentStatus(str, Enum):
+    UNKNOWN = "UNKNOWN"
+    UNQUEUED = "UNQUEUED"
+    UNRESOLVED = "UNRESOLVED"  # unresolved means the status is not fetched successfully
+    SETUP = "SETUP"
+    SUBMITTED = "SUBMITTED"
+    RUNNING = "RUNNING"
+    COMPLETE = "COMPLETE"
+    SUCCESS = "SUCCESS"
+    FAILED = "FAILED"
+    CANCELLED = "CANCELLED"
+    TIMEOUT = "TIMEOUT"
+
 
 _OUTPUT_MAPPING = {
     "name": "name",
@@ -29,7 +47,13 @@ class ExperimentResult:
     def __init__(self, app_inst):
         """Build up the result from the given app instance"""
         self.name = app_inst.expander.experiment_namespace
+
+        # This value is passed to us with an enum of values. Here we want to
+        # make it FAILED/SUCCESS
         self.status = app_inst.get_status()
+        if self.status != ExperimentStatus.SUCCESS:
+            self.status = ExperimentStatus.FAILED
+
         self.n_repeats = app_inst.repeats.n_repeats
         self.experiment_chain = app_inst.chain_order.copy()
         self.tags = list(app_inst.experiment_tags)

--- a/lib/ramble/ramble/experiment_result.py
+++ b/lib/ramble/ramble/experiment_result.py
@@ -28,7 +28,6 @@ class ExperimentStatus(str, Enum):
 
 _OUTPUT_MAPPING = {
     "name": "name",
-    "status": "RAMBLE_STATUS",
     namespace.n_repeats: "N_REPEATS",
     "keys": "keys",
     "contexts": "CONTEXTS",
@@ -48,11 +47,7 @@ class ExperimentResult:
         """Build up the result from the given app instance"""
         self.name = app_inst.expander.experiment_namespace
 
-        # This value is passed to us with an enum of values. Here we want to
-        # make it FAILED/SUCCESS
-        self.status = app_inst.get_status()
-        if self.status != ExperimentStatus.SUCCESS:
-            self.status = ExperimentStatus.FAILED
+        self.status = app_inst.get_ramble_status()
 
         # Most libs can handle this str enum, but convert it to help out
         self.status = self.status.value

--- a/lib/ramble/ramble/experiment_result.py
+++ b/lib/ramble/ramble/experiment_result.py
@@ -54,6 +54,9 @@ class ExperimentResult:
         if self.status != ExperimentStatus.SUCCESS:
             self.status = ExperimentStatus.FAILED
 
+        # Most libs can handle this str enum, but convert it to help out
+        self.status = self.status.value
+
         self.n_repeats = app_inst.repeats.n_repeats
         self.experiment_chain = app_inst.chain_order.copy()
         self.tags = list(app_inst.experiment_tags)

--- a/lib/ramble/ramble/keywords.py
+++ b/lib/ramble/ramble/keywords.py
@@ -31,6 +31,7 @@ default_keys = {
     "experiment_hash": {"type": key_type.reserved, "level": output_level.key},
     "experiment_run_dir": {"type": key_type.reserved, "level": output_level.variable},
     "experiment_status": {"type": key_type.reserved, "level": output_level.key},
+    "RAMBLE_STATUS": {"type": key_type.reserved, "level": output_level.key},
     "experiment_index": {"type": key_type.reserved, "level": output_level.variable},
     "experiment_namespace": {"type": key_type.reserved, "level": output_level.key},
     "simplified_experiment_namespace": {"type": key_type.reserved, "level": output_level.key},

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -264,7 +264,7 @@ class AnalyzePipeline(Pipeline):
         no_analyze_cnt = 0
         for _, app_inst, _ in self._experiment_set.filtered_experiments(self.filters):
             if not (app_inst.is_template or app_inst.repeats.is_repeat_base):
-                if app_inst.get_status() != ramble.application.experiment_status.UNKNOWN.name:
+                if app_inst.get_status() != ramble.application.ExperimentStatus.UNKNOWN:
                     found_valid_experiment = True
             else:
                 no_analyze_cnt += 1

--- a/lib/ramble/ramble/test/experiment_result.py
+++ b/lib/ramble/ramble/test/experiment_result.py
@@ -18,7 +18,7 @@ def test_to_dict(mutable_mock_apps_repo):
     res_dict = exp_res.to_dict()
     assert "name" in res_dict
     assert "application_name" in res_dict
-    assert res_dict["RAMBLE_STATUS"] == "Unknown"
+    assert res_dict["RAMBLE_STATUS"] == "FAILED"
     assert res_dict["RAMBLE_RAW_VARIABLES"]["experiment_status"] == "Unknown"
     assert "EXPERIMENT_CHAIN" in res_dict
     assert "CONTEXTS" in res_dict

--- a/lib/ramble/ramble/test/experiment_result.py
+++ b/lib/ramble/ramble/test/experiment_result.py
@@ -13,13 +13,15 @@ from ramble.experiment_result import ExperimentResult
 
 def test_to_dict(mutable_mock_apps_repo):
     basic_app_inst = mutable_mock_apps_repo.get("basic")
-    basic_app_inst.set_variables({"experiment_status": "Unknown", "test_var": "my_var"}, None)
+    basic_app_inst.set_variables({"experiment_status": "placeholder", "test_var": "my_var"}, None)
+    basic_app_inst.set_status("UNKNOWN")
     exp_res = ExperimentResult(basic_app_inst)
     res_dict = exp_res.to_dict()
+
     assert "name" in res_dict
     assert "application_name" in res_dict
     assert res_dict["RAMBLE_STATUS"] == "FAILED"
-    assert res_dict["RAMBLE_RAW_VARIABLES"]["experiment_status"] == "Unknown"
+    assert res_dict["RAMBLE_RAW_VARIABLES"]["experiment_status"] == "UNKNOWN"
     assert "EXPERIMENT_CHAIN" in res_dict
     assert "CONTEXTS" in res_dict
     assert "TAGS" in res_dict

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1606,7 +1606,7 @@ ramble:
                 if "experiments" in results:
                     for exp in results["experiments"]:
                         f.write("Experiment %s figures of merit:\n" % exp["name"])
-                        f.write("  Status = %s\n" % exp["RAMBLE_STATUS"].value)
+                        f.write("  Status = %s\n" % exp["RAMBLE_STATUS"])
                         if "TAGS" in exp:
                             f.write(f'  Tags = {exp["TAGS"]}\n')
 
@@ -1673,8 +1673,22 @@ ramble:
             out_file = os.path.join(self.root, filename_base + file_extension)
             latest_file = os.path.join(self.root, latest_base + file_extension)
             results_written.append(out_file)
+
+            from ruamel.yaml import RoundTripDumper
+
+            class RambleSafeDumper(RoundTripDumper):
+
+                def ignore_aliases(self, _data):
+                    """Make the dumper NEVER print YAML aliases."""
+                    return True
+
+            def call_value(dumper, data):
+                return dumper.represent_data(data.value)
+
+            RambleSafeDumper.add_representer(ramble.experiment_result.ExperimentStatus, call_value)
+
             with open(out_file, "w+") as f:
-                syaml.dump(results, stream=f)
+                syaml.dump(results, stream=f, Dumper=RambleSafeDumper)
 
             symlinks_updated.append(latest_file)
             self.symlink_result(out_file, latest_file)

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1606,7 +1606,7 @@ ramble:
                 if "experiments" in results:
                     for exp in results["experiments"]:
                         f.write("Experiment %s figures of merit:\n" % exp["name"])
-                        f.write("  Status = %s\n" % exp["RAMBLE_STATUS"])
+                        f.write("  Status = %s\n" % exp["RAMBLE_STATUS"].value)
                         if "TAGS" in exp:
                             f.write(f'  Tags = {exp["TAGS"]}\n')
 

--- a/lib/ramble/spack/util/spack_yaml.py
+++ b/lib/ramble/spack/util/spack_yaml.py
@@ -210,9 +210,9 @@ OrderedLineDumper.add_representer(syaml_str, OrderedLineDumper.represent_str)
 maxint = 2 ** (ctypes.sizeof(ctypes.c_int) * 8 - 1) - 1
 
 
-def dump(obj, default_flow_style=False, stream=None):
+def dump(obj, default_flow_style=False, stream=None, Dumper=SafeDumper):
     return yaml.dump(obj, default_flow_style=default_flow_style, width=maxint,
-                     Dumper=SafeDumper, stream=stream)
+                     Dumper=Dumper, stream=stream)
 
 
 def file_line(mark):

--- a/var/ramble/repos/builtin/workflow_managers/google-batch/workflow_manager.py
+++ b/var/ramble/repos/builtin/workflow_managers/google-batch/workflow_manager.py
@@ -10,7 +10,7 @@ import os
 
 import yaml
 
-from ramble.application import experiment_status
+from ramble.application import ExperimentStatus
 from ramble.util import shell_utils
 from ramble.wmkit import *
 
@@ -222,7 +222,7 @@ class GoogleBatch(WorkflowManagerBase):
         expander = self.app_inst.expander
         run_dir = expander.expand_var_name("experiment_run_dir")
         job_file = os.path.join(run_dir, ".batch_job.yaml")
-        status = experiment_status.UNRESOLVED
+        status = ExperimentStatus.UNRESOLVED
         if not os.path.isfile(job_file):
             logger.warn(
                 f"{self.name} job file is missing in experiment {expander.experiment_namespace}"
@@ -239,9 +239,9 @@ class GoogleBatch(WorkflowManagerBase):
         location = expander.expand_var_name("batch_job_region")
         wm_status_raw = self.runner.get_status(project, location, job_name)
         wm_status = _STATUS_MAP.get(wm_status_raw)
-        if wm_status is not None and hasattr(experiment_status, wm_status):
-            status = getattr(experiment_status, wm_status)
-        if status == experiment_status.UNRESOLVED:
+        if wm_status is not None and hasattr(ExperimentStatus, wm_status):
+            status = getattr(ExperimentStatus, wm_status)
+        if status == ExperimentStatus.UNRESOLVED:
             logger.warn(
                 f"The {self.name} workflow manager failed to resolve the status of job {job_name}.\n "
                 "Enable debug mode (`ramble -d`) for more detailed error messages."

--- a/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
@@ -8,7 +8,7 @@
 
 import os
 
-from ramble.application import experiment_status
+from ramble.application import ExperimentStatus
 from ramble.util import shell_utils
 from ramble.wmkit import *
 
@@ -212,7 +212,7 @@ class Slurm(WorkflowManagerBase):
         expander = self.app_inst.expander
         run_dir = expander.expand_var_name("experiment_run_dir")
         job_id_file = os.path.join(run_dir, ".slurm_job")
-        status = experiment_status.UNRESOLVED
+        status = ExperimentStatus.UNRESOLVED
         if not os.path.isfile(job_id_file):
             logger.warn("job_id file is missing")
             return status
@@ -221,9 +221,9 @@ class Slurm(WorkflowManagerBase):
         self.runner.set_dry_run(workspace.dry_run)
         wm_status_raw = self.runner.get_status(job_id)
         wm_status = _STATUS_MAP.get(wm_status_raw)
-        if wm_status is not None and hasattr(experiment_status, wm_status):
-            status = getattr(experiment_status, wm_status)
-        if status == experiment_status.UNRESOLVED:
+        if wm_status is not None and hasattr(ExperimentStatus, wm_status):
+            status = getattr(ExperimentStatus, wm_status)
+        if status == ExperimentStatus.UNRESOLVED:
             logger.warn(
                 f"The slurm workflow manager failed to resolve the status of job {job_id}. "
                 "Enable debug mode (`ramble -d`) for more detailed error messages."


### PR DESCRIPTION
This PR changes the semantics of RAMBLE_STATUS and experiment_status in the analyze output 

Previously they had the identical bool (FAILED/SUCCESS) value. This change makes `experiment_status` able to retain it's value for unsuccessful experiments (so you can see if they were cancelled, etc)

eg:

```
7457       "RAMBLE_STATUS": "FAILED",
7458       "N_REPEATS": 0,
7459       "application_name": "osu-micro-benchmarks",
7460       "application_namespace": "osu-micro-benchmarks",
7461       "simplified_application_namespace": "osu-micro-benchmarks",
7462       "workload_name": "osu_mbw_mr",
7463       "workload_namespace": "osu-micro-benchmarks.osu_mbw_mr",
7464       "simplified_workload_namespace": "osu-micro-benchmarks-osu-mbw-mr",
7465       "experiments_file": "/Users/robertbird/ramble/var/ramble/workspaces/osu_mbw_mr/all_experiments",
7466       "experiment_name": "h3_2_88.5",
7467       "experiment_hash": "cdd0c44c209e9ad6a845d5233128eff4e8628b63e0b176eaa912e89b900d82fc",
7468       "experiment_status": "SETUP",
```