### PR TITLE
Allow workspace info to print variants

### DIFF
--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -649,6 +649,10 @@ def workspace_info_setup_parser(subparser):
         "--phases", action="store_true", help="If set, phase information will be printed"
     )
 
+    subparser.add_argument(
+        "--variants", action="store_true", help="If set, experiment variants will be printed"
+    )
+
     arguments.add_common_arguments(subparser, ["where", "exclude_where", "filter_tags"])
 
     subparser.add_argument(
@@ -658,7 +662,7 @@ def workspace_info_setup_parser(subparser):
         default=0,
         help="level of verbosity. Add flags to "
         + "increase description of workspace\n"
-        + "level 1 enables software, tags, and templates\n"
+        + "level 1 enables software, tags, templates, and variants\n"
         + "level 2 enables expansions and phases\n",
     )
 
@@ -671,6 +675,7 @@ def workspace_info(args):
         args.software = True
         args.tags = True
         args.templates = True
+        args.variants = True
 
     if args.verbose >= 2:
         args.expansions = True
@@ -801,6 +806,11 @@ def workspace_info(args):
 
                     if args.tags:
                         color.cprint("        Experiment Tags: " + str(app_inst.experiment_tags))
+
+                    if args.variants:
+                        color.cprint(rucolor.nested_4("        Variants: "))
+                        for key, value in app_inst.variants.items():
+                            color.cprint(f"          {key}: {value}")
 
                     if args.expansions:
                         var_groups = [

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -679,7 +679,7 @@ _ramble_workspace_push_to_cache() {
 }
 
 _ramble_workspace_info() {
-    RAMBLE_COMPREPLY="-h --help --software --all-software --templates --expansions --tags --phases --where --exclude-where --filter-tags -v --verbose"
+    RAMBLE_COMPREPLY="-h --help --software --all-software --templates --expansions --tags --phases --variants --where --exclude-where --filter-tags -v --verbose"
 }
 
 _ramble_workspace_edit() {


### PR DESCRIPTION
Example:

```
      Experiment 10: osu-micro-benchmarks.osu_mbw_mr.h3_2_88.3
        Experiment Tags: ['synthetic-benchmarks']
        Variants:
          package_manager: user-managed
          workflow_manager: user-managed
```