### PR TITLE
Avoid leading whitespace

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -1165,7 +1165,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
                         command_part = f"{mpi_cmd}{part}"
                         suffix_part = f"{redirect}{bg_cmd}"
 
-                        expanded_cmd = self.expander.expand_var(command_part, exec_vars)
+                        expanded_cmd = self.expander.expand_var(command_part, exec_vars).lstrip()
                         suffix_cmd = self.expander.expand_var(suffix_part, exec_vars).lstrip()
 
                         self._command_list.append((expanded_cmd + " " + suffix_cmd).rstrip())

--- a/lib/ramble/ramble/test/end_to_end/wrfv4_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/wrfv4_dry_run.py
@@ -8,6 +8,7 @@
 
 import glob
 import os
+import re
 
 import pytest
 
@@ -220,7 +221,7 @@ compilers:
                 # Test the expected portions of the execution command exist
                 assert "sed -i -e 's/ start_hour.*/ start_hour" in data
                 assert "sed -i -e 's/ restart .*/ restart" in data
-                assert "mpirun" in data
+                assert re.search("\nmpirun", data)
                 assert "wrf.exe" in data
 
                 # Test the run script has a reference to the experiment log file


### PR DESCRIPTION
This merge prevents experiments from injecting leading whitespace before `mpi_command` that is added to generated commands.

A test is added to make sure we don't add the whitespace back in later.