### PR TITLE
Add `when` support to formatted executables

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -1192,7 +1192,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
         self.variables[self.keywords.unformatted_command_without_logs] = "\n".join(
             self._command_list_without_logs
         )
-        formatted_exec_groups = [self._formatted_executables]
+        formatted_exec_groups = [{frozenset(): self._formatted_executables}]
 
         objs_to_extract = [self, self.workflow_manager, self.package_manager]
 
@@ -1201,38 +1201,44 @@ class ApplicationBase(metaclass=ApplicationMeta):
                 formatted_exec_groups.append(obj.formatted_executables)
 
         for formatted_exec_group in formatted_exec_groups:
-            for var_name, formatted_conf in formatted_exec_group.items():
-                if var_name in self.variables:
-                    raise FormattedExecutableError(
-                        f"Formatted executable {var_name} defined, but variable "
-                        "definition already exists."
-                    )
+            for when_set, formatted_exec_defs in formatted_exec_group.items():
+                if not self.expander.satisfies(when_set, variant_set=self.object_variants):
+                    continue
 
-                n_indentation = 0
-                if namespace.indentation in formatted_conf:
-                    n_indentation = int(formatted_conf[namespace.indentation])
+                for var_name, formatted_conf in formatted_exec_defs.items():
+                    if var_name in self.variables:
+                        raise FormattedExecutableError(
+                            f"Formatted executable {var_name} defined, but variable "
+                            "definition already exists."
+                        )
 
-                prefix = ""
-                if namespace.prefix in formatted_conf:
-                    prefix = formatted_conf[namespace.prefix]
+                    n_indentation = 0
+                    if namespace.indentation in formatted_conf:
+                        n_indentation = int(formatted_conf[namespace.indentation])
 
-                join_separator = "\n"
-                if namespace.join_separator in formatted_conf:
-                    join_separator = formatted_conf[namespace.join_separator].replace(r"\n", "\n")
+                    prefix = ""
+                    if namespace.prefix in formatted_conf:
+                        prefix = formatted_conf[namespace.prefix]
 
-                indentation = " " * n_indentation
+                    join_separator = "\n"
+                    if namespace.join_separator in formatted_conf:
+                        join_separator = formatted_conf[namespace.join_separator].replace(
+                            r"\n", "\n"
+                        )
 
-                commands_to_format = self._command_list
-                if namespace.commands in formatted_conf:
-                    commands_to_format = formatted_conf[namespace.commands].copy()
+                    indentation = " " * n_indentation
 
-                formatted_lines = []
-                for command in commands_to_format:
-                    expanded = self.expander.expand_var(command)
-                    for out_line in expanded.split("\n"):
-                        formatted_lines.append(indentation + prefix + out_line)
+                    commands_to_format = self._command_list
+                    if namespace.commands in formatted_conf:
+                        commands_to_format = formatted_conf[namespace.commands].copy()
 
-                self.variables[var_name] = join_separator.join(formatted_lines)
+                    formatted_lines = []
+                    for command in commands_to_format:
+                        expanded = self.expander.expand_var(command)
+                        for out_line in expanded.split("\n"):
+                            formatted_lines.append(indentation + prefix + out_line)
+
+                    self.variables[var_name] = join_separator.join(formatted_lines)
 
     def _derive_variables_for_template_path(self, workspace):
         """Define variables for template paths (for add_expand_vars)"""

--- a/lib/ramble/ramble/language/language_base.py
+++ b/lib/ramble/ramble/language/language_base.py
@@ -216,6 +216,7 @@ class DirectiveMeta(type):
                         "register_phase",
                         "figure_of_merit",
                         "figure_of_merit_context",
+                        "formatted_executable",
                     ]:
                         msg = (
                             'directive "{0}" cannot be used within a "when"'

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -656,6 +656,7 @@ def formatted_executable(
     prefix: str = "",
     indentation: int = 0,
     join_separator: str = "\n",
+    when=None,
     **kwargs,
 ):
     """Define a new formatted execution for this object
@@ -664,11 +665,22 @@ def formatted_executable(
         name: Name of the new formatted executable
         prefix: Prefix for each line of the formatted executable
         indentation: Number of spaces to indent before the prefix of each line
+        join_separator: String to use when separating the commands during formatting
         commands: List of commands to expand when generating the formatted executable
+        when (list | None): List of when conditions to apply to directive
     """
 
     def _define_formatted_executable(obj):
-        obj.formatted_executables[name] = {
+        when_list = ramble.language.language_helpers.build_when_list(
+            when, obj, name, "formatted_executable"
+        )
+
+        when_set = frozenset(when_list)
+
+        if when_set not in obj.formatted_executables:
+            obj.formatted_executables[when_set] = {}
+
+        obj.formatted_executables[when_set][name] = {
             "prefix": prefix,
             "indentation": indentation,
             "join_separator": join_separator,

--- a/lib/ramble/ramble/test/when.py
+++ b/lib/ramble/ramble/test/when.py
@@ -378,3 +378,67 @@ test inheritance 12.0
             assert "test inheritance context" in results
             assert "12 integer" in results
             assert "12.0" not in results
+
+
+@pytest.mark.parametrize(
+    "inc_value,type_value",
+    [
+        (True, "preferred"),
+        (True, "testing"),
+        (True, "modifier"),
+        (False, "preferred"),
+    ],
+)
+def test_formatted_exec_when(request, inc_value, type_value):
+    ws_name = request.node.name.replace("[", "_").replace("]", "_")
+
+    global_args = ["-w", ws_name]
+
+    with ramble.workspace.create(ws_name) as ws:
+        workspace(
+            "manage",
+            "experiments",
+            "when-variants",
+            "--wf",
+            "test_wl",
+            "-v",
+            "zlib_path=/not/a/path",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "processes_per_node=1",
+            global_args=global_args,
+        )
+
+        config("add", f"variants:inc_zlib:{inc_value}", global_args=global_args)
+        config("add", f"variants:zlib_type:{type_value}", global_args=global_args)
+
+        (True, "preferred", "     from_variant zlib included with type of preferred"),
+        (True, "testing", "     from_variant zlib included with type of testing"),
+        (True, "modifier", "     from_variant zlib included with type of modifier"),
+        (False, "preferred", "     from_variant zlib not included"),
+
+        if inc_value:
+            inc_str = f"included with type of {type_value}"
+        else:
+            inc_str = "not included"
+        test_str = f"     from_variant zlib {inc_str}"
+
+        ws._re_read()
+        workspace("setup", global_args=global_args)
+
+        exec_file = os.path.join(
+            ws.experiment_dir,
+            "when-variants",
+            "test_wl",
+            "generated",
+            "execute_experiment",
+        )
+
+        with open(exec_file) as f:
+            data = f.read()
+
+            assert test_str in data
+            assert "{test_formatted_exec}" not in data

--- a/var/ramble/repos/builtin.mock/applications/when-variants/application.py
+++ b/var/ramble/repos/builtin.mock/applications/when-variants/application.py
@@ -12,7 +12,14 @@ from ramble.appkit import *
 class WhenVariants(ExecutableApplication):
     name = "when-variants"
 
-    executable("test_exec", "echo '{test_variable}'", use_mpi=False)
+    executable(
+        "test_exec",
+        template=[
+            "echo '{test_variable}'",
+            "echo '{test_formatted_exec}'",
+        ],
+        use_mpi=False,
+    )
 
     workload("test_wl", executable="test_exec")
 
@@ -49,3 +56,48 @@ class WhenVariants(ExecutableApplication):
                 software_spec("zlib-mod", pkg_spec="zlib@1.2.13")
 
         required_package("zlib")
+
+    with when("+inc_zlib"):
+        with when("zlib_type=preferred"):
+            formatted_executable(
+                "test_formatted_exec",
+                prefix=" from_variant ",
+                indentation=4,
+                join_separator="\n",
+                commands=[
+                    "zlib included with type of preferred",
+                ],
+            )
+
+        with when("zlib_type=testing"):
+            formatted_executable(
+                "test_formatted_exec",
+                prefix=" from_variant ",
+                indentation=4,
+                join_separator="\n",
+                commands=[
+                    "zlib included with type of testing",
+                ],
+            )
+
+        with when("zlib_type=modifier"):
+            formatted_executable(
+                "test_formatted_exec",
+                prefix=" from_variant ",
+                indentation=4,
+                join_separator="\n",
+                commands=[
+                    "zlib included with type of modifier",
+                ],
+            )
+
+    with when("~inc_zlib"):
+        formatted_executable(
+            "test_formatted_exec",
+            prefix=" from_variant ",
+            indentation=4,
+            join_separator="\n",
+            commands=[
+                "zlib not included",
+            ],
+        )


### PR DESCRIPTION
This merge adds support for the `when` arugment to the formatted_executable directive. This does not apply to defining formatted_executables within a config section however.