### PR TITLE
Allow repeated `software_specs` in object definitions

### DIFF
--- a/lib/ramble/ramble/cmd/common/info.py
+++ b/lib/ramble/ramble/cmd/common/info.py
@@ -261,6 +261,8 @@ def print_single_attribute(obj, attr, verbose=False, pattern="*", format=support
                                 escaped_sub_val = sub_val.replace("@", "@@")
                                 color.cprint(f"{indentation}{color_sub_name}: {escaped_sub_val}")
                         color.cprint("")
+                    elif hasattr(val, "as_str"):
+                        color.cprint(f"{val.as_str()}")
                     else:
                         color.cprint(f"{str(val)}")
         # If the attribute is not a dict, print using the existing format rules.

--- a/lib/ramble/ramble/cmd/common/info.py
+++ b/lib/ramble/ramble/cmd/common/info.py
@@ -235,28 +235,34 @@ def print_single_attribute(obj, attr, verbose=False, pattern="*", format=support
         # sub items. These need to be iterated over, and we need to escape
         # existing characters that would normally be used to color strings.
         if isinstance(internal_attr, dict):
-            for name, val in internal_attr.items():
+            for name, vals in internal_attr.items():
                 if pattern and not fnmatch.fnmatch(name, pattern):
                     continue
 
-                if isinstance(val, dict):
-                    color_name = ramble.util.colors.section_title(name)
-                    color.cprint(f"{color_name}:")
-                    for sub_name, sub_val in val.items():
-                        # Avoid showing duplicate names for variables
-                        if isinstance(sub_val, WorkloadVariable) and sub_name == sub_val.name:
-                            to_print = f"{indentation}{sub_val}"
-                        else:
-                            color_sub_name = ramble.util.colors.nested_1(sub_name)
-                            to_print = f"{indentation}{color_sub_name}: {sub_val}"
-                        try:
-                            color.cprint(to_print)
-                        except color.ColorParseError:
-                            escaped_sub_val = sub_val.replace("@", "@@")
-                            color.cprint(f"{indentation}{color_sub_name}: {escaped_sub_val}")
-                    color.cprint("")
+                if not isinstance(vals, list):
+                    itr_vals = [vals]
                 else:
-                    color.cprint(f"{str(val)}")
+                    itr_vals = vals
+
+                for val in itr_vals:
+                    if isinstance(val, dict):
+                        color_name = ramble.util.colors.section_title(name)
+                        color.cprint(f"{color_name}:")
+                        for sub_name, sub_val in val.items():
+                            # Avoid showing duplicate names for variables
+                            if isinstance(sub_val, WorkloadVariable) and sub_name == sub_val.name:
+                                to_print = f"{indentation}{sub_val}"
+                            else:
+                                color_sub_name = ramble.util.colors.nested_1(sub_name)
+                                to_print = f"{indentation}{color_sub_name}: {sub_val}"
+                            try:
+                                color.cprint(to_print)
+                            except color.ColorParseError:
+                                escaped_sub_val = sub_val.replace("@", "@@")
+                                color.cprint(f"{indentation}{color_sub_name}: {escaped_sub_val}")
+                        color.cprint("")
+                    else:
+                        color.cprint(f"{str(val)}")
         # If the attribute is not a dict, print using the existing format rules.
         elif isinstance(internal_attr, list):
             to_print = fnmatch.filter(internal_attr, pattern)

--- a/lib/ramble/ramble/cmd/software_definitions.py
+++ b/lib/ramble/ramble/cmd/software_definitions.py
@@ -14,7 +14,6 @@ from llnl.util.tty.colify import colify
 import ramble.repository
 import ramble.software_environments
 from ramble.util.logger import logger
-from ramble.util.spec_utils import specs_conflict
 
 description = "inspect software definitions in object definitions"
 section = "developer"
@@ -76,8 +75,8 @@ def collect_definitions():
                                 used_by[pkg_name] = [obj_namespace]
                             else:
                                 logger.debug(f" Checking package: {pkg_name}")
-                                if specs_conflict(
-                                    definitions[pkg_name], pkg_def, skip_conflicting_when=True
+                                if pkg_def.conflict_spec(
+                                    definitions[pkg_name], skip_conflicting_when=True
                                 ):
                                     if pkg_name not in conflicts:
                                         conflicts[pkg_name] = []
@@ -86,8 +85,8 @@ def collect_definitions():
                                     used_by[pkg_name].append(obj_namespace)
 
                             for spec_name in specs:
-                                if spec_name in pkg_def:
-                                    spec_def = pkg_def[spec_name]
+                                if hasattr(pkg_def, spec_name):
+                                    spec_def = getattr(pkg_def, spec_name)
                                     if spec_def:
                                         if spec_def not in specs[spec_name]:
                                             specs[spec_name][spec_def] = []
@@ -124,8 +123,8 @@ def print_conflicts():
             color.cprint(f'{nested_1("Package")}: {pkg_name}:')
             color.cprint("\tDefined as:")
             for attr in ["pkg_spec", "compiler_spec", "compiler"]:
-                if attr in definitions[pkg_name]:
-                    attr_def = definitions[pkg_name][attr]
+                if hasattr(definitions[pkg_name], attr):
+                    attr_def = getattr(definitions[pkg_name], attr)
                     if attr_def:
                         color.cprint(f'\t\t{attr} = {attr_def.replace("@", "@@")}')
             color.cprint("\tIn objects:")

--- a/lib/ramble/ramble/cmd/software_definitions.py
+++ b/lib/ramble/ramble/cmd/software_definitions.py
@@ -13,7 +13,8 @@ from llnl.util.tty.colify import colify
 
 import ramble.repository
 import ramble.software_environments
-from ramble.util.spec_utils import specs_equiv
+from ramble.util.logger import logger
+from ramble.util.spec_utils import specs_conflict
 
 description = "inspect software definitions in object definitions"
 section = "developer"
@@ -68,25 +69,29 @@ def collect_definitions():
 
             for top_level_attr in top_level_attrs:
                 if hasattr(obj_inst, top_level_attr):
-                    for pkg_name, pkg_def in getattr(obj_inst, top_level_attr).items():
-                        if pkg_name not in definitions:
-                            definitions[pkg_name] = pkg_def.copy()
-                            used_by[pkg_name] = [obj_namespace]
-                        else:
-                            if not specs_equiv(definitions[pkg_name], pkg_def):
-                                if pkg_name not in conflicts:
-                                    conflicts[pkg_name] = []
-                                conflicts[pkg_name].append(obj_namespace)
+                    for pkg_name, pkg_defs in getattr(obj_inst, top_level_attr).items():
+                        for pkg_def in pkg_defs:
+                            if pkg_name not in definitions:
+                                definitions[pkg_name] = pkg_def.copy()
+                                used_by[pkg_name] = [obj_namespace]
                             else:
-                                used_by[pkg_name].append(obj_namespace)
+                                logger.debug(f" Checking package: {pkg_name}")
+                                if specs_conflict(
+                                    definitions[pkg_name], pkg_def, skip_conflicting_when=True
+                                ):
+                                    if pkg_name not in conflicts:
+                                        conflicts[pkg_name] = []
+                                    conflicts[pkg_name].append(obj_namespace)
+                                else:
+                                    used_by[pkg_name].append(obj_namespace)
 
-                        for spec_name in specs:
-                            if spec_name in pkg_def:
-                                spec_def = pkg_def[spec_name]
-                                if spec_def:
-                                    if spec_def not in specs[spec_name]:
-                                        specs[spec_name][spec_def] = []
-                                    specs[spec_name][spec_def].append(obj_namespace)
+                            for spec_name in specs:
+                                if spec_name in pkg_def:
+                                    spec_def = pkg_def[spec_name]
+                                    if spec_def:
+                                        if spec_def not in specs[spec_name]:
+                                            specs[spec_name][spec_def] = []
+                                        specs[spec_name][spec_def].append(obj_namespace)
 
 
 def print_summary():

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -16,6 +16,7 @@ import ramble.success_criteria
 import ramble.variants
 from ramble.util.foms import FomType
 from ramble.util.logger import logger
+from ramble.util.spec_utils import SoftwareSpec
 
 """This module contains directives directives that are shared between multiple object types
 
@@ -155,12 +156,9 @@ def define_compiler(
             obj.compilers[name] = []
 
         obj.compilers[name].append(
-            {
-                "pkg_spec": pkg_spec,
-                "compiler_spec": compiler_spec,
-                "compiler": compiler,
-                "when": when_list,
-            }
+            SoftwareSpec(
+                name, pkg_spec, compiler=compiler, compiler_spec=compiler_spec, when=when_list
+            )
         )
 
     return _execute_define_compiler
@@ -207,12 +205,9 @@ def software_spec(
 
         # Define the spec
         obj.software_specs[name].append(
-            {
-                "pkg_spec": pkg_spec,
-                "compiler_spec": compiler_spec,
-                "compiler": compiler,
-                "when": when_list,
-            }
+            SoftwareSpec(
+                name, pkg_spec, compiler=compiler, compiler_spec=compiler_spec, when=when_list
+            )
         )
 
     return _execute_software_spec

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -151,12 +151,17 @@ def define_compiler(
                 "transition this to use the `when` argument instead."
             )
 
-        obj.compilers[name] = {
-            "pkg_spec": pkg_spec,
-            "compiler_spec": compiler_spec,
-            "compiler": compiler,
-            "when": when_list,
-        }
+        if name not in obj.compilers:
+            obj.compilers[name] = []
+
+        obj.compilers[name].append(
+            {
+                "pkg_spec": pkg_spec,
+                "compiler_spec": compiler_spec,
+                "compiler": compiler,
+                "when": when_list,
+            }
+        )
 
     return _execute_define_compiler
 
@@ -197,13 +202,18 @@ def software_spec(
                 "transition this to use the `when` argument instead."
             )
 
+        if name not in obj.software_specs:
+            obj.software_specs[name] = []
+
         # Define the spec
-        obj.software_specs[name] = {
-            "pkg_spec": pkg_spec,
-            "compiler_spec": compiler_spec,
-            "compiler": compiler,
-            "when": when_list,
-        }
+        obj.software_specs[name].append(
+            {
+                "pkg_spec": pkg_spec,
+                "compiler_spec": compiler_spec,
+                "compiler": compiler,
+                "when": when_list,
+            }
+        )
 
     return _execute_software_spec
 

--- a/lib/ramble/ramble/package_manager.py
+++ b/lib/ramble/ramble/package_manager.py
@@ -114,7 +114,7 @@ class PackageManagerBase(metaclass=PackageManagerMeta):
             for definitions in app_inst.software_specs.values():
                 for info in definitions:
                     if self.app_inst.expander.satisfies(
-                        info["when"], variant_set=self.object_variants
+                        info.when, variant_set=self.object_variants
                     ):
                         return True
 

--- a/lib/ramble/ramble/package_manager.py
+++ b/lib/ramble/ramble/package_manager.py
@@ -111,11 +111,12 @@ class PackageManagerBase(metaclass=PackageManagerMeta):
     def environment_required(self):
         app_inst = self.app_inst
         if hasattr(app_inst, "software_specs"):
-            for info in app_inst.software_specs.values():
-                if self.app_inst.expander.satisfies(
-                    info["when"], variant_set=self.object_variants
-                ):
-                    return True
+            for definitions in app_inst.software_specs.values():
+                for info in definitions:
+                    if self.app_inst.expander.satisfies(
+                        info["when"], variant_set=self.object_variants
+                    ):
+                        return True
 
         return False
 

--- a/lib/ramble/ramble/software_environments.py
+++ b/lib/ramble/ramble/software_environments.py
@@ -313,13 +313,7 @@ class TemplatePackage(SoftwarePackage):
         raw_compiler = _get_spec(pkg_info, "compiler", pm_prefix)
         raw_compiler_spec = _get_spec(pkg_info, "compiler_spec", pm_prefix)
 
-        if raw_spec is None:
-            logger.die(
-                f"When rendering package {self.name} "
-                + f"no spec was found for package manager {pm_name}.\n"
-            )
-
-        spec = expander.expand_var(raw_spec, merge_used_stage=False)
+        spec = expander.expand_var(raw_spec, merge_used_stage=False) if raw_spec else None
         compiler = (
             expander.expand_var(raw_compiler, merge_used_stage=False) if raw_compiler else None
         )
@@ -612,29 +606,31 @@ class TemplateEnvironment(SoftwareEnvironment):
             rendered_env_pkg_name = expander.expand_var(env_pkg_template)
 
             if rendered_env_pkg_name:
-                added = False
+                found = False
                 for template_pkg in all_package_templates.values():
                     expander.flush_used_variable_stage()
                     rendered_pkg = template_pkg.render_package(expander, package_manager)
 
                     if rendered_env_pkg_name == rendered_pkg.name:
-                        expander.merge_used_variable_stage()
+                        found = True
+                        if rendered_pkg.spec is not None:
+                            expander.merge_used_variable_stage()
 
-                        if rendered_pkg.name in all_packages[pm_name]:
-                            if rendered_pkg != all_packages[pm_name][rendered_pkg.name]:
-                                raise RambleSoftwareEnvironmentError(
-                                    f"Environment {name} defined multiple times in inconsistent "
-                                    f"ways.\nPackage with differences is {rendered_pkg.name}"
-                                )
-                            rendered_pkg = all_packages[pm_name][rendered_pkg.name]
-                        else:
-                            all_packages[pm_name][rendered_pkg.name] = rendered_pkg
+                            if rendered_pkg.name in all_packages[pm_name]:
+                                if rendered_pkg != all_packages[pm_name][rendered_pkg.name]:
+                                    raise RambleSoftwareEnvironmentError(
+                                        f"Environment {name} defined multiple "
+                                        "times in inconsistent ways.\n"
+                                        f"Package with differences is {rendered_pkg.name}"
+                                    )
+                                rendered_pkg = all_packages[pm_name][rendered_pkg.name]
+                            else:
+                                all_packages[pm_name][rendered_pkg.name] = rendered_pkg
 
-                        added = True
                         template_pkg.add_rendered_package(rendered_pkg, all_packages, pm_name)
                         new_env.add_package(rendered_pkg)
 
-                if not added:
+                if not found:
                     raise RambleSoftwareEnvironmentError(
                         f"Environment template {self.name} references "
                         f"undefined package {env_pkg_template} rendered to {rendered_env_pkg_name}"

--- a/lib/ramble/ramble/test/application_language.py
+++ b/lib/ramble/ramble/test/application_language.py
@@ -182,7 +182,7 @@ def add_input_file(app_inst, input_num=1):
 # TODO: can this be dried with the modifier language add_compiler?
 @deprecation.fail_if_not_removed
 def add_compiler(app_inst, spec_num=1):
-    spec_name = "Compiler%spec_num"
+    spec_name = f"Compiler{spec_num}"
     spec_pkg_spec = f"compiler_base@{spec_num}.0 +var1 ~var2"
     spec_compiler_spec = "compiler1_base@{spec_num}"
 
@@ -193,7 +193,7 @@ def add_compiler(app_inst, spec_num=1):
         spec_name, pkg_spec=spec_pkg_spec, compiler_spec=spec_compiler_spec  # noqa: F405
     )
 
-    spec_name = "OtherCompiler%spec_num"
+    spec_name = f"OtherCompiler{spec_num}"
     spec_pkg_spec = f"compiler_base@{spec_num}.1 +var1 ~var2 target=x86_64"
     spec_compiler_spec = "compiler2_base@{spec_num}"
 
@@ -207,7 +207,7 @@ def add_compiler(app_inst, spec_num=1):
 
 
 def add_software_spec(app_inst, spec_num=1):
-    spec_name = "NoMPISpec%s" % spec_num
+    spec_name = f"NoMPISpec{spec_num}"
     spec_pkg_spec = f"NoMPISpec@{spec_num} +var1 ~var2 target=x86_64"
     spec_compiler = "spec_compiler1@1.1"
 
@@ -216,7 +216,7 @@ def add_software_spec(app_inst, spec_num=1):
 
     app_inst.software_spec(spec_name, pkg_spec=spec_pkg_spec, compiler=spec_compiler)  # noqa: F405
 
-    spec_name = "MPISpec%s" % spec_num
+    spec_name = f"MPISpec{spec_num}"
     spec_pkg_spec = f"MPISpec@{spec_num} +var1 ~var2 target=x86_64"
     spec_compiler = "spec_compiler1@1.1"
 
@@ -307,8 +307,10 @@ def test_define_compiler_directive(app_class):
     assert hasattr(app_inst, "compilers")
     for name, info in test_defs.items():
         assert name in app_inst.compilers
+        print(app_inst.compilers.keys())
+        assert len(app_inst.compilers[name]) == 1
         for key, value in info.items():
-            assert app_inst.compilers[name][key] == value
+            assert app_inst.compilers[name][0][key] == value
 
 
 @pytest.mark.parametrize("app_class", app_types)
@@ -323,4 +325,4 @@ def test_software_spec_directive(app_class):
     for name, info in test_defs.items():
         assert name in app_inst.software_specs
         for key, value in info.items():
-            assert app_inst.software_specs[name][key] == value
+            assert app_inst.software_specs[name][0][key] == value

--- a/lib/ramble/ramble/test/application_language.py
+++ b/lib/ramble/ramble/test/application_language.py
@@ -310,7 +310,7 @@ def test_define_compiler_directive(app_class):
         print(app_inst.compilers.keys())
         assert len(app_inst.compilers[name]) == 1
         for key, value in info.items():
-            assert app_inst.compilers[name][0][key] == value
+            assert getattr(app_inst.compilers[name][0], key) == value
 
 
 @pytest.mark.parametrize("app_class", app_types)
@@ -325,4 +325,4 @@ def test_software_spec_directive(app_class):
     for name, info in test_defs.items():
         assert name in app_inst.software_specs
         for key, value in info.items():
-            assert app_inst.software_specs[name][0][key] == value
+            assert getattr(app_inst.software_specs[name][0], key) == value

--- a/lib/ramble/ramble/test/cmd/workspace_concretize.py
+++ b/lib/ramble/ramble/test/cmd/workspace_concretize.py
@@ -63,3 +63,42 @@ def test_workspace_concretize_additive(request):
         assert "gcc9" in content
         assert "wrfv4" in content
         assert "intel-oneapi-vtune" in content
+
+
+def test_workspace_multispec_concretize(request):
+    workspace_name = request.node.name
+
+    ws = ramble.workspace.create(workspace_name)
+    global_args = ["-w", workspace_name]
+
+    workspace(
+        "manage",
+        "experiments",
+        "gromacs",
+        "-p",
+        "spack",
+        "-e",
+        "spack_test",
+        "--wf",
+        "water_*",
+        global_args=global_args,
+    )
+    workspace(
+        "manage",
+        "experiments",
+        "gromacs",
+        "-p",
+        "eessi",
+        "-e",
+        "eessi_test",
+        "--wf",
+        "water_*",
+        global_args=global_args,
+    )
+    workspace("concretize", "-q", global_args=global_args)
+
+    with open(ws.config_file_path) as f:
+        content = f.read()
+        assert "gromacs" in content
+        assert "spack_pkg_spec" in content
+        assert "eessi_pkg_spec" in content

--- a/lib/ramble/ramble/test/cmd/workspace_concretize.py
+++ b/lib/ramble/ramble/test/cmd/workspace_concretize.py
@@ -32,7 +32,7 @@ def test_workspace_concretize_additive(request):
 
     with open(ws.config_file_path) as f:
         content = f.read()
-        assert "spack_gromacs" in content
+        assert "gromacs" in content
         assert "gcc9" in content
         assert "wrfv4" not in content
         assert "intel-oneapi-vtune" not in content
@@ -42,7 +42,7 @@ def test_workspace_concretize_additive(request):
 
     with open(ws.config_file_path) as f:
         content = f.read()
-        assert "spack_gromacs" in content
+        assert "gromacs" in content
         assert "gcc9" in content
         assert "wrfv4" in content
         assert "intel-oneapi-vtune" not in content
@@ -59,7 +59,7 @@ def test_workspace_concretize_additive(request):
 
     with open(ws.config_file_path) as f:
         content = f.read()
-        assert "spack_gromacs" in content
+        assert "gromacs" in content
         assert "gcc9" in content
         assert "wrfv4" in content
         assert "intel-oneapi-vtune" in content

--- a/lib/ramble/ramble/test/concretize_builtin.py
+++ b/lib/ramble/ramble/test/concretize_builtin.py
@@ -139,4 +139,4 @@ def test_concretize_allows_invalid_experiment(
         with open(ws.config_file_path) as f:
             data = f.read()
 
-            assert "spack_gromacs" in data
+            assert "gromacs" in data

--- a/lib/ramble/ramble/test/modifier_language.py
+++ b/lib/ramble/ramble/test/modifier_language.py
@@ -203,8 +203,8 @@ def test_software_spec_directive(mod_class):
 
         assert spec_name in mod_inst.software_specs
         for attr in expected_attrs:
-            assert attr in mod_inst.software_specs[spec_name]
-            assert test_def[attr] == mod_inst.software_specs[spec_name][attr]
+            assert attr in mod_inst.software_specs[spec_name][0]
+            assert test_def[attr] == mod_inst.software_specs[spec_name][0][attr]
 
 
 def add_compiler(mod_inst, spec_num=1):
@@ -241,8 +241,8 @@ def test_define_compiler_directive(mod_class):
 
         assert spec_name in mod_inst.compilers
         for attr in expected_attrs:
-            assert attr in mod_inst.compilers[spec_name]
-            assert test_def[attr] == mod_inst.compilers[spec_name][attr]
+            assert attr in mod_inst.compilers[spec_name][0]
+            assert test_def[attr] == mod_inst.compilers[spec_name][0][attr]
 
 
 def add_required_package(mod_inst, pkg_num=1):

--- a/lib/ramble/ramble/test/modifier_language.py
+++ b/lib/ramble/ramble/test/modifier_language.py
@@ -203,8 +203,8 @@ def test_software_spec_directive(mod_class):
 
         assert spec_name in mod_inst.software_specs
         for attr in expected_attrs:
-            assert attr in mod_inst.software_specs[spec_name][0]
-            assert test_def[attr] == mod_inst.software_specs[spec_name][0][attr]
+            assert hasattr(mod_inst.software_specs[spec_name][0], attr)
+            assert test_def[attr] == getattr(mod_inst.software_specs[spec_name][0], attr)
 
 
 def add_compiler(mod_inst, spec_num=1):
@@ -241,8 +241,8 @@ def test_define_compiler_directive(mod_class):
 
         assert spec_name in mod_inst.compilers
         for attr in expected_attrs:
-            assert attr in mod_inst.compilers[spec_name][0]
-            assert test_def[attr] == mod_inst.compilers[spec_name][0][attr]
+            assert hasattr(mod_inst.compilers[spec_name][0], attr)
+            assert test_def[attr] == getattr(mod_inst.compilers[spec_name][0], attr)
 
 
 def add_required_package(mod_inst, pkg_num=1):

--- a/lib/ramble/ramble/util/spec_utils.py
+++ b/lib/ramble/ramble/util/spec_utils.py
@@ -7,33 +7,23 @@
 # except according to those terms.
 
 
-def specs_equiv(spec1, spec2):
-    all_keys = set()
-    for key in spec1.keys():
-        if spec1[key] is not None:
-            all_keys.add(key)
-    for key in spec2.keys():
-        if spec2[key] is not None:
-            all_keys.add(key)
+def specs_conflict(new, existing, prefix="", skip_conflicting_when=False):
+    # Short circuit check if when clauses conflict
+    # (so specs should not be applied at the same time)
+    # Used for printing conflicting software specs.
+    if skip_conflicting_when:
+        new_when = set(new["when"]) if "when" in new else None
+        existing_when = set(existing["when"]) if "when" in existing else None
 
-    if "application_name" in all_keys:
-        all_keys.remove("application_name")
-
-    if "spec_type" in all_keys:
-        all_keys.remove("spec_type")
-
-    if "package_manager" in all_keys:
-        all_keys.remove("package_manager")
-
-    if "when" in all_keys:
-        all_keys.remove("when")
-
-    for key in all_keys:
-        if key not in spec1:
-            return False
-        if key not in spec2:
-            return False
-        if spec1[key] != spec2[key]:
+        if new_when != existing_when:
             return False
 
-    return True
+    prefixed_keys = {}
+    for key in new.keys():
+        if new[key] is not None:
+            prefixed_keys[key] = f"{prefix}{key}"
+
+    for in_key, out_key in prefixed_keys.items():
+        if out_key in existing and new[in_key] != existing[out_key]:
+            return True
+    return False

--- a/lib/ramble/ramble/util/spec_utils.py
+++ b/lib/ramble/ramble/util/spec_utils.py
@@ -6,6 +6,10 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+from typing import Dict, List
+
+import ramble.util.colors
+
 
 def specs_conflict(new, existing, prefix="", skip_conflicting_when=False):
     # Short circuit check if when clauses conflict
@@ -27,3 +31,95 @@ def specs_conflict(new, existing, prefix="", skip_conflicting_when=False):
         if out_key in existing and new[in_key] != existing[out_key]:
             return True
     return False
+
+
+class SoftwareSpec:
+
+    def __init__(
+        self,
+        name: str,
+        pkg_spec: str,
+        prefix: str = "",
+        compiler: str = None,
+        compiler_spec: str = None,
+        when: List[str] = None,
+    ):
+        self.name = name
+        self.pkg_spec = pkg_spec
+        self.prefix = prefix
+        self.compiler = compiler
+        self.compiler_spec = compiler_spec
+        self.when = when.copy()
+
+    def to_dict(self, prefix: str = None):
+        prefix_base = prefix if prefix is not None else self.prefix
+        prefix_str = f"{prefix_base}_" if prefix_base else ""
+
+        attrs = ["pkg_spec", "compiler", "compiler_spec"]
+
+        output = {}
+        for attr in attrs:
+            val = getattr(self, attr, None)
+            if val is not None:
+                output[f"{prefix_str}{attr}"] = val
+        return output
+
+    def config_opts(self):
+        self_dict = self.to_dict()
+        for key, val in self_dict.items():
+            yield f"software:packages:{self.name}:{key}:{val}"
+
+    def as_str(self, indent=0):
+        base_indent = " " * indent
+        indentation = " " * (indent + 4)
+        self_dict = self.to_dict()
+        color_name = ramble.util.colors.section_title(self.name)
+        output = f"{base_indent}{color_name}:\n"
+        for key, val in self_dict.items():
+            color_key = ramble.util.colors.nested_1(key)
+            escaped_val = val.replace("@", "@@")
+            output += f"{indentation}{color_key}: {escaped_val}\n"
+        return output
+
+    def __str__(self):
+        self_dict = self.to_dict(prefix="")
+        self_dict["prefix"] = self.prefix
+        return str(self_dict)
+
+    def copy(self):
+        new_spec = SoftwareSpec(
+            self.name,
+            self.pkg_spec,
+            prefix=self.prefix,
+            compiler=self.compiler,
+            compiler_spec=self.compiler_spec,
+            when=self.when,
+        )
+
+        return new_spec
+
+    def conflict_spec(self, test, skip_conflicting_when: bool = True):
+        if skip_conflicting_when:
+            new_when = set(getattr(self, "when", set()))
+            test_when = set(getattr(test, "when", set()))
+
+            if new_when != test_when:
+                return False
+
+        if self.prefix != test.prefix:
+            return False
+
+        for attr in ["pkg_spec", "compiler", "compiler_spec"]:
+            new_val = getattr(self, attr, None)
+            test_val = getattr(test, attr, None)
+            if new_val != test_val:
+                return True
+
+        return False
+
+    def conflict_dict(self, test_dict: Dict):
+        self_dict = self.to_dict()
+        for key, val in self_dict.items():
+            if key in test_dict and val != test_dict[key]:
+                return True
+        return False

--- a/lib/ramble/ramble/util/spec_utils.py
+++ b/lib/ramble/ramble/util/spec_utils.py
@@ -6,6 +6,7 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+import copy
 from typing import Dict, List
 
 import ramble.util.colors
@@ -87,16 +88,7 @@ class SoftwareSpec:
         return str(self_dict)
 
     def copy(self):
-        new_spec = SoftwareSpec(
-            self.name,
-            self.pkg_spec,
-            prefix=self.prefix,
-            compiler=self.compiler,
-            compiler_spec=self.compiler_spec,
-            when=self.when,
-        )
-
-        return new_spec
+        return copy.deepcopy(self)
 
     def conflict_spec(self, test, skip_conflicting_when: bool = True):
         if skip_conflicting_when:

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -46,7 +46,7 @@ from ramble.util import constants
 from ramble.util.conversions import list_str_to_list
 from ramble.util.logger import logger
 from ramble.util.path import substitute_path_variables
-from ramble.util.spec_utils import specs_equiv
+from ramble.util.spec_utils import specs_conflict
 
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
@@ -1400,11 +1400,22 @@ ramble:
 
         experiment_set = self.build_experiment_set(die_on_validate_error=False)
 
+        pkgman_prefixes = set()
+        for _, app_inst, _ in experiment_set.all_experiments():
+            app_inst.build_modifier_instances()
+            app_inst.add_expand_vars(self)
+            if app_inst.package_manager is not None:
+                pkgman_prefixes.add(app_inst.package_manager.spec_prefix())
+
         for _, app_inst, _ in experiment_set.all_experiments():
             app_inst.build_modifier_instances()
             app_inst.add_expand_vars(self)
             env_name_str = app_inst.expander.expansion_str(ramble.keywords.keywords.env_name)
             env_name = app_inst.expander.expand_var(env_name_str)
+
+            spec_prefix = (
+                f"{app_inst.package_manager.spec_prefix()}_" if len(pkgman_prefixes) > 1 else ""
+            )
 
             if app_inst.package_manager is None:
                 continue
@@ -1414,41 +1425,53 @@ ramble:
                 compiler_dicts.append(mod_inst.compilers)
 
             for compiler_dict in compiler_dicts:
-                for comp, info in compiler_dict.items():
-                    keep_comp = app_inst.expander.satisfies(
-                        info["when"], variant_set=app_inst.object_variants
-                    )
-                    if keep_comp:
-                        if comp not in packages_dict or force:
-                            packages_dict[comp] = syaml.syaml_dict()
-                            packages_dict[comp]["pkg_spec"] = info["pkg_spec"]
+                for comp, definitions in compiler_dict.items():
+                    for info in definitions:
+                        keep_comp = app_inst.expander.satisfies(
+                            info["when"], variant_set=app_inst.object_variants
+                        )
+                        if keep_comp:
+                            if (
+                                comp in packages_dict
+                                and not quiet
+                                and specs_conflict(info, packages_dict[comp], prefix=spec_prefix)
+                            ):
+                                logger.debug(f"  Spec 1: {str(info)}")
+                                logger.debug(f"  Spec 2: {str(packages_dict[comp])}")
+                                raise RambleConflictingDefinitionError(
+                                    f"Compiler {comp} would be defined "
+                                    "in multiple conflicting ways"
+                                )
+
+                            if comp not in packages_dict:
+                                packages_dict[comp] = syaml.syaml_dict()
+
+                            packages_dict[comp][f"{spec_prefix}pkg_spec"] = info["pkg_spec"]
                             ramble.config.add(
-                                f'software:packages:{comp}:pkg_spec:{info["pkg_spec"]}',
+                                f"software:packages:{comp}:"
+                                + f'{spec_prefix}pkg_spec:{info["pkg_spec"]}',
                                 scope=self.ws_file_config_scope_name(),
                             )
                             if "compiler_spec" in info and info["compiler_spec"]:
-                                packages_dict[comp]["compiler_spec"] = info["compiler_spec"]
+                                packages_dict[comp][f"{spec_prefix}compiler_spec"] = info[
+                                    "compiler_spec"
+                                ]
                                 config_path = (
                                     f"software:packages:{comp}:"
-                                    + f'compiler_spec:{info["compiler_spec"]}'
+                                    + f'{spec_prefix}compiler_spec:{info["compiler_spec"]}'
                                 )
                                 ramble.config.add(
                                     config_path, scope=self.ws_file_config_scope_name()
                                 )
                             if "compiler" in info and info["compiler"]:
-                                packages_dict[comp]["compiler"] = info["compiler"]
+                                packages_dict[comp][f"{spec_prefix}compiler"] = info["compiler"]
                                 config_path = (
-                                    f"software:packages:{comp}:" + f'compiler:{info["compiler"]}'
+                                    f"software:packages:{comp}:"
+                                    + f"{spec_prefix}compiler:{info['compiler']}"
                                 )
                                 ramble.config.add(
                                     config_path, scope=self.ws_file_config_scope_name()
                                 )
-                        elif not quiet and not specs_equiv(info, packages_dict[comp]):
-                            logger.debug(f"  Spec 1: {str(info)}")
-                            logger.debug(f"  Spec 2: {str(packages_dict[comp])}")
-                            raise RambleConflictingDefinitionError(
-                                f"Compiler {comp} would be defined " "in multiple conflicting ways"
-                            )
 
             logger.debug(f"Trying to define packages for {env_name}")
             app_packages = []
@@ -1461,30 +1484,42 @@ ramble:
                 software_dicts.append(mod_inst.software_specs)
 
             for software_dict in software_dicts:
-                for spec_name, info in software_dict.items():
-                    keep_pkg = app_inst.expander.satisfies(
-                        info["when"], variant_set=app_inst.object_variants
-                    )
-                    if keep_pkg:
-                        logger.debug(f"    Found spec: {spec_name}")
-                        if spec_name not in packages_dict or force:
-                            packages_dict[spec_name] = syaml.syaml_dict()
-                            packages_dict[spec_name]["pkg_spec"] = info["pkg_spec"]
+                for spec_name, definitions in software_dict.items():
+                    for info in definitions:
+                        keep_pkg = app_inst.expander.satisfies(
+                            info["when"], variant_set=app_inst.object_variants
+                        )
+                        if keep_pkg:
+                            logger.debug(f"    Found spec: {spec_name}")
+                            if (
+                                spec_name in packages_dict
+                                and not quiet
+                                and specs_conflict(
+                                    info, packages_dict[spec_name], prefix=spec_prefix
+                                )
+                            ):
+                                logger.debug(f"  Spec 1: {str(info)}")
+                                logger.debug(f"  Spec 2: {str(packages_dict[spec_name])}")
+                                raise RambleConflictingDefinitionError(
+                                    f"Package {spec_name} would be defined in multiple "
+                                    "conflicting ways"
+                                )
+
+                            if spec_name not in packages_dict:
+                                packages_dict[spec_name] = syaml.syaml_dict()
+
+                            packages_dict[spec_name][f"{spec_prefix}pkg_spec"] = info["pkg_spec"]
                             if "compiler_spec" in info and info["compiler_spec"]:
-                                packages_dict[spec_name]["compiler_spec"] = info["compiler_spec"]
+                                packages_dict[spec_name][f"{spec_prefix}compiler_spec"] = info[
+                                    "compiler_spec"
+                                ]
                             if "compiler" in info and info["compiler"]:
-                                packages_dict[spec_name]["compiler"] = info["compiler"]
+                                packages_dict[spec_name][f"{spec_prefix}compiler"] = info[
+                                    "compiler"
+                                ]
 
-                        elif not quiet and not specs_equiv(info, packages_dict[spec_name]):
-                            logger.debug(f"  Spec 1: {str(info)}")
-                            logger.debug(f"  Spec 2: {str(packages_dict[spec_name])}")
-                            raise RambleConflictingDefinitionError(
-                                f"Package {spec_name} would be defined in multiple "
-                                "conflicting ways"
-                            )
-
-                        if spec_name not in app_packages:
-                            app_packages.append(spec_name)
+                            if spec_name not in app_packages:
+                                app_packages.append(spec_name)
 
             if app_packages:
                 if env_name not in environments_dict:

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -46,7 +46,6 @@ from ramble.util import constants
 from ramble.util.conversions import list_str_to_list
 from ramble.util.logger import logger
 from ramble.util.path import substitute_path_variables
-from ramble.util.spec_utils import specs_conflict
 
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
@@ -1415,7 +1414,7 @@ ramble:
             env_name = app_inst.expander.expand_var(env_name_str)
 
             spec_prefix = (
-                f"{app_inst.package_manager.spec_prefix()}_" if len(pkgman_prefixes) > 1 else ""
+                f"{app_inst.package_manager.spec_prefix()}" if len(pkgman_prefixes) > 1 else ""
             )
 
             if app_inst.package_manager is None:
@@ -1429,13 +1428,13 @@ ramble:
                 for comp, definitions in compiler_dict.items():
                     for info in definitions:
                         keep_comp = app_inst.expander.satisfies(
-                            info["when"], variant_set=app_inst.object_variants
+                            info.when, variant_set=app_inst.object_variants
                         )
                         if keep_comp:
                             if (
                                 not quiet
                                 and comp in packages_dict
-                                and specs_conflict(info, packages_dict[comp], prefix=spec_prefix)
+                                and info.conflict_dict(packages_dict[comp])
                             ):
                                 logger.debug(f"  Spec 1: {str(info)}")
                                 logger.debug(f"  Spec 2: {str(packages_dict[comp])}")
@@ -1450,32 +1449,9 @@ ramble:
                                 newly_created_packages.add(comp)
                                 packages_dict[comp] = syaml.syaml_dict()
 
-                            packages_dict[comp][f"{spec_prefix}pkg_spec"] = info["pkg_spec"]
-                            ramble.config.add(
-                                f"software:packages:{comp}:"
-                                + f'{spec_prefix}pkg_spec:{info["pkg_spec"]}',
-                                scope=self.ws_file_config_scope_name(),
-                            )
-                            if "compiler_spec" in info and info["compiler_spec"]:
-                                packages_dict[comp][f"{spec_prefix}compiler_spec"] = info[
-                                    "compiler_spec"
-                                ]
-                                config_path = (
-                                    f"software:packages:{comp}:"
-                                    + f'{spec_prefix}compiler_spec:{info["compiler_spec"]}'
-                                )
-                                ramble.config.add(
-                                    config_path, scope=self.ws_file_config_scope_name()
-                                )
-                            if "compiler" in info and info["compiler"]:
-                                packages_dict[comp][f"{spec_prefix}compiler"] = info["compiler"]
-                                config_path = (
-                                    f"software:packages:{comp}:"
-                                    + f"{spec_prefix}compiler:{info['compiler']}"
-                                )
-                                ramble.config.add(
-                                    config_path, scope=self.ws_file_config_scope_name()
-                                )
+                            packages_dict[comp].update(info.to_dict(prefix=spec_prefix))
+                            for conf in info.config_opts():
+                                ramble.config.add(conf, scope=self.ws_file_config_scope_name())
 
             logger.debug(f"Trying to define packages for {env_name}")
             app_packages = []
@@ -1491,16 +1467,14 @@ ramble:
                 for spec_name, definitions in software_dict.items():
                     for info in definitions:
                         keep_pkg = app_inst.expander.satisfies(
-                            info["when"], variant_set=app_inst.object_variants
+                            info.when, variant_set=app_inst.object_variants
                         )
                         if keep_pkg:
                             logger.debug(f"    Found spec: {spec_name}")
                             if (
                                 not quiet
                                 and spec_name in packages_dict
-                                and specs_conflict(
-                                    info, packages_dict[spec_name], prefix=spec_prefix
-                                )
+                                and info.conflict_dict(packages_dict[spec_name])
                             ):
                                 logger.debug(f"  Spec 1: {str(info)}")
                                 logger.debug(f"  Spec 2: {str(packages_dict[spec_name])}")
@@ -1514,15 +1488,7 @@ ramble:
                             ):
                                 packages_dict[spec_name] = syaml.syaml_dict()
 
-                            packages_dict[spec_name][f"{spec_prefix}pkg_spec"] = info["pkg_spec"]
-                            if "compiler_spec" in info and info["compiler_spec"]:
-                                packages_dict[spec_name][f"{spec_prefix}compiler_spec"] = info[
-                                    "compiler_spec"
-                                ]
-                            if "compiler" in info and info["compiler"]:
-                                packages_dict[spec_name][f"{spec_prefix}compiler"] = info[
-                                    "compiler"
-                                ]
+                            packages_dict[spec_name].update(info.to_dict(prefix=spec_prefix))
 
                             if spec_name not in app_packages:
                                 app_packages.append(spec_name)

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1395,6 +1395,7 @@ ramble:
 
         packages_dict = full_software_dict[namespace.packages]
         environments_dict = full_software_dict[namespace.environments]
+        newly_created_packages = set()
 
         self.software_environments = ramble.software_environments.SoftwareEnvironments(self)
 
@@ -1432,8 +1433,8 @@ ramble:
                         )
                         if keep_comp:
                             if (
-                                comp in packages_dict
-                                and not quiet
+                                not quiet
+                                and comp in packages_dict
                                 and specs_conflict(info, packages_dict[comp], prefix=spec_prefix)
                             ):
                                 logger.debug(f"  Spec 1: {str(info)}")
@@ -1443,7 +1444,10 @@ ramble:
                                     "in multiple conflicting ways"
                                 )
 
-                            if comp not in packages_dict:
+                            if comp not in packages_dict or (
+                                force and comp not in newly_created_packages
+                            ):
+                                newly_created_packages.add(comp)
                                 packages_dict[comp] = syaml.syaml_dict()
 
                             packages_dict[comp][f"{spec_prefix}pkg_spec"] = info["pkg_spec"]
@@ -1492,8 +1496,8 @@ ramble:
                         if keep_pkg:
                             logger.debug(f"    Found spec: {spec_name}")
                             if (
-                                spec_name in packages_dict
-                                and not quiet
+                                not quiet
+                                and spec_name in packages_dict
                                 and specs_conflict(
                                     info, packages_dict[spec_name], prefix=spec_prefix
                                 )
@@ -1505,7 +1509,9 @@ ramble:
                                     "conflicting ways"
                                 )
 
-                            if spec_name not in packages_dict:
+                            if spec_name not in packages_dict or (
+                                force and spec_name not in newly_created_packages
+                            ):
                                 packages_dict[spec_name] = syaml.syaml_dict()
 
                             packages_dict[spec_name][f"{spec_prefix}pkg_spec"] = info["pkg_spec"]

--- a/var/ramble/repos/builtin/applications/gromacs/application.py
+++ b/var/ramble/repos/builtin/applications/gromacs/application.py
@@ -31,12 +31,12 @@ class Gromacs(ExecutableApplication):
 
         with default_args(compiler="gcc9"):
             software_spec(
-                "spack_gromacs",
+                "gromacs",
                 pkg_spec="gromacs@2020.5",
             )
 
     software_spec(
-        "eessi_gromacs",
+        "gromacs",
         pkg_spec="GROMACS/2024.1-foss-2023b",
         when=["package_manager_family=eessi"],
     )


### PR DESCRIPTION
This merge enables the `software_spec` and `define_compiler` directives to define the same packages multiple times with different definitions that would conflict.

The primary use case for this is while using `when` arguments to change the circumstances for using each of the definition. Errors will still be presented if multiple definitions would actually conflict, to help prevent invalid object definitions.