### PR TITLE
Generate container image from existing spack installation

### DIFF
--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
@@ -576,9 +576,17 @@ class SpackLightweight(PackageManagerBase):
         source_cmd = "\n".join(self.runner.generate_source_command())
         activate_cmd = "\n".join(self.runner.generate_activate_command())
         self.runner.deactivate()
+        user_flags = ramble.config.get(
+            f"{self.runner.buildcache_config_name}:flags"
+        )
+        if user_flags is not None:
+            additional_args = user_flags
+        else:
+            additional_args = ""
         return {
             "source_cmd": source_cmd,
             "activate_cmd": activate_cmd,
+            "additional_args": additional_args,
         }
 
 

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
@@ -546,6 +546,41 @@ class SpackLightweight(PackageManagerBase):
         self.runner.deactivate()
         return pkg_list
 
+    package_manager_variable(
+        "container_registry_name",
+        default="non-existent",
+        description="Name of the container registry to push image to",
+    )
+
+    package_manager_variable(
+        "container_base_image",
+        default="",
+        description="Base image for the container",
+    )
+
+    package_manager_variable(
+        "container_image_tag",
+        default="",
+        description="Tag for the container image",
+    )
+
+    register_template(
+        name="push_container_image",
+        src_path="push_container_image.sh.tpl",
+        dest_path="push_container_image.sh",
+        extra_vars_func="push_container_image_vars",
+    )
+
+    def _push_container_image_vars(self):
+        self.runner.activate()
+        source_cmd = "\n".join(self.runner.generate_source_command())
+        activate_cmd = "\n".join(self.runner.generate_activate_command())
+        self.runner.deactivate()
+        return {
+            "source_cmd": source_cmd,
+            "activate_cmd": activate_cmd,
+        }
+
 
 spack_namespace = "spack"
 

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/push_container_image.sh.tpl
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/push_container_image.sh.tpl
@@ -14,5 +14,5 @@ echo "Pushing container image to registry at $url"
 spack buildcache push \
   --update-index \
   --base-image "{container_base_image}" \
-  --tag "{container_image_tag}" \
+  --tag "{container_image_tag}" {additional_args} \
   "{container_registry_name}"

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/push_container_image.sh.tpl
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/push_container_image.sh.tpl
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+{source_cmd}
+{activate_cmd}
+
+if ! spack mirror list | awk '{print $1}' | grep -q "{container_registry_name}"; then
+  echo "Error: '{container_registry_name}' is not a valid Spack mirror." >&2
+  echo "See https://spack.readthedocs.io/en/latest/containers.html#from-existing-installations on the mirror setup." >&2
+  exit 1
+fi
+
+url=$(spack mirror list | grep "{container_registry_name}" | awk '{print $3)')
+echo "Pushing container image to registry at $url"
+spack buildcache push \
+  --update-index \
+  --base-image "{container_base_image}" \
+  --tag "{container_image_tag}" \
+  "{container_registry_name}"

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/test/spack_lightweight.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/test/spack_lightweight.py
@@ -1,0 +1,64 @@
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.workspace
+from ramble.main import RambleCommand
+
+pytestmark = pytest.mark.usefixtures(
+    "mutable_config",
+    "mutable_mock_workspace_path",
+)
+
+workspace = RambleCommand("workspace")
+
+
+def test_container_push_cache_script(request):
+    ws_name = request.node.name
+    ws = ramble.workspace.create(ws_name)
+    workspace(
+        "manage",
+        "experiments",
+        "hostname",
+        "-p",
+        "spack-lightweight",
+        "--wf",
+        "local",
+        "-v",
+        "n_nodes=1",
+        "-v",
+        "processes_per_node=1",
+        "-v",
+        "container_registry_name=my-oci",
+        "-v",
+        "container_base_image=base-linux",
+        "-v",
+        "container_image_tag=my-tag",
+        global_args=["-w", ws_name],
+    )
+    ws._re_read()
+    with ramble.config.override(
+        "config:spack:", {"buildcache": {"flags": "--private"}}
+    ):
+        workspace("setup", global_args=["-w", ws_name])
+    script_path = os.path.join(
+        ws.experiment_dir,
+        "hostname",
+        "local",
+        "generated",
+        "push_container_image.sh",
+    )
+    assert os.path.exists(script_path)
+    with open(script_path) as f:
+        script = f.read()
+        assert "spack/setup-env.sh" in script
+        assert "spack env activate" in script
+        assert "spack buildcache push" in script
+        assert '--base-image "base-linux"' in script
+        assert '--tag "my-tag" --private' in script


### PR DESCRIPTION
The script facilitates the instruction documented in https://spack.readthedocs.io/en/latest/containers.html#from-existing-installations.