### PR TITLE
Add license_names directive

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -134,6 +134,8 @@ class ApplicationBase(metaclass=ApplicationMeta):
     maintainers: List[str] = []
     tags: List[str] = []
 
+    license_names: List[str] = []
+
     license_inc_name = "license.inc"
 
     def __init__(self, file_path):
@@ -178,6 +180,9 @@ class ApplicationBase(metaclass=ApplicationMeta):
         self._input_lock = None
         self._software_lock = None
         self._experiment_graph = None
+
+        if not self.license_names:
+            self.license_names.append(self.name)
 
         self.hash_inventory = {
             "application_definition": None,
@@ -1428,7 +1433,11 @@ class ApplicationBase(metaclass=ApplicationMeta):
         for scope in config_scopes:
             license_conf = ramble.config.config.get_config("licenses", scope=scope)
             if license_conf:
-                app_licenses = license_conf[self.name] if self.name in license_conf else {}
+                # If we have multiple matches, the last entry should win (latest in hierarchy)
+                app_licenses = {}
+                for lic in self.license_names:
+                    if lic in license_conf:
+                        app_licenses = license_conf[lic]
 
                 for action, conf in app_licenses.items():
                     (env_cmds, var_set) = action_funcs[action](

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -181,8 +181,8 @@ class ApplicationBase(metaclass=ApplicationMeta):
         self._software_lock = None
         self._experiment_graph = None
 
-        if not self.license_names:
-            self.license_names.append(self.name)
+        # Ensure we always have the application name, and this is never empty
+        self.license_names = self.license_names + [self.name]
 
         self.hash_inventory = {
             "application_definition": None,

--- a/lib/ramble/ramble/language/application_language.py
+++ b/lib/ramble/ramble/language/application_language.py
@@ -307,3 +307,21 @@ def environment_variable(
             raise DirectiveError("A workload or workload group is required")
 
     return _execute_environment_variable
+
+
+@application_directive(dicts=())
+def license_name(name, **kwargs):
+    """Add a new license name directive, to specify license name in a declarative way.
+
+    Args:
+        name (str): name to use during license lookup and propagation
+    """
+
+    def _execute_license_name(obj):
+        license_from_base = getattr(obj, "license_names", [])
+
+        # Here it is essential to copy, otherwise we might add to an empty list in the parent
+        # It is important that we preserve order
+        obj.license_names = list(dict.fromkeys(license_from_base + [name]))
+
+    return _execute_license_name

--- a/lib/ramble/ramble/test/application_inheritance.py
+++ b/lib/ramble/ramble/test/application_inheritance.py
@@ -60,4 +60,4 @@ def test_basic_inheritance(mutable_mock_apps_repo):
     assert "Shadowed" in app_inst.workloads["test_wl"].variables["my_var"].description
     assert app_inst.workloads["test_wl"].variables["my_var"].default == "1.0"
 
-    assert app_inst.license_names == ["basic", "basic-inherited-extended"]
+    assert app_inst.license_names == ["basic", "basic-inherited-extended", "basic-inherited"]

--- a/lib/ramble/ramble/test/application_inheritance.py
+++ b/lib/ramble/ramble/test/application_inheritance.py
@@ -59,3 +59,5 @@ def test_basic_inheritance(mutable_mock_apps_repo):
     assert "my_var" in app_inst.workloads["test_wl"].variables
     assert "Shadowed" in app_inst.workloads["test_wl"].variables["my_var"].description
     assert app_inst.workloads["test_wl"].variables["my_var"].default == "1.0"
+
+    assert app_inst.license_names == ["basic", "basic-inherited-extended"]

--- a/lib/ramble/ramble/test/application_language.py
+++ b/lib/ramble/ramble/test/application_language.py
@@ -31,6 +31,7 @@ def test_application_type_features(app_class):
     assert hasattr(test_app, "software_specs")
     assert hasattr(test_app, "required_packages")
     assert hasattr(test_app, "maintainers")
+    assert hasattr(test_app, "license_names")
     assert hasattr(test_app, "package_manager_configs")
 
 
@@ -324,3 +325,13 @@ def test_software_spec_directive(app_class):
         assert name in app_inst.software_specs
         for key, value in info.items():
             assert app_inst.software_specs[name][key] == value
+
+
+@pytest.mark.parametrize("app_class", app_types)
+def test_license_name_directive(app_class):
+    new_license_name = "fake-app"
+
+    app_inst = app_class("/not/a/path")
+    app_inst.license_name(new_license_name)
+
+    assert new_license_name in app_inst.license_names

--- a/lib/ramble/ramble/test/end_to_end/license_name.py
+++ b/lib/ramble/ramble/test/end_to_end/license_name.py
@@ -1,0 +1,182 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.workspace
+from ramble.main import RambleCommand
+
+pytestmark = pytest.mark.usefixtures(
+    "mutable_config", "mutable_mock_workspace_path", "mutable_mock_apps_repo"
+)
+
+workspace = RambleCommand("workspace")
+
+
+def test_license_name_parent(mutable_mock_apps_repo, request):
+    app_name = "basic-inherited-nolicense"
+    test_config = f"""
+ramble:
+  variables:
+    mpi_command: mpirun -n 1
+    batch_submit: ''
+    processes_per_node: 1
+  applications:
+    {app_name}:
+      workloads:
+        template_wl:
+          experiments:
+            test:
+              variables:
+                n_ranks: '1'
+  software:
+    packages: {{}}
+    environments: {{}}
+"""
+
+    test_val = "test_val"
+    test_licenses = f"""
+licenses:
+  basic:
+    set:
+      TEST_VAR: {test_val}
+"""
+    workspace_name = request.node.name
+    ws = ramble.workspace.create(workspace_name)
+    ws.write()
+
+    config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+    with open(config_path, "w+") as f:
+        f.write(test_config)
+
+    license_path = os.path.join(ws.config_dir, "licenses.yaml")
+    with open(license_path, "w+") as f:
+        f.write(test_licenses)
+
+    ws._re_read()
+
+    workspace("setup", "--dry-run", global_args=["-w", workspace_name])
+    run_dir = os.path.join(ws.experiment_dir, "basic/template_wl/test/")
+
+    license_inc_path = os.path.join(ws.root, "shared", "licenses", app_name, "license.inc")
+    with open(license_inc_path) as f:
+        data = f.read()
+        # Test the license is added to the include file
+        assert test_val in data
+
+
+def test_license_name_self_implicit(mutable_mock_apps_repo, request):
+    app_name = "basic-inherited-nolicense"
+    test_config = f"""
+ramble:
+  variables:
+    mpi_command: mpirun -n 1
+    batch_submit: ''
+    processes_per_node: 1
+  applications:
+    {app_name}:
+      workloads:
+        template_wl:
+          experiments:
+            test:
+              variables:
+                n_ranks: '1'
+  software:
+    packages: {{}}
+    environments: {{}}
+"""
+
+    test_val = "test_val"
+    test_licenses = f"""
+licenses:
+  basic:
+    set:
+      TEST_VAR: {test_val}
+  basic-inherited-nolicense:
+    set:
+      TEST_VAR: {test_val}_self
+"""
+    workspace_name = request.node.name
+    ws = ramble.workspace.create(workspace_name)
+    ws.write()
+
+    config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+    with open(config_path, "w+") as f:
+        f.write(test_config)
+
+    license_path = os.path.join(ws.config_dir, "licenses.yaml")
+    with open(license_path, "w+") as f:
+        f.write(test_licenses)
+
+    ws._re_read()
+
+    workspace("setup", "--dry-run", global_args=["-w", workspace_name])
+    run_dir = os.path.join(ws.experiment_dir, "basic/template_wl/test/")
+
+    license_inc_path = os.path.join(ws.root, "shared", "licenses", app_name, "license.inc")
+    with open(license_inc_path) as f:
+        data = f.read()
+        # Test the license is added to the include file
+        assert test_val + "_self" in data
+
+
+def test_license_name_self_explicit(mutable_mock_apps_repo, request):
+    app_name = "basic-inherited"
+    test_config = f"""
+ramble:
+  variables:
+    mpi_command: mpirun -n 1
+    batch_submit: ''
+    processes_per_node: 1
+  applications:
+    {app_name}:
+      workloads:
+        template_wl:
+          experiments:
+            test:
+              variables:
+                n_ranks: '1'
+  software:
+    packages: {{}}
+    environments: {{}}
+"""
+
+    test_val = "test_val"
+    test_licenses = f"""
+licenses:
+  basic:
+    set:
+      TEST_VAR: {test_val}
+  basic-inherited:
+    set:
+      TEST_VAR: {test_val}_self
+"""
+    workspace_name = request.node.name
+    ws = ramble.workspace.create(workspace_name)
+    ws.write()
+
+    config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+    with open(config_path, "w+") as f:
+        f.write(test_config)
+
+    license_path = os.path.join(ws.config_dir, "licenses.yaml")
+    with open(license_path, "w+") as f:
+        f.write(test_licenses)
+
+    ws._re_read()
+
+    workspace("setup", "--dry-run", global_args=["-w", workspace_name])
+    run_dir = os.path.join(ws.experiment_dir, "basic/template_wl/test/")
+
+    license_inc_path = os.path.join(ws.root, "shared", "licenses", app_name, "license.inc")
+    with open(license_inc_path) as f:
+        data = f.read()
+        # Test the license is added to the include file
+        assert test_val + "_self" in data

--- a/lib/ramble/ramble/test/end_to_end/license_name.py
+++ b/lib/ramble/ramble/test/end_to_end/license_name.py
@@ -19,9 +19,10 @@ pytestmark = pytest.mark.usefixtures(
 
 workspace = RambleCommand("workspace")
 
+test_val = "test_val"
 
-def test_license_name_parent(mutable_mock_apps_repo, request):
-    app_name = "basic-inherited-nolicense"
+
+def license_param_core(app_name, workspace_name, test_licenses, expected_val):
     test_config = f"""
 ramble:
   variables:
@@ -41,14 +42,6 @@ ramble:
     environments: {{}}
 """
 
-    test_val = "test_val"
-    test_licenses = f"""
-licenses:
-  basic:
-    set:
-      TEST_VAR: {test_val}
-"""
-    workspace_name = request.node.name
     ws = ramble.workspace.create(workspace_name)
     ws.write()
 
@@ -63,37 +56,30 @@ licenses:
     ws._re_read()
 
     workspace("setup", "--dry-run", global_args=["-w", workspace_name])
-    run_dir = os.path.join(ws.experiment_dir, "basic/template_wl/test/")
 
     license_inc_path = os.path.join(ws.root, "shared", "licenses", app_name, "license.inc")
     with open(license_inc_path) as f:
         data = f.read()
         # Test the license is added to the include file
-        assert test_val in data
+        assert expected_val in data
+
+
+def test_license_name_parent(mutable_mock_apps_repo, request):
+    app_name = "basic-inherited-nolicense"
+    test_licenses = f"""
+licenses:
+  basic:
+    set:
+      TEST_VAR: {test_val}
+"""
+    workspace_name = request.node.name
+    expected_val = test_val
+    license_param_core(app_name, workspace_name, test_licenses, expected_val)
 
 
 def test_license_name_self_implicit(mutable_mock_apps_repo, request):
     app_name = "basic-inherited-nolicense"
-    test_config = f"""
-ramble:
-  variables:
-    mpi_command: mpirun -n 1
-    batch_submit: ''
-    processes_per_node: 1
-  applications:
-    {app_name}:
-      workloads:
-        template_wl:
-          experiments:
-            test:
-              variables:
-                n_ranks: '1'
-  software:
-    packages: {{}}
-    environments: {{}}
-"""
-
-    test_val = "test_val"
+    expected_val = test_val + "_imp"
     test_licenses = f"""
 licenses:
   basic:
@@ -101,54 +87,15 @@ licenses:
       TEST_VAR: {test_val}
   basic-inherited-nolicense:
     set:
-      TEST_VAR: {test_val}_self
+      TEST_VAR: {expected_val}
 """
     workspace_name = request.node.name
-    ws = ramble.workspace.create(workspace_name)
-    ws.write()
-
-    config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
-    with open(config_path, "w+") as f:
-        f.write(test_config)
-
-    license_path = os.path.join(ws.config_dir, "licenses.yaml")
-    with open(license_path, "w+") as f:
-        f.write(test_licenses)
-
-    ws._re_read()
-
-    workspace("setup", "--dry-run", global_args=["-w", workspace_name])
-    run_dir = os.path.join(ws.experiment_dir, "basic/template_wl/test/")
-
-    license_inc_path = os.path.join(ws.root, "shared", "licenses", app_name, "license.inc")
-    with open(license_inc_path) as f:
-        data = f.read()
-        # Test the license is added to the include file
-        assert test_val + "_self" in data
+    license_param_core(app_name, workspace_name, test_licenses, expected_val)
 
 
 def test_license_name_self_explicit(mutable_mock_apps_repo, request):
     app_name = "basic-inherited"
-    test_config = f"""
-ramble:
-  variables:
-    mpi_command: mpirun -n 1
-    batch_submit: ''
-    processes_per_node: 1
-  applications:
-    {app_name}:
-      workloads:
-        template_wl:
-          experiments:
-            test:
-              variables:
-                n_ranks: '1'
-  software:
-    packages: {{}}
-    environments: {{}}
-"""
-
-    test_val = "test_val"
+    expected_val = test_val + "_exp"
     test_licenses = f"""
 licenses:
   basic:
@@ -156,27 +103,7 @@ licenses:
       TEST_VAR: {test_val}
   basic-inherited:
     set:
-      TEST_VAR: {test_val}_self
+      TEST_VAR: {expected_val}
 """
     workspace_name = request.node.name
-    ws = ramble.workspace.create(workspace_name)
-    ws.write()
-
-    config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
-    with open(config_path, "w+") as f:
-        f.write(test_config)
-
-    license_path = os.path.join(ws.config_dir, "licenses.yaml")
-    with open(license_path, "w+") as f:
-        f.write(test_licenses)
-
-    ws._re_read()
-
-    workspace("setup", "--dry-run", global_args=["-w", workspace_name])
-    run_dir = os.path.join(ws.experiment_dir, "basic/template_wl/test/")
-
-    license_inc_path = os.path.join(ws.root, "shared", "licenses", app_name, "license.inc")
-    with open(license_inc_path) as f:
-        data = f.read()
-        # Test the license is added to the include file
-        assert test_val + "_self" in data
+    license_param_core(app_name, workspace_name, test_licenses, expected_val)

--- a/lib/ramble/ramble/test/end_to_end/wrfv4_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/wrfv4_dry_run.py
@@ -227,6 +227,11 @@ compilers:
                 # Test the run script has a reference to the experiment log file
                 assert os.path.join(exp_dir, f"{exp}.out") in data
 
+            assert os.path.isdir(os.path.join(ws1.root, "shared"))
+            assert os.path.isdir(os.path.join(ws1.root, "shared", "licenses"))
+            assert os.path.isdir(os.path.join(ws1.root, "shared", "licenses", "wrfv4"))
+            assert os.path.exists(license_inc_path)
+
             with open(license_inc_path) as f:
                 data = f.read()
                 # Test the license is added to the include file
@@ -456,6 +461,11 @@ licenses:
 
                 # Test the run script has a reference to the experiment log file
                 assert os.path.join(exp_dir, f"{exp}.out") in data
+
+            assert os.path.isdir(os.path.join(ws1.root, "shared"))
+            assert os.path.isdir(os.path.join(ws1.root, "shared", "licenses"))
+            assert os.path.isdir(os.path.join(ws1.root, "shared", "licenses", "wrfv4"))
+            assert os.path.exists(license_inc_path)
 
             with open(license_inc_path) as f:
                 data = f.read()

--- a/var/ramble/repos/builtin.mock/applications/basic-inherited-nolicense/application.py
+++ b/var/ramble/repos/builtin.mock/applications/basic-inherited-nolicense/application.py
@@ -1,0 +1,30 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.app.builtin.mock.basic import Basic as BaseBasic
+from ramble.appkit import *
+
+
+class BasicInheritedNolicense(BaseBasic):
+    name = "basic-inherited-nolicense"
+
+    input_file(
+        "inherited_input",
+        url="file:///tmp/inherited_file.log",
+        description="Again, not a file",
+        extension=".log",
+    )
+
+    workload("test_wl4", executable="foo", input="inherited_input")
+
+    workload_variable(
+        "my_var",
+        default="1.0",
+        description="Shadowed Example var",
+        workload="test_wl",
+    )

--- a/var/ramble/repos/builtin.mock/applications/basic-inherited/application.py
+++ b/var/ramble/repos/builtin.mock/applications/basic-inherited/application.py
@@ -13,6 +13,8 @@ from ramble.appkit import *
 class BasicInherited(BaseBasic):
     name = "basic-inherited"
 
+    license_name("basic-inherited-extended")
+
     input_file(
         "inherited_input",
         url="file:///tmp/inherited_file.log",

--- a/var/ramble/repos/builtin.mock/applications/basic/application.py
+++ b/var/ramble/repos/builtin.mock/applications/basic/application.py
@@ -12,6 +12,8 @@ from ramble.appkit import *
 class Basic(ExecutableApplication):
     name = "basic"
 
+    license_name("basic")
+
     executable("foo", "bar", use_mpi=False)
     executable("bar", "baz", use_mpi=True)
     executable("echo", 'echo "0.25 seconds"', use_mpi=False)


### PR DESCRIPTION
This allows licenses.yaml to inherit from it's parent if needed

If no licesne_name is specified, app_inst.name is used to be backwards compatible

Testing for this case is covered in existing tests Testing for the new inherited behavior is added in new tests