### PR TITLE
Fix incorrect variable definition splitting

### DIFF
--- a/lib/ramble/ramble/test/cmd/workspace_manage.py
+++ b/lib/ramble/ramble/test/cmd/workspace_manage.py
@@ -38,10 +38,18 @@ def test_manage_variable_multiple_equals(request, tmpdir):
         "test_var=foo=bar",
         "-v",
         "test_list_var=[ val1 = val2, val3=val4]",
+        "-v",
+        "test_other_var = test1=test2=test3",
         global_args=global_args,
     )
 
-    tests = ["test_var: foo=bar", "test_list_var:", "- val1 = val2", "- val3=val4"]
+    tests = [
+        "test_var: foo=bar",
+        "test_list_var:",
+        "- val1 = val2",
+        "- val3=val4",
+        "test_other_var: test1=test2=test3",
+    ]
 
     results = [False for _ in tests]
 

--- a/lib/ramble/ramble/test/cmd/workspace_manage.py
+++ b/lib/ramble/ramble/test/cmd/workspace_manage.py
@@ -1,0 +1,54 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import pytest
+
+import ramble.workspace
+from ramble.main import RambleCommand
+
+pytestmark = pytest.mark.usefixtures("mutable_mock_workspace_path")
+
+
+workspace = RambleCommand("workspace")
+
+
+def test_manage_variable_multiple_equals(request, tmpdir):
+    workspace_name = request.node.name
+    ws = ramble.workspace.create(workspace_name)
+
+    global_args = ["-w", workspace_name]
+
+    # Highest precedence, experiment scope
+    workspace(
+        "manage",
+        "experiments",
+        "gromacs",
+        "--wf",
+        "water_bare",
+        "-v",
+        "n_nodes=1",
+        "-v",
+        "n_ranks=1",
+        "-v",
+        "test_var=foo=bar",
+        "-v",
+        "test_list_var=[ val1 = val2, val3=val4]",
+        global_args=global_args,
+    )
+
+    tests = ["test_var: foo=bar", "test_list_var:", "- val1 = val2", "- val3=val4"]
+
+    results = [False for _ in tests]
+
+    with open(ws.config_file_path) as f:
+        for line in f.readlines():
+            for idx, test_str in enumerate(tests):
+                if test_str in line:
+                    results[idx] = True
+
+    assert all(results)

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1207,12 +1207,13 @@ ramble:
         app_inst = ramble.repository.get(application)
 
         var_def_dict = {}
-        def_regex = re.compile(r"(?P<key>.*)=(?P<value>.*)")
+        def_regex = re.compile(r"\s*=\s*")
         for definition in variable_definitions:
-            m = def_regex.match(definition)
+            m = def_regex.search(definition)
+
             if m:
-                key = m.group("key")
-                value = list_str_to_list(m.group("value"))
+                key = definition[0 : m.start()]
+                value = list_str_to_list(definition[m.end() :])
                 var_def_dict[key] = value
             else:
                 logger.die(


### PR DESCRIPTION
This merge fixes an issue where `manage experiments` would incorreclty split variable definitions that included multiple equals signs.

A test is added to help ensure this doesn't happen again as well.