### PR TITLE
Add a `join_str` expander function

### DIFF
--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -29,6 +29,10 @@ def _or(a, b):
     return a or b
 
 
+def _join_str(seq, sep=","):
+    return sep.join(str(i) for i in seq)
+
+
 def _re_search(regex, s):
     import re
 
@@ -78,6 +82,7 @@ supported_scalar_function_pointers = {
     "randrange": random.randrange,
     "randint": random.randint,
     "simplify_str": spack.util.naming.simplify_name,
+    "join_str": _join_str,
     "re_search": _re_search,
 }
 

--- a/lib/ramble/ramble/test/expander.py
+++ b/lib/ramble/ramble/test/expander.py
@@ -26,6 +26,8 @@ def exp_dict():
         "n_ranks": "4",
         "processes_per_node": "2",
         "n_nodes": "2",
+        "cores_per_node": "16",
+        "n_threads": "4",
         "var1": "{var2}",
         "var2": "{var3}",
         "var3": "3",
@@ -124,6 +126,8 @@ def build_variant_set():
         ("{'key1': 'val1', 'key2': 'val2'}", "{'key1': 'val1', 'key2': 'val2'}", set(), 1),
         ("${job_id}", "${job_id}", set(), 1),
         ("${job_id:-}", "${job_id:-}", set(), 1),
+        ("join_str(range(0, 5, 2), ': ')", "0: 2: 4", set(), 1),
+        ("join_str(range(0, {cores_per_node}, {n_threads}))", "0,4,8,12", set(), 1),
     ],
 )
 def test_expansions(input, output, no_expand_vars, passes):


### PR DESCRIPTION
One use-case is to generate strings dynamically, such as the following to generate cpu pinning set:

```
env_vars:
  set:
    I_MPI_PIN_PROCESSOR_LIST: "{join_str(range(0, {cores_per_node}, {n_threads}))}"
```