### PR TITLE
Update tests to use request fixture for workspace names

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -551,6 +551,15 @@ def mock_executable(tmpdir):
 
 
 @pytest.fixture(scope="function")
+def workspace_name(request):
+    """Fixture for constructing a workspace name based on a test name"""
+    import re
+
+    ws_name = re.sub("[^0-9a-zA-Z_-]", "_", request.node.name)
+    return ws_name
+
+
+@pytest.fixture(scope="function")
 def mutable_mock_workspace_path(tmpdir_factory, mutable_config):
     """Fixture for mocking the internal ramble workspaces directory."""
     mock_path = tmpdir_factory.mktemp("mock-workspace-path")

--- a/lib/ramble/ramble/test/application.py
+++ b/lib/ramble/ramble/test/application.py
@@ -438,7 +438,7 @@ def test_define_commands(mutable_mock_apps_repo):
     assert "mpirun" in executable_application_instance.variables["command"]
 
 
-def test_derive_variables_for_template_path(mutable_mock_apps_repo):
+def test_derive_variables_for_template_path(mutable_mock_apps_repo, workspace_name):
     """_set_default_variables_for_template_path"""
     test_config = """
 ramble:
@@ -468,7 +468,6 @@ ramble:
 """
     import os.path
 
-    workspace_name = "test_derive_variables_for_template_path"
     ws1 = ramble.workspace.create(workspace_name)
     ws1.write()
 

--- a/lib/ramble/ramble/test/cmd/deployment.py
+++ b/lib/ramble/ramble/test/cmd/deployment.py
@@ -49,9 +49,8 @@ def check_deployment_files(root, app_name):
 
 
 @pytest.mark.maybeslow
-def test_local_deployment(mutable_config, mutable_mock_workspace_path):
+def test_local_deployment(mutable_config, mutable_mock_workspace_path, workspace_name):
 
-    workspace_name = "test_local_deployment"
     app_name = "namd"
 
     deployment_dir = ""

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -8,6 +8,7 @@
 
 import glob
 import os
+import re
 
 import pytest
 
@@ -175,7 +176,7 @@ def test_workspace_list(mutable_mock_workspace_path):
     assert ".DS_Store" not in out
 
 
-def test_workspace_info():
+def test_workspace_info(workspace_name):
     test_config = """
 ramble:
   variables:
@@ -213,7 +214,6 @@ ramble:
         - zlib
 """
 
-    workspace_name = "test_info"
     ws1 = ramble.workspace.create(workspace_name)
     ws1.write()
 
@@ -229,7 +229,7 @@ ramble:
     check_info_basic(output)
 
 
-def test_workspace_info_prints_all_levels():
+def test_workspace_info_prints_all_levels(workspace_name):
     test_config = """
 ramble:
   variables:
@@ -274,7 +274,6 @@ config:
     conf_level: 1
 """
 
-    workspace_name = "test_workspace_info_prints_all_levels"
     ws1 = ramble.workspace.create(workspace_name)
     ws1.write()
 
@@ -297,7 +296,7 @@ config:
     assert "Variables from Experiment:" in output
 
 
-def test_workspace_info_with_experiment_chain():
+def test_workspace_info_with_experiment_chain(workspace_name):
     test_config = """
 ramble:
   variables:
@@ -329,7 +328,6 @@ ramble:
     environments: {}
 """
 
-    workspace_name = "test_workspace_info_with_experiment_chain"
     ws1 = ramble.workspace.create(workspace_name)
     ws1.write()
 
@@ -346,7 +344,7 @@ ramble:
     assert "- basic.test_wl2.test_experiment.chain.0.basic.test_wl.test_experiment" in output
 
 
-def test_workspace_info_with_where_filter():
+def test_workspace_info_with_where_filter(workspace_name):
     test_config = """
 ramble:
   variables:
@@ -384,7 +382,6 @@ ramble:
         - zlib
 """
 
-    workspace_name = "test_info"
     ws1 = ramble.workspace.create(workspace_name)
     ws1.write()
 
@@ -494,7 +491,7 @@ def test_remove_workspace():
     assert "bar" not in out
 
 
-def test_concretize_command():
+def test_concretize_command(workspace_name):
     test_config = """
 ramble:
   variables:
@@ -529,7 +526,6 @@ ramble:
     environments: {}
 """
 
-    workspace_name = "test_concretize_command"
     ws1 = ramble.workspace.create(workspace_name)
     ws1.write()
 
@@ -567,7 +563,7 @@ def test_concretize_nothing():
         assert search_files_for_string([ws.config_file_path], "pkg_spec:") is False
 
 
-def test_concretize_concrete_config():
+def test_concretize_concrete_config(workspace_name):
     test_config = """
 ramble:
   variables:
@@ -607,7 +603,6 @@ ramble:
         - zlib
 """
 
-    workspace_name = "test_concretize_concrete_config"
     ws1 = ramble.workspace.create(workspace_name)
     ws1.write()
 
@@ -625,7 +620,7 @@ ramble:
         workspace("concretize", global_args=["-w", workspace_name])
 
 
-def test_force_concretize():
+def test_force_concretize(workspace_name):
     test_config = """
 ramble:
   variables:
@@ -665,7 +660,6 @@ ramble:
         - zlib-test
 """
 
-    workspace_name = "test_force_concretize"
     ws1 = ramble.workspace.create(workspace_name)
     ws1.write()
 
@@ -915,7 +909,7 @@ def test_edit_override_gets_correct_path():
         assert output == config_path
 
 
-def test_dryrun_setup():
+def test_dryrun_setup(workspace_name):
     test_config = """
 ramble:
   variables:
@@ -936,7 +930,6 @@ ramble:
     environments: {}
 """
 
-    workspace_name = "test_dryrun"
     ws1 = ramble.workspace.create(workspace_name)
     ws1.write()
 
@@ -959,7 +952,7 @@ ramble:
     )
 
 
-def test_matrix_vector_workspace_full():
+def test_matrix_vector_workspace_full(workspace_name):
     test_config = """
 ramble:
   variables:
@@ -1002,7 +995,6 @@ ramble:
     expected_experiments.add("exp_series_6_4_10_2")
     expected_experiments.add("exp_series_6_4_10_4")
 
-    workspace_name = "test_vec_mat_expansion"
     ws1 = ramble.workspace.create(workspace_name)
     ws1.write()
 
@@ -1031,7 +1023,7 @@ ramble:
         assert os.path.exists(os.path.join(exp_base, exp))
 
 
-def test_invalid_vector_workspace():
+def test_invalid_vector_workspace(workspace_name):
     test_config = """
 ramble:
   variables:
@@ -1055,7 +1047,6 @@ ramble:
     environments: {}
 """
 
-    workspace_name = "test_invalid_vectors"
     ws1 = ramble.workspace.create(workspace_name)
     ws1.write()
 
@@ -1084,7 +1075,7 @@ ramble:
     )
 
 
-def test_invalid_size_matrices_workspace():
+def test_invalid_size_matrices_workspace(workspace_name):
     test_config = """
 ramble:
   variables:
@@ -1107,7 +1098,6 @@ ramble:
     environments: {}
 """
 
-    workspace_name = "test_invalid_size_matrices"
     ws1 = ramble.workspace.create(workspace_name)
     ws1.write()
 
@@ -1130,7 +1120,7 @@ ramble:
     assert "do not result in the same number of elements." in output
 
 
-def test_undefined_var_matrices_workspace():
+def test_undefined_var_matrices_workspace(workspace_name):
     test_config = """
 ramble:
   variables:
@@ -1149,7 +1139,6 @@ ramble:
     environments: {}
 """
 
-    workspace_name = "test_invalid_input_matrices"
     ws1 = ramble.workspace.create(workspace_name)
     ws1.write()
 
@@ -1169,7 +1158,7 @@ ramble:
     assert "variable or zip foo has not been defined yet" in output
 
 
-def test_non_vector_var_matrices_workspace():
+def test_non_vector_var_matrices_workspace(workspace_name):
     test_config = """
 ramble:
   variables:
@@ -1190,7 +1179,6 @@ ramble:
     environments: {}
 """
 
-    workspace_name = "test_non_vector_input_matrices"
     ws1 = ramble.workspace.create(workspace_name)
     ws1.write()
 
@@ -1210,7 +1198,7 @@ ramble:
     assert "variable foo does not refer to a vector" in output
 
 
-def test_multi_use_vector_var_matrices_workspace():
+def test_multi_use_vector_var_matrices_workspace(workspace_name):
     test_config = """
 ramble:
   variables:
@@ -1232,7 +1220,6 @@ ramble:
     environments: {}
 """
 
-    workspace_name = "test_non_vector_input_matrices"
     ws1 = ramble.workspace.create(workspace_name)
     ws1.write()
 
@@ -1252,7 +1239,7 @@ ramble:
     assert "Variable foo has been used in multiple matrices" in output
 
 
-def test_reconcretize_in_configs_dir(tmpdir):
+def test_reconcretize_in_configs_dir(tmpdir, workspace_name):
     """
     Test multiple concretizations while the configs dir is the cwd do not fail.
     This catches a bug that existed when lock files were written incorrectly.
@@ -1286,7 +1273,7 @@ ramble:
                 f.write(config)
             ws._re_read()
 
-    ws_path = str(tmpdir.join("test_reconcretize_in_configs_dir"))
+    ws_path = str(tmpdir.join(workspace_name))
     workspace("create", "-d", ws_path)
     assert ramble.workspace.is_workspace_dir(ws_path)
 
@@ -1314,7 +1301,7 @@ ramble:
             assert namespace.environments in software_dict
 
 
-def test_workspace_archive():
+def test_workspace_archive(workspace_name):
     test_config = """
 ramble:
   variables:
@@ -1342,7 +1329,6 @@ licenses:
       TEST_LIC: 'value'
 """
 
-    workspace_name = "test_basic_archive"
     ws1 = ramble.workspace.create(workspace_name)
     ws1.write()
 
@@ -1418,7 +1404,7 @@ licenses:
     )
 
 
-def test_workspace_archive_include_secrets():
+def test_workspace_archive_include_secrets(workspace_name):
     test_config = """
 ramble:
   variables:
@@ -1446,7 +1432,6 @@ licenses:
       TEST_LIC: 'value'
 """
 
-    workspace_name = "test_basic_archive"
     ws1 = ramble.workspace.create(workspace_name)
     ws1.write()
 
@@ -1484,7 +1469,7 @@ licenses:
     )
 
 
-def test_workspace_tar_archive():
+def test_workspace_tar_archive(workspace_name):
     test_config = """
 ramble:
   variables:
@@ -1505,7 +1490,6 @@ ramble:
     environments: {}
 """
 
-    workspace_name = "test_basic_archive"
     ws1 = ramble.workspace.create(workspace_name)
     ws1.write()
 
@@ -1558,7 +1542,7 @@ ramble:
     assert os.path.exists(os.path.join(ws1.archive_dir, "archive.latest.tar.gz"))
 
 
-def test_workspace_tar_upload_archive():
+def test_workspace_tar_upload_archive(workspace_name):
     test_config = """
 ramble:
   variables:
@@ -1579,7 +1563,6 @@ ramble:
     environments: {}
 """
 
-    workspace_name = "test_basic_archive"
     ws1 = ramble.workspace.create(workspace_name)
     ws1.write()
 
@@ -1638,7 +1621,7 @@ ramble:
     assert os.path.exists(os.path.join(remote_archive_path, ws1.latest_archive + ".tar.gz"))
 
 
-def test_workspace_tar_upload_archive_config_url():
+def test_workspace_tar_upload_archive_config_url(workspace_name):
     test_config = """
 ramble:
   variables:
@@ -1659,7 +1642,6 @@ ramble:
     environments: {}
 """
 
-    workspace_name = "test_basic_archive"
     ws1 = ramble.workspace.create(workspace_name)
     ws1.write()
 
@@ -1720,7 +1702,7 @@ ramble:
     assert os.path.exists(os.path.join(remote_archive_path, ws1.latest_archive + ".tar.gz"))
 
 
-def test_workspace_archive_includes_exec_logs(request):
+def test_workspace_archive_includes_exec_logs(workspace_name):
     test_config = """
 ramble:
   variables:
@@ -1741,7 +1723,6 @@ ramble:
     environments: {}
 """
 
-    workspace_name = request.node.name
     ws1 = ramble.workspace.create(workspace_name)
     ws1.write()
 
@@ -1771,7 +1752,7 @@ ramble:
         assert os.path.isfile(file.replace(ws1.root, ws1.latest_archive_path))
 
 
-def test_dryrun_noexpvars_setup():
+def test_dryrun_noexpvars_setup(workspace_name):
     test_config = """
 ramble:
   variables:
@@ -1790,7 +1771,6 @@ ramble:
     environments: {}
 """
 
-    workspace_name = "test_dryrun"
     ws1 = ramble.workspace.create(workspace_name)
     ws1.write()
 
@@ -1813,9 +1793,8 @@ ramble:
     )
 
 
-def test_workspace_include():
+def test_workspace_include(workspace_name):
 
-    workspace_name = "test_info"
     ws1 = ramble.workspace.create(workspace_name)
     ws1.write()
 
@@ -1872,7 +1851,7 @@ ramble:
 
 
 @pytest.mark.parametrize("tpl_name", ["env_path"])
-def test_invalid_template_name_errors(tpl_name, capsys):
+def test_invalid_template_name_errors(tpl_name, capsys, workspace_name):
     test_config = """
 ramble:
   variables:
@@ -1891,7 +1870,6 @@ ramble:
     environments: {}
 """
 
-    workspace_name = "test_invalid_template_name"
     ws1 = ramble.workspace.create(workspace_name)
     ws1.write()
 
@@ -1912,7 +1890,7 @@ ramble:
         ws1._re_read()
 
 
-def test_custom_executables_info():
+def test_custom_executables_info(workspace_name):
     test_config = """
 ramble:
   variables:
@@ -1953,7 +1931,6 @@ ramble:
     environments: {}
 """
 
-    workspace_name = "test_custom_executables_info"
     ws1 = ramble.workspace.create(workspace_name)
     ws1.write()
 
@@ -1971,7 +1948,7 @@ ramble:
     assert "exp_level_cmd" in output
 
 
-def test_custom_executables_order_info():
+def test_custom_executables_order_info(workspace_name):
     test_config = """
 ramble:
   variables:
@@ -2015,7 +1992,6 @@ ramble:
     environments: {}
 """
 
-    workspace_name = "test_custom_executables_info"
     ws1 = ramble.workspace.create(workspace_name)
     ws1.write()
 
@@ -2031,7 +2007,7 @@ ramble:
     assert "['exp_level_cmd', 'wl_level_cmd', 'app_level_cmd']" in output
 
 
-def test_workspace_simplify():
+def test_workspace_simplify(workspace_name):
     test_ws_config = """
 ramble:
   variants:
@@ -2094,7 +2070,6 @@ software:
       compiler_spec: gcc@10.5.0
 """
 
-    workspace_name = "test_simplify"
     ws1 = ramble.workspace.create(workspace_name)
     ws1.write()
 
@@ -2139,8 +2114,7 @@ def write_variables_config_file(file_path, levels, value):
             f.write(f"  scope{i}: {value}\n")
 
 
-def test_workspace_config_precedence(request, tmpdir):
-    workspace_name = request.node.name
+def test_workspace_config_precedence(workspace_name, tmpdir):
     ws = ramble.workspace.create(workspace_name)
 
     global_args = ["-w", workspace_name]
@@ -2189,9 +2163,7 @@ def test_workspace_config_precedence(request, tmpdir):
     assert "scope3 = workspace" in output
 
 
-def test_workspace_info_software(request):
-    workspace_name = request.node.name
-
+def test_workspace_info_software(workspace_name):
     ramble.workspace.create(workspace_name)
 
     global_args = ["-w", workspace_name]
@@ -2317,8 +2289,7 @@ def test_workspace_info_software(request):
     assert "spack-test" not in output
 
 
-def test_workspace_no_empty_workloads(request):
-    workspace_name = request.node.name
+def test_workspace_no_empty_workloads(workspace_name):
     global_args = ["-w", workspace_name]
 
     with ramble.workspace.create(workspace_name) as ws:
@@ -2344,8 +2315,8 @@ def test_workspace_no_empty_workloads(request):
 
 
 def test_no_inherit_active_workspace_variants(request):
-    workspace1_name = f"{request.node.name}_1"
-    workspace2_name = f"{request.node.name}_2"
+    workspace1_name = re.sub("[^0-9a-zA-Z_-]", "_", request.node.name) + "_1"
+    workspace2_name = re.sub("[^0-9a-zA-Z_-]", "_", request.node.name) + "_2"
 
     global_args = ["-w", workspace1_name]
 

--- a/lib/ramble/ramble/test/cmd/workspace_concretize.py
+++ b/lib/ramble/ramble/test/cmd/workspace_concretize.py
@@ -19,9 +19,7 @@ pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_p
 workspace = RambleCommand("workspace")
 
 
-def test_workspace_concretize_additive(request):
-    workspace_name = request.node.name
-
+def test_workspace_concretize_additive(workspace_name):
     ws = ramble.workspace.create(workspace_name)
     global_args = ["-w", workspace_name]
 
@@ -65,9 +63,7 @@ def test_workspace_concretize_additive(request):
         assert "intel-oneapi-vtune" in content
 
 
-def test_workspace_multispec_concretize(request):
-    workspace_name = request.node.name
-
+def test_workspace_multispec_concretize(workspace_name):
     ws = ramble.workspace.create(workspace_name)
     global_args = ["-w", workspace_name]
 

--- a/lib/ramble/ramble/test/cmd/workspace_manage.py
+++ b/lib/ramble/ramble/test/cmd/workspace_manage.py
@@ -17,8 +17,7 @@ pytestmark = pytest.mark.usefixtures("mutable_mock_workspace_path")
 workspace = RambleCommand("workspace")
 
 
-def test_manage_variable_multiple_equals(request, tmpdir):
-    workspace_name = request.node.name
+def test_manage_variable_multiple_equals(workspace_name, tmpdir):
     ws = ramble.workspace.create(workspace_name)
 
     global_args = ["-w", workspace_name]

--- a/lib/ramble/ramble/test/concretize_builtin.py
+++ b/lib/ramble/ramble/test/concretize_builtin.py
@@ -7,6 +7,7 @@
 # except according to those terms.
 
 import os
+import re
 
 import pytest
 
@@ -20,7 +21,9 @@ config = RambleCommand("config")
 workspace = RambleCommand("workspace")
 
 
-def test_concretize_does_not_set_required(mutable_config, mutable_mock_workspace_path):
+def test_concretize_does_not_set_required(
+    mutable_config, mutable_mock_workspace_path, workspace_name
+):
     """
     Verify that concretizing an application with required set to True
     does not insert a required statement into software dict.
@@ -74,9 +77,6 @@ ramble:
     environments: {}
 """
 
-    import re
-
-    workspace_name = "test_concretize_does_not_set_required"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 
@@ -101,13 +101,11 @@ ramble:
 
 
 def test_concretize_allows_invalid_experiment(
-    mutable_config, mutable_mock_workspace_path, request
+    mutable_config, mutable_mock_workspace_path, workspace_name
 ):
-    ws_name = request.node.name
+    global_args = ["-w", workspace_name]
 
-    global_args = ["-w", ws_name]
-
-    with ramble.workspace.create(ws_name) as ws:
+    with ramble.workspace.create(workspace_name) as ws:
 
         workspace(
             "manage",

--- a/lib/ramble/ramble/test/end_to_end/analyze_fom_output.py
+++ b/lib/ramble/ramble/test/end_to_end/analyze_fom_output.py
@@ -63,8 +63,7 @@ ramble:
     return ws
 
 
-def test_analyze_fom_output():
-    workspace_name = "test-fom-output"
+def test_analyze_fom_output(workspace_name):
     ws = _setup_workspace(workspace_name)
 
     workspace("analyze", "-p", global_args=["-w", workspace_name])
@@ -76,8 +75,7 @@ def test_analyze_fom_output():
         assert "possible hostname = test-user.c.googlers.com" in content
 
 
-def test_analyze_print(monkeypatch):
-    workspace_name = "test-analyze-print"
+def test_analyze_print(monkeypatch, workspace_name):
     _setup_workspace(workspace_name)
 
     msg_list = []
@@ -97,10 +95,9 @@ def test_analyze_print(monkeypatch):
 
 
 # If an app has no FOM defined, analyze should not fail due to the lack of FOMs
-def test_analyze_success_with_no_fom_defined(mock_applications, request):
-    ws_name = request.node.name
-    global_args = ["-w", ws_name]
-    ws = ramble.workspace.create(ws_name)
+def test_analyze_success_with_no_fom_defined(mock_applications, workspace_name):
+    global_args = ["-w", workspace_name]
+    ws = ramble.workspace.create(workspace_name)
     workspace(
         "manage",
         "experiments",
@@ -115,7 +112,7 @@ def test_analyze_success_with_no_fom_defined(mock_applications, request):
     )
     ws._re_read()
     workspace("setup", "--dry-run", global_args=global_args)
-    workspace("analyze", global_args=["-w", ws_name])
+    workspace("analyze", global_args=["-w", workspace_name])
     result_file = os.path.join(ws.root, "results.latest.txt")
     with open(result_file) as f:
         content = f.read()
@@ -123,10 +120,9 @@ def test_analyze_success_with_no_fom_defined(mock_applications, request):
 
 
 # If app has FOM defined, analyze fails when no FOM is detected from the experiment
-def test_analyze_fail_with_no_fom_detected(mock_applications, request):
-    ws_name = request.node.name
-    global_args = ["-w", ws_name]
-    ws = ramble.workspace.create(ws_name)
+def test_analyze_fail_with_no_fom_detected(mock_applications, workspace_name):
+    global_args = ["-w", workspace_name]
+    ws = ramble.workspace.create(workspace_name)
     workspace(
         "manage",
         "experiments",
@@ -143,7 +139,7 @@ def test_analyze_fail_with_no_fom_detected(mock_applications, request):
     )
     ws._re_read()
     workspace("setup", "--dry-run", global_args=global_args)
-    workspace("analyze", global_args=["-w", ws_name])
+    workspace("analyze", global_args=["-w", workspace_name])
     result_file = os.path.join(ws.root, "results.latest.txt")
     with open(result_file) as f:
         content = f.read()

--- a/lib/ramble/ramble/test/end_to_end/analyze_upload.py
+++ b/lib/ramble/ramble/test/end_to_end/analyze_upload.py
@@ -22,7 +22,7 @@ workspace = RambleCommand("workspace")
 
 
 @pytest.mark.maybeslow
-def test_analyze_upload(request):
+def test_analyze_upload(workspace_name):
     test_config = """
 ramble:
   config:
@@ -45,8 +45,7 @@ ramble:
     packages: {}
     environments: {}
 """
-    ws_name = request.node.name
-    ws = ramble.workspace.create(ws_name)
+    ws = ramble.workspace.create(workspace_name)
     ws.write()
 
     config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
@@ -56,12 +55,12 @@ ramble:
 
     ws._re_read()
 
-    workspace("setup", "--dry-run", global_args=["-w", ws_name])
+    workspace("setup", "--dry-run", global_args=["-w", workspace_name])
     exp_out = os.path.join(ws.experiment_dir, "hostname", "local", "test", "test.out")
     with open(exp_out, "w") as f:
         f.write("test-user.c.googlers.com\n")
 
-    workspace("analyze", "--upload", global_args=["-w", ws_name])
+    workspace("analyze", "--upload", global_args=["-w", workspace_name])
 
     analyze_log = os.path.join(ws.log_dir, "analyze.latest.out")
 

--- a/lib/ramble/ramble/test/end_to_end/chained_experiment_var_inheritance.py
+++ b/lib/ramble/ramble/test/end_to_end/chained_experiment_var_inheritance.py
@@ -24,7 +24,7 @@ workspace = RambleCommand("workspace")
 
 
 @pytest.mark.maybeslow
-def test_chained_experiment_variable_inheritance(request):
+def test_chained_experiment_variable_inheritance(workspace_name):
     test_config = r"""
 ramble:
   variants:
@@ -121,7 +121,6 @@ ramble:
 
     filters = ramble.filters.Filters()
 
-    workspace_name = request.node.name
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 

--- a/lib/ramble/ramble/test/end_to_end/chained_experiment_variant_propagation.py
+++ b/lib/ramble/ramble/test/end_to_end/chained_experiment_variant_propagation.py
@@ -24,7 +24,7 @@ workspace = RambleCommand("workspace")
 
 
 @pytest.mark.maybeslow
-def test_chained_experiment_variant_propagation(request):
+def test_chained_experiment_variant_propagation(workspace_name):
     test_config = r"""
 ramble:
   variants:
@@ -120,8 +120,6 @@ ramble:
     setup_cls = ramble.pipeline.pipeline_class(setup_type)
 
     filters = ramble.filters.Filters()
-
-    workspace_name = request.node.name
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 

--- a/lib/ramble/ramble/test/end_to_end/concretize_with_different_package_managers.py
+++ b/lib/ramble/ramble/test/end_to_end/concretize_with_different_package_managers.py
@@ -22,7 +22,7 @@ workspace = RambleCommand("workspace")
 
 
 def test_concretize_with_different_package_managers(
-    mutable_config, mutable_mock_workspace_path, request
+    mutable_config, mutable_mock_workspace_path, workspace_name
 ):
     test_config = """
 ramble:
@@ -56,7 +56,6 @@ ramble:
     environments: {}
 """
 
-    workspace_name = request.node.name
     with ramble.workspace.create(workspace_name) as ws1:
         ws1.write()
 

--- a/lib/ramble/ramble/test/end_to_end/config_section_env_vars.py
+++ b/lib/ramble/ramble/test/end_to_end/config_section_env_vars.py
@@ -7,6 +7,7 @@
 # except according to those terms.
 
 import os
+import re
 
 import pytest
 
@@ -21,7 +22,9 @@ pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_p
 workspace = RambleCommand("workspace")
 
 
-def test_config_section_env_vars(mutable_config, mutable_mock_workspace_path, mock_applications):
+def test_config_section_env_vars(
+    mutable_config, mutable_mock_workspace_path, mock_applications, workspace_name
+):
     test_config = """
 ramble:
   variables:
@@ -45,7 +48,6 @@ ramble:
     packages: {}
     environments: {}
 """
-    workspace_name = "test_config_section_env_vars"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 
@@ -60,8 +62,6 @@ ramble:
         experiment_root = ws.experiment_dir
         exp1_dir = os.path.join(experiment_root, "basic", "test_wl", "simple_test")
         exp1_script = os.path.join(exp1_dir, "execute_experiment")
-
-        import re
 
         export_regex = re.compile(r"export MY_VAR=TEST")
 

--- a/lib/ramble/ramble/test/end_to_end/configvar_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/configvar_dry_run.py
@@ -22,7 +22,7 @@ workspace = RambleCommand("workspace")
 
 
 @pytest.mark.maybeslow
-def test_configvar_dry_run(mutable_config, mutable_mock_workspace_path):
+def test_configvar_dry_run(mutable_config, mutable_mock_workspace_path, workspace_name):
     test_scopes = ["site", "system", "user"]
 
     var_name1 = "test1"
@@ -82,7 +82,6 @@ ramble:
     for i, scope in enumerate(test_scopes):
         config("--scope", scope, "add", f"env_vars:set:{var_name2}{i}:{var_val}")
 
-    workspace_name = "test_sitevar"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 

--- a/lib/ramble/ramble/test/end_to_end/custom_executables.py
+++ b/lib/ramble/ramble/test/end_to_end/custom_executables.py
@@ -7,6 +7,7 @@
 # except according to those terms.
 
 import os
+import re
 
 import pytest
 
@@ -21,7 +22,9 @@ pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_p
 workspace = RambleCommand("workspace")
 
 
-def test_custom_executables(mutable_config, mutable_mock_workspace_path, mock_applications):
+def test_custom_executables(
+    mutable_config, mutable_mock_workspace_path, mock_applications, workspace_name
+):
     test_config = """
 ramble:
   variables:
@@ -84,7 +87,6 @@ ramble:
     packages: {}
     environments: {}
 """
-    workspace_name = "test_custom_executables"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 
@@ -99,8 +101,6 @@ ramble:
         experiment_root = ws.experiment_dir
         exp_dir = os.path.join(experiment_root, "interleved-env-vars", "test_wl3", "simple_test")
         exp_script = os.path.join(exp_dir, "execute_experiment")
-
-        import re
 
         custom_regex = re.compile(r"^lscpu >> .* &$")
         export_regex = re.compile(r"export MY_VAR=TEST")

--- a/lib/ramble/ramble/test/end_to_end/define_package_paths.py
+++ b/lib/ramble/ramble/test/end_to_end/define_package_paths.py
@@ -28,7 +28,7 @@ def _spack_loc_log_line(pkg_spec):
     return f"with args: ['location', '-i', '{pkg_spec}']"
 
 
-def test_define_package_paths():
+def test_define_package_paths(workspace_name):
     test_config = """
 ramble:
   variants:
@@ -60,7 +60,6 @@ ramble:
         - gromacs
         - intel-mpi
 """
-    workspace_name = "test-define-package-paths"
     ws = ramble.workspace.create(workspace_name)
     ws.write()
 
@@ -96,7 +95,7 @@ ramble:
         assert impi_log_line not in content
 
 
-def test_package_path_variables():
+def test_package_path_variables(workspace_name):
     test_config = """
 ramble:
   variants:
@@ -129,7 +128,6 @@ ramble:
         - gromacs
         - intel-mpi
 """
-    workspace_name = "test-define-package-paths"
     ws = ramble.workspace.create(workspace_name)
     ws.write()
 

--- a/lib/ramble/ramble/test/end_to_end/dryrun_chained_experiments.py
+++ b/lib/ramble/ramble/test/end_to_end/dryrun_chained_experiments.py
@@ -29,7 +29,7 @@ workspace = RambleCommand("workspace")
 
 @pytest.mark.maybeslow
 @pytest.mark.filterwarnings("ignore:invalid decimal literal")
-def test_dryrun_chained_experiments(mutable_config, mutable_mock_workspace_path):
+def test_dryrun_chained_experiments(mutable_config, mutable_mock_workspace_path, workspace_name):
     test_config = r"""
 ramble:
   variants:
@@ -120,7 +120,6 @@ ramble:
 
     filters = ramble.filters.Filters()
 
-    workspace_name = "test_dryrun_chained_experiments"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 

--- a/lib/ramble/ramble/test/end_to_end/dryrun_copies_external_env.py
+++ b/lib/ramble/ramble/test/end_to_end/dryrun_copies_external_env.py
@@ -23,7 +23,9 @@ pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_p
 workspace = RambleCommand("workspace")
 
 
-def test_dryrun_copies_external_env(mutable_config, mutable_mock_workspace_path, tmpdir):
+def test_dryrun_copies_external_env(
+    mutable_config, mutable_mock_workspace_path, tmpdir, workspace_name
+):
     test_spack_env = """
 spack:
   specs: [ 'wrf' ]
@@ -63,7 +65,6 @@ ramble:
     setup_cls = ramble.pipeline.pipeline_class(setup_type)
     filters = ramble.filters.Filters()
 
-    workspace_name = "test_dryrun_copies_external_env"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 

--- a/lib/ramble/ramble/test/end_to_end/dryrun_series_contains_package_paths.py
+++ b/lib/ramble/ramble/test/end_to_end/dryrun_series_contains_package_paths.py
@@ -24,7 +24,7 @@ workspace = RambleCommand("workspace")
 
 
 def test_dryrun_series_contains_package_paths(
-    mutable_config, mutable_mock_workspace_path, mock_applications
+    mutable_config, mutable_mock_workspace_path, mock_applications, workspace_name
 ):
     test_config = r"""
 ramble:
@@ -59,7 +59,6 @@ ramble:
     setup_cls = ramble.pipeline.pipeline_class(setup_type)
     filters = ramble.filters.Filters()
 
-    workspace_name = "test_dryrun_series_contains_package_paths"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 

--- a/lib/ramble/ramble/test/end_to_end/env_var_builtin.py
+++ b/lib/ramble/ramble/test/end_to_end/env_var_builtin.py
@@ -7,6 +7,7 @@
 # except according to those terms.
 
 import os
+import re
 
 import pytest
 
@@ -21,7 +22,9 @@ pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_p
 workspace = RambleCommand("workspace")
 
 
-def test_env_var_builtin(mutable_config, mutable_mock_workspace_path, mock_applications):
+def test_env_var_builtin(
+    mutable_config, mutable_mock_workspace_path, mock_applications, workspace_name
+):
     test_config = """
 ramble:
   config:
@@ -63,7 +66,6 @@ ramble:
     packages: {}
     environments: {}
 """
-    workspace_name = "test_env_var_command"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 
@@ -82,8 +84,6 @@ ramble:
         exp2_script = os.path.join(exp2_dir, "execute_experiment")
         exp3_dir = os.path.join(experiment_root, "interleved-env-vars", "test_wl3", "simple_test")
         exp3_script = os.path.join(exp3_dir, "execute_experiment")
-
-        import re
 
         export_regex = re.compile(r"export MY_VAR=TEST")
         cmd1_regex = re.compile("bar >>")
@@ -127,7 +127,9 @@ ramble:
             assert cmd_found and export_found
 
 
-def test_env_var_from_app_only(mutable_config, mutable_mock_workspace_path, mock_applications):
+def test_env_var_from_app_only(
+    mutable_config, mutable_mock_workspace_path, mock_applications, workspace_name
+):
     test_config = """
 ramble:
   variables:
@@ -148,7 +150,6 @@ ramble:
     packages: {}
     environments: {}
 """
-    workspace_name = "test_env_var_from_app_only"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 

--- a/lib/ramble/ramble/test/end_to_end/env_var_leakage.py
+++ b/lib/ramble/ramble/test/end_to_end/env_var_leakage.py
@@ -21,7 +21,7 @@ pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_p
 workspace = RambleCommand("workspace")
 
 
-def test_env_vars_do_not_leak(mutable_config, mutable_mock_workspace_path):
+def test_env_vars_do_not_leak(mutable_config, mutable_mock_workspace_path, workspace_name):
     test_config = """
 ramble:
   config:
@@ -54,7 +54,6 @@ ramble:
     packages: {}
     environments: {}
 """
-    workspace_name = "test_env_var_command"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 

--- a/lib/ramble/ramble/test/end_to_end/exclusive_filtered_vector_workloads.py
+++ b/lib/ramble/ramble/test/end_to_end/exclusive_filtered_vector_workloads.py
@@ -21,7 +21,9 @@ pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_p
 workspace = RambleCommand("workspace")
 
 
-def test_exclusive_filtered_vector_workloads(mutable_config, mutable_mock_workspace_path):
+def test_exclusive_filtered_vector_workloads(
+    mutable_config, mutable_mock_workspace_path, workspace_name
+):
     test_config = """
 ramble:
   variables:
@@ -43,7 +45,6 @@ ramble:
     packages: {}
     environments: {}
 """
-    workspace_name = "test_exclusive_filtered_vector_workloads"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 

--- a/lib/ramble/ramble/test/end_to_end/expanded_fom_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/expanded_fom_dry_run.py
@@ -22,7 +22,9 @@ pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_p
 workspace = RambleCommand("workspace")
 
 
-def test_expanded_foms_dry_run(mutable_config, mutable_mock_workspace_path, mock_applications):
+def test_expanded_foms_dry_run(
+    mutable_config, mutable_mock_workspace_path, mock_applications, workspace_name
+):
     test_config = """
 ramble:
   variables:
@@ -43,7 +45,6 @@ ramble:
     environments: {}
 """
 
-    workspace_name = "test_end_to_end_expanded_foms"
     with ramble.workspace.create(workspace_name) as ws1:
         ws1.write()
 

--- a/lib/ramble/ramble/test/end_to_end/experiment_excludes.py
+++ b/lib/ramble/ramble/test/end_to_end/experiment_excludes.py
@@ -24,7 +24,7 @@ workspace = RambleCommand("workspace")
 
 
 @pytest.mark.long
-def test_wrfv4_exclusions(mutable_config, mutable_mock_workspace_path, request):
+def test_wrfv4_exclusions(mutable_config, mutable_mock_workspace_path, workspace_name):
     test_config = """
 ramble:
   variants:
@@ -135,7 +135,6 @@ compilers:
     extra_rpaths: []
 """
 
-    workspace_name = request.node.name
     with ramble.workspace.create(workspace_name) as ws1:
         ws1.write()
 

--- a/lib/ramble/ramble/test/end_to_end/experiment_hashes.py
+++ b/lib/ramble/ramble/test/end_to_end/experiment_hashes.py
@@ -17,9 +17,7 @@ import spack.util.spack_json as sjson
 workspace = RambleCommand("workspace")
 
 
-def test_experiment_hashes(mutable_config, mutable_mock_workspace_path, request):
-    workspace_name = request.node.name
-
+def test_experiment_hashes(mutable_config, mutable_mock_workspace_path, workspace_name):
     ws1 = ramble.workspace.create(workspace_name)
 
     global_args = ["-w", workspace_name]

--- a/lib/ramble/ramble/test/end_to_end/experiment_repeats.py
+++ b/lib/ramble/ramble/test/end_to_end/experiment_repeats.py
@@ -24,7 +24,7 @@ workspace = RambleCommand("workspace")
 
 
 @pytest.mark.long
-def test_gromacs_repeats(mutable_config, mutable_mock_workspace_path):
+def test_gromacs_repeats(mutable_config, mutable_mock_workspace_path, workspace_name):
     test_config = """
 ramble:
   variants:
@@ -78,7 +78,6 @@ ramble:
         - intel-mpi
 """
 
-    workspace_name = "test_end_to_end_repeats"
     with ramble.workspace.create(workspace_name) as ws1:
         ws1.write()
 
@@ -177,7 +176,7 @@ ramble:
                 assert "summary::variance = 61.727 s^2" in data
 
         # When --summary-only, only the base experiments are included
-        workspace("analyze", "-s", global_args=["-w", workspace_name])
+        workspace("analyze", "-s", global_args=["-w", workspace_name])  # noqa: E501
         result_file = glob.glob(os.path.join(ws1.root, "results.latest.txt"))[0]
         with open(result_file) as f:
             data = f.read()
@@ -187,7 +186,7 @@ ramble:
 
 
 @pytest.mark.long
-def test_repeat_stats(mutable_config, mutable_mock_workspace_path, request):
+def test_repeat_stats(mutable_config, mutable_mock_workspace_path, workspace_name):
     test_config = """
 ramble:
   variables:
@@ -203,7 +202,6 @@ ramble:
             sleep_test:
               n_repeats: 3
 """
-    workspace_name = request.node.name
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
         config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)

--- a/lib/ramble/ramble/test/end_to_end/experiment_templates.py
+++ b/lib/ramble/ramble/test/end_to_end/experiment_templates.py
@@ -21,7 +21,7 @@ pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_p
 workspace = RambleCommand("workspace")
 
 
-def test_experiment_templates(mutable_config, mutable_mock_workspace_path):
+def test_experiment_templates(mutable_config, mutable_mock_workspace_path, workspace_name):
     test_config = r"""
 ramble:
   variables:
@@ -49,7 +49,6 @@ ramble:
                 command: '{execute_experiment}'
                 order: 'after_root'
 """
-    workspace_name = "test_experiment_templates"
     with ramble.workspace.create(workspace_name) as ws1:
         ws1.write()
 

--- a/lib/ramble/ramble/test/end_to_end/explicit_zips.py
+++ b/lib/ramble/ramble/test/end_to_end/explicit_zips.py
@@ -24,7 +24,7 @@ workspace = RambleCommand("workspace")
 
 
 @pytest.mark.long
-def test_wrfv4_explicit_zips(mutable_config, mutable_mock_workspace_path):
+def test_wrfv4_explicit_zips(mutable_config, mutable_mock_workspace_path, workspace_name):
     test_config = """
 ramble:
   variants:
@@ -117,7 +117,6 @@ licenses:
       WRF_LICENSE: port@server
 """
 
-    workspace_name = "test_end_to_end_wrfv4"
     with ramble.workspace.create(workspace_name) as ws1:
         ws1.write()
 

--- a/lib/ramble/ramble/test/end_to_end/fom_log_file_path.py
+++ b/lib/ramble/ramble/test/end_to_end/fom_log_file_path.py
@@ -24,9 +24,7 @@ on = RambleCommand("on")
 workspace = RambleCommand("workspace")
 
 
-def test_relative_fom_log_works(mutable_config, mutable_mock_workspace_path, request):
-    workspace_name = request.node.name
-
+def test_relative_fom_log_works(mutable_config, mutable_mock_workspace_path, workspace_name):
     global_args = ["-w", workspace_name]
 
     ws = ramble.workspace.create(workspace_name)

--- a/lib/ramble/ramble/test/end_to_end/formatted_executables.py
+++ b/lib/ramble/ramble/test/end_to_end/formatted_executables.py
@@ -7,6 +7,7 @@
 # except according to those terms.
 
 import os
+import re
 
 import pytest
 
@@ -24,7 +25,7 @@ pytestmark = pytest.mark.usefixtures(
 workspace = RambleCommand("workspace")
 
 
-def test_formatted_executables():
+def test_formatted_executables(workspace_name):
     test_config = r"""
 ramble:
   variables:
@@ -66,7 +67,6 @@ ramble:
     packages: {}
     environments: {}
 """
-    workspace_name = "test_formatted_executables"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 
@@ -98,7 +98,7 @@ ramble:
             assert "\n" + " " * 2 + "test_from_ws mpirun -n 16 -ppn 16 test" in data
 
 
-def test_redefined_executable_errors():
+def test_redefined_executable_errors(workspace_name):
     test_config = r"""
 ramble:
   variables:
@@ -123,7 +123,6 @@ ramble:
     packages: {}
     environments: {}
 """
-    workspace_name = "test_redefined_executable_errors"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 
@@ -139,7 +138,7 @@ ramble:
             assert "Formatted executable var_exec_name defined" in output
 
 
-def test_object_formatted_executables(mock_modifiers, request):
+def test_object_formatted_executables(mock_modifiers, workspace_name):
     mod_config = r"""
 modifiers:
 - name: formatted-exec-mod
@@ -148,8 +147,6 @@ modifiers:
     template_suffix = r"""
 {mod_formatted_exec}
 """
-    workspace_name = request.node.name
-
     ws = ramble.workspace.create(workspace_name)
     global_args = ["-w", workspace_name]
 
@@ -192,7 +189,7 @@ modifiers:
         assert '    FROM_MOD echo "Test formatted exec"' in data
 
 
-def test_nested_formatted_executables_are_properly_formatted(request):
+def test_nested_formatted_executables_are_properly_formatted(workspace_name):
     test_config = r"""
 ramble:
   variables:
@@ -236,7 +233,6 @@ ramble:
     packages: {}
     environments: {}
 """
-    workspace_name = request.node.name
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 
@@ -255,8 +251,6 @@ ramble:
         experiment_root = ws.experiment_dir
         exp_dir = os.path.join(experiment_root, "basic", "working_wl", "simple_test")
         exp_script = os.path.join(exp_dir, "execute_experiment")
-
-        import re
 
         test_regexes = [
             re.compile(r"^  test_l3 l3line1$"),

--- a/lib/ramble/ramble/test/end_to_end/globbing_patterns.py
+++ b/lib/ramble/ramble/test/end_to_end/globbing_patterns.py
@@ -7,6 +7,7 @@
 # except according to those terms.
 
 import os
+import re
 
 import pytest
 
@@ -22,7 +23,11 @@ workspace = RambleCommand("workspace")
 
 
 def test_globbing_patterns(
-    mutable_config, mutable_mock_workspace_path, mock_applications, mock_modifiers
+    mutable_config,
+    mutable_mock_workspace_path,
+    mock_applications,
+    mock_modifiers,
+    workspace_name,
 ):
     test_config = """
 ramble:
@@ -52,7 +57,6 @@ ramble:
     packages: {}
     environments: {}
 """
-    workspace_name = "test_globbing_patterns"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 
@@ -73,8 +77,6 @@ ramble:
             experiment_root, "glob-patterns", "test_three_exec", "test_wildcard_3_execs"
         )
         exp2_script = os.path.join(exp2_dir, "execute_experiment")
-
-        import re
 
         test_cmd_regex = re.compile("base test .*>>")
         glob_cmd_regex = re.compile("test foo .*>>")

--- a/lib/ramble/ramble/test/end_to_end/gromacs_size_expansion.py
+++ b/lib/ramble/ramble/test/end_to_end/gromacs_size_expansion.py
@@ -21,7 +21,7 @@ pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_p
 workspace = RambleCommand("workspace")
 
 
-def test_gromacs_size_expansion(mutable_config, mutable_mock_workspace_path):
+def test_gromacs_size_expansion(mutable_config, mutable_mock_workspace_path, workspace_name):
     test_config = """
 ramble:
   variants:
@@ -58,7 +58,6 @@ ramble:
         - intel-mpi
 """
 
-    workspace_name = "test_gromacs_size_expansion"
     with ramble.workspace.create(workspace_name) as ws1:
         ws1.write()
 

--- a/lib/ramble/ramble/test/end_to_end/included_configuration_files.py
+++ b/lib/ramble/ramble/test/end_to_end/included_configuration_files.py
@@ -26,7 +26,7 @@ workspace = RambleCommand("workspace")
 
 
 @pytest.mark.long
-def test_included_configuration_files(mutable_config, mutable_mock_workspace_path, request):
+def test_included_configuration_files(mutable_config, mutable_mock_workspace_path, workspace_name):
 
     test_config = """
 ramble:
@@ -111,7 +111,6 @@ software:
       - intel-mpi
 """
 
-    workspace_name = request.node.name
     with ramble.workspace.create(workspace_name) as ws1:
         ws1.write()
 

--- a/lib/ramble/ramble/test/end_to_end/inclusive_filtered_vector_workloads.py
+++ b/lib/ramble/ramble/test/end_to_end/inclusive_filtered_vector_workloads.py
@@ -21,7 +21,9 @@ pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_p
 workspace = RambleCommand("workspace")
 
 
-def test_inclusive_filtered_vector_workloads(mutable_config, mutable_mock_workspace_path):
+def test_inclusive_filtered_vector_workloads(
+    mutable_config, mutable_mock_workspace_path, workspace_name
+):
     test_config = """
 ramble:
   variables:
@@ -43,7 +45,6 @@ ramble:
     packages: {}
     environments: {}
 """
-    workspace_name = "test_inclusive_filtered_vector_workloads"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 

--- a/lib/ramble/ramble/test/end_to_end/known_applications.py
+++ b/lib/ramble/ramble/test/end_to_end/known_applications.py
@@ -26,7 +26,7 @@ config = RambleCommand("config")
 @pytest.mark.long
 @deprecation.fail_if_not_removed
 @pytest.mark.filterwarnings("ignore:invalid escape sequence:DeprecationWarning")
-def test_known_applications(application, package_manager, mock_file_auto_create, request):
+def test_known_applications(application, package_manager, mock_file_auto_create, workspace_name):
     setup_type = ramble.pipeline.pipelines.setup
     analyze_type = ramble.pipeline.pipelines.analyze
     archive_type = ramble.pipeline.pipelines.archive
@@ -35,7 +35,7 @@ def test_known_applications(application, package_manager, mock_file_auto_create,
     archive_cls = ramble.pipeline.pipeline_class(archive_type)
     filters = ramble.filters.Filters()
 
-    ws_name = request.node.name.replace("[", "_").replace("]", "_")
+    ws_name = workspace_name
 
     with ramble.workspace.create(ws_name) as ws:
         ws.write()
@@ -90,7 +90,9 @@ def test_known_applications(application, package_manager, mock_file_auto_create,
 @pytest.mark.long
 @deprecation.fail_if_not_removed
 @pytest.mark.filterwarnings("ignore:invalid escape sequence:DeprecationWarning")
-def test_known_workflow_managers(workflow_manager, mock_file_auto_create, mutable_config, request):
+def test_known_workflow_managers(
+    workflow_manager, mock_file_auto_create, mutable_config, workspace_name
+):
     setup_type = ramble.pipeline.pipelines.setup
     analyze_type = ramble.pipeline.pipelines.analyze
     archive_type = ramble.pipeline.pipelines.archive
@@ -99,9 +101,7 @@ def test_known_workflow_managers(workflow_manager, mock_file_auto_create, mutabl
     archive_cls = ramble.pipeline.pipeline_class(archive_type)
     filters = ramble.filters.Filters()
 
-    ws_name = request.node.name.replace("[", "_").replace("]", "_")
-
-    with ramble.workspace.create(ws_name) as ws:
+    with ramble.workspace.create(workspace_name) as ws:
         ws.write()
         args = [
             "gromacs",
@@ -121,7 +121,7 @@ def test_known_workflow_managers(workflow_manager, mock_file_auto_create, mutabl
         args.append("--wm")
         args.append(workflow_manager)
 
-        workspace("manage", "experiments", *args, global_args=["-w", ws_name])
+        workspace("manage", "experiments", *args, global_args=["-w", workspace_name])
 
         # Handle workflow manager. Remove variables defined in the workflow to
         # ensure we catch invalid configurations.
@@ -131,10 +131,10 @@ def test_known_workflow_managers(workflow_manager, mock_file_auto_create, mutabl
                 workflow_manager, object_type=ramble.repository.ObjectTypes.workflow_managers
             )
             for var in wm_inst.object_variables[frozenset()]:
-                config("remove", f"variables:{var.name}", global_args=["-w", ws_name])
+                config("remove", f"variables:{var.name}", global_args=["-w", workspace_name])
 
             for var_name in wm_inst.templates:
-                config("remove", f"variables:{var_name}", global_args=["-w", ws_name])
+                config("remove", f"variables:{var_name}", global_args=["-w", workspace_name])
 
         ws._re_read()
         ws.concretize()

--- a/lib/ramble/ramble/test/end_to_end/license_name.py
+++ b/lib/ramble/ramble/test/end_to_end/license_name.py
@@ -64,7 +64,7 @@ ramble:
         assert expected_val in data
 
 
-def test_license_name_parent(mutable_mock_apps_repo, request):
+def test_license_name_parent(mutable_mock_apps_repo, workspace_name):
     app_name = "basic-inherited-nolicense"
     test_licenses = f"""
 licenses:
@@ -72,12 +72,11 @@ licenses:
     set:
       TEST_VAR: {test_val}
 """
-    workspace_name = request.node.name
     expected_val = test_val
     license_param_core(app_name, workspace_name, test_licenses, expected_val)
 
 
-def test_license_name_self_implicit(mutable_mock_apps_repo, request):
+def test_license_name_self_implicit(mutable_mock_apps_repo, workspace_name):
     app_name = "basic-inherited-nolicense"
     expected_val = test_val + "_imp"
     test_licenses = f"""
@@ -89,11 +88,10 @@ licenses:
     set:
       TEST_VAR: {expected_val}
 """
-    workspace_name = request.node.name
     license_param_core(app_name, workspace_name, test_licenses, expected_val)
 
 
-def test_license_name_self_explicit(mutable_mock_apps_repo, request):
+def test_license_name_self_explicit(mutable_mock_apps_repo, workspace_name):
     app_name = "basic-inherited"
     expected_val = test_val + "_exp"
     test_licenses = f"""
@@ -105,5 +103,4 @@ licenses:
     set:
       TEST_VAR: {expected_val}
 """
-    workspace_name = request.node.name
     license_param_core(app_name, workspace_name, test_licenses, expected_val)

--- a/lib/ramble/ramble/test/end_to_end/malformed_config.py
+++ b/lib/ramble/ramble/test/end_to_end/malformed_config.py
@@ -24,7 +24,7 @@ pytestmark = pytest.mark.usefixtures(
 workspace = RambleCommand("workspace")
 
 
-def test_missing_config_keys():
+def test_missing_config_keys(workspace_name):
     test_config = """
 amble:
   variables:
@@ -39,8 +39,7 @@ amble:
           experiments:
             test: {}
 """
-    ws_name = "test_missing_config_keys"
-    ws = ramble.workspace.create(ws_name)
+    ws = ramble.workspace.create(workspace_name)
     ws.write()
 
     config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
@@ -54,4 +53,4 @@ amble:
         ramble.workspace.RambleActiveWorkspaceError,
         match="ramble.yaml needs to contain at least one of the required keys",
     ):
-        workspace("info", global_args=["-w", ws_name])
+        workspace("info", global_args=["-w", workspace_name])

--- a/lib/ramble/ramble/test/end_to_end/manage_software.py
+++ b/lib/ramble/ramble/test/end_to_end/manage_software.py
@@ -19,8 +19,7 @@ pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_p
 workspace = RambleCommand("workspace")
 
 
-def test_manage_software(mutable_config, mutable_mock_workspace_path):
-    workspace_name = "test_manage_software"
+def test_manage_software(mutable_config, mutable_mock_workspace_path, workspace_name):
     with ramble.workspace.create(workspace_name) as ws1:
         ws1.write()
 

--- a/lib/ramble/ramble/test/end_to_end/merge_config_files.py
+++ b/lib/ramble/ramble/test/end_to_end/merge_config_files.py
@@ -22,7 +22,9 @@ workspace = RambleCommand("workspace")
 config = RambleCommand("config")
 
 
-def test_merge_config_files(mutable_config, mutable_mock_workspace_path, mock_applications):
+def test_merge_config_files(
+    mutable_config, mutable_mock_workspace_path, mock_applications, workspace_name
+):
     test_applications = """
 applications:
   zlib:
@@ -64,7 +66,6 @@ licenses:
     set:
       TEST_LICENSE: 'port@server'
 """
-    workspace_name = "test_merge_config_files"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 

--- a/lib/ramble/ramble/test/end_to_end/missing_mpi_cmd.py
+++ b/lib/ramble/ramble/test/end_to_end/missing_mpi_cmd.py
@@ -24,7 +24,7 @@ pytestmark = pytest.mark.usefixtures(
 workspace = RambleCommand("workspace")
 
 
-def test_missing_mpi_cmd():
+def test_missing_mpi_cmd(workspace_name):
     test_config = """
 ramble:
   variants:
@@ -46,7 +46,6 @@ ramble:
               variables:
                 n_nodes: '1'
 """
-    workspace_name = "test-missing-mpi-cmd"
     ws = ramble.workspace.create(workspace_name)
     ws.write()
 

--- a/lib/ramble/ramble/test/end_to_end/missing_required_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/missing_required_dry_run.py
@@ -22,7 +22,7 @@ pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_p
 workspace = RambleCommand("workspace")
 
 
-def test_missing_required_dry_run(mutable_config, mutable_mock_workspace_path):
+def test_missing_required_dry_run(mutable_config, mutable_mock_workspace_path, workspace_name):
     """Tests tty.die at end of ramble.application_types.spack._create_software_env"""
     test_config = """
 ramble:
@@ -60,7 +60,6 @@ ramble:
         - wrfv3
 """
 
-    workspace_name = "test_missing_required_dry_run"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 

--- a/lib/ramble/ramble/test/end_to_end/nested_compilers_are_installed.py
+++ b/lib/ramble/ramble/test/end_to_end/nested_compilers_are_installed.py
@@ -25,7 +25,9 @@ pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_p
 workspace = RambleCommand("workspace")
 
 
-def test_nested_compilers_are_installed(mutable_config, mutable_mock_workspace_path, capsys):
+def test_nested_compilers_are_installed(
+    mutable_config, mutable_mock_workspace_path, capsys, workspace_name
+):
     test_config = """
 ramble:
   variants:
@@ -71,7 +73,6 @@ ramble:
     setup_cls = ramble.pipeline.pipeline_class(setup_type)
     filters = ramble.filters.Filters()
 
-    workspace_name = "test_nested_compilers_are_installed"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 

--- a/lib/ramble/ramble/test/end_to_end/nested_config_templates.py
+++ b/lib/ramble/ramble/test/end_to_end/nested_config_templates.py
@@ -22,7 +22,7 @@ pytestmark = pytest.mark.usefixtures(
 workspace = RambleCommand("workspace")
 
 
-def test_nested_config_templates(request):
+def test_nested_config_templates(workspace_name):
     test_config = """
 ramble:
   variables:
@@ -38,7 +38,6 @@ ramble:
               variables:
                 n_nodes: 1
 """
-    workspace_name = request.node.name
     ws = ramble.workspace.create(workspace_name)
     ws.write()
     config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)

--- a/lib/ramble/ramble/test/end_to_end/object_import.py
+++ b/lib/ramble/ramble/test/end_to_end/object_import.py
@@ -20,10 +20,9 @@ pytestmark = pytest.mark.usefixtures(
 workspace = RambleCommand("workspace")
 
 
-def test_object_import_separate_python_source(request):
-    ws_name = request.node.name
-    ws = ramble.workspace.create(ws_name)
-    global_args = ["-w", ws_name]
+def test_object_import_separate_python_source(workspace_name):
+    ws = ramble.workspace.create(workspace_name)
+    global_args = ["-w", workspace_name]
 
     workspace(
         "manage",

--- a/lib/ramble/ramble/test/end_to_end/object_validation.py
+++ b/lib/ramble/ramble/test/end_to_end/object_validation.py
@@ -20,9 +20,7 @@ pytestmark = pytest.mark.usefixtures(
 workspace = RambleCommand("workspace")
 
 
-def test_object_validation():
-    workspace_name = "test-validation"
-
+def test_object_validation(workspace_name):
     global_args = ["-w", workspace_name]
 
     ws = ramble.workspace.create(workspace_name)

--- a/lib/ramble/ramble/test/end_to_end/package_manager_config.py
+++ b/lib/ramble/ramble/test/end_to_end/package_manager_config.py
@@ -20,7 +20,7 @@ pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_p
 workspace = RambleCommand("workspace")
 
 
-def test_package_manager_config_zlib(mock_applications):
+def test_package_manager_config_zlib(mock_applications, workspace_name):
     test_config = """
 ramble:
   variants:
@@ -47,7 +47,6 @@ ramble:
         - zlib
 """
 
-    workspace_name = "test_package_manager_config_zlib"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 

--- a/lib/ramble/ramble/test/end_to_end/package_manager_provenance.py
+++ b/lib/ramble/ramble/test/end_to_end/package_manager_provenance.py
@@ -21,9 +21,7 @@ workspace = RambleCommand("workspace")
 
 
 @pytest.mark.maybeslow
-def test_spack_package_manager_provenance_zlib(mock_applications, request):
-    workspace_name = request.node.name
-
+def test_spack_package_manager_provenance_zlib(mock_applications, workspace_name):
     ws = ramble.workspace.create(workspace_name)
 
     global_args = ["-w", workspace_name]
@@ -100,9 +98,7 @@ def test_spack_package_manager_provenance_zlib(mock_applications, request):
             assert "zlib" in names
 
 
-def test_usermanged_package_manager_provenance_zlib(mock_applications, request):
-    workspace_name = request.node.name
-
+def test_usermanged_package_manager_provenance_zlib(mock_applications, workspace_name):
     ws = ramble.workspace.create(workspace_name)
 
     global_args = ["-w", workspace_name]

--- a/lib/ramble/ramble/test/end_to_end/package_manager_requirements.py
+++ b/lib/ramble/ramble/test/end_to_end/package_manager_requirements.py
@@ -23,7 +23,7 @@ workspace = RambleCommand("workspace")
 
 
 @pytest.mark.long
-def test_package_manager_requirements_zlib(mock_applications, mock_modifiers):
+def test_package_manager_requirements_zlib(mock_applications, mock_modifiers, workspace_name):
     test_config = """
 ramble:
   variants:
@@ -54,7 +54,6 @@ ramble:
     except RunnerError as e:
         pytest.skip(e)
 
-    workspace_name = "test_package_manager_requirements_zlib"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 
@@ -76,7 +75,7 @@ ramble:
             assert "debug: true" in data
 
 
-def test_package_manager_requirements_error(mock_applications, mock_modifiers):
+def test_package_manager_requirements_error(mock_applications, mock_modifiers, workspace_name):
     test_config = """
 ramble:
   variants:
@@ -107,7 +106,6 @@ ramble:
     except RunnerError as e:
         pytest.skip(e)
 
-    workspace_name = "test_package_manager_requirements_error"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 

--- a/lib/ramble/ramble/test/end_to_end/package_manager_unique_env_dirs.py
+++ b/lib/ramble/ramble/test/end_to_end/package_manager_unique_env_dirs.py
@@ -15,9 +15,7 @@ workspace = RambleCommand("workspace")
 config = RambleCommand("config")
 
 
-def test_env_dirs_do_not_collide(mutable_config, mutable_mock_workspace_path, request):
-    workspace_name = request.node.name
-
+def test_env_dirs_do_not_collide(mutable_config, mutable_mock_workspace_path, workspace_name):
     ws = ramble.workspace.create(workspace_name)
 
     global_args = ["-w", workspace_name]

--- a/lib/ramble/ramble/test/end_to_end/passthrough_variables.py
+++ b/lib/ramble/ramble/test/end_to_end/passthrough_variables.py
@@ -7,6 +7,7 @@
 # except according to those terms.
 
 import os
+import re
 
 import pytest
 
@@ -23,7 +24,9 @@ config = ramble.main.RambleCommand("config")
 workspace = RambleCommand("workspace")
 
 
-def test_passthrough_variables(mutable_config, mutable_mock_workspace_path, mock_applications):
+def test_passthrough_variables(
+    mutable_config, mutable_mock_workspace_path, mock_applications, workspace_name
+):
     test_config = """
 ramble:
   variables:
@@ -47,7 +50,6 @@ ramble:
     packages: {}
     environments: {}
 """
-    workspace_name = "test_config_section_env_vars"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 
@@ -63,8 +65,6 @@ ramble:
         exp1_dir = os.path.join(experiment_root, "basic", "test_wl2", "simple_test")
         exp1_script = os.path.join(exp1_dir, "execute_experiment")
 
-        import re
-
         undefined_regex = re.compile(r"{undefined_var}")
 
         # Assert undefined variable is found
@@ -76,7 +76,7 @@ ramble:
             assert undefined_found
 
 
-def test_disable_passthrough(mutable_config, mutable_mock_workspace_path):
+def test_disable_passthrough(mutable_config, mutable_mock_workspace_path, workspace_name):
     test_config = """
 ramble:
   variables:
@@ -95,7 +95,6 @@ ramble:
     packages: {}
     environments: {}
 """
-    workspace_name = "test_disable_passthrough"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 

--- a/lib/ramble/ramble/test/end_to_end/phase_selection.py
+++ b/lib/ramble/ramble/test/end_to_end/phase_selection.py
@@ -33,7 +33,9 @@ def enable_verbose():
     llnl.util.tty._verbose = old_setting
 
 
-def test_workspace_phase_selection(mutable_config, mutable_mock_workspace_path, enable_verbose):
+def test_workspace_phase_selection(
+    mutable_config, mutable_mock_workspace_path, enable_verbose, workspace_name
+):
     test_config = """
 ramble:
   variants:
@@ -110,7 +112,6 @@ licenses:
       WRF_LICENSE: port@server
 """
 
-    workspace_name = "test_end_to_end_wrfv4"
     with ramble.workspace.create(workspace_name) as ws1:
         ws1.write()
 

--- a/lib/ramble/ramble/test/end_to_end/phase_selection_with_dependencies.py
+++ b/lib/ramble/ramble/test/end_to_end/phase_selection_with_dependencies.py
@@ -34,7 +34,7 @@ def enable_verbose():
 
 @pytest.mark.long
 def test_workspace_phase_selection_with_dependencies(
-    mutable_config, mutable_mock_workspace_path, enable_verbose
+    mutable_config, mutable_mock_workspace_path, enable_verbose, workspace_name
 ):
     test_config = """
 ramble:
@@ -112,7 +112,6 @@ licenses:
       WRF_LICENSE: port@server
 """
 
-    workspace_name = "test_workspace_phase_selection_with_dependencies"
     with ramble.workspace.create(workspace_name) as ws1:
         ws1.write()
 

--- a/lib/ramble/ramble/test/end_to_end/registered_builtin_order.py
+++ b/lib/ramble/ramble/test/end_to_end/registered_builtin_order.py
@@ -21,10 +21,9 @@ pytestmark = pytest.mark.usefixtures(
 workspace = RambleCommand("workspace")
 
 
-def test_registered_builtin_order(request):
-    ws_name = request.node.name
-    ws = ramble.workspace.create(ws_name)
-    global_args = ["-w", ws_name]
+def test_registered_builtin_order(workspace_name):
+    ws = ramble.workspace.create(workspace_name)
+    global_args = ["-w", workspace_name]
 
     workspace(
         "manage",

--- a/lib/ramble/ramble/test/end_to_end/setup_analyze.py
+++ b/lib/ramble/ramble/test/end_to_end/setup_analyze.py
@@ -32,7 +32,7 @@ pytestmark = [
 ws_cmd = RambleCommand("workspace")
 
 
-def test_setup_analyze(test_case_path, request):
+def test_setup_analyze(test_case_path, workspace_name):
     """test_setup_analyze tests ramble objects that contain a `test_cases` directory.
 
     Specifically, it assumes the following structure for the `test_cases` directory:
@@ -63,9 +63,8 @@ def test_setup_analyze(test_case_path, request):
             else:
                 shutil.copy(item, dest)
 
-    ws_name = request.node.name.replace("[", "_").replace("]", "_")
-    global_args = ["-w", ws_name]
-    ws = ramble.workspace.create(ws_name)
+    global_args = ["-w", workspace_name]
+    ws = ramble.workspace.create(workspace_name)
     ws.write()
     src_config_dir_path = test_case_path / "configs"
     if src_config_dir_path.is_dir():

--- a/lib/ramble/ramble/test/end_to_end/shared_context.py
+++ b/lib/ramble/ramble/test/end_to_end/shared_context.py
@@ -28,7 +28,11 @@ workspace = RambleCommand("workspace")
 
 
 def test_shared_contexts(
-    mutable_config, mutable_mock_workspace_path, mock_applications, mock_modifiers
+    mutable_config,
+    mutable_mock_workspace_path,
+    mock_applications,
+    mock_modifiers,
+    workspace_name,
 ):
     test_config = """
 ramble:
@@ -52,7 +56,6 @@ ramble:
     packages: {}
     environments: {}
 """
-    workspace_name = "test_shared_context"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 

--- a/lib/ramble/ramble/test/end_to_end/short_builtin_dep_name.py
+++ b/lib/ramble/ramble/test/end_to_end/short_builtin_dep_name.py
@@ -22,7 +22,7 @@ pytestmark = pytest.mark.usefixtures(
 workspace = RambleCommand("workspace")
 
 
-def test_short_builtin_dep_name(mock_applications):
+def test_short_builtin_dep_name(mock_applications, workspace_name):
     test_config = """
 ramble:
   variants:
@@ -42,8 +42,7 @@ ramble:
     packages: {}
     environments: {}
 """
-    ws_name = "test_short_builtin_dep_name"
-    ws = ramble.workspace.create(ws_name)
+    ws = ramble.workspace.create(workspace_name)
     ramble.workspace.activate(ws)
     ws.write()
 
@@ -55,4 +54,4 @@ ramble:
     ws._re_read()
 
     with pytest.raises(GraphNodeAmbiguousError):
-        workspace("setup", "--dry-run", global_args=["-w", ws_name])
+        workspace("setup", "--dry-run", global_args=["-w", workspace_name])

--- a/lib/ramble/ramble/test/end_to_end/spack_env_cache.py
+++ b/lib/ramble/ramble/test/end_to_end/spack_env_cache.py
@@ -25,7 +25,7 @@ pytestmark = pytest.mark.usefixtures(
 workspace = RambleCommand("workspace")
 
 
-def test_spack_env_cache():
+def test_spack_env_cache(workspace_name):
     test_config = """
 ramble:
   variants:
@@ -71,7 +71,6 @@ ramble:
         - intel-mpi
 """
     try:
-        workspace_name = "test-spack-env-cache"
         ws = ramble.workspace.create(workspace_name)
         ws.write()
 

--- a/lib/ramble/ramble/test/end_to_end/tag_filtering.py
+++ b/lib/ramble/ramble/test/end_to_end/tag_filtering.py
@@ -47,6 +47,7 @@ def test_workspace_tag_filtering(
     tag,
     expected_experiments,
     unexpected_experiments,
+    workspace_name,
 ):
     test_config = """
 ramble:
@@ -77,7 +78,6 @@ ramble:
     environments: {}
 """
 
-    workspace_name = f"test_tag_filtering_{tag}"
     with ramble.workspace.create(workspace_name) as ws1:
         ws1.write()
 

--- a/lib/ramble/ramble/test/end_to_end/template.py
+++ b/lib/ramble/ramble/test/end_to_end/template.py
@@ -22,7 +22,7 @@ pytestmark = pytest.mark.usefixtures(
 workspace = RambleCommand("workspace")
 
 
-def test_template():
+def test_template(workspace_name):
     test_config = """
 ramble:
   variables:
@@ -39,7 +39,6 @@ ramble:
                 n_nodes: 1
                 hello_name: santa
 """
-    workspace_name = "test_template"
     ws = ramble.workspace.create(workspace_name)
     ws.write()
     config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
@@ -81,7 +80,7 @@ ramble:
     assert "script.sh" in files
 
 
-def test_template_inherited():
+def test_template_inherited(workspace_name):
     test_config = """
 ramble:
   variables:
@@ -96,7 +95,6 @@ ramble:
           experiments:
             test: {}
 """
-    workspace_name = "test_template_inherited"
     ws = ramble.workspace.create(workspace_name)
     ws.write()
     config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
@@ -120,7 +118,7 @@ ramble:
     assert os.path.isfile(script_path)
 
 
-def test_executable_templates_no_trailing_spaces(mutable_mock_apps_repo):
+def test_executable_templates_no_trailing_spaces(mutable_mock_apps_repo, workspace_name):
     test_config = """
 ramble:
   variables:
@@ -139,7 +137,6 @@ ramble:
     packages: {}
     environments: {}
 """
-    workspace_name = "test_executable_templates_no_trailing_spaces"
     ws = ramble.workspace.create(workspace_name)
     ws.write()
     config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
@@ -157,7 +154,7 @@ ramble:
         assert "EOF " not in content
 
 
-def test_template_wrong_extension(mutable_mock_apps_repo):
+def test_template_wrong_extension(mutable_mock_apps_repo, workspace_name):
     template_src_name = "template_wrong_extension.sh"
     ext = constants.TEMPLATE_EXTENSION
     test_config = f"""
@@ -175,7 +172,6 @@ ramble:
           experiments:
             test: {{}}
 """
-    workspace_name = "test_template_wrong_extension"
     ws = ramble.workspace.create(workspace_name)
     ws.write()
     config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)

--- a/lib/ramble/ramble/test/end_to_end/unused_compilers_are_skipped.py
+++ b/lib/ramble/ramble/test/end_to_end/unused_compilers_are_skipped.py
@@ -25,7 +25,9 @@ pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_p
 workspace = RambleCommand("workspace")
 
 
-def test_unused_compilers_are_skipped(mutable_config, mutable_mock_workspace_path, capsys):
+def test_unused_compilers_are_skipped(
+    mutable_config, mutable_mock_workspace_path, capsys, workspace_name
+):
     test_config = """
 ramble:
   variants:
@@ -69,7 +71,6 @@ ramble:
     setup_cls = ramble.pipeline.pipeline_class(setup_type)
     filters = ramble.filters.Filters()
 
-    workspace_name = "test_unused_compilers_are_skipped"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 

--- a/lib/ramble/ramble/test/end_to_end/variant_propagation.py
+++ b/lib/ramble/ramble/test/end_to_end/variant_propagation.py
@@ -19,12 +19,11 @@ workspace = RambleCommand("workspace")
 
 
 def test_variant_propagation_in_new_workspace(
-    mutable_config, mutable_mock_workspace_path, request
+    mutable_config, mutable_mock_workspace_path, workspace_name
 ):
-    ws_name = request.node.name
     ramble.config.add("variants:package_manager:spack")
     ramble.config.add("variants:workflow_manager:slurm")
-    with ramble.workspace.create(ws_name) as ws1:
+    with ramble.workspace.create(workspace_name) as ws1:
         ws1.write()
 
         config_path = ws1.config_file_path

--- a/lib/ramble/ramble/test/end_to_end/vector_workloads.py
+++ b/lib/ramble/ramble/test/end_to_end/vector_workloads.py
@@ -21,7 +21,7 @@ pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_p
 workspace = RambleCommand("workspace")
 
 
-def test_vector_workloads(mutable_config, mutable_mock_workspace_path):
+def test_vector_workloads(mutable_config, mutable_mock_workspace_path, workspace_name):
     test_config = """
 ramble:
   variables:
@@ -43,7 +43,6 @@ ramble:
     packages: {}
     environments: {}
 """
-    workspace_name = "test_vector_workloads"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 

--- a/lib/ramble/ramble/test/end_to_end/workspace_includes.py
+++ b/lib/ramble/ramble/test/end_to_end/workspace_includes.py
@@ -24,8 +24,7 @@ pytestmark = pytest.mark.usefixtures(
 workspace = RambleCommand("workspace")
 
 
-def test_workspace_add_includes(request):
-    workspace_name = request.node.name
+def test_workspace_add_includes(workspace_name):
     ws = ramble.workspace.create(workspace_name)
     global_args = ["-w", workspace_name]
 
@@ -52,8 +51,7 @@ def test_workspace_add_includes(request):
         assert "- $workspace_configs/auxiliary_software_files" in data
 
 
-def test_workspace_remove_includes_index(request):
-    workspace_name = request.node.name
+def test_workspace_remove_includes_index(workspace_name):
     ws = ramble.workspace.create(workspace_name)
     global_args = ["-w", workspace_name]
 
@@ -96,8 +94,7 @@ def test_workspace_remove_includes_index(request):
         assert "- $workspace_configs/auxiliary_software_files" not in data
 
 
-def test_workspace_remove_includes_pattern(request):
-    workspace_name = request.node.name
+def test_workspace_remove_includes_pattern(workspace_name):
     ws = ramble.workspace.create(workspace_name)
     global_args = ["-w", workspace_name]
 

--- a/lib/ramble/ramble/test/end_to_end/wrfv4_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/wrfv4_dry_run.py
@@ -25,7 +25,7 @@ workspace = RambleCommand("workspace")
 
 
 @pytest.mark.long
-def test_wrfv4_spack_dry_run(mutable_config, mutable_mock_workspace_path):
+def test_wrfv4_spack_dry_run(mutable_config, mutable_mock_workspace_path, workspace_name):
     test_config = """
 ramble:
   variants:
@@ -119,7 +119,6 @@ compilers:
     extra_rpaths: []
 """
 
-    workspace_name = "test_end_to_end_wrfv4"
     with ramble.workspace.create(workspace_name) as ws1:
         ws1.write()
 
@@ -321,7 +320,7 @@ compilers:
 
 
 @pytest.mark.maybeslow
-def test_wrfv4_no_pkg_man_dry_run(mutable_config, mutable_mock_workspace_path):
+def test_wrfv4_no_pkg_man_dry_run(mutable_config, mutable_mock_workspace_path, workspace_name):
     test_config = """
 ramble:
   variables:
@@ -374,7 +373,6 @@ licenses:
       WRF_LICENSE: port@server
 """
 
-    workspace_name = "test_end_to_end_wrfv4"
     with ramble.workspace.create(workspace_name) as ws1:
         ws1.write()
 

--- a/lib/ramble/ramble/test/get_file_path.py
+++ b/lib/ramble/ramble/test/get_file_path.py
@@ -24,7 +24,7 @@ pytestmark = pytest.mark.usefixtures(
 workspace = RambleCommand("workspace")
 
 
-def test_get_file_path(mock_applications, mock_file_auto_create):
+def test_get_file_path(mock_applications, mock_file_auto_create, workspace_name):
     test_config = """
 ramble:
   config:
@@ -45,7 +45,6 @@ ramble:
     packages: {}
     environments: {}
 """
-    workspace_name = "test-get-file-path"
     ws = ramble.workspace.create(workspace_name)
     ws.write()
 

--- a/lib/ramble/ramble/test/modifier_application.py
+++ b/lib/ramble/ramble/test/modifier_application.py
@@ -19,7 +19,7 @@ pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_p
 workspace = RambleCommand("workspace")
 
 
-def test_wrfv4_aps_test(mutable_config, mutable_mock_workspace_path):
+def test_wrfv4_aps_test(mutable_config, mutable_mock_workspace_path, workspace_name):
     test_config = """
 ramble:
   variants:
@@ -63,7 +63,6 @@ ramble:
         - intel-oneapi-vtune
 """
 
-    workspace_name = "test_wrfv4_modified_aps"
     with ramble.workspace.create(workspace_name) as ws1:
         ws1.write()
 

--- a/lib/ramble/ramble/test/modifier_functionality/experiment_modification.py
+++ b/lib/ramble/ramble/test/modifier_functionality/experiment_modification.py
@@ -15,10 +15,8 @@ workspace = RambleCommand("workspace")
 
 
 def test_experiment_modification(
-    mutable_mock_workspace_path, mutable_applications, mock_modifiers, request
+    mutable_mock_workspace_path, mutable_applications, mock_modifiers, workspace_name
 ):
-    workspace_name = request.node.name
-
     test_config = """
 ramble:
   variables:

--- a/lib/ramble/ramble/test/modifier_functionality/mock_env_var_modifiers.py
+++ b/lib/ramble/ramble/test/modifier_functionality/mock_env_var_modifiers.py
@@ -47,10 +47,14 @@ workspace = RambleCommand("workspace")
     ],
 )
 def test_gromacs_dry_run_mock_env_vars_mod(
-    mutable_mock_workspace_path, mutable_applications, mock_modifiers, scope, factory, answer
+    mutable_mock_workspace_path,
+    mutable_applications,
+    mock_modifiers,
+    scope,
+    factory,
+    answer,
+    workspace_name,
 ):
-    workspace_name = "test_gromacs_dry_run_mock_env_vars_mod"
-
     test_modifiers = [
         (scope, factory()),
     ]

--- a/lib/ramble/ramble/test/modifier_functionality/mock_layered_modifications.py
+++ b/lib/ramble/ramble/test/modifier_functionality/mock_layered_modifications.py
@@ -17,10 +17,8 @@ workspace = RambleCommand("workspace")
 
 
 def test_layered_variable_modifications(
-    mutable_mock_workspace_path, mutable_applications, mock_modifiers
+    mutable_mock_workspace_path, mutable_applications, mock_modifiers, workspace_name
 ):
-    workspace_name = "test_gromacs_dry_run_mock_spack_mod"
-
     test_modifiers = [
         (SCOPES.experiment, modifier_helpers.named_modifier("test-mod")),
         (SCOPES.experiment, modifier_helpers.named_modifier("test-mod-2")),

--- a/lib/ramble/ramble/test/modifier_functionality/mock_modifier_dry_run.py
+++ b/lib/ramble/ramble/test/modifier_functionality/mock_modifier_dry_run.py
@@ -38,9 +38,8 @@ def test_gromacs_dry_run_mock_mods(
     mock_modifiers,
     scope,
     modifier_mode,
+    workspace_name,
 ):
-    workspace_name = "test_gromacs_dry_run_mock_mods"
-
     test_modifiers = [
         (scope, modifier_helpers.named_modifier(mock_modifier, modifier_mode)),
     ]

--- a/lib/ramble/ramble/test/modifier_functionality/mock_modifier_phases.py
+++ b/lib/ramble/ramble/test/modifier_functionality/mock_modifier_phases.py
@@ -30,10 +30,8 @@ workspace = RambleCommand("workspace")
     ],
 )
 def test_gromacs_dry_run_mock_mod_phase(
-    mutable_mock_workspace_path, mutable_applications, mock_modifiers, scope
+    mutable_mock_workspace_path, mutable_applications, mock_modifiers, scope, workspace_name
 ):
-    workspace_name = "test_gromacs_dry_run_mock_mod_phase"
-
     test_modifiers = [
         (scope, modifier_helpers.named_modifier("mod-phase")),
     ]

--- a/lib/ramble/ramble/test/modifier_functionality/mock_modifier_spack_configs.py
+++ b/lib/ramble/ramble/test/modifier_functionality/mock_modifier_spack_configs.py
@@ -29,10 +29,8 @@ workspace = RambleCommand("workspace")
     ],
 )
 def test_gromacs_mock_spack_config_mod(
-    mutable_mock_workspace_path, mutable_applications, mock_modifiers, scope
+    mutable_mock_workspace_path, mutable_applications, mock_modifiers, scope, workspace_name
 ):
-    workspace_name = "test_gromacs_mock_spack_config_mod"
-
     test_modifiers = [
         (scope, modifier_helpers.named_modifier("spack-mod")),
     ]

--- a/lib/ramble/ramble/test/modifier_functionality/mock_repeated_modifications.py
+++ b/lib/ramble/ramble/test/modifier_functionality/mock_repeated_modifications.py
@@ -17,10 +17,8 @@ workspace = RambleCommand("workspace")
 
 
 def test_repeated_variable_modifications(
-    mutable_mock_workspace_path, mutable_applications, mock_modifiers, request
+    mutable_mock_workspace_path, mutable_applications, mock_modifiers, workspace_name
 ):
-    workspace_name = request.node.name
-
     test_modifiers = [
         (SCOPES.experiment, modifier_helpers.named_modifier("repeat-var-mod")),
     ]

--- a/lib/ramble/ramble/test/modifier_functionality/mock_spack_modifier.py
+++ b/lib/ramble/ramble/test/modifier_functionality/mock_spack_modifier.py
@@ -30,10 +30,8 @@ workspace = RambleCommand("workspace")
     ],
 )
 def test_gromacs_dry_run_mock_spack_mod(
-    mutable_mock_workspace_path, mutable_applications, mock_modifiers, scope
+    mutable_mock_workspace_path, mutable_applications, mock_modifiers, scope, workspace_name
 ):
-    workspace_name = "test_gromacs_dry_run_mock_spack_mod"
-
     test_modifiers = [
         (scope, modifier_helpers.named_modifier("spack-mod")),
     ]

--- a/lib/ramble/ramble/test/modifier_functionality/modifier_nested_var_dry_run.py
+++ b/lib/ramble/ramble/test/modifier_functionality/modifier_nested_var_dry_run.py
@@ -15,9 +15,8 @@ workspace = RambleCommand("workspace")
 
 
 def test_nested_modifier_var(
-    mutable_mock_workspace_path, mutable_applications, mock_modifiers, request
+    mutable_mock_workspace_path, mutable_applications, mock_modifiers, workspace_name
 ):
-    workspace_name = request.node.name
     global_args = ["-w", workspace_name]
 
     with ramble.workspace.create(workspace_name) as ws1:

--- a/lib/ramble/ramble/test/modifier_functionality/modifier_prepare_analysis.py
+++ b/lib/ramble/ramble/test/modifier_functionality/modifier_prepare_analysis.py
@@ -32,10 +32,8 @@ on_cmd = RambleCommand("on")
     ],
 )
 def test_basic_dry_run_mock_prepare_analysis_mod(
-    mutable_mock_workspace_path, mock_applications, mock_modifiers, scope
+    mutable_mock_workspace_path, mock_applications, mock_modifiers, scope, workspace_name
 ):
-    workspace_name = "test_basic_dry_run_mock_prepare_analysis_mod"
-
     test_modifiers = [(scope, modifier_helpers.named_modifier("prepare-analysis"))]
 
     with ramble.workspace.create(workspace_name) as ws1:

--- a/lib/ramble/ramble/test/modifier_functionality/multi_modifier_dry_run.py
+++ b/lib/ramble/ramble/test/modifier_functionality/multi_modifier_dry_run.py
@@ -50,10 +50,8 @@ workspace = RambleCommand("workspace")
     ],
 )
 def test_gromacs_multi_modifier_dry_run(
-    mutable_mock_workspace_path, mutable_applications, scopes, factories, answers
+    mutable_mock_workspace_path, mutable_applications, scopes, factories, answers, workspace_name
 ):
-    workspace_name = "test_gromacs_multi_modifier_dry_run"
-
     test_modifiers = []
 
     for scope, factory in zip(scopes, factories):

--- a/lib/ramble/ramble/test/modifier_functionality/single_modifier_dry_run.py
+++ b/lib/ramble/ramble/test/modifier_functionality/single_modifier_dry_run.py
@@ -35,10 +35,8 @@ workspace = RambleCommand("workspace")
     ],
 )
 def test_gromacs_single_full_modifier_dry_run(
-    mutable_mock_workspace_path, mutable_applications, scope, factory, answer
+    mutable_mock_workspace_path, mutable_applications, scope, factory, answer, workspace_name
 ):
-    workspace_name = "test_gromacs_single_modifier_dry_run"
-
     test_modifiers = [
         (scope, factory()),
     ]

--- a/lib/ramble/ramble/test/success_criteria_functionality/always_print_foms.py
+++ b/lib/ramble/ramble/test/success_criteria_functionality/always_print_foms.py
@@ -20,7 +20,9 @@ workspace = RambleCommand("workspace")
 ramble_on = RambleCommand("on")
 
 
-def test_always_print_foms(mutable_config, mutable_mock_workspace_path, mock_applications):
+def test_always_print_foms(
+    mutable_config, mutable_mock_workspace_path, mock_applications, workspace_name
+):
     test_config = """
 ramble:
   variables:
@@ -40,7 +42,6 @@ ramble:
     packages: {}
     environments: {}
 """
-    workspace_name = "test_always_print_foms"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 

--- a/lib/ramble/ramble/test/success_criteria_functionality/repeat_success_strict.py
+++ b/lib/ramble/ramble/test/success_criteria_functionality/repeat_success_strict.py
@@ -20,7 +20,9 @@ workspace = RambleCommand("workspace")
 ramble_on = RambleCommand("on")
 
 
-def test_repeat_success_strict(mutable_config, mutable_mock_workspace_path, mock_applications):
+def test_repeat_success_strict(
+    mutable_config, mutable_mock_workspace_path, mock_applications, workspace_name
+):
     test_config = """
 ramble:
   config:
@@ -43,7 +45,6 @@ ramble:
     packages: {}
     environments: {}
 """
-    workspace_name = "test_repeat_success_strict"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 

--- a/lib/ramble/ramble/test/success_criteria_functionality/success_fom_comparison.py
+++ b/lib/ramble/ramble/test/success_criteria_functionality/success_fom_comparison.py
@@ -52,7 +52,14 @@ workspace = RambleCommand("workspace")
     ],
 )
 def test_success_fom_comparison(
-    mutable_config, mutable_mock_workspace_path, mock_applications, value, formula, result, scope
+    mutable_config,
+    mutable_mock_workspace_path,
+    mock_applications,
+    value,
+    formula,
+    result,
+    scope,
+    workspace_name,
 ):
 
     success_criteria_definitions = [
@@ -67,7 +74,6 @@ def test_success_fom_comparison(
         )
     ]
 
-    workspace_name = "test_success_fom_comparison"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 

--- a/lib/ramble/ramble/test/success_criteria_functionality/success_fom_globbing.py
+++ b/lib/ramble/ramble/test/success_criteria_functionality/success_fom_globbing.py
@@ -52,7 +52,14 @@ workspace = RambleCommand("workspace")
     ],
 )
 def test_success_fom_globbing(
-    mutable_config, mutable_mock_workspace_path, mock_applications, value, formula, result, scope
+    mutable_config,
+    mutable_mock_workspace_path,
+    mock_applications,
+    value,
+    formula,
+    result,
+    scope,
+    workspace_name,
 ):
 
     success_criteria_definitions = [
@@ -68,7 +75,6 @@ def test_success_fom_globbing(
         )
     ]
 
-    workspace_name = "test_success_fom_globbing"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 

--- a/lib/ramble/ramble/test/success_criteria_functionality/success_functions.py
+++ b/lib/ramble/ramble/test/success_criteria_functionality/success_functions.py
@@ -20,7 +20,9 @@ workspace = RambleCommand("workspace")
 ramble_on = RambleCommand("on")
 
 
-def test_success_function(mutable_config, mutable_mock_workspace_path, mock_applications):
+def test_success_function(
+    mutable_config, mutable_mock_workspace_path, mock_applications, workspace_name
+):
     test_config = """
 ramble:
   variables:
@@ -40,7 +42,6 @@ ramble:
     packages: {}
     environments: {}
 """
-    workspace_name = "test_success_function"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 

--- a/lib/ramble/ramble/test/success_criteria_functionality/success_modifiers.py
+++ b/lib/ramble/ramble/test/success_criteria_functionality/success_modifiers.py
@@ -48,13 +48,13 @@ def test_success_modifier(
     value,
     result,
     scope,
+    workspace_name,
 ):
 
     modifier = [
         (scope, {"name": "success-criteria"}),
     ]
 
-    workspace_name = "test_success_modifier"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 

--- a/lib/ramble/ramble/test/success_criteria_functionality/success_scoping.py
+++ b/lib/ramble/ramble/test/success_criteria_functionality/success_scoping.py
@@ -20,7 +20,7 @@ workspace = RambleCommand("workspace")
 ramble_on = RambleCommand("on")
 
 
-def test_disconnected_success(mock_applications, request):
+def test_disconnected_success(mock_applications, workspace_name):
     test_config = """
 ramble:
   variables:
@@ -51,7 +51,6 @@ ramble:
     packages: {}
     environments: {}
 """
-    workspace_name = request.node.name
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 

--- a/lib/ramble/ramble/test/success_criteria_functionality/success_variable_fom_comparison.py
+++ b/lib/ramble/ramble/test/success_criteria_functionality/success_variable_fom_comparison.py
@@ -53,7 +53,14 @@ config = RambleCommand("config")
     ],
 )
 def test_success_variable_fom_comparison(
-    mutable_config, mutable_mock_workspace_path, mock_applications, value, formula, result, scope
+    mutable_config,
+    mutable_mock_workspace_path,
+    mock_applications,
+    value,
+    formula,
+    result,
+    scope,
+    workspace_name,
 ):
 
     success_criteria_definitions = [
@@ -68,7 +75,6 @@ def test_success_variable_fom_comparison(
         )
     ]
 
-    workspace_name = "test_success_fom_comparison"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 

--- a/lib/ramble/ramble/test/workflow_manager_functionality/workflow_manager.py
+++ b/lib/ramble/ramble/test/workflow_manager_functionality/workflow_manager.py
@@ -21,9 +21,7 @@ pytestmark = pytest.mark.usefixtures(
 )
 
 
-def test_default_workflow_manager_banner():
-    workspace_name = "test_workflow_manager_default"
-
+def test_default_workflow_manager_banner(workspace_name):
     test_config = """
 ramble:
   variables:

--- a/lib/ramble/ramble/test/workflow_manager_functionality/workflow_manager_foms.py
+++ b/lib/ramble/ramble/test/workflow_manager_functionality/workflow_manager_foms.py
@@ -22,8 +22,7 @@ pytestmark = pytest.mark.usefixtures(
 
 
 @pytest.mark.maybeslow
-def test_workflow_manager_foms(mutable_mock_wms_repo):
-    workspace_name = "test_workflow_manager_foms"
+def test_workflow_manager_foms(mutable_mock_wms_repo, workspace_name):
     test_config = """
 ramble:
   variants:

--- a/lib/ramble/ramble/test/workspace_hashing/unsetup_workspace_cannot_analyze.py
+++ b/lib/ramble/ramble/test/workspace_hashing/unsetup_workspace_cannot_analyze.py
@@ -27,6 +27,7 @@ def test_unsetup_workspace_cannot_analyze(
     mutable_config,
     mutable_mock_workspace_path,
     mock_applications,
+    workspace_name,
 ):
     test_config = """
 ramble:
@@ -58,7 +59,6 @@ ramble:
         packages:
         - zlib
 """
-    workspace_name = "test_unsetup_workspace_cannot_analyze"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 

--- a/lib/ramble/ramble/test/workspace_hashing/workspace_setup_creates_inventory.py
+++ b/lib/ramble/ramble/test/workspace_hashing/workspace_setup_creates_inventory.py
@@ -23,7 +23,7 @@ workspace = RambleCommand("workspace")
 
 
 def test_workspace_setup_creates_inventory(
-    mutable_config, mutable_mock_workspace_path, mock_applications
+    mutable_config, mutable_mock_workspace_path, mock_applications, workspace_name
 ):
     test_config = """
 ramble:
@@ -48,7 +48,6 @@ ramble:
     packages: {}
     environments: {}
 """
-    workspace_name = "test_workspace_setup_creates_inventory"
     with ramble.workspace.create(workspace_name) as ws:
         ws.write()
 


### PR DESCRIPTION
This merge changes the workspace names in tests to use the request fixture so workspace names can be based off of the test name instead of having to hardcode strings for the workspace name.