### PR TITLE
Exclude top-level import statements from coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,12 @@ exclude_lines = [
     'if 0:',
     'if False:',
     'if __name__ == .__main__.:',
+
+    # Ignore import statements:
+    # Imports (and defs) are not counted due to coverage being run after
+    # these modules are already initialized.
+    '^import .*',
+    '^from .* import .*',
 ]
 ignore_errors = true
 include = [


### PR DESCRIPTION
Since our tests are invoked after most Ramble modules are already initialized, import statements (and other ones like `def`, `class` etc.) are not counted by the coverage tool.

One option could be to invoke `coverage run` instead of using `pytest-cov`, but that requires handling subprocess invocation and I couldn't get that to work nicely.

It seems relatively harmless to exclude these import statements, as even if a file is completely excluded from a test run, the actual content would still show up as missing coverage.