### PR TITLE
Allow `manage experiments` to accept a workflow manager option

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -720,6 +720,31 @@ def pytest_generate_tests(metafunc):
 
         metafunc.parametrize("mock_package_managers", all_package_managers)
 
+    if "workflow_manager" in metafunc.fixturenames:
+        from ramble.main import RambleCommand
+
+        list_cmd = RambleCommand("list")
+
+        all_workflow_managers = ["None"]
+        repo_pms = list_cmd("--type", "workflow_managers").split("\n")
+
+        for pm_str in repo_pms:
+            m = name_regex.match(pm_str)
+            if m:
+                all_workflow_managers.append(m.group("name"))
+
+        metafunc.parametrize("workflow_manager", all_workflow_managers)
+
+    if "mock_workflow_managers" in metafunc.fixturenames:
+        obj_type = ramble.repository.ObjectTypes.workflow_managers
+        repo_path = ramble.repository.Repo(ramble.paths.mock_builtin_path, obj_type)
+
+        all_workflow_managers = ["None"]
+        for mod_name in repo_path.all_object_names():
+            all_workflow_managers.append(mod_name)
+
+        metafunc.parametrize("mock_workflow_managers", all_workflow_managers)
+
     if "config_section" in metafunc.fixturenames:
         from ramble.main import RambleCommand
 

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -1120,7 +1120,15 @@ def workspace_manage_experiments_setup_parser(subparser):
         "-p",
         dest="package_manager",
         default=None,
-        help="name of (optional) package to define within the experiment scope",
+        help="name of (optional) package manager to use within the experiment scope",
+    )
+
+    subparser.add_argument(
+        "--workflow-manager",
+        "--wm",
+        dest="workflow_manager",
+        default=None,
+        help="name of (optional) workflow manager to use within the experiment scope",
     )
 
     subparser.add_argument(
@@ -1215,6 +1223,7 @@ def workspace_manage_experiments(args):
         variable_definitions,
         args.experiment_name,
         args.package_manager,
+        args.workflow_manager,
         zips,
         matrix,
         args.overwrite,

--- a/lib/ramble/ramble/test/end_to_end/known_applications.py
+++ b/lib/ramble/ramble/test/end_to_end/known_applications.py
@@ -26,7 +26,7 @@ workspace = RambleCommand("workspace")
 @pytest.mark.long
 @deprecation.fail_if_not_removed
 @pytest.mark.filterwarnings("ignore:invalid escape sequence:DeprecationWarning")
-def test_known_applications(application, package_manager, mock_file_auto_create):
+def test_known_applications(application, package_manager, mock_file_auto_create, request):
     setup_type = ramble.pipeline.pipelines.setup
     analyze_type = ramble.pipeline.pipelines.analyze
     archive_type = ramble.pipeline.pipelines.archive
@@ -35,7 +35,7 @@ def test_known_applications(application, package_manager, mock_file_auto_create)
     archive_cls = ramble.pipeline.pipeline_class(archive_type)
     filters = ramble.filters.Filters()
 
-    ws_name = f"test_all_apps_{application}"
+    ws_name = request.node.name.replace("[", "_").replace("]", "_")
 
     with ramble.workspace.create(ws_name) as ws:
         ws.write()
@@ -58,11 +58,70 @@ def test_known_applications(application, package_manager, mock_file_auto_create)
             args.append("-p")
             args.append(package_manager)
 
-        workspace("generate-config", *args, global_args=["-w", ws_name])
+        workspace("manage", "experiments", *args, global_args=["-w", ws_name])
 
         ws._re_read()
         ws.concretize()
         ws._re_read()
+
+        if package_manager != "user-managed":
+            with open(ws.config_file_path) as f:
+                data = f.read()
+                assert package_manager in data
+
+        ws.dry_run = True
+        setup_pipeline = setup_cls(ws, filters)
+        setup_pipeline.run()
+        analyze_pipeline = analyze_cls(ws, filters)
+        analyze_pipeline.run()
+        archive_pipeline = archive_cls(ws, filters, create_tar=True)
+        archive_pipeline.run()
+
+
+@pytest.mark.long
+@deprecation.fail_if_not_removed
+@pytest.mark.filterwarnings("ignore:invalid escape sequence:DeprecationWarning")
+def test_known_workflow_managers(workflow_manager, mock_file_auto_create, request):
+    setup_type = ramble.pipeline.pipelines.setup
+    analyze_type = ramble.pipeline.pipelines.analyze
+    archive_type = ramble.pipeline.pipelines.archive
+    setup_cls = ramble.pipeline.pipeline_class(setup_type)
+    analyze_cls = ramble.pipeline.pipeline_class(analyze_type)
+    archive_cls = ramble.pipeline.pipeline_class(archive_type)
+    filters = ramble.filters.Filters()
+
+    ws_name = request.node.name.replace("[", "_").replace("]", "_")
+
+    with ramble.workspace.create(ws_name) as ws:
+        ws.write()
+        args = [
+            "gromacs",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "n_ranks=1",
+            "-w",
+            "test_workload",
+        ]
+        # Handle `user-managed` package manager
+        app_inst = ramble.repository.get("gromacs")
+        for pkg in app_inst.required_packages.keys():
+            args.append("-v")
+            args.append(f"{pkg}_path='/not/real/path'")
+
+        args.append("--wm")
+        args.append(workflow_manager)
+
+        workspace("manage", "experiments", *args, global_args=["-w", ws_name])
+
+        ws._re_read()
+        ws.concretize()
+        ws._re_read()
+
+        with open(ws.config_file_path) as f:
+            data = f.read()
+            assert workflow_manager in data
+
         ws.dry_run = True
         setup_pipeline = setup_cls(ws, filters)
         setup_pipeline.run()

--- a/lib/ramble/ramble/test/end_to_end/known_applications.py
+++ b/lib/ramble/ramble/test/end_to_end/known_applications.py
@@ -21,6 +21,7 @@ from ramble.main import RambleCommand
 pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_path")
 
 workspace = RambleCommand("workspace")
+config = RambleCommand("config")
 
 
 @pytest.mark.long
@@ -81,7 +82,7 @@ def test_known_applications(application, package_manager, mock_file_auto_create,
 @pytest.mark.long
 @deprecation.fail_if_not_removed
 @pytest.mark.filterwarnings("ignore:invalid escape sequence:DeprecationWarning")
-def test_known_workflow_managers(workflow_manager, mock_file_auto_create, request):
+def test_known_workflow_managers(workflow_manager, mock_file_auto_create, mutable_config, request):
     setup_type = ramble.pipeline.pipelines.setup
     analyze_type = ramble.pipeline.pipelines.analyze
     archive_type = ramble.pipeline.pipelines.archive
@@ -113,6 +114,19 @@ def test_known_workflow_managers(workflow_manager, mock_file_auto_create, reques
         args.append(workflow_manager)
 
         workspace("manage", "experiments", *args, global_args=["-w", ws_name])
+
+        # Handle workflow manager. Remove variables defined in the workflow to
+        # ensure we catch invalid configurations.
+        if workflow_manager != "None":
+            ws._re_read()
+            wm_inst = ramble.repository.get(
+                workflow_manager, object_type=ramble.repository.ObjectTypes.workflow_managers
+            )
+            for var_name in wm_inst.wm_vars:
+                config("remove", f"variables:{var_name}", global_args=["-w", ws_name])
+
+            for var_name in wm_inst.templates:
+                config("remove", f"variables:{var_name}", global_args=["-w", ws_name])
 
         ws._re_read()
         ws.concretize()

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1115,6 +1115,7 @@ ramble:
         variable_definitions,
         experiment_name,
         package_manager=None,
+        workflow_manager=None,
         zips=None,
         matrix=None,
         overwrite=False,
@@ -1137,6 +1138,7 @@ ramble:
                                               within generated experiments
             experiment_name (str): The name of the experiments to add
             package_manager (str): Name of package manager to use for the generated experiments
+            workflow_manager (str): Name of workflow manager to use for the generated experiments
             zips (list(str) | None): List of strings representing zips to define, in the
                               format zipname=[var1,var2,var3]
             matrix (str): String representing a matrix to define within the
@@ -1286,10 +1288,15 @@ ramble:
             exps_dict[experiment_name] = syaml.syaml_dict()
             exp_dict = exps_dict[experiment_name]
 
-            if package_manager is not None:
+            if package_manager is not None or workflow_manager is not None:
                 exp_dict[namespace.variants] = syaml.syaml_dict()
                 variants_dict = exp_dict[namespace.variants]
-                variants_dict[namespace.package_manager] = package_manager
+
+                if package_manager is not None:
+                    variants_dict[namespace.package_manager] = package_manager
+
+                if workflow_manager is not None:
+                    variants_dict[namespace.workflow_manager] = workflow_manager
 
             if namespace.variables not in exp_dict:
                 exp_dict[namespace.variables] = yaml.comments.CommentedMap()

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -728,7 +728,7 @@ _ramble_workspace_rm() {
 _ramble_workspace_generate_config() {
     if $list_options
     then
-        RAMBLE_COMPREPLY="-h --help --workload-filter --wf --variable-filter --vf --variable-definition -v --experiment-name -e --package-manager -p --dry-run --print --overwrite --include-default-variables -i --workload-name-variable -w --zip -z --matrix -m"
+        RAMBLE_COMPREPLY="-h --help --workload-filter --wf --variable-filter --vf --variable-definition -v --experiment-name -e --package-manager -p --workflow-manager --wm --dry-run --print --overwrite --include-default-variables -i --workload-name-variable -w --zip -z --matrix -m"
     else
         _all_applications
     fi
@@ -746,7 +746,7 @@ _ramble_workspace_manage() {
 _ramble_workspace_manage_experiments() {
     if $list_options
     then
-        RAMBLE_COMPREPLY="-h --help --workload-filter --wf --variable-filter --vf --variable-definition -v --experiment-name -e --package-manager -p --dry-run --print --overwrite --include-default-variables -i --workload-name-variable -w --zip -z --matrix -m"
+        RAMBLE_COMPREPLY="-h --help --workload-filter --wf --variable-filter --vf --variable-definition -v --experiment-name -e --package-manager -p --workflow-manager --wm --dry-run --print --overwrite --include-default-variables -i --workload-name-variable -w --zip -z --matrix -m"
     else
         _all_applications
     fi


### PR DESCRIPTION
This merge allows the `manage experiments` command to set workflow managers in the generated experiments.