### PR TITLE
Add pytest-clarity as a dev dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,7 @@ coverage
 pre-commit
 pytest-xdist
 pytest-cov
+pytest-clarity
 line_profiler
 isort
 codecov-cli


### PR DESCRIPTION
This plugin makes it much easier to identify diffs from test assertion failures. Especially relevant for the `setup_analyze` test, since the main assertion uses `in` op, which doesn't have detailed explanation by the builtin pytest hook.

![image](https://github.com/user-attachments/assets/283fc6ce-4179-4b58-b3ae-9f68b8463896)
