### PR TITLE
Use the `--fast` option instead of `-m "not long"`

### DIFF
--- a/share/ramble/qa/run-unit-tests
+++ b/share/ramble/qa/run-unit-tests
@@ -67,7 +67,7 @@ fi
 if [[ "$LONG" == "true" ]]; then
   $(which ramble) unit-test ${PYTEST_ADDOPTS} -x --verbose ${UNIT_TEST_COVERAGE_ADDOPTS}
 else
-  $(which ramble) unit-test ${PYTEST_ADDOPTS} -x --verbose ${UNIT_TEST_COVERAGE_ADDOPTS} -m "not long"
+  $(which ramble) unit-test ${PYTEST_ADDOPTS} -x --verbose ${UNIT_TEST_COVERAGE_ADDOPTS} --fast
 fi
 if [ $? != 0 ]; then
     ERROR=1


### PR DESCRIPTION
We have a few more pytest marks (`maybeslow`, `db` and `network`) besides `long` that denote slower tests.