### PR TITLE
cover all possible status

### DIFF
--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
@@ -1400,7 +1400,9 @@ class SpackRunner(CommandRunner):
                         info = (
                             info_line[:3]
                             .replace("[+]", "")
+                            .replace("[^]", "")
                             .replace(" - ", "")
+                            .replace("[-]", "")
                             .replace("[e]", "")
                             + info_line[3:]
                         )


### PR DESCRIPTION
Cover missing status from `spack spec -h`
```
                        [+] installed       [^] installed in an upstream
                         -  not installed   [-] missing dep of installed package
```
                  