### PR TITLE
Update archive to include all executable log files

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -1681,6 +1681,25 @@ class ApplicationBase(metaclass=ApplicationMeta):
         archive_lock = lk.Lock(os.path.join(archive_experiment_dir, ".ramble-exp-archive"))
 
         with lk.WriteTransaction(archive_lock):
+            # Copy all log files from executables
+            exec_logs = set()
+            workload = self.workloads[self.expander.workload_name]
+            for exec_name in workload.executables:
+                if exec_name in self.executables:
+                    exec_obj = self.executables[exec_name]
+                    exec_log = self.expander.expand_var(exec_obj.redirect)
+                    exec_logs.add(exec_log)
+
+            for exec_log in exec_logs:
+                file = exec_log
+                if not os.path.isabs(file):
+                    file = os.path.join(experiment_run_dir, exec_log)
+
+                if os.path.isfile(file):
+                    dest_dir = os.path.dirname(file.replace(workspace.root, ws_archive_dir))
+                    fs.mkdirp(dest_dir)
+                    shutil.copy(file, dest_dir)
+
             # Copy all of the templates to the archive directory
             for template_name, _ in workspace.all_templates():
                 src = os.path.join(experiment_run_dir, template_name)

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -32,6 +32,7 @@ pytestmark = pytest.mark.usefixtures(
 
 config = RambleCommand("config")
 workspace = RambleCommand("workspace")
+on = RambleCommand("on")
 
 
 @pytest.fixture()
@@ -1717,6 +1718,57 @@ ramble:
     assert os.path.exists(ws1.latest_archive_path + ".tar.gz")
 
     assert os.path.exists(os.path.join(remote_archive_path, ws1.latest_archive + ".tar.gz"))
+
+
+def test_workspace_archive_includes_exec_logs(request):
+    test_config = """
+ramble:
+  variables:
+    mpi_command: ''
+    batch_submit: '{execute_experiment}'
+    processes_per_node: '1'
+    n_ranks: '{processes_per_node}*{n_nodes}'
+  applications:
+    fom-log-path:
+      workloads:
+        test:
+          experiments:
+            test_experiment:
+              variables:
+                n_nodes: '1'
+  software:
+    packages: {}
+    environments: {}
+"""
+
+    workspace_name = request.node.name
+    ws1 = ramble.workspace.create(workspace_name)
+    ws1.write()
+
+    config_path = os.path.join(ws1.config_dir, ramble.workspace.config_file_name)
+
+    with open(config_path, "w+") as f:
+        f.write(test_config)
+
+    ws1._re_read()
+
+    workspace("setup", global_args=["-w", workspace_name])
+    on(global_args=["-w", workspace_name])
+
+    expected_files = [
+        os.path.join(ws1.experiment_dir, "fom-log-path", "test", "test_experiment", "log.file"),
+        os.path.join(
+            ws1.experiment_dir, "fom-log-path", "test", "test_experiment", "other.log.file"
+        ),
+    ]
+
+    for file in expected_files:
+        assert os.path.isfile(file)
+
+    workspace("archive", global_args=["-w", workspace_name])
+
+    for file in expected_files:
+        assert os.path.isfile(file.replace(ws1.root, ws1.latest_archive_path))
 
 
 def test_dryrun_noexpvars_setup():

--- a/var/ramble/repos/builtin.mock/applications/fom-log-path/application.py
+++ b/var/ramble/repos/builtin.mock/applications/fom-log-path/application.py
@@ -15,8 +15,14 @@ class FomLogPath(ExecutableApplication):
     executable(
         "write-fom", "echo 'fom: test'", redirect="log.file", use_mpi=False
     )
+    executable(
+        "write-log",
+        "echo 'fom: test'",
+        redirect="other.log.file",
+        use_mpi=False,
+    )
 
-    workload("test", executable="write-fom")
+    workload("test", executables=["write-fom", "write-log"])
 
     figure_of_merit(
         "test_fom",


### PR DESCRIPTION
This merge fixes an issue where archives omitted executable log files that did not have figures of merit extracted from them.

A test is added to ensure this functionality remains too.