### PR TITLE
Fix workload string representation printing repeated vars

### DIFF
--- a/lib/ramble/ramble/workload.py
+++ b/lib/ramble/ramble/workload.py
@@ -193,8 +193,12 @@ class Workload:
                         out_str += f"{indentation}            {variant}\n"
                 else:
                     out_str += rucolor.nested_2(f"{indentation}        Unconditional\n")
+
+                var_dict = {}
                 for var in var_list:
-                    out_str += var.as_str(n_indent + 12)
+                    var_dict[var.name] = var
+                for var_name in sorted(var_dict.keys()):
+                    out_str += var_dict[var_name].as_str(n_indent + 12)
 
         if self.environment_variables:
             out_str += rucolor.nested_1(f"{indentation}    Environment Variables:\n")


### PR DESCRIPTION
This merge fixes an issue that was introduced with the `when` argument on variable directives.

After `when` was added, variables were placed in a list within the workloads (instead of a dict, which they were in before that change). This change meant that variables were now able to be defined multiple times within the workload, with the understanding that the last definition is the one that would actually apply to the workload.

This merge updates this by building a temporary dictionary of variables in a workload, and using that to print as a string. Additionally, the variables are now sorted by name instead of being printed by insertion order.