### PR TITLE
Fix up unit-test listing

### DIFF
--- a/lib/ramble/ramble/cmd/unit_test.py
+++ b/lib/ramble/ramble/cmd/unit_test.py
@@ -11,7 +11,6 @@ import argparse
 import collections
 import io
 import os
-import re
 import shutil
 import sys
 
@@ -121,14 +120,20 @@ def setup_parser(subparser):
 
 def do_list(args, extra_args):
     """Print a lists of tests than what pytest offers."""
-    # Run test collection and get the tree out.
+
+    def colorize(c, prefix):
+        if isinstance(prefix, tuple):
+            return "::".join(color.colorize(f"@{c}{{{p}}}") for p in prefix if p != "()")
+        return color.colorize(f"@{c}{{{prefix}}}")
+
+    # Run test collection with quiet mode, to extract a list of <path>::<test_name>.
     old_output = sys.stdout
     try:
         sys.stdout = output = io.StringIO()
         try:
             import pytest
 
-            pytest.main(["--collect-only"] + extra_args)
+            pytest.main(["--collect-only", "-q"] + extra_args)
         except ImportError:
             logger.die("Pytest python module not found. Ensure requirements.txt are installed.")
     finally:
@@ -136,43 +141,20 @@ def do_list(args, extra_args):
 
     lines = output.getvalue().split("\n")
     tests = collections.defaultdict(set)
-    prefix = []
-
-    print("All lines =")
-    print(lines)
-
     # collect tests into sections
     for line in lines:
-        match = re.match(r"(\s*)<([^ ]*) '([^']*)'", line)
-        if not match:
+        if "::" not in line:
             continue
-        indent, nodetype, name = match.groups()
-
-        # strip parametrized tests
-        if "[" in name:
-            name = name[: name.index("[")]
-
-        depth = len(indent) // 2
-
-        if nodetype.endswith("Function"):
-            key = tuple(prefix)
-            tests[key].add(name)
-            print(f"added test {key}={name} from {nodetype}")
-        else:
-            prefix = prefix[:depth]
-            prefix.append(name)
-            print(f"added prefix {name}")
-
-    def colorize(c, prefix):
-        if isinstance(prefix, tuple):
-            return "::".join(color.colorize(f"@{c}{{{p}}}") for p in prefix if p != "()")
-        return color.colorize(f"@{c}{{{prefix}}}")
+        [path, test_name] = line.split("::", 1)
+        # dedupe parametrized tests
+        if "[" in test_name:
+            test_name = test_name[: test_name.index("[")]
+        tests[path].add(test_name)
 
     if args.list == "list":
-        files = {prefix[0] for prefix in tests}
+        files = tests.keys()
         color_files = [colorize("B", file) for file in sorted(files)]
         colify(color_files)
-
     elif args.list == "long":
         for prefix, functions in sorted(tests.items()):
             path = colorize("*B", prefix) + "::"
@@ -180,7 +162,6 @@ def do_list(args, extra_args):
             color.cprint(path)
             colify(functions, indent=4)
             print()
-
     else:  # args.list == "names"
         all_functions = [
             colorize("*B", prefix) + "::" + colorize("c", f)

--- a/lib/ramble/ramble/test/cmd/unit_test.py
+++ b/lib/ramble/ramble/test/cmd/unit_test.py
@@ -1,0 +1,63 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import pytest
+
+from ramble import main
+
+pytestmark = pytest.mark.maybeslow
+
+ramble_test = main.RambleCommand("unit-test")
+
+
+def test_unit_test_list():
+    output = ramble_test("--list")
+    # Surely this file should show up in the list
+    assert "ramble/test/cmd/unit_test.py" in output
+    # But individual test should not show up
+    assert "test_unit_test_list" not in output
+
+
+def test_long_list():
+    output = ramble_test("-L")
+    assert "lib/ramble/ramble/test/cmd/unit_test.py::\n" in output
+    assert "    test_long_list" in output
+
+
+def test_full_list():
+    output = ramble_test("-N")
+    assert "lib/ramble/ramble/test/cmd/unit_test.py::test_full_list\n" in output
+
+
+def test_pytest_help():
+    output = ramble_test("-H")
+    assert "-k EXPRESSION" in output
+    assert "pytest-warnings:" in output
+    assert "--collect-only" in output
+
+
+def test_failed_import():
+    with pytest.raises(main.RambleCommandError):
+        ramble_test("-p", "fake-mod")
+
+
+def test_list_only_lib():
+    output = ramble_test("--lib", "-l")
+    assert "var/ramble/repos" not in output
+    assert "lib/ramble/ramble/test" in output
+
+
+def test_list_only_objects():
+    output = ramble_test("--obj", "-l")
+    assert "var/ramble/repos" in output
+    assert "lib/ramble/ramble/test" not in output
+
+
+def test_external_repo():
+    with pytest.raises(FileNotFoundError):
+        ramble_test("--repo-path", "non-existent-path")


### PR DESCRIPTION
Newer pytest changed its `--collect-only` output, which then busts the assumption in our code's regex matching. (Spack's corresponding change a while back: https://github.com/spack/spack/pull/25371.) In this case, instead of relying on explicit regex parsing, use pytest's `--quiet` flag to get the `path::test_name` pair.

Also add in test coverage for the unit-test command.