### PR TITLE
Label slow tests

### DIFF
--- a/lib/ramble/ramble/test/cmd/deployment.py
+++ b/lib/ramble/ramble/test/cmd/deployment.py
@@ -48,6 +48,7 @@ def check_deployment_files(root, app_name):
         assert os.path.isfile(f)
 
 
+@pytest.mark.maybeslow
 def test_local_deployment(mutable_config, mutable_mock_workspace_path):
 
     workspace_name = "test_local_deployment"

--- a/lib/ramble/ramble/test/end_to_end/chained_experiment_var_inheritance.py
+++ b/lib/ramble/ramble/test/end_to_end/chained_experiment_var_inheritance.py
@@ -23,6 +23,7 @@ pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_p
 workspace = RambleCommand("workspace")
 
 
+@pytest.mark.maybeslow
 def test_chained_experiment_variable_inheritance(request):
     test_config = r"""
 ramble:

--- a/lib/ramble/ramble/test/end_to_end/chained_experiment_variant_propagation.py
+++ b/lib/ramble/ramble/test/end_to_end/chained_experiment_variant_propagation.py
@@ -23,6 +23,7 @@ pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_p
 workspace = RambleCommand("workspace")
 
 
+@pytest.mark.maybeslow
 def test_chained_experiment_variant_propagation(request):
     test_config = r"""
 ramble:

--- a/lib/ramble/ramble/test/end_to_end/configvar_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/configvar_dry_run.py
@@ -21,6 +21,7 @@ pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_p
 workspace = RambleCommand("workspace")
 
 
+@pytest.mark.maybeslow
 def test_configvar_dry_run(mutable_config, mutable_mock_workspace_path):
     test_scopes = ["site", "system", "user"]
 

--- a/lib/ramble/ramble/test/end_to_end/dryrun_chained_experiments.py
+++ b/lib/ramble/ramble/test/end_to_end/dryrun_chained_experiments.py
@@ -27,6 +27,7 @@ pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_p
 workspace = RambleCommand("workspace")
 
 
+@pytest.mark.maybeslow
 @pytest.mark.filterwarnings("ignore:invalid decimal literal")
 def test_dryrun_chained_experiments(mutable_config, mutable_mock_workspace_path):
     test_config = r"""

--- a/lib/ramble/ramble/test/end_to_end/package_manager_provenance.py
+++ b/lib/ramble/ramble/test/end_to_end/package_manager_provenance.py
@@ -20,6 +20,7 @@ pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_p
 workspace = RambleCommand("workspace")
 
 
+@pytest.mark.maybeslow
 def test_spack_package_manager_provenance_zlib(mock_applications, request):
     workspace_name = request.node.name
 

--- a/lib/ramble/ramble/test/end_to_end/wrfv4_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/wrfv4_dry_run.py
@@ -315,6 +315,7 @@ compilers:
                 assert os.path.exists(os.path.join(exp_dir, f"rsl.error.000{i}"))
 
 
+@pytest.mark.maybeslow
 def test_wrfv4_no_pkg_man_dry_run(mutable_config, mutable_mock_workspace_path):
     test_config = """
 ramble:

--- a/lib/ramble/ramble/test/gcs_fetch.py
+++ b/lib/ramble/ramble/test/gcs_fetch.py
@@ -58,6 +58,7 @@ def test_gcsfetchstrategy_downloaded(tmpdir, _fetch_method):
             fetcher.fetch()
 
 
+@pytest.mark.network
 @pytest.mark.parametrize("_fetch_method", ["curl", "urllib"])
 def test_gcsfetchstrategy_download(tmpdir, _fetch_method):
     """Ensure fetch of fie."""

--- a/lib/ramble/ramble/test/uploader.py
+++ b/lib/ramble/ramble/test/uploader.py
@@ -36,6 +36,7 @@ def test_upload_results_errs(upload_uri, upload_type, results, expected_err_msg)
             upload_results(results)
 
 
+@pytest.mark.maybeslow
 def test_data_preparation(request, mock_applications):
     ws_name = request.node.name
 


### PR DESCRIPTION
Add labels to tests that consistently take more than 5secs to complete, based on the unit-test summary like the following:

```
================================================================= slowest 30 durations =================================================================
53.81s call     lib/ramble/ramble/test/end_to_end/package_manager_provenance.py::test_spack_package_manager_provenance_zlib
33.69s call     lib/ramble/ramble/test/uploader.py::test_data_preparation
```