### PR TITLE
Update how execution graphs handle builtins

### DIFF
--- a/lib/ramble/ramble/graphs.py
+++ b/lib/ramble/ramble/graphs.py
@@ -312,9 +312,6 @@ class ExecutableGraph(AttributeGraph):
                 head_node = node
             tail_node = node
 
-        tail_prepend_builtin = None
-        tail_append_builtin = None
-
         # Add (missing) required builtins
         for builtins in builtin_groups:
             for builtin, blt_conf in builtins.items():
@@ -322,23 +319,12 @@ class ExecutableGraph(AttributeGraph):
                     blt_node = self.node_definitions[builtin]
                     super().update_graph(blt_node)
 
-                    # TODO: This should include `depends_on` as well.
-                    relative = bool(blt_conf["dependents"])
-
-                    if not relative and blt_conf["injection_method"] == "prepend":
+                    if blt_conf["injection_method"] == "prepend":
                         if head_node is not None:
                             super().update_graph(head_node, [blt_node])
-
-                        if tail_prepend_builtin is not None:
-                            super().update_graph(blt_node, [tail_prepend_builtin])
-                        tail_prepend_builtin = blt_node
-                    elif not relative and blt_conf["injection_method"] == "append":
+                    elif blt_conf["injection_method"] == "append":
                         if tail_node is not None:
                             super().update_graph(blt_node, [tail_node])
-
-                        if tail_append_builtin is not None:
-                            super().update_graph(blt_node, [tail_append_builtin])
-                        tail_append_builtin = blt_node
 
                     if blt_conf["depends_on"]:
                         deps = []

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -370,6 +370,13 @@ def register_builtin(
 
     NOTE: When specifying explicit dependencies, cycles can be created which
     will cause an error when trying to construct the final executable order.
+    One possible way to resolve those issues is to make sure that builtins
+    which depend on each other have the same injection method (or at least do
+    not have conflicting injection methods). As an example, if builtin `a` has
+    an injection method of prepend, and builtin `b` lists `a` as a dependent
+    but has an injection method of append, then this will create a cycle. If b
+    has it's injection method updated to be `prepend` the cycle will be
+    resolved.
 
     Args:
         name (str): Name of builtin (should be the name of a class method) to register

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -365,8 +365,11 @@ def register_builtin(
     The 'injection_method' attribute controls where the builtin will be
     injected into the executable list.
     Options are:
-    - 'prepend' -- This builtin will be injected at the beginning of the executable list
-    - 'append' -- This builtin will be injected at the end of the executable list
+    - 'prepend' -- This builtin will be injected before the executables for the experiment
+    - 'append' -- This builtin will be injected after the executables for the experiment
+
+    NOTE: When specifying explicit dependencies, cycles can be created which
+    will cause an error when trying to construct the final executable order.
 
     Args:
         name (str): Name of builtin (should be the name of a class method) to register
@@ -376,7 +379,7 @@ def register_builtin(
         depends_on (list(str) | None): The names of builtins this builtin depends on
                                        (and must execute after).
         dependents (list(str) | None): The names of builtins that should come
-                                       after the current one.
+                                       after this builtin
     """
     if depends_on is None:
         depends_on = []

--- a/lib/ramble/ramble/test/end_to_end/registered_builtin_order.py
+++ b/lib/ramble/ramble/test/end_to_end/registered_builtin_order.py
@@ -1,0 +1,97 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+import re
+
+import pytest
+
+import ramble.workspace
+from ramble.main import RambleCommand
+
+pytestmark = pytest.mark.usefixtures(
+    "mutable_config", "mutable_mock_workspace_path", "mutable_mock_apps_repo"
+)
+
+workspace = RambleCommand("workspace")
+
+
+def test_registered_builtin_order(request):
+    ws_name = request.node.name
+    ws = ramble.workspace.create(ws_name)
+    global_args = ["-w", ws_name]
+
+    workspace(
+        "manage",
+        "experiments",
+        "register-builtin",
+        "--wf",
+        "test_wl2",
+        "-v",
+        "n_nodes=1",
+        "-v",
+        "processes_per_node=1",
+        "-v",
+        "mpi_command='mpirun -n {n_ranks}'",
+        "-p",
+        "spack",
+        global_args=global_args,
+    )
+
+    workspace(
+        "manage",
+        "software",
+        "--pkg",
+        "zlib",
+        "--spec",
+        "zlib",
+        global_args=global_args,
+    )
+
+    workspace(
+        "manage",
+        "software",
+        "--env",
+        "register-builtin",
+        "--environment-packages",
+        "zlib",
+        global_args=global_args,
+    )
+
+    workspace("setup", "--dry-run", global_args=global_args)
+
+    regex_order = [
+        re.compile(r'echo "bar"'),
+        re.compile(r'echo "foo"'),
+        re.compile(r"\. .*spack.*setup-env.sh"),
+        re.compile(r"spack env activate"),
+        re.compile(r"mpirun.*baz"),
+        re.compile(r'echo "dep-before-post-builtin"'),
+        re.compile(r'echo "post-builtin"'),
+        re.compile(r'echo "dep-after-post-builtin"'),
+    ]
+
+    found_order = [False for _ in regex_order]
+
+    found_idx = 0
+
+    rendered_script = os.path.join(
+        ws.experiment_dir, "register-builtin", "test_wl2", "generated", "execute_experiment"
+    )
+
+    with open(rendered_script) as f:
+        for line in f.readlines():
+            print(f"Line = '{line}'")
+            cur_regex = regex_order[found_idx]
+            if cur_regex.search(line):
+                print(f"  -- Found! Moving to idx: {found_idx + 1}")
+                found_order[found_idx] = True
+                found_idx += 1
+
+    assert all(found_order)
+    assert found_idx == len(found_order)

--- a/var/ramble/repos/builtin.mock/applications/register-builtin/application.py
+++ b/var/ramble/repos/builtin.mock/applications/register-builtin/application.py
@@ -50,3 +50,30 @@ class RegisterBuiltin(ExecutableApplication):
 
     def test_builtin_pre(self):
         return ['echo "bar"']
+
+    register_builtin(
+        "test_builtin_post", required=True, injection_method="append"
+    )
+
+    def test_builtin_post(self):
+        return ['echo "post-builtin"']
+
+    register_builtin(
+        "test_builtin_dep_after_post",
+        required=True,
+        injection_method="append",
+        depends_on=["test_builtin_post"],
+    )
+
+    def test_builtin_dep_after_post(self):
+        return ['echo "dep-after-post-builtin"']
+
+    register_builtin(
+        "test_builtin_dep_before_post",
+        required=True,
+        injection_method="append",
+        dependents=["test_builtin_post"],
+    )
+
+    def test_builtin_dep_before_post(self):
+        return ['echo "dep-before-post-builtin"']


### PR DESCRIPTION
This merge attempts to strengthen the semantics around the ways to order builtins within object definitions. A test is also added to verify the ordering of builtins relative to the experiment's executables.