### PR TITLE
Prevent workspace create form using active workspace variants

### DIFF
--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -2278,3 +2278,22 @@ def test_workspace_no_empty_workloads(request):
             data = f.read()
             assert "basic:" not in data
             assert "workloads: {}" not in data
+
+
+def test_no_inherit_active_workspace_variants(request):
+    workspace1_name = f"{request.node.name}_1"
+    workspace2_name = f"{request.node.name}_2"
+
+    global_args = ["-w", workspace1_name]
+
+    workspace("create", workspace1_name)
+    config("add", "variants:package_manager:spack", global_args=global_args)
+    config("add", "variants:workflow_manager:slurm", global_args=global_args)
+
+    workspace("create", workspace2_name, global_args=global_args)
+
+    with ramble.workspace.read(workspace2_name) as ws2:
+        with open(ws2.config_file_path) as f:
+            data = f.read()
+            assert "spack" not in data
+            assert "slurm" not in data

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -602,10 +602,17 @@ cd "{experiment_run_dir}"
 
         # Construct string for default variants
         variant_string = ""
-        variant_dict = ramble.config.get("variants")
-        variant_defs = []
 
-        for var, val in variant_dict.items():
+        all_variants = {}
+        for scope in ramble.config.scopes():
+            if "workspace" not in scope:
+                variant_dict = ramble.config.get("variants", scope=scope)
+
+                for var, val in variant_dict.items():
+                    all_variants[var] = val
+
+        variant_defs = []
+        for var, val in all_variants.items():
             variant_defs.append(f"    {var}: {val}")
 
         if variant_defs:


### PR DESCRIPTION
This merge fixes an issue where `ramble workspace create` would replicate variants defined in an active workspace. After this change, newly created workspaces only replicate variants set outside of any other workspace scope.