### PR TITLE
Fix incorrect definition for no_expand_vars in modifiers

### DIFF
--- a/lib/ramble/ramble/modifier.py
+++ b/lib/ramble/ramble/modifier.py
@@ -263,7 +263,8 @@ class ModifierBase(metaclass=ModifierMeta):
                 continue
 
             for var in var_list:
-                yield var.name
+                if not var.expandable:
+                    yield var.name
 
     def selected_variables(self):
         """Extract all variables which would be included based

--- a/lib/ramble/ramble/test/modifier_functionality/modifier_nested_var_dry_run.py
+++ b/lib/ramble/ramble/test/modifier_functionality/modifier_nested_var_dry_run.py
@@ -1,0 +1,66 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import ramble.workspace
+from ramble.main import RambleCommand
+
+workspace = RambleCommand("workspace")
+
+
+def test_nested_modifier_var(
+    mutable_mock_workspace_path, mutable_applications, mock_modifiers, request
+):
+    workspace_name = request.node.name
+    global_args = ["-w", workspace_name]
+
+    with ramble.workspace.create(workspace_name) as ws1:
+
+        workspace(
+            "manage",
+            "experiments",
+            "gromacs",
+            "--wf",
+            "water_bare",
+            "-e",
+            "test",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "n_ranks=1",
+            "-p",
+            "spack",
+            global_args=global_args,
+        )
+
+        workspace("concretize", global_args=global_args)
+
+        template_path = os.path.join(ws1.config_dir, "test_template.tpl")
+
+        with open(template_path, "w+") as f:
+            f.write("{level1_mod_var}")
+
+        modifier_config_path = os.path.join(ws1.config_dir, "modifiers.yaml")
+
+        with open(modifier_config_path, "w+") as f:
+            f.write("modifiers:\n")
+            f.write("- name: test-mod\n")
+            f.write("  mode: test\n")
+
+        workspace("setup", "--dry-run", global_args=global_args)
+
+        exec_script = os.path.join(
+            ws1.experiment_dir, "gromacs", "water_bare", "test", "test_template"
+        )
+
+        with open(exec_script) as f:
+            data = f.read()
+            assert "testing nested" in data
+            assert "{level1_mod_var}" not in data
+            assert "{level2_mod_var}" not in data

--- a/var/ramble/repos/builtin.mock/modifiers/test-mod/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/test-mod/modifier.py
@@ -32,6 +32,20 @@ class TestMod(BasicModifier):
         "exp-scope", description="This is a test mode at the experiment scope"
     )
 
+    modifier_variable(
+        "level1_mod_var",
+        default="testing {level2_mod_var}",
+        description="Test nesting modifier variables",
+        modes=["test"],
+    )
+
+    modifier_variable(
+        "level2_mod_var",
+        default="nested",
+        description="Test nesting modifier variables",
+        modes=["test"],
+    )
+
     variable_modification(
         "test_var_mod",
         "test-mod-append",


### PR DESCRIPTION
This merge fixes an issue where no_expand_vars for modifiers would return all modifier variables that were satisfied by the defined variants. This incorrectly caused all nested variables to be defined as not expandable, and caused their expansion to be wrong.

A test is also added to cover this case in the future.