### PR TITLE
Fix success criteria being overwritten by subsequently defined success criteria

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -177,6 +177,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
         self._pipeline_graphs = None
         self.package_manager = None
         self.custom_executables = {}
+        self.success_list = None
         self._exp_lock = None
         self._input_lock = None
         self._software_lock = None
@@ -339,6 +340,13 @@ class ApplicationBase(metaclass=ApplicationMeta):
                 "Valid workflow managers can be listed via:\n"
                 "\tramble list --type workflow_managers"
             )
+
+    def set_success_list(self, success_criteria):
+        self.success_list = ramble.success_criteria.ScopedCriteriaList()
+
+        if success_criteria:
+            for conf in success_criteria:
+                self.success_list.add_criteria("experiment", **conf)
 
     def build_phase_order(self):
         if self._pipeline_graphs is not None:
@@ -530,7 +538,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
 
         backup_variables = self.variables.copy()
 
-        self._define_commands(self._executable_graph, workspace.success_list)
+        self._define_commands(self._executable_graph, self.success_list)
         self._define_formatted_executables()
 
         ########################
@@ -569,7 +577,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
                         self.expander.expand_var_name(var)
 
         # Add variables from success criteria
-        criteria_list = workspace.success_list
+        criteria_list = self.success_list
         for criteria in criteria_list.all_criteria():
             if criteria.mode == "fom_comparison":
                 self.expander.expand_var(criteria.fom_formula)
@@ -1094,7 +1102,8 @@ class ApplicationBase(metaclass=ApplicationMeta):
         self._command_list = []
         self._command_list_without_logs = []
 
-        if success_list is None:
+        success_list = self.success_list
+        if not success_list:
             success_list = ramble.success_criteria.ScopedCriteriaList()
 
         # Inject all prepended chained experiments
@@ -1497,7 +1506,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
 
         exp_lock = self.experiment_lock()
 
-        self._define_commands(self._executable_graph, workspace.success_list)
+        self._define_commands(self._executable_graph, self.success_list)
         self._define_formatted_executables()
 
         with lk.WriteTransaction(exp_lock):
@@ -1713,7 +1722,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
                     shutil.copy(src_path, archive_experiment_dir)
 
             # Copy all figure of merit files
-            criteria_list = workspace.success_list
+            criteria_list = self.success_list
             analysis_files, _ = self._analysis_dicts(criteria_list)
             for file in analysis_files.keys():
                 if os.path.exists(file):
@@ -1793,7 +1802,9 @@ class ApplicationBase(metaclass=ApplicationMeta):
 
         fom_values = {}
 
-        criteria_list = workspace.success_list
+        criteria_list = self.success_list
+        if not criteria_list:
+            criteria_list = ramble.success_criteria.ScopedCriteriaList()
         criteria_list.reset()
 
         files, definitions = self._analysis_dicts(criteria_list)

--- a/lib/ramble/ramble/context.py
+++ b/lib/ramble/ramble/context.py
@@ -33,6 +33,7 @@ class Context:
         self.chained_experiments = []
         self.modifiers = []
         self.context_name = None
+        self.success_criteria = []
         self.exclude = {}
         self.zips = {}
         self.matrices = []
@@ -92,6 +93,8 @@ class Context:
             self.n_repeats = int(in_context.n_repeats)
         if in_context.formatted_executables:
             self.formatted_executables.update(in_context.formatted_executables)
+        if in_context.success_criteria:
+            self.success_criteria.extend(in_context.success_criteria)
 
 
 def create_context_from_dict(context_name, in_dict):
@@ -168,5 +171,8 @@ def create_context_from_dict(context_name, in_dict):
 
     if namespace.formatted_executables in in_dict:
         new_context.formatted_executables = in_dict[namespace.formatted_executables].copy()
+
+    if namespace.success in in_dict:
+        new_context.success_criteria = in_dict[namespace.success].copy()
 
     return new_context

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -66,6 +66,7 @@ class ExperimentSet:
         workspace_context.modifiers = workspace.get_workspace_modifiers()
         workspace_context.zips = workspace.get_workspace_zips()
         workspace_context.variants = workspace.get_workspace_variants()
+        workspace_context.success_criteria = workspace.get_workspace_success_criteria()
 
         try:
             self.keywords.check_reserved_keys(workspace_context.variables)
@@ -477,6 +478,8 @@ class ExperimentSet:
                 repeats,
             )
 
+            app_inst.set_success_list(final_context.success_criteria)
+
             exp_used_variables = app_inst.build_used_variables(self._workspace)
             used_variables = used_variables.union(exp_used_variables)
         render_group.used_variables = used_variables.copy()
@@ -548,6 +551,7 @@ class ExperimentSet:
                         )
                     pass
 
+                app_inst.set_success_list(final_context.success_criteria)
                 rendered_experiments.add(final_exp_namespace)
                 self.experiments[final_exp_namespace] = app_inst
                 self.experiment_order.append(final_exp_namespace)

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -30,7 +30,6 @@ import ramble.uploader
 import ramble.util.hashing
 import ramble.util.path
 import ramble.workspace
-from ramble.namespace import namespace
 from ramble.util.file_util import create_symlink
 from ramble.util.logger import logger
 
@@ -242,10 +241,6 @@ class AnalyzePipeline(Pipeline):
         print_results=False,
         summary_only=False,
     ):
-        workspace_success = {namespace.success: ramble.config.config.get_config(namespace.success)}
-
-        workspace.extract_success_criteria("workspace", workspace_success)
-
         super().__init__(workspace, filters)
         self.action_string = "Analyzing"
         self.output_formats = ["text"] if output_formats is None else output_formats

--- a/lib/ramble/ramble/success_criteria.py
+++ b/lib/ramble/ramble/success_criteria.py
@@ -30,16 +30,10 @@ class ScopedCriteriaList:
     _valid_scopes = [
         "application_definition",
         "modifier_definition",
-        "workspace",
-        "application",
-        "workload",
         "experiment",
     ]
     _flush_scopes = {
         "experiment": ["experiment"],
-        "workload": ["workload", "experiment"],
-        "application": ["application", "workload", "experiment"],
-        "workspace": ["workspace", "application", "workload", "experiment"],
         "modifier_definition": ["modifier_definition"],
         "application_definition": ["application_definition"],
     }

--- a/lib/ramble/ramble/test/success_criteria.py
+++ b/lib/ramble/ramble/test/success_criteria.py
@@ -70,12 +70,6 @@ def test_criteria_list(tmpdir):
 
     criteria_list.add_criteria("experiment", "test-exp", "string", r".*Experiment.*", log_path)
 
-    criteria_list.add_criteria("workload", "test-wl", "string", r".*Some output.*", log_path)
-
-    criteria_list.add_criteria("application", "test-app", "string", r".*exit code.*", log_path)
-
-    criteria_list.add_criteria("workspace", "test-ws", "string", r".*Into a log file.*", log_path)
-
     remark_all(list(criteria_list.all_criteria()), log_path)
 
     assert criteria_list.passed()

--- a/lib/ramble/ramble/test/success_criteria_functionality/success_scoping.py
+++ b/lib/ramble/ramble/test/success_criteria_functionality/success_scoping.py
@@ -63,9 +63,18 @@ ramble:
 
         workspace("setup", global_args=["-w", workspace_name])
         ramble_on(global_args=["-w", workspace_name])
-        workspace("analyze", global_args=["-w", workspace_name])
+        workspace(
+            "analyze", "--where", "{experiment_index} == 1", global_args=["-w", workspace_name]
+        )
 
         with open(os.path.join(ws.root, "results.latest.txt")) as f:
             data = f.read()
-            assert "FAILED" in data
-            assert "SUCCESS" in data
+            assert "Status = SUCCESS" in data
+
+        workspace(
+            "analyze", "--where", "{experiment_index} == 2", global_args=["-w", workspace_name]
+        )
+
+        with open(os.path.join(ws.root, "results.latest.txt")) as f:
+            data = f.read()
+            assert "Status = FAILED" in data

--- a/lib/ramble/ramble/test/success_criteria_functionality/success_scoping.py
+++ b/lib/ramble/ramble/test/success_criteria_functionality/success_scoping.py
@@ -1,0 +1,71 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.workspace
+from ramble.main import RambleCommand
+
+# everything here uses the mock_workspace_path
+pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_path")
+
+workspace = RambleCommand("workspace")
+ramble_on = RambleCommand("on")
+
+
+def test_disconnected_success(mock_applications, request):
+    test_config = """
+ramble:
+  variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: '{execute_experiment}'
+    processes_per_node: '1'
+    n_threads: '1'
+  applications:
+    basic:
+      workloads:
+        working_wl:
+          experiments:
+            pass-experiment:
+              variables:
+                n_nodes: 1
+              success_criteria:
+              - name: always-pass
+                mode: string
+                match: '.*seconds.*'
+            fail-experiment:
+              variables:
+                n_nodes: 1
+              success_criteria:
+              - name: always-fail
+                mode: string
+                match: 'Blarg'
+  software:
+    packages: {}
+    environments: {}
+"""
+    workspace_name = request.node.name
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+
+        config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+
+        with open(config_path, "w+") as f:
+            f.write(test_config)
+        ws._re_read()
+
+        workspace("setup", global_args=["-w", workspace_name])
+        ramble_on(global_args=["-w", workspace_name])
+        workspace("analyze", global_args=["-w", workspace_name])
+
+        with open(os.path.join(ws.root, "results.latest.txt")) as f:
+            data = f.read()
+            assert "FAILED" in data
+            assert "SUCCESS" in data

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -31,7 +31,6 @@ import ramble.schema.applications
 import ramble.schema.merged
 import ramble.schema.workspace
 import ramble.software_environments
-import ramble.success_criteria
 import ramble.util.env
 import ramble.util.hashing
 import ramble.util.install_cache
@@ -472,8 +471,6 @@ class Workspace:
         # It's used to cache package provenance info from different package managers.
         self.pkg_prov_cache = defaultdict(dict)
 
-        self.success_list = ramble.success_criteria.ScopedCriteriaList()
-
         # Key for each application config should be it's filepath
         # Format for an application config should be:
         #  {
@@ -821,20 +818,6 @@ ramble:
         self._previous_active = None  # previously active environment
         self.specs = []
 
-    def extract_success_criteria(self, scope, contents):
-        """Extract success citeria, and inject it into the scoped list
-
-        Extract success criteria from a contents dictionary, and inject it into
-        the scoped success list within the right scope.
-        """
-        self.success_list.flush_scope(scope)
-
-        if namespace.success in contents:
-            logger.debug(" ---- Found success in %s" % scope)
-            for conf in contents[namespace.success]:
-                logger.debug(" ---- Adding criteria %s" % conf["name"])
-                self.success_list.add_criteria(scope, **conf)
-
     def all_specs(self):
         import ramble.spec
 
@@ -890,8 +873,6 @@ ramble:
         for application, contents in app_dict.items():
             application_context = ramble.context.create_context_from_dict(application, contents)
 
-            self.extract_success_criteria("application", contents)
-
             yield contents, application_context
 
         logger.debug("  Iterating over configs in directories...")
@@ -906,8 +887,6 @@ ramble:
                 application_context = ramble.context.create_context_from_dict(
                     application, contents
                 )
-
-                self.extract_success_criteria("application", contents)
 
                 yield contents, application_context
 
@@ -928,8 +907,6 @@ ramble:
         for workload, contents in workloads.items():
             workload_context = ramble.context.create_context_from_dict(workload, contents)
 
-            self.extract_success_criteria("workload", contents)
-
             yield contents, workload_context
 
     def all_experiments(self, workload):
@@ -947,8 +924,6 @@ ramble:
         experiments = workload[namespace.experiment]
         for experiment, contents in experiments.items():
             experiment_context = ramble.context.create_context_from_dict(experiment, contents)
-
-            self.extract_success_criteria("experiment", contents)
 
             yield contents, experiment_context
 
@@ -2181,6 +2156,10 @@ ramble:
     def get_workspace_variants(self):
         """Return a dict of workspace variants"""
         return ramble.config.config.get_config("variants")
+
+    def get_workspace_success_criteria(self):
+        """Return a dict of workspace success_criteria"""
+        return ramble.config.config.get_config("success_criteria")
 
     def get_software_dict(self):
         """Return the software dictionary for this workspace"""


### PR DESCRIPTION
This merge fixes an issue where workspaces that contained multiple applications / experiments and each had their own scoped success criteria would evaluate success criteria incorrectly.

The original goal was that each experiment would have its own success criteria that was scope for just that experiment. This would allow disjoint criteria to be defined for each experiment and all them to be evaluated correctly. Previously, the workspace owned the success criteria, and as a result only the last experiment in the YAML would have their success criteria defined in the list. This would cause some experiments to erroneously fail as a result of using success criteria that are invalid for their definitions.

The fix was to push success criteria into the context object, and allow the experiments to own their own success criteria instead of storing this information in the workspace.