### PR TITLE
Allow `when` on all variable types

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -390,10 +390,11 @@ class ApplicationBase(metaclass=ApplicationMeta):
         self.no_expand_vars = set()
         workload_name = self.expander.workload_name
         if workload_name in self.workloads:
-            for var in self.workloads[workload_name].variables.values():
-                if self.expander.satisfies(var.when, self.object_variants):
-                    if not var.expandable:
-                        self.no_expand_vars.add(var.name)
+            for when_key, var_list in self.workloads[workload_name].variables.items():
+                if self.expander.satisfies(when_key, self.object_variants):
+                    for var in var_list:
+                        if not var.expandable:
+                            self.no_expand_vars.add(var.name)
 
         self.expander.set_no_expand_vars(self.no_expand_vars)
 
@@ -1041,12 +1042,15 @@ class ApplicationBase(metaclass=ApplicationMeta):
         wl_vars = {}
 
         if self.expander.workload_name in self.workloads:
-            for var in self.workloads[self.expander.workload_name].variables.values():
-                if self.expander.satisfies(var.when, self.object_variants):
-                    wl_vars[var.name] = var
+            for when_key, var_list in self.workloads[
+                self.expander.workload_name
+            ].variables.items():
+                if self.expander.satisfies(when_key, self.object_variants):
+                    for var in var_list:
+                        wl_vars[var.name] = var
 
-        for when_set, var_list in self.object_variables.items():
-            if self.expander.satisfies(when_set, self.object_variants):
+        for when_key, var_list in self.object_variables.items():
+            if self.expander.satisfies(when_key, self.object_variants):
                 for var in var_list:
                     wl_vars[var.name] = var
 

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -280,9 +280,10 @@ class ApplicationBase(metaclass=ApplicationMeta):
                 self.object_variants.merge_default_variants(getattr(obj, "object_variants"))
                 self.object_variants.merge_multi_value_variants(obj_variants)
 
-        for obj_type, obj in self._objects():
-            if obj_type is ramble.repository.ObjectTypes.applications:
-                self.object_variants.multi_value_variant("application_name", value=obj.name)
+        base_chain = self.__class__.__mro__
+        for cls in base_chain:
+            if hasattr(cls, "name") and getattr(cls, "name") is not None:
+                self.object_variants.multi_value_variant("application_name", value=cls.name)
 
         self.object_variants.default_variant(
             "workload_name",

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -539,7 +539,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
                 self.variables[var.name] = var.default
 
         if self.workflow_manager is not None:
-            for var in self.workflow_manager.wm_vars.values():
+            for var in self.workflow_manager.object_variables:
                 self.variables[var.name] = var.default
 
         ##########################################
@@ -1036,7 +1036,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
             var_sets.append(mod_inst.mode_variables())
 
         if self.workflow_manager is not None:
-            var_sets.append(self.workflow_manager.wm_vars)
+            var_sets.append(self.workflow_manager.variable_definitions())
 
         for var_set in var_sets:
             for var, val in var_set.items():

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -537,20 +537,21 @@ class ApplicationBase(metaclass=ApplicationMeta):
         # Define extra variables
         ########################
 
-        # Add modifier mode variables defaults as a placeholder:
+        var_objs = []
+
         for mod_inst in self._modifier_instances:
-            for var in mod_inst.mode_variables().values():
-                if var.name not in self.variables:
-                    self.variables[var.name] = var.default
+            var_objs.append(mod_inst)
 
         if self.package_manager is not None:
-            # Add package manager variable defaults as placeholder
-            for var in self.package_manager.object_variables:
-                self.variables[var.name] = var.default
+            var_objs.append(self.package_manager)
 
         if self.workflow_manager is not None:
-            for var in self.workflow_manager.object_variables:
-                self.variables[var.name] = var.default
+            var_objs.append(self.workflow_manager)
+
+        for var_obj in var_objs:
+            for var in var_obj.selected_variables().values():
+                if var.name not in self.variables:
+                    self.variables[var.name] = var.default
 
         ##########################################
         # Expand used variables to track all usage
@@ -1035,19 +1036,27 @@ class ApplicationBase(metaclass=ApplicationMeta):
         """Set default experiment variables (for add_expand_vars),
         if they haven't been set already"""
         # Set default experiment variables, if they haven't been set already
+        var_objs = []
         var_sets = []
+
+        # Built var_objs list
+        if self.package_manager is not None:
+            var_objs.append(self.package_manager)
+
+        if self.workflow_manager is not None:
+            var_objs.append(self.workflow_manager)
+
+        for mod_inst in self._modifier_instances:
+            var_objs.append(mod_inst)
+
+        # Built var_sets list
         if self.expander.workload_name in self.workloads:
             var_sets.append(self.workloads[self.expander.workload_name].variables)
 
-        if self.package_manager is not None:
-            var_sets.append(self.package_manager.variable_definitions())
+        for var_obj in var_objs:
+            var_sets.append(var_obj.selected_variables())
 
-        for mod_inst in self._modifier_instances:
-            var_sets.append(mod_inst.mode_variables())
-
-        if self.workflow_manager is not None:
-            var_sets.append(self.workflow_manager.variable_definitions())
-
+        # Define variables from var_sets
         for var_set in var_sets:
             for var, val in var_set.items():
                 if var not in self.variables.keys():

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -266,10 +266,6 @@ class ApplicationBase(metaclass=ApplicationMeta):
         """
 
         self.variants = variants.copy()
-        for _, obj in self._objects(exclude_types=[ramble.repository.ObjectTypes.applications]):
-            obj_variants = getattr(obj, "object_variants", None)
-            if obj_variants is not None:
-                self.object_variants.merge_default_variants(getattr(obj, "object_variants"))
 
         for name, value in variants.items():
             expanded_value = self.expander.expand_var(value, typed=True)
@@ -281,6 +277,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
         for _, obj in self._objects(exclude_types=[ramble.repository.ObjectTypes.applications]):
             obj_variants = getattr(obj, "object_variants", None)
             if obj_variants is not None:
+                self.object_variants.merge_default_variants(getattr(obj, "object_variants"))
                 self.object_variants.merge_multi_value_variants(obj_variants)
 
         for obj_type, obj in self._objects():
@@ -394,8 +391,9 @@ class ApplicationBase(metaclass=ApplicationMeta):
         workload_name = self.expander.workload_name
         if workload_name in self.workloads:
             for var in self.workloads[workload_name].variables.values():
-                if not var.expandable:
-                    self.no_expand_vars.add(var.name)
+                if self.expander.satisfies(var.when, self.object_variants):
+                    if not var.expandable:
+                        self.no_expand_vars.add(var.name)
 
         self.expander.set_no_expand_vars(self.no_expand_vars)
 
@@ -1032,34 +1030,37 @@ class ApplicationBase(metaclass=ApplicationMeta):
             )
             self.variables[input_conf["input_name"]] = input_path
 
+    def selected_variables(self):
+        """Extract all variables which would be included based
+        on the current variants.
+
+        Returns:
+            (dict) Keys are variable names, values are variable instances
+        """
+
+        wl_vars = {}
+
+        if self.expander.workload_name in self.workloads:
+            for var in self.workloads[self.expander.workload_name].variables.values():
+                if self.expander.satisfies(var.when, self.object_variants):
+                    wl_vars[var.name] = var
+
+        for when_set, var_list in self.object_variables.items():
+            if self.expander.satisfies(when_set, self.object_variants):
+                for var in var_list:
+                    wl_vars[var.name] = var
+
+        return wl_vars
+
     def _set_default_experiment_variables(self):
         """Set default experiment variables (for add_expand_vars),
         if they haven't been set already"""
         # Set default experiment variables, if they haven't been set already
-        var_objs = []
-        var_sets = []
-
-        # Built var_objs list
-        if self.package_manager is not None:
-            var_objs.append(self.package_manager)
-
-        if self.workflow_manager is not None:
-            var_objs.append(self.workflow_manager)
-
-        for mod_inst in self._modifier_instances:
-            var_objs.append(mod_inst)
-
-        # Built var_sets list
-        if self.expander.workload_name in self.workloads:
-            var_sets.append(self.workloads[self.expander.workload_name].variables)
-
-        for var_obj in var_objs:
-            var_sets.append(var_obj.selected_variables())
 
         # Define variables from var_sets
-        for var_set in var_sets:
-            for var, val in var_set.items():
-                if var not in self.variables.keys():
+        for _, obj in self._objects():
+            for var, val in obj.selected_variables().items():
+                if var not in self.variables:
                     self.define_variable(var, val.default)
 
         if self.expander.workload_name in self.workloads:

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -535,7 +535,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
 
         if self.package_manager is not None:
             # Add package manager variable defaults as placeholder
-            for var in self.package_manager.package_manager_variables.values():
+            for var in self.package_manager.object_variables:
                 self.variables[var.name] = var.default
 
         if self.workflow_manager is not None:
@@ -1030,7 +1030,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
             var_sets.append(self.workloads[self.expander.workload_name].variables)
 
         if self.package_manager is not None:
-            var_sets.append(self.package_manager.package_manager_variables)
+            var_sets.append(self.package_manager.variable_definitions())
 
         for mod_inst in self._modifier_instances:
             var_sets.append(mod_inst.mode_variables())

--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -283,6 +283,16 @@ class ApplicationBase(metaclass=ApplicationMeta):
             if obj_variants is not None:
                 self.object_variants.merge_multi_value_variants(obj_variants)
 
+        for obj_type, obj in self._objects():
+            if obj_type is ramble.repository.ObjectTypes.applications:
+                self.object_variants.multi_value_variant("application_name", value=obj.name)
+
+        self.object_variants.default_variant(
+            "workload_name",
+            default=self.expander.workload_name,
+            description="Name of experiment workload",
+        )
+
     def _set_package_manager(self):
         pkgman_name = conversions.canonical_none(
             self.object_variants.value(namespace.package_manager)

--- a/lib/ramble/ramble/language/application_language.py
+++ b/lib/ramble/ramble/language/application_language.py
@@ -204,6 +204,7 @@ def workload_variable(
     workload_group=None,
     expandable: bool = True,
     track_used: bool = True,
+    when=None,
     **kwargs,
 ):
     """Define a new variable to be used in experiments
@@ -226,6 +227,7 @@ def workload_variable(
         track_used (bool): True if the variable should be tracked as used,
                            False if not. Can help with allowing lists without vecotizing
                            experiments.
+        when (list | None): List of when conditions to apply to directive
     """
 
     def _execute_workload_variable(app):
@@ -234,12 +236,17 @@ def workload_variable(
             workload, workloads, app.workloads, "workload", "workloads", "workload_variable"
         )
 
+        when_list = ramble.language.language_helpers.build_when_list(
+            when, app, name, "workload_variable"
+        )
+
         workload_var = ramble.workload.WorkloadVariable(
             name,
             default=default,
             description=description,
             values=values,
             expandable=expandable,
+            when=when_list,
             **kwargs,
         )
 

--- a/lib/ramble/ramble/language/application_language.py
+++ b/lib/ramble/ramble/language/application_language.py
@@ -225,7 +225,7 @@ def workload_variable(
         workload_group (str): Name of workload group this variable is used in
         expandable (bool): True if the variable should be expanded, False if not.
         track_used (bool): True if the variable should be tracked as used,
-                           False if not. Can help with allowing lists without vecotizing
+                           False if not. Can help with allowing lists without vectorizing
                            experiments.
         when (list | None): List of when conditions to apply to directive
     """

--- a/lib/ramble/ramble/language/language_base.py
+++ b/lib/ramble/ramble/language/language_base.py
@@ -232,6 +232,11 @@ class DirectiveMeta(type):
                         "figure_of_merit_context",
                         "formatted_executable",
                         "register_validator",
+                        "variable",
+                        "workload_variable",
+                        "modifier_variable",
+                        "package_manager_variable",
+                        "workflow_manager_variable",
                     ]:
                         msg = (
                             'directive "{0}" cannot be used within a "when"'

--- a/lib/ramble/ramble/language/language_base.py
+++ b/lib/ramble/ramble/language/language_base.py
@@ -10,6 +10,7 @@
 directives, which are to allow functions to be invoked at class level
 """
 
+import copy
 import functools
 from collections.abc import Sequence  # novm
 from typing import Any, Dict, List
@@ -60,6 +61,7 @@ class DirectiveMeta(type):
 
     # Set of all known directives
     _directive_names = set()
+    _directive_init_values = {}
     _directives_to_be_executed = []
     _directive_functions = {}
     _directive_classes = {}
@@ -114,8 +116,8 @@ class DirectiveMeta(type):
         if valid_module:
             # Ensure the presence of the dictionaries associated
             # with the directives
-            for d in DirectiveMeta._directive_names:
-                setattr(cls, d, {})
+            for d, t in DirectiveMeta._directive_init_values.items():
+                setattr(cls, d, copy.deepcopy(t))
 
             directive_attrs = {
                 "_directive_functions": {},
@@ -141,7 +143,7 @@ class DirectiveMeta(type):
         super().__init__(name, bases, attr_dict)
 
     @classmethod
-    def directive(cls, dicts=None):
+    def directive(cls, dicts=None, init_value=None):
         """Decorator for Ramble directives.
 
         Ramble directives allow you to modify an object while it is being
@@ -179,6 +181,11 @@ class DirectiveMeta(type):
         and that if no directive actually modified it, it will just be an empty
         dict.
 
+        The ``(init_value={})`` part allows objects in Ramble to define what the
+        type of the attribute defined by the `dicts` argument will be. This
+        allows ``(dicts="variables", init_value=[])`` which makes the attribute
+        a list instead of a dict, which is the default.
+
         This is just a modular way to add storage attributes to the Application
         class, and it's how Ramble gets information from the applications to
         the core.
@@ -191,8 +198,14 @@ class DirectiveMeta(type):
             message = "dicts arg must be list, tuple, or string. Found {0}"
             raise TypeError(message.format(type(dicts)))
 
+        if init_value is None:
+            init_value = {}
+
         # Add the dictionary names if not already there
-        DirectiveMeta._directive_names |= set(dicts)
+        dicts_set = set(dicts)
+        DirectiveMeta._directive_names |= dicts_set
+        for attr_name in dicts_set:
+            DirectiveMeta._directive_init_values[attr_name] = init_value
 
         # This decorator just returns the directive functions
         def _decorator(decorated_function):

--- a/lib/ramble/ramble/language/modifier_language.py
+++ b/lib/ramble/ramble/language/modifier_language.py
@@ -284,7 +284,7 @@ def required_variable(var: str, results_level="variable", modes=None, descriptio
     return _mark_required_var
 
 
-@modifier_directive("modifier_variables")
+@modifier_directive(dicts=())
 def modifier_variable(
     name: str,
     default,
@@ -294,6 +294,7 @@ def modifier_variable(
     modes: Optional[list] = None,
     expandable: bool = True,
     track_used: bool = False,
+    when=None,
     **kwargs,
 ):
     """Define a variable for this modifier
@@ -309,6 +310,7 @@ def modifier_variable(
         track_used (bool): True if the variable should be tracked as used,
                            False if not. Can help with allowing lists without vecotizing
                            experiments.
+        when (list | None): List of when conditions to apply to directive
     """
 
     def _define_modifier_variable(mod):
@@ -318,17 +320,24 @@ def modifier_variable(
             mode, modes, mod.modes, "mode", "modes", "modifier_variable"
         )
 
-        for mode_name in all_modes:
-            if mode_name not in mod.modifier_variables:
-                mod.modifier_variables[mode_name] = {}
+        base_when_list = ramble.language.language_helpers.build_when_list(
+            when, mod, name, "figure_of_merit_context"
+        )
 
-            mod.modifier_variables[mode_name][name] = ramble.workload.WorkloadVariable(
-                name,
-                default=default,
-                description=description,
-                values=values,
-                expandable=expandable,
-                **kwargs,
+        for mode_name in all_modes:
+            mode_variant = f"{mod.name}_mode={mode_name}"
+            when_list = base_when_list + [mode_variant]
+
+            mod.object_variables.append(
+                ramble.workload.WorkloadVariable(
+                    name,
+                    default=default,
+                    description=description,
+                    values=values,
+                    expandable=expandable,
+                    when=when_list,
+                    **kwargs,
+                )
             )
 
     return _define_modifier_variable

--- a/lib/ramble/ramble/language/modifier_language.py
+++ b/lib/ramble/ramble/language/modifier_language.py
@@ -328,17 +328,17 @@ def modifier_variable(
             mode_variant = f"{mod.name}_mode={mode_name}"
             when_list = base_when_list + [mode_variant]
 
-            mod.object_variables.append(
-                ramble.workload.WorkloadVariable(
-                    name,
-                    default=default,
-                    description=description,
-                    values=values,
-                    expandable=expandable,
-                    when=when_list,
-                    **kwargs,
-                )
-            )
+            ramble.language.shared_language.variable(
+                name,
+                default,
+                description=description,
+                values=values,
+                expandable=expandable,
+                track_used=track_used,
+                when=when_list,
+                error_context="modifier_variable",
+                **kwargs,
+            )(mod)
 
     return _define_modifier_variable
 

--- a/lib/ramble/ramble/language/modifier_language.py
+++ b/lib/ramble/ramble/language/modifier_language.py
@@ -321,7 +321,7 @@ def modifier_variable(
         )
 
         base_when_list = ramble.language.language_helpers.build_when_list(
-            when, mod, name, "figure_of_merit_context"
+            when, mod, name, "modifier_variable"
         )
 
         for mode_name in all_modes:

--- a/lib/ramble/ramble/language/modifier_language.py
+++ b/lib/ramble/ramble/language/modifier_language.py
@@ -308,7 +308,7 @@ def modifier_variable(
         modes (list): List of modes this variable is used in
         expandable (bool): True if the variable should be expanded, False if not.
         track_used (bool): True if the variable should be tracked as used,
-                           False if not. Can help with allowing lists without vecotizing
+                           False if not. Can help with allowing lists without vectorizing
                            experiments.
         when (list | None): List of when conditions to apply to directive
     """

--- a/lib/ramble/ramble/language/modifier_language.py
+++ b/lib/ramble/ramble/language/modifier_language.py
@@ -316,7 +316,7 @@ def modifier_variable(
     def _define_modifier_variable(mod):
         import ramble.workload
 
-        all_modes = ramble.language.language_helpers.require_definition(
+        all_modes = ramble.language.language_helpers.merge_definitions(
             mode, modes, mod.modes, "mode", "modes", "modifier_variable"
         )
 
@@ -326,7 +326,6 @@ def modifier_variable(
 
         for mode_name in all_modes:
             mode_variant = f"{mod.name}_mode={mode_name}"
-            #  when_list = base_when_list + [mode_variant]
 
             ramble.language.shared_language.variable(
                 name,

--- a/lib/ramble/ramble/language/modifier_language.py
+++ b/lib/ramble/ramble/language/modifier_language.py
@@ -326,7 +326,7 @@ def modifier_variable(
 
         for mode_name in all_modes:
             mode_variant = f"{mod.name}_mode={mode_name}"
-            when_list = base_when_list + [mode_variant]
+            #  when_list = base_when_list + [mode_variant]
 
             ramble.language.shared_language.variable(
                 name,
@@ -335,7 +335,7 @@ def modifier_variable(
                 values=values,
                 expandable=expandable,
                 track_used=track_used,
-                when=when_list,
+                when=base_when_list + [mode_variant],
                 error_context="modifier_variable",
                 **kwargs,
             )(mod)

--- a/lib/ramble/ramble/language/package_manager_language.py
+++ b/lib/ramble/ramble/language/package_manager_language.py
@@ -21,13 +21,14 @@ class PackageManagerMeta(ramble.language.shared_language.SharedMeta):
 package_manager_directive = PackageManagerMeta.directive
 
 
-@package_manager_directive("package_manager_variables")
+@package_manager_directive(dicts=())
 def package_manager_variable(
     name: str,
     default,
     description: str,
     values: Optional[list] = None,
     expandable: bool = True,
+    when=None,
     **kwargs,
 ):
     """Define a variable for this package manager
@@ -38,17 +39,26 @@ def package_manager_variable(
         description (str): Description of variable's purpose
         values (list): Optional list of suggested values for this variable
         expandable (bool): True if the variable should be expanded, False if not.
+        when (list | None): List of when conditions to apply to directive
     """
 
     def _define_package_manager_variable(pm):
         import ramble.workload
 
-        pm.package_manager_variables[name] = ramble.workload.WorkloadVariable(
-            name,
-            default=default,
-            description=description,
-            values=values,
-            expandable=expandable,
+        when_list = ramble.language.language_helpers.build_when_list(
+            when, pm, name, "package_manager_variable"
+        )
+
+        pm.object_variables.append(
+            ramble.workload.WorkloadVariable(
+                name,
+                default=default,
+                description=description,
+                values=values,
+                expandable=expandable,
+                when=when_list,
+                **kwargs,
+            )
         )
 
     return _define_package_manager_variable

--- a/lib/ramble/ramble/language/package_manager_language.py
+++ b/lib/ramble/ramble/language/package_manager_language.py
@@ -41,7 +41,7 @@ def package_manager_variable(
         values (list): Optional list of suggested values for this variable
         expandable (bool): True if the variable should be expanded, False if not.
         track_used (bool): True if the variable should be tracked as used,
-                           False if not. Can help with allowing lists without vecotizing
+                           False if not. Can help with allowing lists without vectorizing
         when (list | None): List of when conditions to apply to directive
     """
 

--- a/lib/ramble/ramble/language/package_manager_language.py
+++ b/lib/ramble/ramble/language/package_manager_language.py
@@ -28,6 +28,7 @@ def package_manager_variable(
     description: str,
     values: Optional[list] = None,
     expandable: bool = True,
+    track_used: bool = False,
     when=None,
     **kwargs,
 ):
@@ -39,27 +40,23 @@ def package_manager_variable(
         description (str): Description of variable's purpose
         values (list): Optional list of suggested values for this variable
         expandable (bool): True if the variable should be expanded, False if not.
+        track_used (bool): True if the variable should be tracked as used,
+                           False if not. Can help with allowing lists without vecotizing
         when (list | None): List of when conditions to apply to directive
     """
 
     def _define_package_manager_variable(pm):
-        import ramble.workload
-
-        when_list = ramble.language.language_helpers.build_when_list(
-            when, pm, name, "package_manager_variable"
-        )
-
-        pm.object_variables.append(
-            ramble.workload.WorkloadVariable(
-                name,
-                default=default,
-                description=description,
-                values=values,
-                expandable=expandable,
-                when=when_list,
-                **kwargs,
-            )
-        )
+        ramble.language.shared_language.variable(
+            name,
+            default,
+            description=description,
+            values=values,
+            expandable=expandable,
+            track_used=track_used,
+            when=when,
+            error_context="package_manager_variable",
+            **kwargs,
+        )(pm)
 
     return _define_package_manager_variable
 

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -747,6 +747,51 @@ def register_validator(
     return _define_validator
 
 
+@shared_directive("object_variables", init_value=[])
+def variable(
+    name: str,
+    default,
+    description: str,
+    values: Optional[list] = None,
+    expandable: bool = True,
+    track_used: bool = False,
+    when=None,
+    **kwargs,
+):
+    """Define a variable for this modifier
+
+    Args:
+        name (str): Name of variable to define
+        default: Default value of variable definition
+        description (str): Description of variable's purpose
+        values (list): Optional list of suggested values for this variable
+        expandable (bool): True if the variable should be expanded, False if not.
+        track_used (bool): True if the variable should be tracked as used,
+                           False if not. Can help with allowing lists without vecotizing
+                           experiments.
+        when (list | None): List of when conditions to apply to directive
+    """
+
+    def _define_variable(obj):
+        import ramble.workload
+
+        when_list = ramble.language.language_helpers.build_when_list(when, obj, name, "variable")
+
+        obj.object_variables.append(
+            ramble.workload.WorkloadVariable(
+                name,
+                default=default,
+                description=description,
+                values=values,
+                expandable=expandable,
+                when=when_list,
+                **kwargs,
+            )
+        )
+
+    return _define_variable
+
+
 @shared_directive(dicts=())
 def variant(
     name: str,

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -747,7 +747,7 @@ def register_validator(
     return _define_validator
 
 
-@shared_directive("object_variables", init_value=[])
+@shared_directive("object_variables")
 def variable(
     name: str,
     default,
@@ -780,14 +780,18 @@ def variable(
             when, obj, name, error_context
         )
 
-        obj.object_variables.append(
+        when_set = frozenset(when_list)
+
+        if when_set not in obj.object_variables:
+            obj.object_variables[when_set] = []
+
+        obj.object_variables[when_set].append(
             ramble.workload.WorkloadVariable(
                 name,
                 default=default,
                 description=description,
                 values=values,
                 expandable=expandable,
-                when=when_list,
                 **kwargs,
             )
         )

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -756,6 +756,7 @@ def variable(
     expandable: bool = True,
     track_used: bool = False,
     when=None,
+    error_context="variable",
     **kwargs,
 ):
     """Define a variable for this modifier
@@ -775,7 +776,9 @@ def variable(
     def _define_variable(obj):
         import ramble.workload
 
-        when_list = ramble.language.language_helpers.build_when_list(when, obj, name, "variable")
+        when_list = ramble.language.language_helpers.build_when_list(
+            when, obj, name, error_context
+        )
 
         obj.object_variables.append(
             ramble.workload.WorkloadVariable(

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -768,7 +768,7 @@ def variable(
         values (list): Optional list of suggested values for this variable
         expandable (bool): True if the variable should be expanded, False if not.
         track_used (bool): True if the variable should be tracked as used,
-                           False if not. Can help with allowing lists without vecotizing
+                           False if not. Can help with allowing lists without vectorizing
                            experiments.
         when (list | None): List of when conditions to apply to directive
     """

--- a/lib/ramble/ramble/language/workflow_manager_language.py
+++ b/lib/ramble/ramble/language/workflow_manager_language.py
@@ -19,12 +19,13 @@ class WorkflowManagerMeta(ramble.language.shared_language.SharedMeta):
 workflow_manager_directive = WorkflowManagerMeta.directive
 
 
-@workflow_manager_directive("wm_vars")
+@workflow_manager_directive(dicts=())
 def workflow_manager_variable(
     name: str,
     default,
     description: str,
     values: Optional[list] = None,
+    when=None,
     **kwargs,
 ):
     """Define a variable for this wm
@@ -33,16 +34,24 @@ def workflow_manager_variable(
         default: Default value if the variable is not defined
         description: Description of the variable
         values: Optional list of suggested values for this variable
+        when (list | None): List of when conditions to apply to directive
     """
 
     def _define_wm_variable(wm):
         import ramble.workload
 
-        wm.wm_vars[name] = ramble.workload.WorkloadVariable(
-            name,
-            default=default,
-            description=description,
-            values=values,
+        when_list = ramble.language.language_helpers.build_when_list(
+            when, wm, name, "workflow_manager_variable"
+        )
+
+        wm.object_variables.append(
+            ramble.workload.WorkloadVariable(
+                name,
+                default=default,
+                description=description,
+                values=values,
+                when=when_list,
+            )
         )
 
     return _define_wm_variable

--- a/lib/ramble/ramble/language/workflow_manager_language.py
+++ b/lib/ramble/ramble/language/workflow_manager_language.py
@@ -25,6 +25,8 @@ def workflow_manager_variable(
     default,
     description: str,
     values: Optional[list] = None,
+    expandable: bool = True,
+    track_used: bool = False,
     when=None,
     **kwargs,
 ):
@@ -34,25 +36,24 @@ def workflow_manager_variable(
         default: Default value if the variable is not defined
         description: Description of the variable
         values: Optional list of suggested values for this variable
+        expandable (bool): True if the variable should be expanded, False if not.
+        track_used (bool): True if the variable should be tracked as used,
+                           False if not. Can help with allowing lists without vecotizing
         when (list | None): List of when conditions to apply to directive
     """
 
     def _define_wm_variable(wm):
-        import ramble.workload
-
-        when_list = ramble.language.language_helpers.build_when_list(
-            when, wm, name, "workflow_manager_variable"
-        )
-
-        wm.object_variables.append(
-            ramble.workload.WorkloadVariable(
-                name,
-                default=default,
-                description=description,
-                values=values,
-                when=when_list,
-            )
-        )
+        ramble.language.shared_language.variable(
+            name,
+            default,
+            description=description,
+            values=values,
+            expandable=expandable,
+            track_used=track_used,
+            when=when,
+            error_context="workflow_manager_variable",
+            **kwargs,
+        )(wm)
 
     return _define_wm_variable
 

--- a/lib/ramble/ramble/language/workflow_manager_language.py
+++ b/lib/ramble/ramble/language/workflow_manager_language.py
@@ -38,7 +38,7 @@ def workflow_manager_variable(
         values: Optional list of suggested values for this variable
         expandable (bool): True if the variable should be expanded, False if not.
         track_used (bool): True if the variable should be tracked as used,
-                           False if not. Can help with allowing lists without vecotizing
+                           False if not. Can help with allowing lists without vectorizing
         when (list | None): List of when conditions to apply to directive
     """
 

--- a/lib/ramble/ramble/modifier.py
+++ b/lib/ramble/ramble/modifier.py
@@ -252,24 +252,26 @@ class ModifierBase(metaclass=ModifierMeta):
             (str): Variable name
         """
 
-        for var in self.object_variables:
-            if not self.expander.satisfies(var.when, variant_set=self.object_variants):
+        for when_key, var_list in self.object_variables.items():
+            if not self.expander.satisfies(when_key, self.object_variants):
                 continue
 
-            yield var.name
+            for var in var_list:
+                yield var.name
 
-    def mode_variables(self):
+    def selected_variables(self):
         """Return a dict of variables that should be defined for the current mode"""
 
-        mode_variables = {}
+        mod_variables = {}
 
-        for var in self.object_variables:
-            if not self.expander.satisfies(var.when, variant_set=self.object_variants):
+        for when_key, var_list in self.object_variables.items():
+            if not self.expander.satisfies(when_key, self.object_variants):
                 continue
 
-            mode_variables[var.name] = var
+            for var in var_list:
+                mod_variables[var.name] = var
 
-        return mode_variables
+        return mod_variables
 
     def artifact_inventory(self, workspace, app_inst=None):
         """Return an inventory of modifier artifacts

--- a/lib/ramble/ramble/modifier.py
+++ b/lib/ramble/ramble/modifier.py
@@ -135,7 +135,13 @@ class ModifierBase(metaclass=ModifierMeta):
 
     def inherit_from_application(self, app):
         self.expander = app.expander.copy()
-        self.object_variants = app.object_variants.copy()
+        self.object_variants.merge_default_variants(app.object_variants)
+
+        for name, value in app.variants.items():
+            expanded_value = self.expander.expand_var(value, typed=True)
+            self.object_variants.experiment_variant(name, expanded_value)
+
+        self.object_variants.merge_multi_value_variants(app.object_variants)
         modded_vars = self.modded_variables(app)
         self.expander._variables.update(modded_vars)
 
@@ -260,7 +266,12 @@ class ModifierBase(metaclass=ModifierMeta):
                 yield var.name
 
     def selected_variables(self):
-        """Return a dict of variables that should be defined for the current mode"""
+        """Extract all variables which would be included based
+        on the current variants.
+
+        Returns:
+            (dict) Keys are variable names, values are variable instances
+        """
 
         mod_variables = {}
 

--- a/lib/ramble/ramble/modifier.py
+++ b/lib/ramble/ramble/modifier.py
@@ -135,6 +135,7 @@ class ModifierBase(metaclass=ModifierMeta):
 
     def inherit_from_application(self, app):
         self.expander = app.expander.copy()
+        self.object_variants = app.object_variants.copy()
         modded_vars = self.modded_variables(app)
         self.expander._variables.update(modded_vars)
 
@@ -251,18 +252,24 @@ class ModifierBase(metaclass=ModifierMeta):
             (str): Variable name
         """
 
-        if self._usage_mode in self.modifier_variables:
-            for var, var_conf in self.modifier_variables[self._usage_mode].items():
-                if not var_conf.expandable:
-                    yield var
+        for var in self.object_variables:
+            if not self.expander.satisfies(var.when, variant_set=self.object_variants):
+                continue
+
+            yield var.name
 
     def mode_variables(self):
         """Return a dict of variables that should be defined for the current mode"""
 
-        if self._usage_mode in self.modifier_variables:
-            return self.modifier_variables[self._usage_mode]
-        else:
-            return {}
+        mode_variables = {}
+
+        for var in self.object_variables:
+            if not self.expander.satisfies(var.when, variant_set=self.object_variants):
+                continue
+
+            mode_variables[var.name] = var
+
+        return mode_variables
 
     def artifact_inventory(self, workspace, app_inst=None):
         """Return an inventory of modifier artifacts

--- a/lib/ramble/ramble/package_manager.py
+++ b/lib/ramble/ramble/package_manager.py
@@ -120,6 +120,16 @@ class PackageManagerBase(metaclass=PackageManagerMeta):
 
         return False
 
+    def variable_definitions(self):
+        all_vars = {}
+        for var in self.object_variables:
+            if not self.app_inst.expander.satisfies(
+                var.when, variant_set=self.app_inst.object_variants
+            ):
+                continue
+            all_vars[var.name] = var
+        return all_vars
+
     def get_spec_str(self, pkg, all_pkgs, compiler):
         """Return a spec string for the given pkg
 

--- a/lib/ramble/ramble/package_manager.py
+++ b/lib/ramble/ramble/package_manager.py
@@ -121,6 +121,12 @@ class PackageManagerBase(metaclass=PackageManagerMeta):
         return False
 
     def selected_variables(self):
+        """Extract all variables which would be included based
+        on the current variants.
+
+        Returns:
+            (dict) Keys are variable names, values are variable instances
+        """
         all_vars = {}
         for when_key, var_list in self.object_variables.items():
             if not self.app_inst.expander.satisfies(when_key, self.app_inst.object_variants):

--- a/lib/ramble/ramble/package_manager.py
+++ b/lib/ramble/ramble/package_manager.py
@@ -120,14 +120,14 @@ class PackageManagerBase(metaclass=PackageManagerMeta):
 
         return False
 
-    def variable_definitions(self):
+    def selected_variables(self):
         all_vars = {}
-        for var in self.object_variables:
-            if not self.app_inst.expander.satisfies(
-                var.when, variant_set=self.app_inst.object_variants
-            ):
+        for when_key, var_list in self.object_variables.items():
+            if not self.app_inst.expander.satisfies(when_key, self.app_inst.object_variants):
                 continue
-            all_vars[var.name] = var
+
+            for var in var_list:
+                all_vars[var.name] = var
         return all_vars
 
     def get_spec_str(self, pkg, all_pkgs, compiler):

--- a/lib/ramble/ramble/test/application.py
+++ b/lib/ramble/ramble/test/application.py
@@ -49,11 +49,11 @@ def test_basic_app(mutable_mock_apps_repo):
     example_input = basic_inst.workloads["test_wl"].find_input("input")
     assert example_input is not None
 
-    assert len(basic_inst.workloads["test_wl"].variables) == 2
-    my_var = basic_inst.workloads["test_wl"].find_variable("my_var")
-    assert my_var is not None
-    assert my_var.default == "1.0"
-    assert my_var.description == "Example var"
+    assert len(basic_inst.workloads["test_wl"].variables[frozenset()]) == 2
+    possible_vars = basic_inst.workloads["test_wl"].find_variable("my_var")
+    assert len(possible_vars) == 1
+    assert possible_vars[0].default == "1.0"
+    assert possible_vars[0].description == "Example var"
 
     assert "test_wl2" in basic_inst.workloads
     assert len(basic_inst.workloads["test_wl2"].executables) == 1
@@ -519,15 +519,21 @@ def test_workload_groups(mutable_mock_apps_repo):
     assert "empty" in workload_group_inst.workload_groups
     assert "test_wlg" in workload_group_inst.workload_groups
 
-    my_var = workload_group_inst.workloads["test_wl"].find_variable("test_var")
-    assert my_var is not None
-    assert my_var.default == "2.0"
-    assert my_var.description == "Test workload vars and groups"
+    possible_vars = workload_group_inst.workloads["test_wl"].find_variable("test_var")
+    assert len(possible_vars) >= 1
+    found = False
+    for var in possible_vars:
+        if var.default == "2.0" and var.description == "Test workload vars and groups":
+            found = True
+    assert found
 
-    my_mixed_var_wl = workload_group_inst.workloads["test_wl"].find_variable("test_var_mixed")
-    assert my_mixed_var_wl is not None
-    assert my_mixed_var_wl.default == "3.0"
-    assert my_mixed_var_wl.description == "Test vars for workload and groups"
+    possible_vars = workload_group_inst.workloads["test_wl"].find_variable("test_var_mixed")
+    assert len(possible_vars) >= 1
+    found = False
+    for var in possible_vars:
+        if var.default == "3.0" and var.description == "Test vars for workload and groups":
+            found = True
+    assert found
 
 
 def test_workload_groups_inherited(mutable_mock_apps_repo):
@@ -543,12 +549,19 @@ def test_workload_groups_inherited(mutable_mock_apps_repo):
     assert "test_wl" in wlgi_inst.workload_groups["test_wlg"]
 
     # Ensure a new workload can obtain the parent level vars via groups
-    my_var = wlgi_inst.workloads["test_wl3"].find_variable("test_var")
-    assert my_var is not None
-    assert my_var.default == "2.0"
-    assert my_var.description == "Test workload vars and groups"
+    possible_vars = wlgi_inst.workloads["test_wl3"].find_variable("test_var")
+    assert len(possible_vars) >= 1
+    found = False
+    for var in possible_vars:
+        if var.default == "2.0" and var.description == "Test workload vars and groups":
+            found = True
+    assert found
 
     for wl in ["test_wl", "test_wl3"]:
-        my_mixed_var_wl = wlgi_inst.workloads[wl].find_variable("test_var_mixed")
-        assert my_mixed_var_wl is not None
-        assert my_mixed_var_wl.default == "3.0"
+        possible_vars = wlgi_inst.workloads[wl].find_variable("test_var_mixed")
+        assert len(possible_vars) >= 1
+        found = False
+        for var in possible_vars:
+            if var.default == "3.0":
+                found = True
+        assert found

--- a/lib/ramble/ramble/test/application_inheritance.py
+++ b/lib/ramble/ramble/test/application_inheritance.py
@@ -55,9 +55,14 @@ def test_basic_inheritance(mutable_mock_apps_repo):
     assert app_inst.inputs["inherited_input"]["url"] == "file:///tmp/inherited_file.log"
     assert app_inst.inputs["inherited_input"]["description"] == "Again, not a file"
 
-    assert "my_base_var" in app_inst.workloads["test_wl"].variables
-    assert "my_var" in app_inst.workloads["test_wl"].variables
-    assert "Shadowed" in app_inst.workloads["test_wl"].variables["my_var"].description
-    assert app_inst.workloads["test_wl"].variables["my_var"].default == "1.0"
+    possible_vars = app_inst.workloads["test_wl"].find_variable("my_base_var")
+    assert len(possible_vars) == 1
+    possible_vars = app_inst.workloads["test_wl"].find_variable("my_var")
+    assert len(possible_vars) >= 1
+    found = False
+    for var in possible_vars:
+        if "Shadowed" in var.description and var.default == "1.0":
+            found = True
+    assert found
 
     assert app_inst.license_names == ["basic", "basic-inherited-extended", "basic-inherited"]

--- a/lib/ramble/ramble/test/end_to_end/known_applications.py
+++ b/lib/ramble/ramble/test/end_to_end/known_applications.py
@@ -130,7 +130,7 @@ def test_known_workflow_managers(workflow_manager, mock_file_auto_create, mutabl
             wm_inst = ramble.repository.get(
                 workflow_manager, object_type=ramble.repository.ObjectTypes.workflow_managers
             )
-            for var in wm_inst.object_variables:
+            for var in wm_inst.object_variables[frozenset()]:
                 config("remove", f"variables:{var.name}", global_args=["-w", ws_name])
 
             for var_name in wm_inst.templates:

--- a/lib/ramble/ramble/test/end_to_end/known_applications.py
+++ b/lib/ramble/ramble/test/end_to_end/known_applications.py
@@ -130,8 +130,8 @@ def test_known_workflow_managers(workflow_manager, mock_file_auto_create, mutabl
             wm_inst = ramble.repository.get(
                 workflow_manager, object_type=ramble.repository.ObjectTypes.workflow_managers
             )
-            for var_name in wm_inst.wm_vars:
-                config("remove", f"variables:{var_name}", global_args=["-w", ws_name])
+            for var in wm_inst.object_variables:
+                config("remove", f"variables:{var.name}", global_args=["-w", ws_name])
 
             for var_name in wm_inst.templates:
                 config("remove", f"variables:{var_name}", global_args=["-w", ws_name])

--- a/lib/ramble/ramble/test/modifier_language.py
+++ b/lib/ramble/ramble/test/modifier_language.py
@@ -468,21 +468,21 @@ def test_modifier_variable_directive(mod_class):
     test_defs = []
 
     mod_inst = mod_class("/not/a/path")
+    mod_inst.name = "mock-test-mod"
     test_defs.append(add_modifier_variable(mod_inst))
 
     for test_def in test_defs:
         found = False
 
-        for var in mod_inst.object_variables:
-            if var.name == test_def["name"]:
-                mode_variant = f"{mod_inst.name}_mode={test_def['mode']}"
-
-                assert mode_variant in var.when
-                assert test_def["description"] == var.description
-                assert test_def["default"] == var.default
-                found = True
-
-            assert found
+        for when_set, var_list in mod_inst.object_variables.items():
+            for var in var_list:
+                if var.name == test_def["name"]:
+                    mode_variant = f"mock-test-mod_mode={test_def['mode']}"
+                    assert mode_variant in when_set
+                    assert test_def["description"] == var.description
+                    assert test_def["default"] == var.default
+                    found = True
+        assert found
 
 
 @pytest.mark.parametrize("mod_class", mod_types)

--- a/lib/ramble/ramble/test/modifier_language.py
+++ b/lib/ramble/ramble/test/modifier_language.py
@@ -31,7 +31,6 @@ def test_modifier_type_features(mod_class):
     assert hasattr(test_mod, "required_packages")
     assert hasattr(test_mod, "success_criteria")
     assert hasattr(test_mod, "builtins")
-    assert hasattr(test_mod, "modifier_variables")
     assert hasattr(test_mod, "executable_modifiers")
     assert hasattr(test_mod, "env_var_modifications")
     assert hasattr(test_mod, "maintainers")
@@ -471,16 +470,19 @@ def test_modifier_variable_directive(mod_class):
     mod_inst = mod_class("/not/a/path")
     test_defs.append(add_modifier_variable(mod_inst))
 
-    assert hasattr(mod_inst, "modifier_variables")
-
     for test_def in test_defs:
-        mode = test_def["mode"]
-        var_name = test_def["name"]
+        found = False
 
-        assert mode in mod_inst.modifier_variables
-        assert test_def["name"] in mod_inst.modifier_variables[mode]
-        assert test_def["description"] == mod_inst.modifier_variables[mode][var_name].description
-        assert test_def["default"] == mod_inst.modifier_variables[mode][var_name].default
+        for var in mod_inst.object_variables:
+            if var.name == test_def["name"]:
+                mode_variant = f"{mod_inst.name}_mode={test_def['mode']}"
+
+                assert mode_variant in var.when
+                assert test_def["description"] == var.description
+                assert test_def["default"] == var.default
+                found = True
+
+            assert found
 
 
 @pytest.mark.parametrize("mod_class", mod_types)

--- a/lib/ramble/ramble/test/package_manager_language.py
+++ b/lib/ramble/ramble/test/package_manager_language.py
@@ -20,7 +20,7 @@ pm_types = [
 def test_pkg_man_type_features(pm_class):
     pm_path = "/path/to/pm"
     test_pm = pm_class(pm_path)
-    assert hasattr(test_pm, "package_manager_variable")
+    assert hasattr(test_pm, "object_variables")
     assert hasattr(test_pm, "maintainers")
 
 
@@ -45,9 +45,12 @@ def test_pkg_man_variables(pm_class):
 
     var_name = test_defs["name"]
 
-    assert hasattr(pm_inst, "package_manager_variables")
-    assert var_name in pm_inst.package_manager_variables
-    assert pm_inst.package_manager_variables[var_name].default is not None
-    assert pm_inst.package_manager_variables[var_name].default == test_defs["default"]
-    assert pm_inst.package_manager_variables[var_name].description is not None
-    assert pm_inst.package_manager_variables[var_name].description == test_defs["description"]
+    assert hasattr(pm_inst, "object_variables")
+
+    found = False
+    for var in pm_inst.object_variables:
+        if var_name == var.name:
+            assert var.default == test_defs["default"]
+            assert var.description == test_defs["description"]
+            found = True
+    assert found

--- a/lib/ramble/ramble/test/package_manager_language.py
+++ b/lib/ramble/ramble/test/package_manager_language.py
@@ -48,7 +48,7 @@ def test_pkg_man_variables(pm_class):
     assert hasattr(pm_inst, "object_variables")
 
     found = False
-    for var in pm_inst.object_variables:
+    for var in pm_inst.object_variables[frozenset()]:
         if var_name == var.name:
             assert var.default == test_defs["default"]
             assert var.description == test_defs["description"]

--- a/lib/ramble/ramble/test/when.py
+++ b/lib/ramble/ramble/test/when.py
@@ -489,6 +489,226 @@ def test_formatted_exec_when(request, inc_value, type_value):
             assert "{test_formatted_exec}" not in data
 
 
+@pytest.mark.parametrize(
+    "inc_value,type_value",
+    [
+        (True, "preferred"),
+        (True, "testing"),
+        (True, "modifier"),
+        (False, "preferred"),
+    ],
+)
+def test_variable_when(request, inc_value, type_value):
+    ws_name = request.node.name.replace("[", "_").replace("]", "_")
+
+    global_args = ["-w", ws_name]
+
+    with ramble.workspace.create(ws_name) as ws:
+        workspace(
+            "manage",
+            "experiments",
+            "when-variants",
+            "--wf",
+            "test_wl",
+            "-v",
+            "zlib_path=/not/a/path",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "processes_per_node=1",
+            global_args=global_args,
+        )
+
+        config("add", f"variants:inc_zlib:{inc_value}", global_args=global_args)
+        config("add", f"variants:zlib_type:{type_value}", global_args=global_args)
+
+        if inc_value:
+            test_str = f"Standard was {type_value}"
+        else:
+            test_str = "Standard was unincluded"
+
+        ws._re_read()
+        workspace("setup", global_args=global_args)
+
+        exec_file = os.path.join(
+            ws.experiment_dir,
+            "when-variants",
+            "test_wl",
+            "generated",
+            "execute_experiment",
+        )
+
+        with open(exec_file) as f:
+            data = f.read()
+
+            assert test_str in data
+
+
+@pytest.mark.parametrize(
+    "inc_value",
+    [True, False],
+)
+def test_package_manager_variable_when(request, inc_value, mutable_mock_pkg_mans_repo):
+    ws_name = request.node.name.replace("[", "_").replace("]", "_")
+
+    global_args = ["-w", ws_name]
+
+    with ramble.workspace.create(ws_name) as ws:
+        workspace(
+            "manage",
+            "experiments",
+            "when-variants",
+            "--wf",
+            "test_wl",
+            "-v",
+            "zlib_path=/not/a/path",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "processes_per_node=1",
+            "-p",
+            "when-package-manager",
+            global_args=global_args,
+        )
+
+        config("add", f"variants:package_manager_included:{inc_value}", global_args=global_args)
+
+        if inc_value:
+            test_str = "PM test: included"
+        else:
+            test_str = "PM test: {pm_var_test}"
+
+        ws._re_read()
+        workspace("setup", global_args=global_args)
+
+        exec_file = os.path.join(
+            ws.experiment_dir,
+            "when-variants",
+            "test_wl",
+            "generated",
+            "execute_experiment",
+        )
+
+        with open(exec_file) as f:
+            data = f.read()
+
+            assert test_str in data
+
+
+@pytest.mark.parametrize(
+    "inc_value",
+    [True, False],
+)
+def test_workflow_manager_variable_when(request, inc_value, mutable_mock_wms_repo):
+    ws_name = request.node.name.replace("[", "_").replace("]", "_")
+
+    global_args = ["-w", ws_name]
+
+    with ramble.workspace.create(ws_name) as ws:
+        workspace(
+            "manage",
+            "experiments",
+            "when-variants",
+            "--wf",
+            "test_wl",
+            "-v",
+            "zlib_path=/not/a/path",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "processes_per_node=1",
+            "--wm",
+            "when-workflow-manager",
+            global_args=global_args,
+        )
+
+        config("add", f"variants:workflow_manager_included:{inc_value}", global_args=global_args)
+
+        if inc_value:
+            test_str = "WM test: included"
+        else:
+            test_str = "WM test: {wm_var_test}"
+
+        ws._re_read()
+        workspace("setup", global_args=global_args)
+
+        exec_file = os.path.join(
+            ws.experiment_dir,
+            "when-variants",
+            "test_wl",
+            "generated",
+            "execute_experiment",
+        )
+
+        with open(exec_file) as f:
+            data = f.read()
+
+            assert test_str in data
+
+
+@pytest.mark.parametrize(
+    "inc_value",
+    [True, False],
+)
+def test_modifier_variable_when(request, inc_value, mutable_mock_mods_repo):
+    ws_name = request.node.name.replace("[", "_").replace("]", "_")
+
+    global_args = ["-w", ws_name]
+
+    with ramble.workspace.create(ws_name) as ws:
+
+        workspace(
+            "manage",
+            "experiments",
+            "when-variants",
+            "--wf",
+            "test_wl",
+            "-v",
+            "zlib_path=/not/a/path",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "processes_per_node=1",
+            global_args=global_args,
+        )
+
+        config_path = os.path.join(ws.config_dir, "modifiers.yaml")
+        with open(config_path, "w+") as f:
+            f.write("modifiers:\n")
+            f.write(" - name: when-modifier\n")
+
+        config("add", f"variants:modifier_included:{inc_value}", global_args=global_args)
+
+        if inc_value:
+            test_str = "MOD test: included"
+        else:
+            test_str = "MOD test: {mod_var_test}"
+
+        ws._re_read()
+        workspace("setup", global_args=global_args)
+
+        exec_file = os.path.join(
+            ws.experiment_dir,
+            "when-variants",
+            "test_wl",
+            "generated",
+            "execute_experiment",
+        )
+
+        with open(exec_file) as f:
+            data = f.read()
+
+            assert test_str in data
+
+
 def test_success_criteria_when(request):
     ws_name = request.node.name
 

--- a/lib/ramble/ramble/test/when.py
+++ b/lib/ramble/ramble/test/when.py
@@ -490,6 +490,55 @@ def test_formatted_exec_when(request, inc_value, type_value):
 
 
 @pytest.mark.parametrize(
+    "workload_name",
+    ["test_wl", "test_unset_wl"],
+)
+def test_variable_when_workload_constraint(request, workload_name):
+    ws_name = request.node.name.replace("[", "_").replace("]", "_")
+
+    global_args = ["-w", ws_name]
+
+    with ramble.workspace.create(ws_name) as ws:
+        workspace(
+            "manage",
+            "experiments",
+            "when-variants",
+            "--wf",
+            workload_name,
+            "-v",
+            "zlib_path=/not/a/path",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "processes_per_node=1",
+            global_args=global_args,
+        )
+
+        if workload_name == "test_wl":
+            test_str = "Test when workload variable is_defined"
+        else:
+            test_str = "Test when workload variable {test_when_var}"
+
+        ws._re_read()
+        workspace("setup", global_args=global_args)
+
+        exec_file = os.path.join(
+            ws.experiment_dir,
+            "when-variants",
+            workload_name,
+            "generated",
+            "execute_experiment",
+        )
+
+        with open(exec_file) as f:
+            data = f.read()
+
+            assert test_str in data
+
+
+@pytest.mark.parametrize(
     "inc_value,type_value",
     [
         (True, "preferred"),

--- a/lib/ramble/ramble/variants.py
+++ b/lib/ramble/ramble/variants.py
@@ -119,7 +119,10 @@ class VariantSet:
             value: The value the variant should take.
         """
         if name in self.default_variants:
-            if value not in self.default_variants[name].values:
+            if (
+                self.default_variants[name].values
+                and value not in self.default_variants[name].values
+            ):
                 raise RambleVariantError(
                     f"When defining variant {name} the value {value} is not valid.\n"
                     f"   Valid values include: {self.default_variants[name].values}"

--- a/lib/ramble/ramble/workflow_manager.py
+++ b/lib/ramble/ramble/workflow_manager.py
@@ -121,12 +121,12 @@ class WorkflowManagerBase(metaclass=WorkflowManagerMeta):
     def __str__(self):
         return self.name
 
-    def variable_definitions(self):
+    def selected_variables(self):
         all_vars = {}
-        for var in self.object_variables:
-            if not self.app_inst.expander.satisfies(
-                var.when, variant_set=self.app_inst.object_variants
-            ):
+        for when_key, var_list in self.object_variables.items():
+            if not self.app_inst.expander.satisfies(when_key, self.app_inst.object_variants):
                 continue
-            all_vars[var.name] = var
+
+            for var in var_list:
+                all_vars[var.name] = var
         return all_vars

--- a/lib/ramble/ramble/workflow_manager.py
+++ b/lib/ramble/ramble/workflow_manager.py
@@ -122,6 +122,13 @@ class WorkflowManagerBase(metaclass=WorkflowManagerMeta):
         return self.name
 
     def selected_variables(self):
+        """Extract all variables which would be included based
+        on the current variants.
+
+        Returns:
+            (dict) Keys are variable names, values are variable instances
+        """
+
         all_vars = {}
         for when_key, var_list in self.object_variables.items():
             if not self.app_inst.expander.satisfies(when_key, self.app_inst.object_variants):

--- a/lib/ramble/ramble/workflow_manager.py
+++ b/lib/ramble/ramble/workflow_manager.py
@@ -120,3 +120,13 @@ class WorkflowManagerBase(metaclass=WorkflowManagerMeta):
 
     def __str__(self):
         return self.name
+
+    def variable_definitions(self):
+        all_vars = {}
+        for var in self.object_variables:
+            if not self.app_inst.expander.satisfies(
+                var.when, variant_set=self.app_inst.object_variants
+            ):
+                continue
+            all_vars[var.name] = var
+        return all_vars

--- a/lib/ramble/ramble/workload.py
+++ b/lib/ramble/ramble/workload.py
@@ -62,7 +62,7 @@ class WorkloadVariable:
 
         print_attrs = ["Description", "Default", "Values"]
 
-        out_str = rucolor.nested_2(f"{indentation}{self.name}:\n")
+        out_str = rucolor.nested_3(f"{indentation}{self.name}:\n")
         for print_attr in print_attrs:
             name = print_attr
             if print_attr == "Values":
@@ -184,8 +184,15 @@ class Workload:
 
         if self.variables:
             out_str += rucolor.nested_1(f"{indentation}    Variables:\n")
-            for var in self.variables.values():
-                out_str += var.as_str(n_indent + 4)
+            for when_set, var_list in self.variables.items():
+                if when_set:
+                    out_str += rucolor.nested_2(f"{indentation}        When conditions:\n")
+                    for variant in when_set:
+                        out_str += f"{indentation}            {variant}\n"
+                else:
+                    out_str += rucolor.nested_2(f"{indentation}        Unconditional\n")
+                for var in var_list:
+                    out_str += var.as_str(n_indent + 12)
 
         if self.environment_variables:
             out_str += rucolor.nested_1(f"{indentation}    Environment Variables:\n")
@@ -200,7 +207,10 @@ class Workload:
         Args:
             variable (WorkloadVariable): New variable to add to this workload
         """
-        self.variables[variable.name] = variable
+        when_key = frozenset(variable.when)
+        if when_key not in self.variables:
+            self.variables[when_key] = []
+        self.variables[when_key].append(variable)
 
     def add_environment_variable(self, env_var: WorkloadEnvironmentVariable):
         """Add an environment variable to this workload
@@ -282,10 +292,12 @@ class Workload:
         Returns:
             (WorkloadVariable | None): Variable instance if it exists, None if it is not found
         """
-        if name in self.variables:
-            return self.variables[name]
-        else:
-            return None
+        named_vars = []
+        for var_list in self.variables.values():
+            for var in var_list:
+                if var.name == name:
+                    named_vars.append(var)
+        return named_vars
 
     def find_environment_variable(self, name):
         """Find an environment variable in this workload

--- a/lib/ramble/ramble/workload.py
+++ b/lib/ramble/ramble/workload.py
@@ -23,7 +23,6 @@ class WorkloadVariable:
         values=None,
         expandable: bool = True,
         track_used: bool = True,
-        when=None,
         **kwargs,
     ):
         """Constructor for a new variable
@@ -34,8 +33,6 @@ class WorkloadVariable:
             description (str): Description of variable
             values: List of suggested values for variable
             expandable (bool): True if variable can be expanded, False otherwise
-            track_used (bool): True if variable should be considered used,
-                            False to ignore it for vectorizing experiments
             when (list | None): List of when conditions to apply to directive
         """
         self.name = name
@@ -44,7 +41,6 @@ class WorkloadVariable:
         self.values = values.copy() if isinstance(values, list) else [values]
         self.expandable = expandable
         self.track_used = track_used
-        self.when = when.copy() if when else frozenset()
 
     def __str__(self):
         if not hasattr(self, "_str_indent"):

--- a/lib/ramble/ramble/workload.py
+++ b/lib/ramble/ramble/workload.py
@@ -34,6 +34,8 @@ class WorkloadVariable:
             description (str): Description of variable
             values: List of suggested values for variable
             expandable (bool): True if variable can be expanded, False otherwise
+            track_used (bool): True if variable should be considered used,
+                               False to ignore it for vectorizing experiments
             when (list | None): List of when conditions to apply to directive
         """
         self.name = name

--- a/lib/ramble/ramble/workload.py
+++ b/lib/ramble/ramble/workload.py
@@ -23,6 +23,7 @@ class WorkloadVariable:
         values=None,
         expandable: bool = True,
         track_used: bool = True,
+        when=None,
         **kwargs,
     ):
         """Constructor for a new variable
@@ -35,6 +36,7 @@ class WorkloadVariable:
             expandable (bool): True if variable can be expanded, False otherwise
             track_used (bool): True if variable should be considered used,
                             False to ignore it for vectorizing experiments
+            when (list | None): List of when conditions to apply to directive
         """
         self.name = name
         self.default = default
@@ -42,6 +44,7 @@ class WorkloadVariable:
         self.values = values.copy() if isinstance(values, list) else [values]
         self.expandable = expandable
         self.track_used = track_used
+        self.when = when.copy() if when else frozenset()
 
     def __str__(self):
         if not hasattr(self, "_str_indent"):

--- a/lib/ramble/ramble/workload.py
+++ b/lib/ramble/ramble/workload.py
@@ -23,6 +23,7 @@ class WorkloadVariable:
         values=None,
         expandable: bool = True,
         track_used: bool = True,
+        when=None,
         **kwargs,
     ):
         """Constructor for a new variable
@@ -41,6 +42,7 @@ class WorkloadVariable:
         self.values = values.copy() if isinstance(values, list) else [values]
         self.expandable = expandable
         self.track_used = track_used
+        self.when = when.copy() if when else []
 
     def __str__(self):
         if not hasattr(self, "_str_indent"):

--- a/var/ramble/repos/builtin.mock/applications/when-variants/application.py
+++ b/var/ramble/repos/builtin.mock/applications/when-variants/application.py
@@ -17,6 +17,10 @@ class WhenVariants(ExecutableApplication):
         template=[
             "echo '{test_variable}'",
             "echo '{test_formatted_exec}'",
+            "echo 'Standard was {standard_variable}'",
+            "echo 'PM test: {pm_var_test}'",
+            "echo 'WM test: {wm_var_test}'",
+            "echo 'MOD test: {mod_var_test}'",
         ],
         use_mpi=False,
     )
@@ -83,6 +87,12 @@ class WhenVariants(ExecutableApplication):
                 ],
             )
 
+            variable(
+                "standard_variable",
+                default="preferred",
+                description="Test usage of the `variable` directive",
+            )
+
         with when("zlib_type=testing"):
             formatted_executable(
                 "test_formatted_exec",
@@ -92,6 +102,12 @@ class WhenVariants(ExecutableApplication):
                 commands=[
                     "zlib included with type of testing",
                 ],
+            )
+
+            variable(
+                "standard_variable",
+                default="testing",
+                description="Test usage of the `variable` directive",
             )
 
         with when("zlib_type=modifier"):
@@ -105,6 +121,12 @@ class WhenVariants(ExecutableApplication):
                 ],
             )
 
+            variable(
+                "standard_variable",
+                default="modifier",
+                description="Test usage of the `variable` directive",
+            )
+
     with when("~inc_zlib"):
         formatted_executable(
             "test_formatted_exec",
@@ -114,4 +136,10 @@ class WhenVariants(ExecutableApplication):
             commands=[
                 "zlib not included",
             ],
+        )
+
+        variable(
+            "standard_variable",
+            default="unincluded",
+            description="Test usage of the `variable` directive",
         )

--- a/var/ramble/repos/builtin.mock/applications/when-variants/application.py
+++ b/var/ramble/repos/builtin.mock/applications/when-variants/application.py
@@ -21,11 +21,13 @@ class WhenVariants(ExecutableApplication):
             "echo 'PM test: {pm_var_test}'",
             "echo 'WM test: {wm_var_test}'",
             "echo 'MOD test: {mod_var_test}'",
+            "echo 'Test when workload variable {test_when_var}'",
         ],
         use_mpi=False,
     )
 
     workload("test_wl", executable="test_exec")
+    workload("test_unset_wl", executable="test_exec")
 
     with default_args(workload="test_wl"):
         workload_variable(
@@ -62,7 +64,15 @@ class WhenVariants(ExecutableApplication):
             message="When validation is enabled, this test needs n_nodes=2",
         )
 
+    with when("workload_name=test_wl"):
+        variable(
+            "test_when_var",
+            default="is_defined",
+            description="Test workload constrained variable definition",
+        )
+
     with default_args(when=["package_manager_family=spack", "+inc_zlib"]):
+
         with when("zlib_type=preferred"):
             software_spec("zlib-pref", pkg_spec="zlib@1.2.12")
 

--- a/var/ramble/repos/builtin.mock/modifiers/when-modifier/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/when-modifier/modifier.py
@@ -1,0 +1,31 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.modkit import *  # noqa: F403
+
+
+class WhenModifier(BasicModifier):
+    name = "when-modifier"
+
+    mode("standard", "Standard execution mode")
+    default_mode("standard")
+
+    variant(
+        "modifier_included",
+        default=False,
+        values=[True, False],
+        description="Test variant",
+    )
+
+    with when("+modifier_included"):
+        modifier_variable(
+            "mod_var_test",
+            mode="standard",
+            default="included",
+            description="Test variable",
+        )

--- a/var/ramble/repos/builtin.mock/package_managers/when-package-manager/package_manager.py
+++ b/var/ramble/repos/builtin.mock/package_managers/when-package-manager/package_manager.py
@@ -1,0 +1,25 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.pkgmankit import *  # noqa: F403
+
+
+class WhenPackageManager(PackageManagerBase):
+    name = "when-package-manager"
+
+    variant(
+        "package_manager_included",
+        default=False,
+        values=[True, False],
+        description="Test variant",
+    )
+
+    with when("+package_manager_included"):
+        package_manager_variable(
+            "pm_var_test", default="included", description="Test variable"
+        )

--- a/var/ramble/repos/builtin.mock/workflow_managers/when-workflow-manager/workflow_manager.py
+++ b/var/ramble/repos/builtin.mock/workflow_managers/when-workflow-manager/workflow_manager.py
@@ -1,0 +1,25 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.wmkit import *
+
+
+class WhenWorkflowManager(WorkflowManagerBase):
+    name = "when-workflow-manager"
+
+    variant(
+        "workflow_manager_included",
+        default=False,
+        values=[True, False],
+        description="Test variant",
+    )
+
+    with when("+workflow_manager_included"):
+        workflow_manager_variable(
+            "wm_var_test", default="included", description="Test variable"
+        )

--- a/var/ramble/repos/builtin/applications/intel-mlc/application.py
+++ b/var/ramble/repos/builtin/applications/intel-mlc/application.py
@@ -186,7 +186,9 @@ class IntelMlc(ExecutableApplication):
 
         thread_dist = app_inst.expander.expand_var_name("thread_distribution")
         if thread_dist == "{thread_distribution}":
-            thread_dist = workload.variables["thread_distribution"].default
+            possible_vars = workload.find_variable("thread_distribution")
+            assert len(possible_vars) == 1
+            thread_dist = possible_vars[0].default
 
         ppn = int(app_inst.expander.expand_var_name("processes_per_node"))
         n_threads = int(app_inst.expander.expand_var_name("n_threads"))
@@ -195,7 +197,9 @@ class IntelMlc(ExecutableApplication):
             "spread_divisions"
         )
         if spread_divisions == "{spread_divisions}":
-            spread_divisions = workload.variables["spread_divisions"].default
+            possible_vars = workload.find_variable("spread_divisions")
+            assert len(possible_vars) == 1
+            spread_divisions = possible_vars[0].default
 
         try:
             spread_divisions = int(spread_divisions)

--- a/var/ramble/repos/builtin/base_applications/hpl/base_application.py
+++ b/var/ramble/repos/builtin/base_applications/hpl/base_application.py
@@ -398,9 +398,12 @@ class Hpl(ExecutableApplication):
             nBlocks -= nBlocks % lcmPQ
             problemSize = blockSize * nBlocks
 
-            for name, var in self.workloads["standard"].variables.items():
-                if var.name not in self.variables:
-                    self.define_variable(var.name, var.default)
+            for when_key, var_list in self.workloads[
+                "standard"
+            ].variables.items():
+                if self.expander.satisfies(when_key, self.object_variants):
+                    for var in var_list:
+                        self.define_variable(var.name, var.default)
 
             # Key = Variable name
             # Value = Value to override variable with


### PR DESCRIPTION
This merge enables support for `when` conditions on all variable types (`modifier_variable`,`package_manager_variable`, `workflow_manager_variable`, and `workload_variable`). Additionally, it introduces a new shared_language directive called `variable` that can define generic variables for each object type.

The variable definitions using the object specific interface for modifiers, package managers, and workflow managers simply wraps the generic variable directive. Workload variables are handled a little differently, as they still need to be connected nicely to workload groups.

There are additional variants defined for `application_name` and `workload_name`.