### PR TITLE
Add support for running tests defined in a custom Ramble object repo

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -11,6 +11,7 @@ import collections
 import io
 import os
 import os.path
+import pathlib
 import shutil
 
 import py
@@ -47,6 +48,20 @@ def pytest_addoption(parser):
         default=False,
         help='runs only "fast" unit tests, instead of the whole suite',
     )
+    group.addoption(
+        "--repo-path",
+        default=None,
+        help="runs only tests under the given Ramble object repo path",
+    )
+
+
+def pytest_configure(config):
+    repo_path = config.getoption("--repo-path")
+    if not repo_path:
+        return
+    path = pathlib.Path(repo_path)
+    # Define testpaths
+    config.args = [p for p in path.rglob("test") if p.is_dir()]
 
 
 def pytest_collection_modifyitems(config, items):
@@ -154,28 +169,45 @@ def mock_wms_repo_path():
     yield ramble.repository.Repo(ramble.paths.mock_builtin_path, obj_type)
 
 
+def _get_obj_repo_path(obj_type, extra_repo_path):
+    repos = []
+    # extra_repo_path takes precedence
+    if extra_repo_path is not None:
+        try:
+            repo = ramble.repository.Repo(extra_repo_path, obj_type)
+            repos.append(repo)
+        except ramble.repository.BadRepoError:
+            pass
+    repos.append(ramble.repository.Repo(ramble.paths.builtin_path, obj_type))
+    yield ramble.repository.RepoPath(*repos, object_type=obj_type)
+
+
 @pytest.fixture(scope="function")
-def mutable_apps_repo_path():
+def mutable_apps_repo_path(pytestconfig):
     obj_type = ramble.repository.ObjectTypes.applications
-    yield ramble.repository.Repo(ramble.paths.builtin_path, obj_type)
+    extra_repo_path = pytestconfig.getoption("--repo-path")
+    yield from _get_obj_repo_path(obj_type, extra_repo_path)
 
 
 @pytest.fixture(scope="function")
-def mutable_mods_repo_path():
+def mutable_mods_repo_path(pytestconfig):
     obj_type = ramble.repository.ObjectTypes.modifiers
-    yield ramble.repository.Repo(ramble.paths.builtin_path, obj_type)
+    extra_repo_path = pytestconfig.getoption("--repo-path")
+    yield from _get_obj_repo_path(obj_type, extra_repo_path)
 
 
 @pytest.fixture(scope="function")
-def mutable_pkg_mans_repo_path():
+def mutable_pkg_mans_repo_path(pytestconfig):
     obj_type = ramble.repository.ObjectTypes.package_managers
-    yield ramble.repository.Repo(ramble.paths.builtin_path, obj_type)
+    extra_repo_path = pytestconfig.getoption("--repo-path")
+    yield from _get_obj_repo_path(obj_type, extra_repo_path)
 
 
 @pytest.fixture(scope="function")
-def mutable_wms_repo_path():
+def mutable_wms_repo_path(pytestconfig):
     obj_type = ramble.repository.ObjectTypes.workflow_managers
-    yield ramble.repository.Repo(ramble.paths.builtin_path, obj_type)
+    extra_repo_path = pytestconfig.getoption("--repo-path")
+    yield from _get_obj_repo_path(obj_type, extra_repo_path)
 
 
 @pytest.fixture(scope="function")

--- a/lib/ramble/ramble/cmd/unit_test.py
+++ b/lib/ramble/ramble/cmd/unit_test.py
@@ -10,7 +10,9 @@
 import argparse
 import collections
 import io
+import os
 import re
+import shutil
 import sys
 
 import llnl.util.tty.color as color
@@ -47,6 +49,13 @@ def setup_parser(subparser):
         action="store_true",
         default=False,
         help="run only tests under the builtin object repo directory",
+    )
+    limited.add_argument(
+        "-r",
+        "--repo-path",
+        default=None,
+        dest="repo_path",
+        help="run tests under the given object repo root (used for testing external object repo)",
     )
 
     # extra ramble arguments to list tests
@@ -192,6 +201,8 @@ def add_back_pytest_args(args, unknown_args):
         result += ["--ignore-glob", "var/ramble/repos/*"]
     elif args.obj:
         result += ["--ignore-glob", "lib/ramble/ramble/test/*"]
+    elif args.repo_path:
+        result += ["--repo-path", args.repo_path]
     result += unknown_args or []
     result += args.pytest_args or []
     if args.expression:
@@ -213,20 +224,39 @@ def unit_test(parser, args, unknown_args):
     # add back any parsed pytest args we need to pass to pytest
     pytest_args = add_back_pytest_args(args, unknown_args)
 
-    pytest_root = ramble.paths.ramble_root
+    pytest_root = args.repo_path or ramble.paths.ramble_root
 
-    # pytest.ini lives in the root of the ramble repository.
-    with working_dir(pytest_root):
-        if args.list:
-            do_list(args, pytest_args)
-            return
+    # conftest.py and pytest.ini live in the root of the ramble repository.
+    # need to ensure the same when repo_path is specified.
+    copied_conftest_path = None
+    copied_ini_path = None
+    try:
+        with working_dir(pytest_root):
 
-        with ramble.workspace.no_active_workspace():
-            try:
-                import pytest
+            def _ensure_path_in_cwd(filename):
+                if not os.path.exists(filename):
+                    shutil.copyfile(os.path.join(ramble.paths.ramble_root, filename), filename)
+                    return os.path.join(pytest_root, filename)
+                return None
 
-                return pytest.main(pytest_args)
-            except ImportError:
-                logger.die(
-                    "Pytest python module not found. Ensure requirements.txt are installed."
-                )
+            copied_conftest_path = _ensure_path_in_cwd("conftest.py")
+            copied_ini_path = _ensure_path_in_cwd("pytest.ini")
+
+            if args.list:
+                do_list(args, pytest_args)
+                return
+
+            with ramble.workspace.no_active_workspace():
+                try:
+                    import pytest
+
+                    return pytest.main(pytest_args)
+                except ImportError:
+                    logger.die(
+                        "Pytest python module not found. Ensure requirements.txt are installed."
+                    )
+    finally:
+        if copied_conftest_path is not None:
+            os.remove(copied_conftest_path)
+        if copied_ini_path is not None:
+            os.remove(copied_ini_path)

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -621,7 +621,7 @@ _ramble_style() {
 _ramble_unit_test() {
     if $list_options
     then
-        RAMBLE_COMPREPLY="-h --help -H --pytest-help --lib --obj -l --list -L --list-long -N --list-names -s -k --showlocals"
+        RAMBLE_COMPREPLY="-h --help -H --pytest-help --lib --obj -r --repo-path -l --list -L --list-long -N --list-names -s -k --showlocals"
     else
         _tests
     fi


### PR DESCRIPTION
This is done by doing the following:

* Add a `--repo-path` option to `ramble unit-test`, which can be used to point to the custom repo.

* Copy pytest configs (`pytest.ini` and `conftest.py`), if needed, to the custom repo root.

* Use pytest's `pytest_configure` hook to override `pytest.ini`'s `testpaths` setting.

* Extend the various `mutable_*` fixtures so that they look at both builtin and the custom repos.

Example run:

```
~/hpc-dev/ramble$ ramble unit-test -r ../ramble-applications
========================================================================================= test session starts ==========================================================================================
platform linux -- Python 3.13.0, pytest-8.3.3, pluggy-1.5.0
rootdir: /usr/local/google/home/linsword/hpc-dev/ramble-applications
configfile: pytest.ini
plugins: xdist-3.6.1, cov-6.0.0
collected 1 item

applications/sys-info/test/sys-info.py .                                                                                                                                                         [100%]

========================================================================================= slowest 30 durations =========================================================================================
0.09s call     applications/sys-info/test/sys-info.py::test_sysinfo_builtin
0.02s setup    applications/sys-info/test/sys-info.py::test_sysinfo_builtin

(1 durations < 0.005s hidden.  Use -vv to show these durations.)
========================================================================================== 1 passed in 0.17s ===========================================================================================
```