### PR TITLE
Update default workflow manager to be user-managed

### DIFF
--- a/etc/ramble/defaults/variants.yaml
+++ b/etc/ramble/defaults/variants.yaml
@@ -1,3 +1,3 @@
 variants:
   package_manager: user-managed
-  workflow_manager: null
+  workflow_manager: user-managed

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -330,22 +330,20 @@ class ApplicationBase(metaclass=ApplicationMeta):
             self.object_variants.value(namespace.workflow_manager)
         )
 
-        if workflow_name is not None:
-            try:
-                wfman_type = ramble.repository.ObjectTypes.workflow_managers
-                self.workflow_manager = ramble.repository.get(workflow_name, wfman_type).copy()
-                self.workflow_manager.set_application(self)
-            except ramble.repository.UnknownObjectError:
-                logger.die(
-                    f"{workflow_name} is not a valid workflow manager. "
-                    "Valid workflow managers can be listed via:\n"
-                    "\tramble list --type workflow_managers"
-                )
+        # Map None to the default of user-managed
+        if workflow_name is None:
+            workflow_name = "user-managed"
 
-        if self.workflow_manager is None:
-            base_path = os.path.join(ramble.paths.module_path, "workflow_manager.py")
-            self.workflow_manager = ramble.workflow_manager.WorkflowManagerBase(base_path)
+        try:
+            wfman_type = ramble.repository.ObjectTypes.workflow_managers
+            self.workflow_manager = ramble.repository.get(workflow_name, wfman_type).copy()
             self.workflow_manager.set_application(self)
+        except ramble.repository.UnknownObjectError:
+            logger.die(
+                f"{workflow_name} is not a valid workflow manager. "
+                "Valid workflow managers can be listed via:\n"
+                "\tramble list --type workflow_managers"
+            )
 
     def build_phase_order(self):
         if self._pipeline_graphs is not None:

--- a/lib/ramble/ramble/test/workflow_manager_functionality/workflow_manager.py
+++ b/lib/ramble/ramble/test/workflow_manager_functionality/workflow_manager.py
@@ -1,0 +1,56 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.workspace
+from ramble.main import RambleCommand
+
+workspace = RambleCommand("workspace")
+
+pytestmark = pytest.mark.usefixtures(
+    "mutable_config",
+    "mutable_mock_workspace_path",
+)
+
+
+def test_default_workflow_manager_banner():
+    workspace_name = "test_workflow_manager_default"
+
+    test_config = """
+ramble:
+  variables:
+    processes_per_node: 1
+    n_nodes: 1
+    mpi_command: ""
+    batch_submit: ""
+  applications:
+    hostname:
+      workloads:
+        local:
+          experiments:
+            test_default: {}
+"""
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+        config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+        with open(config_path, "w+") as f:
+            f.write(test_config)
+        ws._re_read()
+        workspace("setup", "--dry-run", global_args=["-D", ws.root])
+
+        path = os.path.join(ws.experiment_dir, "hostname", "local", "test_default")
+        with open(os.path.join(path, "execute_experiment")) as f:
+            content = f.read()
+            assert "{workflow_banner}" not in content
+            assert (
+                "If this file is not the same as the above path, it is unlikely that this script"
+                in content
+            )

--- a/lib/ramble/ramble/workflow_manager.py
+++ b/lib/ramble/ramble/workflow_manager.py
@@ -37,13 +37,7 @@ class WorkflowManagerBase(metaclass=WorkflowManagerMeta):
 
     workflow_manager_variable(
         "workflow_banner",
-        default="""# ****************************************************
-# * No workflow is used with this experiment
-# * Execution command: {batch_submit}
-# * If this file is not the same as the above path, it is unlikely that this script
-# * is used when `ramble on` executes experiments.
-# ****************************************************
-""",
+        default="",
         description="Banner to describe the workflow within execution templates",
     )
 

--- a/var/ramble/repos/builtin/workflow_managers/user-managed/workflow_manager.py
+++ b/var/ramble/repos/builtin/workflow_managers/user-managed/workflow_manager.py
@@ -1,0 +1,28 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.wm.builtin.slurm import Slurm as SlurmBase
+from ramble.wmkit import *
+
+
+class UserManaged(WorkflowManagerBase):
+    """Simple workflow manager that offers sensible default behavior"""
+
+    name = "user-managed"
+
+    workflow_manager_variable(
+        "workflow_banner",
+        default="""# ****************************************************
+# * No workflow is used with this experiment
+# * Execution command: {batch_submit}
+# * If this file is not the same as the above path, it is unlikely that this script
+# * is used when `ramble on` executes experiments.
+# ****************************************************
+""",
+        description="Banner to describe the workflow within execution templates",
+    )

--- a/var/ramble/repos/builtin/workflow_managers/user-managed/workflow_manager.py
+++ b/var/ramble/repos/builtin/workflow_managers/user-managed/workflow_manager.py
@@ -6,7 +6,6 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-from ramble.wm.builtin.slurm import Slurm as SlurmBase
 from ramble.wmkit import *
 
 


### PR DESCRIPTION
Changed the default workflow manager to be UserManaged (and not none, which is now disallowed / assumed to be UserManaged) 

Previously we instantiated the base manager. This pulls the implies functionality into a concrete class 