### PR TITLE
Minor: change error message to point to requirements-dev.txt

### DIFF
--- a/lib/ramble/ramble/cmd/unit_test.py
+++ b/lib/ramble/ramble/cmd/unit_test.py
@@ -135,7 +135,9 @@ def do_list(args, extra_args):
 
             pytest.main(["--collect-only", "-q"] + extra_args)
         except ImportError:
-            logger.die("Pytest python module not found. Ensure requirements.txt are installed.")
+            logger.die(
+                "Pytest python module not found. Ensure requirements-dev.txt are installed."
+            )
     finally:
         sys.stdout = old_output
 
@@ -200,7 +202,9 @@ def unit_test(parser, args, unknown_args):
 
             return pytest.main(["-h"])
         except ImportError:
-            logger.die("Pytest python module not found. Ensure requirements.txt are installed.")
+            logger.die(
+                "Pytest python module not found. Ensure requirements-dev.txt are installed."
+            )
 
     # add back any parsed pytest args we need to pass to pytest
     pytest_args = add_back_pytest_args(args, unknown_args)
@@ -234,7 +238,8 @@ def unit_test(parser, args, unknown_args):
                     return pytest.main(pytest_args)
                 except ImportError:
                     logger.die(
-                        "Pytest python module not found. Ensure requirements.txt are installed."
+                        "Pytest python module not found. "
+                        "Ensure requirements-dev.txt are installed."
                     )
     finally:
         if copied_conftest_path is not None:

--- a/lib/ramble/ramble/test/cmd/unit_test.py
+++ b/lib/ramble/ramble/test/cmd/unit_test.py
@@ -41,9 +41,15 @@ def test_pytest_help():
     assert "--collect-only" in output
 
 
-def test_failed_import():
-    with pytest.raises(main.RambleCommandError):
-        ramble_test("-p", "fake-mod")
+@pytest.mark.parametrize(
+    "extra_flag",
+    [(""), ("--list")],
+    ids=["main", "list"],
+)
+def test_failed_import(extra_flag):
+    out = ramble_test(extra_flag, "-p", "fake-pytest", fail_on_error=False)
+    assert ramble_test.returncode == 1
+    assert "Ensure requirements-dev.txt are installed" in out
 
 
 def test_list_only_lib():


### PR DESCRIPTION
This is a minor cleanup, as now dev deps (like `pytest`) are defined in requirements-dev.txt.