### PR TITLE
Package manager load/unload environment commands

### DIFF
--- a/lib/ramble/ramble/package_manager.py
+++ b/lib/ramble/ramble/package_manager.py
@@ -260,6 +260,16 @@ class PackageManagerBase(metaclass=PackageManagerMeta):
         del workspace
         return []
 
+    def environment_load_commands(self) -> List[str]:
+        """Stub method for acquiring the commands to load
+        an experiment's execution environment"""
+        return []
+
+    def environment_unload_commands(self) -> List[str]:
+        """Stub method for acquiring the commands to unload an
+        experiment's execution environment"""
+        return []
+
 
 class PackageManagerError(RambleError):
     """

--- a/var/ramble/repos/builtin/package_managers/environment-modules/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/environment-modules/package_manager.py
@@ -8,6 +8,7 @@
 
 import os
 import re
+from typing import List
 
 import llnl.util.filesystem as fs
 
@@ -140,3 +141,9 @@ class EnvironmentModules(PackageManagerBase):
                         )
                     )
         return pkg_list
+
+    def environment_load_commands(self) -> List[str]:
+        return self.module_list()
+
+    def environment_unload_commands(self) -> List[str]:
+        return ["module purge"]

--- a/var/ramble/repos/builtin/package_managers/pip/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/pip/package_manager.py
@@ -236,6 +236,13 @@ class Pip(PackageManagerBase):
             pkg_list.append(info)
         return pkg_list
 
+    def environment_load_commands(self):
+        self.runner.configure_env(self.app_inst.expander.env_path)
+        return [self.runner.generate_activate_command()]
+
+    def environment_unload_commands(self):
+        return [self.runner.generate_deactivate_command()]
+
 
 package_name_regex = re.compile(
     r"\s*(?P<pkg_name>[A-Z0-9][A-Z0-9._-]*[A-Z0-9]|[A-Z0-9]).*", re.IGNORECASE

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
@@ -508,6 +508,19 @@ class SpackLightweight(PackageManagerBase):
     def spack_deactivate(self):
         return self.runner.generate_deactivate_command()
 
+    def environment_load_commands(self):
+        commands = []
+        self.runner.activate()
+        commands.extend(self.runner.generate_source_command())
+        commands.extend(self.runner.generate_activate_command())
+        self.runner.deactivate()
+        return commands
+
+    def environment_unload_commands(self):
+        commands = []
+        commands.extend(self.runner.generate_deactiate_command())
+        return commands
+
     def get_spec_str(self, pkg, all_pkgs, compiler):
         """Return a spec string for the given pkg
 


### PR DESCRIPTION
This merge adds methods to package manager classes that can be used to determine their commands for loading or unloading environments within an experiment. These can be used by other objects to construct multi-step templates that might need to re-load (or swap) environments.