### PR TITLE
Add a modifier for Darshan

### DIFF
--- a/var/ramble/repos/builtin/modifiers/darshan/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/darshan/modifier.py
@@ -1,0 +1,116 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+from ramble.modkit import *
+from ramble.util import executable
+
+
+class Darshan(BasicModifier):
+    """Define a modifier for applying Darshan on MPI apps."""
+
+    name = "darshan"
+
+    tags("profiler", "io-characterization")
+
+    maintainers("linsword13")
+
+    mode("mpi", description="Mode for applying on MPI apps")
+    default_mode("mpi")
+
+    modifier_variable(
+        "darshan_log_path",
+        default="{experiment_run_dir}/darshan_logs",
+        description="Path to store darshan logs",
+        mode="mpi",
+    )
+
+    modifier_variable(
+        "darshan_summary_cmd",
+        # darshan-job-summary.pl generates a summary pdf, which is nicer to get an overview.
+        # However that has a bunch of dependencies (texlive, perl modules, etc) that are not
+        # properly accounted for in spack's darshan-util package. So as a default, use the
+        # text-generated parser.
+        default="darshan-parser",
+        description="Command to generate Darshan report",
+        mode="mpi",
+    )
+
+    with when("package_manager_family=spack"):
+        software_spec(
+            "darshan-runtime",
+            pkg_spec="darshan-runtime@3.4.6 +mpi",
+        )
+        software_spec(
+            "darshan-util",
+            pkg_spec="darshan-util@3.4.6",
+        )
+        software_spec(
+            "texlive",
+            pkg_spec="texlive",
+        )
+
+        required_package("darshan-runtime")
+        required_package("darshan-util")
+
+    variable_modification(
+        "mpi_command",
+        # This variable is filled in as part of the exec modifier below
+        "${_EXTRA_DARSHAN_MOD_MPI_COMMAND}",
+        method="append",
+        mode="mpi",
+    )
+
+    executable_modifier("instrument_darshan")
+
+    def instrument_darshan(self, exec_name, exec, app_inst):
+        # Only support instrumenting MPI apps for now
+        if not exec.mpi or self._usage_mode != "mpi":
+            return [], []
+        pre_cmds = [
+            # Set it here instead of via env_var_modification,
+            # as this needs to override the value Spack sets
+            'export DARSHAN_LOG_DIR_PATH="{darshan_log_path}"',
+            "rm -rf {darshan_log_path}",
+            "mkdir -p {darshan_log_path}",
+        ]
+        post_cmds = ["unset DARSHAN_LOG_DIR_PATH"]
+        darshan_path = os.path.join(
+            self.expander.expand_var_name("darshan-runtime_path"),
+            "lib",
+            "libdarshan.so",
+        )
+        if (
+            self.expander.expand_var_name("intel-oneapi-mpi_path")
+            != "{intel-oneapi-mpi_path}"
+        ):
+            env_flag = "-genv"
+        elif self.expander.expand_var_name("openmpi_path") != "{openmpi_path}":
+            env_flag = "-x"
+        else:
+            env_flag = ""
+        if env_flag:
+            pre_cmds.append(
+                f'_EXTRA_DARSHAN_MOD_MPI_COMMAND="{env_flag} LD_PRELOAD {darshan_path}"'
+            )
+            post_cmds.append("unset _EXTRA_DARSHAN_MOD_MPI_COMMAND")
+        post_cmds.append("{darshan_summary_cmd} {darshan_log_path}/*")
+        pre_exec = [
+            executable.CommandExecutable(
+                f"set-darshan-vars-{exec_name}",
+                template=pre_cmds,
+            )
+        ]
+        post_exec = [
+            executable.CommandExecutable(
+                f"unset-darshan-vars-{exec_name}",
+                template=post_cmds,
+            )
+        ]
+        return pre_exec, post_exec

--- a/var/ramble/repos/builtin/modifiers/darshan/test/darshan.py
+++ b/var/ramble/repos/builtin/modifiers/darshan/test/darshan.py
@@ -1,0 +1,80 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.workspace
+from ramble.main import RambleCommand
+
+workspace = RambleCommand("workspace")
+
+pytestmark = pytest.mark.usefixtures(
+    "mutable_config",
+    "mutable_mock_workspace_path",
+)
+
+
+def test_darshan(request):
+    ws_name = request.node.name
+    test_config = """
+ramble:
+  modifiers:
+  - name: darshan
+  variables:
+    processes_per_node: 1
+    n_nodes: 2
+    mpi_command: 'mpirun -n {n_rank}'
+    batch_submit: '{execute_experiment}'
+    darshan-runtime_path: 'fake-darshan-rt'
+    darshan-util_path: 'fake-darshan-util'
+  applications:
+    hostname:
+      workloads:
+        parallel:
+          experiments:
+            test-impi:
+              variables:
+                intel-oneapi-mpi_path: 'fake-impi-path'
+                darshan_log_path: 'darshan-log-dir'
+            test-ompi:
+              variables:
+                openmpi_path: 'fake-ompi-path'
+"""
+    ws = ramble.workspace.create(ws_name)
+    ws.write()
+    config_path = os.path.join(
+        ws.config_dir, ramble.workspace.config_file_name
+    )
+    with open(config_path, "w+") as f:
+        f.write(test_config)
+    ws._re_read()
+    workspace("setup", "--dry-run", global_args=["-D", ws.root])
+    run_dir = os.path.join(
+        ws.experiment_dir, "hostname", "parallel", "test-impi"
+    )
+    with open(os.path.join(run_dir, "execute_experiment")) as f:
+        content = f.read()
+        assert 'export DARSHAN_LOG_DIR_PATH="darshan-log-dir"' in content
+        assert (
+            '_EXTRA_DARSHAN_MOD_MPI_COMMAND="-genv LD_PRELOAD fake-darshan-rt/lib/libdarshan.so"'
+            in content
+        )
+        assert "unset _EXTRA_DARSHAN_MOD_MPI_COMMAND" in content
+        assert "unset DARSHAN_LOG_DIR_PATH" in content
+        assert "darshan-parser" in content
+    run_dir2 = os.path.join(
+        ws.experiment_dir, "hostname", "parallel", "test-ompi"
+    )
+    with open(os.path.join(run_dir2, "execute_experiment")) as f:
+        content = f.read()
+        assert (
+            '_EXTRA_DARSHAN_MOD_MPI_COMMAND="-x LD_PRELOAD fake-darshan-rt/lib/libdarshan.so"'
+            in content
+        )


### PR DESCRIPTION
Example PDF output  based on the ramble config below: 
[test.darshan.pdf](https://github.com/user-attachments/files/20536350/test.darshan.pdf)


```
ramble:
  variants:
    package_manager: spack
    workflow_manager: slurm
  env_vars:
    set:
      OMP_NUM_THREADS: '{n_threads}'
  variables:
    processes_per_node: 56
    slurm_partition: c2dstandard
    mpi_command: mpirun -n {n_ranks} -ppn {processes_per_node} -hostfile hostfile
  applications:
    ior:
      workloads:
        single-file:
          experiments:
            test:
              variables:
                n_nodes: 2
                n_threads: 1
                additional_args: -a MPIIO
  software:
    packages:
      gcc14:
        pkg_spec: gcc@14.2.0 target=x86_64
        compiler_spec: gcc@14.2.0
      impi2021:
        pkg_spec: intel-oneapi-mpi@2021.13.1 target=zen3
        compiler: gcc14
      ior:
        pkg_spec: ior target=zen3
        compiler: gcc14
      darshan_runtime:
        pkg_spec: darshan-runtime@3.4.6 +mpi scheduler=slurm target=zen3
        compiler: gcc14
      darshan_util:
        pkg_spec: darshan-util@3.4.6 target=zen3
        compiler: gcc14
    environments:
      ior:
        packages:
        - ior
        - impi2021
        - darshan_runtime
        - darshan_util
  modifiers:
  - name: darshan
```