### PR TITLE
Add generated object lists to documentation

### DIFF
--- a/lib/ramble/docs/application_list.rst
+++ b/lib/ramble/docs/application_list.rst
@@ -1,0 +1,20 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+.. _application-list:
+
+================
+Application List
+================
+
+This is a list of applications you can create experiments for using Ramble.  It is
+automatically generated based on the applications in this Ramble
+version.
+
+.. raw:: html
+   :file: application_list.html

--- a/lib/ramble/docs/base_application_list.rst
+++ b/lib/ramble/docs/base_application_list.rst
@@ -1,0 +1,20 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+.. _base-application-list:
+
+================
+Base Application List
+================
+
+This is a list of base applications you can inherit from within other  for using Ramble.  It is
+automatically generated based on the base applications in this Ramble
+version.
+
+.. raw:: html
+   :file: base_application_list.html

--- a/lib/ramble/docs/base_modifiers_list.rst
+++ b/lib/ramble/docs/base_modifiers_list.rst
@@ -1,0 +1,20 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+.. _base-modifier-list:
+
+================
+Base Modifier List
+================
+
+This is a list of base modifiers you can inherit from when creating new
+modifiers for use in Ramble. This list is automatically generated based on the
+base modifiers in this Ramble version.
+
+.. raw:: html
+   :file: base_modifier_list.html

--- a/lib/ramble/docs/base_package_manager_list.rst
+++ b/lib/ramble/docs/base_package_manager_list.rst
@@ -1,0 +1,20 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+.. _base-package-manager-list:
+
+=========================
+Base Package Manager List
+=========================
+
+This is a list of base package managers that can be inherited from when
+creating new package managers within Ramble.  It is automatically generated
+based on the package managers in this Ramble version.
+
+.. raw:: html
+   :file: base_package_manager_list.html

--- a/lib/ramble/docs/base_workflow_manager_list.rst
+++ b/lib/ramble/docs/base_workflow_manager_list.rst
@@ -1,0 +1,20 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+.. _base-workflow-manager-list:
+
+==========================
+Base Workflow Manager List
+==========================
+
+This is a list of base workflow managers you can inherit from when creating new
+workflow managers within Ramble.  It is automatically generated based on the
+base workflow managers in this Ramble version.
+
+.. raw:: html
+   :file: base_workflow_manager_list.html

--- a/lib/ramble/docs/conf.py
+++ b/lib/ramble/docs/conf.py
@@ -45,7 +45,21 @@ os.environ["COLIFY_SIZE"] = "25x120"
 os.environ["COLUMNS"] = "120"
 
 # Generate full package list if needed
-subprocess.call(["ramble", "list", "--format=html", "--update=package_list.html"])
+object_types = [
+    ("applications", "application"),
+    ("modifiers", "modifier"),
+    ("package_managers", "package_manager"),
+    ("workflow_managers", "workflow_manager"),
+    ("base_applications", "base_application"),
+    ("base_modifiers", "base_modifier"),
+    ("base_package_managers", "base_package_manager"),
+    ("base_workflow_managers", "base_workflow_manager"),
+]
+
+for obj, fn in object_types:
+    subprocess.call(
+        ["ramble", "list", f"--type={obj}", "--format=html", f"--update={fn}_list.html"]
+    )
 
 # Generate a command index if an update is needed
 subprocess.call(

--- a/lib/ramble/docs/index.rst
+++ b/lib/ramble/docs/index.rst
@@ -40,6 +40,19 @@ If you're new to Ramble and want to start using it, see :doc:`getting_started`.
 
 .. toctree::
    :maxdepth: 2
+   :caption: Object Lists
+
+   application_list
+   modifier_list
+   package_manager_list
+   workflow_manager_list
+   base_application_list
+   base_modifier_list
+   base_package_manager_list
+   base_workflow_manager_list
+
+.. toctree::
+   :maxdepth: 2
    :caption: Contributing
 
    Contributing Guidelines <https://github.com/GoogleCloudPlatform/ramble#contributing>

--- a/lib/ramble/docs/modifier_list.rst
+++ b/lib/ramble/docs/modifier_list.rst
@@ -1,0 +1,20 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+.. _modifier-list:
+
+================
+Modifier List
+================
+
+This is a list of modifiers you can use to augment experiments created using
+Ramble. This list is automatically generated based on the modifiers in this
+Ramble version.
+
+.. raw:: html
+   :file: modifier_list.html

--- a/lib/ramble/docs/package_manager_list.rst
+++ b/lib/ramble/docs/package_manager_list.rst
@@ -1,0 +1,20 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+.. _package-manager-list:
+
+================
+Package Manager List
+================
+
+This is a list of package managers available within Ramble, for managing
+experiment software stacks.  It is automatically generated based on the
+package managers in this Ramble version.
+
+.. raw:: html
+   :file: package_manager_list.html

--- a/lib/ramble/docs/workflow_manager_list.rst
+++ b/lib/ramble/docs/workflow_manager_list.rst
@@ -1,0 +1,20 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+.. _workflow-manager-list:
+
+=====================
+Workflow Manager List
+=====================
+
+This is a list of workflow managers you can use within experiments created with
+Ramble.  It is automatically generated based on the workflow managers in this
+Ramble version.
+
+.. raw:: html
+   :file: workflow_manager_list.html

--- a/lib/ramble/ramble/cmd/common/list.py
+++ b/lib/ramble/ramble/cmd/common/list.py
@@ -86,7 +86,7 @@ def github_url(objs, object_type):
     """Link to an object file on github."""
     obj_def = ramble.repository.type_definitions[object_type]
     url = (
-        "https://github.com/ramble/ramble/blob/develop/var/ramble/repos/builtina/"
+        "https://github.com/GoogleCloudPlatform/ramble/blob/develop/var/ramble/repos/builtin/"
         + f'{obj_def["dir_name"]}/'
         + "{0}"
         + f'/{obj_def["file_name"]}'
@@ -172,7 +172,10 @@ def html(obj_names, out, object_type):
         out.write('<tr class="row-odd">\n' if i % 2 == 0 else '<tr class="row-even">\n')
         for name in row:
             out.write("<td>\n")
-            out.write(f'<a class="reference internal" href="#{name}">{name}</a></td>\n')
+            if name is not None:
+                out.write(f'<a class="reference internal" href="#{name}">{name}</a></td>\n')
+            else:
+                out.write("</td>\n")
             out.write("</td>\n")
         out.write("</tr>\n")
     out.write("</tbody>\n")


### PR DESCRIPTION
This merge adds object lists for all of Ramble's object types to the documentation.