### PR TITLE
Fix escaped braces expanding an unexpected number of times

### DIFF
--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -12,6 +12,7 @@ import operator
 import random
 import re
 import string
+from contextlib import contextmanager
 from typing import Dict, FrozenSet, List, Union
 
 import ramble.error
@@ -175,6 +176,7 @@ class ExpansionNode:
         evaluation_func=eval,
         no_expand_vars=None,
         used_vars=None,
+        replace_escaped_braces=None,
     ):
         """Define the value for this node.
 
@@ -196,6 +198,8 @@ class ExpansionNode:
                 strings
             no_expand_vars (set): set of variable names that should never be
                 expanded
+            replace_escaped_braces (bool): Whether escaped curly braces are replaced
+                                           as part of expansion or not.
         """
         if no_expand_vars is None:
             no_expand_vars = set()
@@ -240,6 +244,7 @@ class ExpansionNode:
                             expansion_dict,
                             expansion_dict[keyword],
                             allow_passthrough=allow_passthrough,
+                            replace_escaped_braces=replace_escaped_braces,
                         )
                 else:
                     self.value = keyword
@@ -285,7 +290,7 @@ class ExpansionNode:
                     self.value = replaced_contents
 
                 # Replace escaped curly braces with curly braces
-                if isinstance(self.value, str):
+                if replace_escaped_braces and isinstance(self.value, str):
                     self.value = self.value.replace("\\{", "{").replace("\\}", "}")
 
 
@@ -378,6 +383,7 @@ class Expander:
         if no_expand_vars is None:
             no_expand_vars = set()
 
+        self._replace_escaped_braces = True
         self._keywords = ramble.keywords.keywords
 
         self._variables = variables
@@ -523,6 +529,15 @@ class Expander:
 
         return self._experiment_run_dir
 
+    @contextmanager
+    def preserve_escaped_braces(self):
+        previous = self._replace_escaped_braces
+        self._replace_escaped_braces = False
+        try:
+            yield
+        finally:
+            self._replace_escaped_braces = previous
+
     def expand_lists(self, var):
         """Expand a variable into a list if possible
 
@@ -556,6 +571,7 @@ class Expander:
         allow_passthrough: bool = True,
         typed: bool = False,
         merge_used_stage: bool = True,
+        replace_escaped_braces: bool = None,
     ):
         """Convert a variable name to an expansion string, and expand it
 
@@ -571,6 +587,8 @@ class Expander:
             typed (bool): Whether the return type should be typed or not
             merge_used_stage (bool): Whether tracked variables are merged into
                                      the used variable set or not.
+            replace_escaped_braces (bool): Whether escaped curly braces are replaced
+                                           as part of expansion or not.
         """
         return self.expand_var(
             self.expansion_str(var_name),
@@ -587,6 +605,7 @@ class Expander:
         allow_passthrough: bool = True,
         typed: bool = False,
         merge_used_stage: bool = True,
+        replace_escaped_braces=None,
     ):
         """Perform expansion of a string
 
@@ -601,6 +620,8 @@ class Expander:
             typed (bool): Whether the return type should be typed or not
             merge_used_stage (bool): Whether tracked variables are merged into
                                      the used variable set or not.
+            replace_escaped_braces (bool): Whether escaped curly braces are replaced
+                                           as part of expansion or not.
         """
 
         if var is None or var == "None":
@@ -613,6 +634,8 @@ class Expander:
             passthrough_setting = False
 
         logger.debug(f"BEGINNING OF EXPAND_VAR STACK ON {var}")
+        logger.debug(f" REPLACE VAR (1): {replace_escaped_braces}")
+        logger.debug(f" REPLACE VAR (2): {self._replace_escaped_braces}")
         expansions = self._variables
         if extra_vars:
             expansions = self._variables.copy()
@@ -620,7 +643,10 @@ class Expander:
 
         try:
             value = self._partial_expand(
-                expansions, str(var), allow_passthrough=passthrough_setting
+                expansions,
+                str(var),
+                allow_passthrough=passthrough_setting,
+                replace_escaped_braces=replace_escaped_braces,
             )
         except RamblePassthroughError as e:
             if not passthrough_setting:
@@ -719,7 +745,13 @@ class Expander:
     def expansion_str(in_str):
         return f"{ExpansionDelimiter.left}{in_str}{ExpansionDelimiter.right}"
 
-    def _partial_expand(self, expansion_vars, in_str, allow_passthrough=True):
+    def _partial_expand(
+        self,
+        expansion_vars,
+        in_str,
+        allow_passthrough=True,
+        replace_escaped_braces=None,
+    ):
         """Perform expansion of a string with some variables
 
         args:
@@ -728,9 +760,22 @@ class Expander:
           allow_passthrough (bool): Define if variables are allowed to passthrough
                                     without being expanded.
 
+          replace_escaped_braces (bool): Whether escaped curly braces are replaced
+                                         as part of expansion or not.
+
         returns:
           in_str (str): Expanded version of input string
         """
+
+        if replace_escaped_braces is None:
+            replace_escaped_braces = self._replace_escaped_braces
+
+        if not isinstance(replace_escaped_braces, bool):
+            logger.error(
+                "Partial expand called with invalid value "
+                f"for replace_escaped_braces of {replace_escaped_braces}\n"
+                "Value must be a boolean."
+            )
 
         if isinstance(in_str, str):
             str_graph = ExpansionGraph(in_str)
@@ -742,6 +787,7 @@ class Expander:
                     evaluation_func=self.perform_math_eval,
                     no_expand_vars=self._no_expand_vars,
                     used_vars=self._used_variable_stage,
+                    replace_escaped_braces=replace_escaped_braces,
                 )
 
             return str(str_graph.root.value)

--- a/lib/ramble/ramble/test/end_to_end/formatted_executables.py
+++ b/lib/ramble/ramble/test/end_to_end/formatted_executables.py
@@ -273,3 +273,58 @@ ramble:
                         tests[idx] = True
 
         assert all(tests)
+
+
+def test_formatted_executables_escaped_braces(workspace_name):
+    test_config = r"""
+ramble:
+  variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: '{execute_experiment}'
+    processes_per_node: '16'
+    n_threads: '1'
+  internals:
+    custom_executables:
+      escaped_command:
+        template:
+        - 'echo "\{experiment_index\}"'
+        - '{escaped_formatted_exec}'
+    executable_injection:
+    - name: escaped_command
+  formatted_executables:
+    escaped_formatted_exec:
+      commands:
+      - 'echo "\{experiment_namespace\}"'
+  applications:
+    basic:
+      workloads:
+        working_wl:
+          experiments:
+            simple_test:
+              variables:
+                n_nodes: 1
+  software:
+    packages: {}
+    environments: {}
+"""
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+
+        config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+
+        with open(config_path, "w+") as f:
+            f.write(test_config)
+
+        ws._re_read()
+
+        workspace("setup", "--dry-run", global_args=["-w", workspace_name])
+
+        experiment_root = ws.experiment_dir
+        exp_dir = os.path.join(experiment_root, "basic", "working_wl", "simple_test")
+        exp_script = os.path.join(exp_dir, "execute_experiment")
+
+        with open(exp_script) as f:
+            data = f.read()
+            assert r'echo "{experiment_index}"' in data
+            assert r'echo "{experiment_namespace}"' in data
+            assert "{escaped_formatted_exec}" not in data

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -1260,144 +1260,158 @@ class ApplicationBase(metaclass=ApplicationMeta):
         if len(self._command_list) > 0:
             return
 
-        self._command_list = []
-        self._command_list_without_logs = []
+        # Do not replace escaped braces here, to allow them to
+        # be replace properly when templates are written.
+        with self.expander.preserve_escaped_braces():
+            self._command_list = []
+            self._command_list_without_logs = []
 
-        success_list = self.success_list
-        if not success_list:
-            success_list = ramble.success_criteria.ScopedCriteriaList()
+            success_list = self.success_list
+            if not success_list:
+                success_list = ramble.success_criteria.ScopedCriteriaList()
 
-        # Inject all prepended chained experiments
-        for chained_exp in self.chain_prepend:
-            self._command_list.append(self.chain_commands[chained_exp])
-            self._command_list_without_logs.append(
-                self.chain_commands[chained_exp]
-            )
+            # Inject all prepended chained experiments
+            for chained_exp in self.chain_prepend:
+                self._command_list.append(self.chain_commands[chained_exp])
+                self._command_list_without_logs.append(
+                    self.chain_commands[chained_exp]
+                )
 
-        # ensure all log files are purged and set up
-        logs = []
+            # ensure all log files are purged and set up
+            logs = []
 
-        for exec_node in exec_graph.walk():
-            if isinstance(
-                exec_node.attribute, ramble.util.executable.CommandExecutable
-            ):
-                exec_cmd = exec_node.attribute
-                if exec_cmd.redirect:
-                    expanded_log = self.expander.expand_var(exec_cmd.redirect)
-                    logs.append(expanded_log)
+            for exec_node in exec_graph.walk():
+                if isinstance(
+                    exec_node.attribute,
+                    ramble.util.executable.CommandExecutable,
+                ):
+                    exec_cmd = exec_node.attribute
+                    if exec_cmd.redirect:
+                        expanded_log = self.expander.expand_var(
+                            exec_cmd.redirect
+                        )
+                        logs.append(expanded_log)
 
-        analysis_logs, _ = self._analysis_dicts(success_list)
+            analysis_logs, _ = self._analysis_dicts(success_list)
 
-        for log in analysis_logs:
-            logs.append(log)
+            for log in analysis_logs:
+                logs.append(log)
 
-        logs = list(dict.fromkeys(logs))
+            logs = list(dict.fromkeys(logs))
 
-        for log in logs:
-            self._command_list.append('rm -f "%s"' % log)
-            self._command_list.append('touch "%s"' % log)
+            for log in logs:
+                self._command_list.append('rm -f "%s"' % log)
+                self._command_list.append('touch "%s"' % log)
 
-        for exec_node in exec_graph.walk():
-            exec_vars = {"executable_name": exec_node.key}
+            for exec_node in exec_graph.walk():
+                exec_vars = {"executable_name": exec_node.key}
 
-            if isinstance(
-                exec_node.attribute, ramble.util.executable.CommandExecutable
-            ):
-                exec_vars.update(exec_node.attribute.variables)
-
-            for mod in self._modifier_instances:
-                if mod.applies_to_executable(exec_node.key):
-                    exec_vars.update(mod.modded_variables(self, exec_vars))
-
-            if isinstance(
-                exec_node.attribute, ramble.util.executable.CommandExecutable
-            ):
-                # Process directive defined executables
-                base_command = exec_node.attribute.copy()
-                pre_commands = []
-                post_commands = []
+                if isinstance(
+                    exec_node.attribute,
+                    ramble.util.executable.CommandExecutable,
+                ):
+                    exec_vars.update(exec_node.attribute.variables)
 
                 for mod in self._modifier_instances:
                     if mod.applies_to_executable(exec_node.key):
-                        pre_cmd, post_cmd = mod.apply_executable_modifiers(
-                            exec_node.key, base_command, app_inst=self
-                        )
-                        pre_commands.extend(pre_cmd)
-                        post_commands.extend(post_cmd)
+                        exec_vars.update(mod.modded_variables(self, exec_vars))
 
-                command_configs = pre_commands.copy()
-                command_configs.append(base_command)
-                command_configs.extend(post_commands)
+                if isinstance(
+                    exec_node.attribute,
+                    ramble.util.executable.CommandExecutable,
+                ):
+                    # Process directive defined executables
+                    base_command = exec_node.attribute.copy()
+                    pre_commands = []
+                    post_commands = []
 
-                for cmd_conf in command_configs:
-                    mpi_cmd = ""
-                    if cmd_conf.mpi:
-                        raw_mpi_cmd = self.expander.expand_var(
-                            "{mpi_command}", exec_vars
-                        ).strip()
-                        if (
-                            not raw_mpi_cmd
-                            and int(
-                                self.expander.expand_var_name(
-                                    self.keywords.n_nodes
+                    for mod in self._modifier_instances:
+                        if mod.applies_to_executable(exec_node.key):
+                            pre_cmd, post_cmd = mod.apply_executable_modifiers(
+                                exec_node.key, base_command, app_inst=self
+                            )
+                            pre_commands.extend(pre_cmd)
+                            post_commands.extend(post_cmd)
+
+                    command_configs = pre_commands.copy()
+                    command_configs.append(base_command)
+                    command_configs.extend(post_commands)
+
+                    for cmd_conf in command_configs:
+                        mpi_cmd = ""
+                        if cmd_conf.mpi:
+                            raw_mpi_cmd = self.expander.expand_var(
+                                "{mpi_command}",
+                                exec_vars,
+                            ).strip()
+                            if (
+                                not raw_mpi_cmd
+                                and int(
+                                    self.expander.expand_var_name(
+                                        self.keywords.n_nodes
+                                    )
                                 )
+                                > 1
+                            ):
+                                logger.warn(
+                                    f"Command {cmd_conf.name} requires a non-empty `mpi_command` "
+                                    "variable in a multi-node experiment"
+                                )
+                            mpi_cmd = " " + raw_mpi_cmd + " "
+
+                        redirect = ""
+                        if cmd_conf.redirect:
+                            out_log = self.expander.expand_var(
+                                cmd_conf.redirect,
+                                exec_vars,
                             )
-                            > 1
-                        ):
-                            logger.warn(
-                                f"Command {cmd_conf.name} requires a non-empty `mpi_command` "
-                                "variable in a multi-node experiment"
+                            output_operator = cmd_conf.output_capture
+
+                            redirect_mapper = output_mapper()
+                            redirect = redirect_mapper.generate_out_string(
+                                out_log, output_operator
                             )
-                        mpi_cmd = " " + raw_mpi_cmd + " "
 
-                    redirect = ""
-                    if cmd_conf.redirect:
-                        out_log = self.expander.expand_var(
-                            cmd_conf.redirect, exec_vars
-                        )
-                        output_operator = cmd_conf.output_capture
+                        if cmd_conf.run_in_background:
+                            bg_cmd = " &"
+                        else:
+                            bg_cmd = ""
 
-                        redirect_mapper = output_mapper()
-                        redirect = redirect_mapper.generate_out_string(
-                            out_log, output_operator
-                        )
+                        for part in cmd_conf.template:
+                            command_part = f"{mpi_cmd}{part}"
+                            suffix_part = f"{redirect}{bg_cmd}"
 
-                    if cmd_conf.run_in_background:
-                        bg_cmd = " &"
-                    else:
-                        bg_cmd = ""
+                            expanded_cmd = self.expander.expand_var(
+                                command_part,
+                                exec_vars,
+                            ).lstrip()
+                            suffix_cmd = self.expander.expand_var(
+                                suffix_part,
+                                exec_vars,
+                            ).lstrip()
 
-                    for part in cmd_conf.template:
-                        command_part = f"{mpi_cmd}{part}"
-                        suffix_part = f"{redirect}{bg_cmd}"
+                            self._command_list.append(
+                                (expanded_cmd + " " + suffix_cmd).rstrip()
+                            )
+                            self._command_list_without_logs.append(
+                                expanded_cmd
+                            )
 
-                        expanded_cmd = self.expander.expand_var(
-                            command_part, exec_vars
-                        ).lstrip()
-                        suffix_cmd = self.expander.expand_var(
-                            suffix_part, exec_vars
-                        ).lstrip()
+                else:  # All Builtins
+                    func = exec_node.attribute
+                    func_cmds = func()
+                    for cmd in func_cmds:
+                        expanded = self.expander.expand_var(cmd, exec_vars)
+                        self._command_list.append(expanded)
+                        self._command_list_without_logs.append(expanded)
 
-                        self._command_list.append(
-                            (expanded_cmd + " " + suffix_cmd).rstrip()
-                        )
-                        self._command_list_without_logs.append(expanded_cmd)
-
-            else:  # All Builtins
-                func = exec_node.attribute
-                func_cmds = func()
-                for cmd in func_cmds:
-                    expanded = self.expander.expand_var(cmd, exec_vars)
-                    self._command_list.append(expanded)
-                    self._command_list_without_logs.append(expanded)
-
-        # Inject all appended chained experiments
-        for chained_exp in self.chain_append:
-            expanded = self.expander.expand_var(
-                self.chain_commands[chained_exp]
-            )
-            self._command_list.append(expanded)
-            self._command_list_without_logs.append(expanded)
+            # Inject all appended chained experiments
+            for chained_exp in self.chain_append:
+                expanded = self.expander.expand_var(
+                    self.chain_commands[chained_exp]
+                )
+                self._command_list.append(expanded)
+                self._command_list_without_logs.append(expanded)
 
     def _define_formatted_executables(self):
         """Define variables representing the formatted executables
@@ -1463,7 +1477,11 @@ class ApplicationBase(metaclass=ApplicationMeta):
 
                     formatted_lines = []
                     for command in commands_to_format:
-                        expanded = self.expander.expand_var(command)
+                        # Do not replace escaped braces here, to allow them to
+                        # be replace properly when templates are written.
+                        expanded = self.expander.expand_var(
+                            command, replace_escaped_braces=False
+                        )
                         for out_line in expanded.split("\n"):
                             formatted_lines.append(
                                 indentation + prefix + out_line


### PR DESCRIPTION
This merge fixes an issue where escaped curly braces that are used in custom and formatted executables are expanded an unexpected number of times. In this case, the fix allows the expander to *not* strip the escape characters (and leave them for a later expansion pass to strip).

This is then used on some of the expansion calls while building up the internal template definitions but it is not used when the final template is written out. This allows the template writing process (which should be the last call to the expander before output is written to disk) to be the step that actually replaces escaped braces with unescaped braces.