### PR TITLE
Allow `workspace archive` to accept additional patterns to archive

### DIFF
--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -1016,6 +1016,17 @@ def workspace_archive_setup_parser(subparser):
         help="If set, secrets are included in the archive. Default is false",
     )
 
+    subparser.add_argument(
+        "--archive-pattern",
+        dest="archive_patterns",
+        nargs="+",
+        action="append",
+        help=(
+            "patterns to specify additionally files that will be included in the archive. "
+            "Paths are relative to workspace root."
+        ),
+    )
+
     arguments.add_common_arguments(
         subparser,
         ["phases", "include_phase_dependencies", "where", "exclude_where", "profile_phases"],
@@ -1032,6 +1043,10 @@ def workspace_archive(args):
         exclude_where_filters=args.exclude_where,
     )
 
+    archive_patterns = (
+        list(itertools.chain.from_iterable(args.archive_patterns)) if args.archive_patterns else []
+    )
+
     pipeline_cls = ramble.pipeline.pipeline_class(current_pipeline)
     pipeline = pipeline_cls(
         ws,
@@ -1040,6 +1055,7 @@ def workspace_archive(args):
         archive_prefix=args.archive_prefix,
         upload_url=args.upload_url,
         include_secrets=args.include_secrets,
+        archive_patterns=archive_patterns,
     )
 
     workspace_run_pipeline(args, pipeline)

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -318,6 +318,7 @@ class ArchivePipeline(Pipeline):
         archive_prefix=None,
         upload_url=None,
         include_secrets=False,
+        archive_patterns=None,
     ):
         super().__init__(workspace, filters)
         self.action_string = "Archiving"
@@ -326,6 +327,7 @@ class ArchivePipeline(Pipeline):
         self.include_secrets = include_secrets
         self.archive_prefix = archive_prefix
         self.archive_name = None
+        self.archive_patterns = archive_patterns.copy() if archive_patterns else []
 
         if self.upload_url and not self.create_tar:
             logger.warn("Upload URL is currently only supported when using tar format (-t)")
@@ -397,6 +399,15 @@ class ArchivePipeline(Pipeline):
                     dest = src.replace(self.workspace.log_dir, archive_logs)
                     fs.mkdirp(os.path.dirname(dest))
                     shutil.copyfile(src, dest)
+
+        for pattern in self.archive_patterns:
+            pattern_path = self.workspace.root + os.sep + pattern
+            for file in glob.glob(pattern_path):
+                dest_dir = os.path.dirname(
+                    file.replace(self.workspace.root, self.workspace.latest_archive_path)
+                )
+                fs.mkdirp(dest_dir)
+                shutil.copy(file, dest_dir)
 
         archive_path_latest = os.path.join(self.workspace.archive_dir, "archive.latest")
         create_symlink(archive_path, archive_path_latest)

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -1354,13 +1354,17 @@ licenses:
     with open(lic_path, "w+") as f:
         f.write(test_licenses)
 
-    # Create more templates
+    # Create more templates, and test files to archive
     new_templates = []
     for i in range(0, 5):
-        new_template = os.path.join(ws1.config_dir, "test_template.%s" % i)
+        new_template = os.path.join(ws1.config_dir, f"test_template.{i}")
         new_templates.append(new_template)
         f = open(new_template, "w+")
         f.close()
+
+        new_archive_file = os.path.join(ws1.root, f"test_pattern.{i}")
+        with open(new_archive_file, "w+") as f:
+            f.write("Test archive file")
 
     ws1._re_read()
 
@@ -1374,14 +1378,14 @@ licenses:
     # Create files that match archive pattern
     new_files = []
     for i in range(0, 5):
-        new_name = "archive_test.%s" % i
+        new_name = f"archive_test.{i}"
         new_file = os.path.join(experiment_dir, new_name)
 
         new_files.append(new_file)
         f = open(new_file, "w+")
         f.close()
 
-    workspace("archive", global_args=["-w", workspace_name])
+    workspace("archive", "--archive-pattern", "test_pattern*", global_args=["-w", workspace_name])
 
     assert ws1.latest_archive
     assert os.path.exists(ws1.latest_archive_path)
@@ -1394,6 +1398,13 @@ licenses:
     for file in new_files:
         archived_path = file.replace(ws1.root, ws1.latest_archive_path)
         assert os.path.exists(archived_path)
+
+    # Check for archive pattern files
+    for i in range(0, 5):
+        archived_path = os.path.join(ws1.latest_archive_path, f"test_pattern.{i}")
+        assert os.path.isfile(archived_path)
+        with open(archived_path) as f:
+            assert "Test archive file" in f.read()
 
     assert not os.path.exists(
         os.path.join(
@@ -1450,7 +1461,7 @@ licenses:
     # Create more templates
     new_templates = []
     for i in range(0, 5):
-        new_template = os.path.join(ws1.config_dir, "test_template.%s" % i)
+        new_template = os.path.join(ws1.config_dir, f"test_template.{i}")
         new_templates.append(new_template)
         f = open(new_template, "w+")
         f.close()

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -646,7 +646,7 @@ _ramble_workspace_activate() {
 }
 
 _ramble_workspace_archive() {
-    RAMBLE_COMPREPLY="-h --help --tar-archive -t --prefix -p --upload-url -u --include-secrets --phases --include-phase-dependencies --where --exclude-where --profile-phase"
+    RAMBLE_COMPREPLY="-h --help --tar-archive -t --prefix -p --upload-url -u --include-secrets --archive-pattern --phases --include-phase-dependencies --where --exclude-where --profile-phase"
 }
 
 _ramble_workspace_deactivate() {


### PR DESCRIPTION
This merge adds an argument to `ramble workspace archive` which allows additional patterns to be specified (relative to the workspace root) which will be included in the archive.