### PR TITLE
Fix up `ramble unit-test` autocompletion

### DIFF
--- a/lib/ramble/ramble/cmd/commands.py
+++ b/lib/ramble/ramble/cmd/commands.py
@@ -131,7 +131,7 @@ _positional_to_subroutine = {
     "keys": "_keys",
     "help_command": "_subcommands",
     "namespace": "_repos",
-    "pytest": "_tests",
+    "pytest": "_unit_tests",
 }
 
 

--- a/share/ramble/bash/ramble-completion.in
+++ b/share/ramble/bash/ramble-completion.in
@@ -160,10 +160,10 @@ _workspaces() {
     RAMBLE_COMPREPLY="$RAMBLE_WORKSPACES"
 }
 
-_tests() {
+_unit_tests() {
     if [[ -z "${RAMBLE_TESTS:-}" ]]
     then
-        RAMBLE_TESTS="$(ramble test -l)"
+        RAMBLE_TESTS="$(ramble unit-test -l)"
     fi
     RAMBLE_COMPREPLY="$RAMBLE_TESTS"
 }

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -160,10 +160,10 @@ _workspaces() {
     RAMBLE_COMPREPLY="$RAMBLE_WORKSPACES"
 }
 
-_tests() {
+_unit_tests() {
     if [[ -z "${RAMBLE_TESTS:-}" ]]
     then
-        RAMBLE_TESTS="$(ramble test -l)"
+        RAMBLE_TESTS="$(ramble unit-test -l)"
     fi
     RAMBLE_COMPREPLY="$RAMBLE_TESTS"
 }
@@ -623,7 +623,7 @@ _ramble_unit_test() {
     then
         RAMBLE_COMPREPLY="-h --help -H --pytest-help --lib --obj -r --repo-path -l --list -L --list-long -N --list-names -s -k --showlocals"
     else
-        _tests
+        _unit_tests
     fi
 }
 


### PR DESCRIPTION
Otherwise tabbing produces the following error:

```
$ ramble unit-test ==> Error: Command test does not exist.
==> Error: Command test does not exist.
```