### PR TITLE
Remove extra .tar.gz in lammps

### DIFF
--- a/var/ramble/repos/builtin/applications/lammps/application.py
+++ b/var/ramble/repos/builtin/applications/lammps/application.py
@@ -274,7 +274,7 @@ class Lammps(ExecutableApplication):
 
     workload_variable(
         "input_stage",
-        default="stable_23Jun2022_update3.tar.gz",
+        default="stable_23Jun2022_update3",
         description="Stage name of LAMMPS input archive",
         workloads=["hns-reaxff"],
     )


### PR DESCRIPTION
Develop will result in:
```
input_file(
    "lammps-stage",
    url="https://github.com/lammps/lammps/archive/refs/tags/stable_23Jun2022_update3.tar.gz.tar.gz",
    target_dir="{application_input_dir}/lammps-input-stage",
    description="Stage of lammps source from release",
)
```
Note the extra `.tar.gz`, which does not exist. This will result in the error:
```
==> Failed fetching input stable_23Jun2022_update3 in application lammps
==> Input url was: https://github.com/lammps/lammps/archive/refs/tags/stable_23Jun2022_update3.tar.gz.tar.gz
==> Error: All fetchers failed
```