### PR TITLE
Add basic test coverage for local deployments

### DIFF
--- a/lib/ramble/ramble/test/cmd/deployment.py
+++ b/lib/ramble/ramble/test/cmd/deployment.py
@@ -1,0 +1,83 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+import sys
+
+import pytest
+
+import llnl.util.filesystem as fs
+
+import ramble.config
+import ramble.workspace
+from ramble.error import RambleCommandError
+from ramble.main import RambleCommand
+
+import spack.util.url
+
+deployment = RambleCommand("deployment")
+workspace = RambleCommand("workspace")
+
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+
+pytestmark = pytest.mark.usefixtures(
+    "mutable_config",
+    "mutable_mock_workspace_path",
+)
+
+
+def test_local_push(mutable_config, mutable_mock_workspace_path):
+
+    workspace_name = "test_manage_software"
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+
+        config_path = ws.config_file_path
+
+        workspace(
+            "manage",
+            "experiments",
+            "wrfv4",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            "-p",
+            "spack",
+            global_args=["-w", workspace_name],
+        )
+        workspace("concretize", global_args=["-w", workspace_name])
+
+        ws._re_read()
+
+        deployment(
+            "push",
+            global_args=["-w", workspace_name],
+        )
+
+        deployment_dir = os.path.join(ws.root, "deployments")
+        this_deployment_dir = os.path.join(deployment_dir, workspace_name)
+
+        configs_dir = os.path.join(this_deployment_dir, "configs")
+        tpl = os.path.join(configs_dir, "execute_experiment.tpl")
+        yaml = os.path.join(configs_dir, "ramble.yaml")
+
+        object_dir = os.path.join(this_deployment_dir, "object_repo")
+        spack_pm = os.path.join(
+            object_dir, "package_managers", "spack-lightweight", "package_manager.py"
+        )
+        wrf_app = os.path.join(object_dir, "applications", "wrfv4", "application.py")
+        wrf_pkg = os.path.join(object_dir, "packages", "wrf", "package.py")
+
+        dir_list = [deployment_dir, this_deployment_dir, configs_dir, object_dir]
+        for d in dir_list:
+            assert os.path.isdir(d)
+
+        file_list = [tpl, yaml, spack_pm, wrf_app, wrf_pkg]
+        for f in file_list:
+            assert os.path.isfile(f)

--- a/lib/ramble/ramble/test/cmd/deployment.py
+++ b/lib/ramble/ramble/test/cmd/deployment.py
@@ -11,14 +11,9 @@ import sys
 
 import pytest
 
-import llnl.util.filesystem as fs
-
 import ramble.config
 import ramble.workspace
-from ramble.error import RambleCommandError
 from ramble.main import RambleCommand
-
-import spack.util.url
 
 deployment = RambleCommand("deployment")
 workspace = RambleCommand("workspace")
@@ -31,9 +26,31 @@ pytestmark = pytest.mark.usefixtures(
 )
 
 
-def test_local_push(mutable_config, mutable_mock_workspace_path):
+def check_deployment_files(root):
+    configs_dir = os.path.join(root, "configs")
+    tpl = os.path.join(configs_dir, "execute_experiment.tpl")
+    yaml = os.path.join(configs_dir, "ramble.yaml")
 
-    workspace_name = "test_manage_software"
+    object_dir = os.path.join(root, "object_repo")
+    spack_pm = os.path.join(
+        object_dir, "package_managers", "spack-lightweight", "package_manager.py"
+    )
+    wrf_app = os.path.join(object_dir, "applications", "wrfv4", "application.py")
+    wrf_pkg = os.path.join(object_dir, "packages", "wrf", "package.py")
+
+    dir_list = [root, root, configs_dir, object_dir]
+    for d in dir_list:
+        assert os.path.isdir(d)
+
+    file_list = [tpl, yaml, spack_pm, wrf_app, wrf_pkg]
+    for f in file_list:
+        assert os.path.isfile(f)
+
+
+def test_local_deployment(mutable_config, mutable_mock_workspace_path):
+
+    workspace_name = "test_local_deployment"
+    deployment_dir = ""
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 
@@ -63,21 +80,22 @@ def test_local_push(mutable_config, mutable_mock_workspace_path):
         deployment_dir = os.path.join(ws.root, "deployments")
         this_deployment_dir = os.path.join(deployment_dir, workspace_name)
 
-        configs_dir = os.path.join(this_deployment_dir, "configs")
-        tpl = os.path.join(configs_dir, "execute_experiment.tpl")
-        yaml = os.path.join(configs_dir, "ramble.yaml")
+        check_deployment_files(this_deployment_dir)
 
-        object_dir = os.path.join(this_deployment_dir, "object_repo")
-        spack_pm = os.path.join(
-            object_dir, "package_managers", "spack-lightweight", "package_manager.py"
+    workspace_name = "test_local_pull"
+    with ramble.workspace.create(workspace_name) as ws:
+        deployment(
+            "pull",
+            "-p",
+            os.path.join(deployment_dir, "test_local_deployment"),
+            global_args=["-w", workspace_name],
         )
-        wrf_app = os.path.join(object_dir, "applications", "wrfv4", "application.py")
-        wrf_pkg = os.path.join(object_dir, "packages", "wrf", "package.py")
+        config_path = ws.config_file_path
 
-        dir_list = [deployment_dir, this_deployment_dir, configs_dir, object_dir]
-        for d in dir_list:
-            assert os.path.isdir(d)
+        with open(config_path) as f:
+            content = f.read()
+            # Check that wrf has a package, and the package is in an environment
+            assert "pkg_spec: wrf" in content
+            assert "- wrfv4" in content
 
-        file_list = [tpl, yaml, spack_pm, wrf_app, wrf_pkg]
-        for f in file_list:
-            assert os.path.isfile(f)
+        check_deployment_files(ws.root)

--- a/lib/ramble/ramble/test/cmd/deployment.py
+++ b/lib/ramble/ramble/test/cmd/deployment.py
@@ -26,7 +26,7 @@ pytestmark = pytest.mark.usefixtures(
 )
 
 
-def check_deployment_files(root):
+def check_deployment_files(root, app_name):
     configs_dir = os.path.join(root, "configs")
     tpl = os.path.join(configs_dir, "execute_experiment.tpl")
     yaml = os.path.join(configs_dir, "ramble.yaml")
@@ -35,8 +35,8 @@ def check_deployment_files(root):
     spack_pm = os.path.join(
         object_dir, "package_managers", "spack-lightweight", "package_manager.py"
     )
-    app = os.path.join(object_dir, "applications", "gromacs", "application.py")
-    pkg = os.path.join(object_dir, "packages", "gromacs", "package.py")
+    app = os.path.join(object_dir, "applications", app_name, "application.py")
+    pkg = os.path.join(object_dir, "packages", app_name, "package.py")
 
     dir_list = [root, root, configs_dir, object_dir]
     for d in dir_list:
@@ -50,6 +50,8 @@ def check_deployment_files(root):
 def test_local_deployment(mutable_config, mutable_mock_workspace_path):
 
     workspace_name = "test_local_deployment"
+    app_name = "namd"
+
     deployment_dir = ""
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
@@ -59,7 +61,7 @@ def test_local_deployment(mutable_config, mutable_mock_workspace_path):
         workspace(
             "manage",
             "experiments",
-            "gromacs",
+            app_name,
             "-v",
             "n_ranks=1",
             "-v",
@@ -80,7 +82,7 @@ def test_local_deployment(mutable_config, mutable_mock_workspace_path):
         deployment_dir = os.path.join(ws.root, "deployments")
         this_deployment_dir = os.path.join(deployment_dir, workspace_name)
 
-        check_deployment_files(this_deployment_dir)
+        check_deployment_files(this_deployment_dir, app_name)
 
     workspace_name = "test_local_pull"
     with ramble.workspace.create(workspace_name) as ws:
@@ -95,6 +97,6 @@ def test_local_deployment(mutable_config, mutable_mock_workspace_path):
         with open(config_path) as f:
             content = f.read()
             # Check that the app has a package, and the package is in an environment
-            assert "pkg_spec: gromacs" in content
+            assert f"pkg_spec: {app_name}" in content
 
-        check_deployment_files(ws.root)
+        check_deployment_files(ws.root, app_name)

--- a/lib/ramble/ramble/test/cmd/deployment.py
+++ b/lib/ramble/ramble/test/cmd/deployment.py
@@ -35,14 +35,14 @@ def check_deployment_files(root):
     spack_pm = os.path.join(
         object_dir, "package_managers", "spack-lightweight", "package_manager.py"
     )
-    wrf_app = os.path.join(object_dir, "applications", "wrfv4", "application.py")
-    wrf_pkg = os.path.join(object_dir, "packages", "wrf", "package.py")
+    app = os.path.join(object_dir, "applications", "gromacs", "application.py")
+    pkg = os.path.join(object_dir, "packages", "gromacs", "package.py")
 
     dir_list = [root, root, configs_dir, object_dir]
     for d in dir_list:
         assert os.path.isdir(d)
 
-    file_list = [tpl, yaml, spack_pm, wrf_app, wrf_pkg]
+    file_list = [tpl, yaml, spack_pm, app, pkg]
     for f in file_list:
         assert os.path.isfile(f)
 
@@ -59,7 +59,7 @@ def test_local_deployment(mutable_config, mutable_mock_workspace_path):
         workspace(
             "manage",
             "experiments",
-            "wrfv4",
+            "gromacs",
             "-v",
             "n_ranks=1",
             "-v",
@@ -94,8 +94,7 @@ def test_local_deployment(mutable_config, mutable_mock_workspace_path):
 
         with open(config_path) as f:
             content = f.read()
-            # Check that wrf has a package, and the package is in an environment
-            assert "pkg_spec: wrf" in content
-            assert "- wrfv4" in content
+            # Check that the app has a package, and the package is in an environment
+            assert "pkg_spec: gromacs" in content
 
         check_deployment_files(ws.root)


### PR DESCRIPTION
This is not ready for merge, since finding this bug we want to make some changed to the workflow manager first (but the test content is still valuable)

This relies on a bug fix from #980 and thus that should be merged first