### PR TITLE
update yaml.load > yaml.safe_load

### DIFF
--- a/lib/ramble/ramble/repository.py
+++ b/lib/ramble/ramble/repository.py
@@ -1115,7 +1115,7 @@ class Repo:
         """Check for a YAML config file in this db's root directory."""
         try:
             with open(self.config_file) as reponame_file:
-                yaml_data = yaml.load(reponame_file)
+                yaml_data = yaml.safe_load(reponame_file)
 
                 if (
                     not yaml_data


### PR DESCRIPTION
when I ran benchpark commands I received an warning message saying to use yaml.safe_load to prevent any unsecured files as well as fixing the warning message output.