### PR TITLE
Add a front-end command for managing modifiers within a workspace

### DIFF
--- a/lib/ramble/docs/workspace.rst
+++ b/lib/ramble/docs/workspace.rst
@@ -231,6 +231,7 @@ Specifically, this command can help you populate values in the ramble.yaml for:
   * Experiment definitions
   * Software definitions
   * Workspace includes
+  * Workspace modifiers
 
 These can be combined over multiple invocations to express very powerful
 experiment configurations. The options are extensive, and are thus not covered
@@ -263,6 +264,21 @@ different version, one may type:
     $ ramble workspace manage software --pkg gcc9 --package-spec gcc@9.4.0 --overwrite
 
 This would update the software package definition names ``gcc9`` to have a new package spec.
+
+Modifiers can be applied to various levels of a workspace configuration. To
+simplify the workflow around adding and removing modifiers from a set of
+experiments, users can use the following commands:
+
+.. code-block:: console
+
+  $ ramble workspace manage modifiers --list
+  $ ramble workspace manage modifiers --add -s workspace -n lscpu
+  $ ramble workspace manage modifiers --remove -s workspace -n lscpu
+
+When performing the ``--remove`` action, the scope argument (``-s``) on these
+commands has a robust syntax that allows users to specify various scopes within
+a workspace (``workspace``, ``application``, ``application:workload``, or
+``application:workload:experiment``).
 
 Finally, ``ramble workspace manage includes`` can be used to quickly and easy
 add includes when using a hierarchical workspace.

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -60,7 +60,7 @@ subcommands = [
     "manage",
 ]
 
-manage_commands = ["experiments", "software", "includes"]
+manage_commands = ["experiments", "software", "includes", "modifiers"]
 
 
 def workspace_activate_setup_parser(subparser):
@@ -1444,6 +1444,134 @@ def workspace_manage_includes(args):
     elif args.add_include:
         with ws.write_transaction():
             ws.add_include(args.add_include)
+
+
+def workspace_manage_modifiers_setup_parser(subparser):
+    """manage workspace modifiers"""
+    actions = subparser.add_mutually_exclusive_group()
+    actions.add_argument(
+        "--list", "-l", action="store_true", help="whether to print existing modifiers"
+    )
+
+    actions.add_argument(
+        "--add",
+        action="store_true",
+        help="whether to remove an existing modifier by index",
+    )
+
+    actions.add_argument(
+        "--remove",
+        action="store_true",
+        help="whether to remove an existing modifier by index",
+    )
+
+    subparser.add_argument(
+        "--mod-index",
+        "-i",
+        dest="remove_index",
+        metavar="INDEX",
+        help="index of modifier to remove, only used with --remove",
+    )
+
+    subparser.add_argument(
+        "--scope",
+        "-s",
+        dest="scope",
+        metavar="SCOPE",
+        default=None,
+        help="scope of modifier to manage. Can be a glob when removing. Of the form "
+        "<application_name>:<workload_name>:<experiment_name> or 'workspace' to "
+        "manage workspace modifiers.",
+    )
+
+    subparser.add_argument(
+        "--name",
+        "-n",
+        dest="name",
+        metavar="NAME",
+        default=None,
+        help="name of modifier to manage. Can be a glob when removing, and defaults to '*'. "
+        "Should be the name of a modifier object.",
+    )
+
+    subparser.add_argument(
+        "--mode",
+        "-m",
+        dest="mode",
+        metavar="MODE",
+        default=None,
+        help="mode of modifier to manage. Can be a glob when removing, and defaults to None, "
+        "using the default for the modifier. ",
+    )
+
+    subparser.add_argument(
+        "--on-executable",
+        "-e",
+        dest="on_executable",
+        metavar="EXEC_LIST",
+        default=None,
+        help="list of 'on_executable' strings to apply for a new modifier. Ignored when removing. "
+        "Should be of the form '[<pattern1>,<pattern2>,<pattern3>...]'",
+    )
+
+    subparser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="whether to print the config without editing it, or to edit it directly.",
+    )
+
+
+def workspace_manage_modifiers(args):
+    """Execute workspace manage modifiers command"""
+
+    ws = ramble.cmd.require_active_workspace(cmd_name="workspace manage modifiers")
+
+    if args.list:
+        with ws.read_transaction():
+            ws.print_modifiers()
+    elif args.remove:
+        remove_index = None
+        if args.remove_index:
+            remove_index = int(args.remove_index)
+
+        with ws.write_transaction():
+            removed = ws.remove_modifier(
+                remove_index=remove_index,
+                scope_pattern=args.scope,
+                name_pattern=args.name,
+                mode_pattern=args.mode,
+                dry_run=args.dry_run,
+            )
+
+            if args.dry_run:
+                ws.print_config()
+
+            if removed > 1:
+                logger.msg(f"Removed {removed} modifiers from workspace.")
+            elif removed == 1:
+                logger.msg(f"Removed {removed} modifier from workspace.")
+            else:
+                logger.msg("No modifiers matched criteria. 0 modifiers removed from workspace.")
+
+    elif args.add:
+        with ws.write_transaction():
+            added = ws.add_modifier(
+                scope=args.scope,
+                name_pattern=args.name,
+                mode=args.mode,
+                on_executable=args.on_executable,
+                dry_run=args.dry_run,
+            )
+
+            if args.dry_run:
+                ws.print_config()
+
+            if added > 1:
+                logger.msg(f"Added {added} modifiers to workspace.")
+            elif added == 1:
+                logger.msg(f"Added {added} modifier to workspace.")
+            else:
+                logger.msg("No modifiers matched criteria. 0 modifiers added to workspace.")
 
 
 def workspace_generate_config_setup_parser(subparser):

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -1448,7 +1448,7 @@ def workspace_manage_includes(args):
 
 def workspace_manage_modifiers_setup_parser(subparser):
     """manage workspace modifiers"""
-    actions = subparser.add_mutually_exclusive_group()
+    actions = subparser.add_mutually_exclusive_group(required=True)
     actions.add_argument(
         "--list", "-l", action="store_true", help="whether to print existing modifiers"
     )
@@ -1469,6 +1469,8 @@ def workspace_manage_modifiers_setup_parser(subparser):
         "--mod-index",
         "-i",
         dest="remove_index",
+        default=None,
+        type=int,
         metavar="INDEX",
         help="index of modifier to remove, only used with --remove",
     )
@@ -1526,13 +1528,10 @@ def workspace_manage_modifiers(args):
 
     ws = ramble.cmd.require_active_workspace(cmd_name="workspace manage modifiers")
 
-    if args.list:
-        with ws.read_transaction():
-            ws.print_modifiers()
-    elif args.remove:
+    if args.remove:
         remove_index = None
-        if args.remove_index:
-            remove_index = int(args.remove_index)
+        if args.remove_index is not None:
+            remove_index = args.remove_index
 
         with ws.write_transaction():
             removed = ws.remove_modifier(
@@ -1572,6 +1571,9 @@ def workspace_manage_modifiers(args):
                 logger.msg(f"Added {added} modifier to workspace.")
             else:
                 logger.msg("No modifiers matched criteria. 0 modifiers added to workspace.")
+    elif args.list:
+        with ws.read_transaction():
+            ws.print_modifiers()
 
 
 def workspace_generate_config_setup_parser(subparser):

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -2335,3 +2335,288 @@ def test_no_inherit_active_workspace_variants(request):
             data = f.read()
             assert "spack" not in data
             assert "slurm" not in data
+
+
+@pytest.mark.parametrize(
+    "mod_scope,mod_conf",
+    [
+        ("workspace", {"name": "lscpu", "mode": "standard", "on_executable": ["*"]}),
+        ("basic", {"name": "lscpu"}),
+        ("basic:test_wl", {"name": "lscpu", "mode": "standard"}),
+        ("basic:test_wl:generated", {"name": "lscpu", "on_executable": ["*"]}),
+    ],
+)
+def test_manage_single_modifiers(workspace_name, mod_scope, mod_conf):
+    global_args = ["-w", workspace_name]
+
+    with ramble.workspace.create(workspace_name) as ws:
+
+        workspace(
+            "manage",
+            "experiments",
+            "basic",
+            "--wf",
+            "test_wl",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            global_args=global_args,
+        )
+
+        list_output = workspace("manage", "modifiers", "--list", global_args=global_args)
+
+        assert "Workspace contains 0 modifiers" in list_output
+
+        with open(ws.config_file_path) as f:
+            data = f.read()
+            assert "modifiers" not in data
+            assert mod_conf["name"] not in data
+
+        add_args = ["-s", mod_scope, "-n", mod_conf["name"]]
+        remove_args = ["-s", mod_scope, "-n", mod_conf["name"]]
+        if "mode" in mod_conf:
+            add_args.append("-m")
+            add_args.append(mod_conf["mode"])
+            remove_args.append("-m")
+            remove_args.append(mod_conf["mode"])
+
+        on_exec_str = None
+        if "on_executable" in mod_conf:
+            on_exec_str = "[" + ",".join(mod_conf["on_executable"]) + "]"
+            add_args.append("-e")
+            add_args.append(on_exec_str)
+
+        workspace("manage", "modifiers", "--add", *add_args, global_args=global_args)
+
+        list_output = workspace("manage", "modifiers", "--list", global_args=global_args)
+
+        assert f"Modifier scope: {mod_scope}" in list_output
+        assert f"Name: {mod_conf['name']}" in list_output
+        if "mode" in mod_conf:
+            assert f"Mode: {mod_conf['mode']}" in list_output
+
+        with open(ws.config_file_path) as f:
+            data = f.read()
+            assert "modifiers" in data
+            assert f"- name: {mod_conf['name']}" in data
+            if "mode" in mod_conf:
+                assert f"mode: {mod_conf['mode']}" in data
+            if on_exec_str is not None:
+                assert "on_executable" in data
+
+        workspace("manage", "modifiers", "--remove", *remove_args, global_args=global_args)
+
+        list_output = workspace("manage", "modifiers", "--list", global_args=global_args)
+
+        assert "Workspace contains 0 modifiers" in list_output
+
+        with open(ws.config_file_path) as f:
+            data = f.read()
+            assert "modifiers" not in data
+            assert mod_conf["name"] not in data
+
+
+def test_manage_modifier_remove_scope_globs(workspace_name):
+    global_args = ["-w", workspace_name]
+    mod_scope = "workspace"
+
+    with ramble.workspace.create(workspace_name) as ws:
+
+        workspace(
+            "manage",
+            "experiments",
+            "basic",
+            "--wf",
+            "test_wl",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            global_args=global_args,
+        )
+
+        list_output = workspace("manage", "modifiers", "--list", global_args=global_args)
+
+        assert "Workspace contains 0 modifiers" in list_output
+
+        with open(ws.config_file_path) as f:
+            data = f.read()
+            assert "modifiers" not in data
+            assert "intel-aps" not in data
+            assert "intel-vtune" not in data
+
+        workspace(
+            "manage",
+            "modifiers",
+            "--add",
+            "-s",
+            "workspace",
+            "-n",
+            "intel-aps",
+            global_args=global_args,
+        )
+        workspace(
+            "manage",
+            "modifiers",
+            "--add",
+            "-s",
+            "basic:test_wl",
+            "-n",
+            "intel-vtune",
+            global_args=global_args,
+        )
+        workspace(
+            "manage",
+            "modifiers",
+            "--add",
+            "-s",
+            "basic:test_wl:generated",
+            "-n",
+            "intel-vtune",
+            global_args=global_args,
+        )
+
+        list_output = workspace("manage", "modifiers", "--list", global_args=global_args)
+
+        assert "Workspace contains 3 modifiers" in list_output
+        assert f"Modifier scope: {mod_scope}" in list_output
+        assert "Name: intel-aps" in list_output
+        assert "Name: intel-vtune" in list_output
+
+        with open(ws.config_file_path) as f:
+            data = f.read()
+            assert "modifiers" in data
+            assert "- name: intel-aps" in data
+            assert "- name: intel-vtune" in data
+
+        workspace(
+            "manage", "modifiers", "--remove", "-s", "*", "-n", "intel*", global_args=global_args
+        )
+
+        list_output = workspace("manage", "modifiers", "--list", global_args=global_args)
+
+        assert "Workspace contains 0 modifiers" in list_output
+
+        with open(ws.config_file_path) as f:
+            data = f.read()
+            assert "modifiers" not in data
+            assert "intel-aps" not in data
+            assert "intel-tune" not in data
+
+
+def test_manage_modifier_name_globs(workspace_name):
+    global_args = ["-w", workspace_name]
+    mod_scope = "workspace"
+
+    with ramble.workspace.create(workspace_name) as ws:
+
+        workspace(
+            "manage",
+            "experiments",
+            "basic",
+            "--wf",
+            "test_wl",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            global_args=global_args,
+        )
+
+        list_output = workspace("manage", "modifiers", "--list", global_args=global_args)
+
+        assert "Workspace contains 0 modifiers" in list_output
+
+        with open(ws.config_file_path) as f:
+            data = f.read()
+            assert "modifiers" not in data
+            assert "intel" not in data
+
+        add_args = ["-s", mod_scope, "-n", "intel*"]
+        remove_args = ["-s", mod_scope, "-n", "intel*"]
+
+        workspace("manage", "modifiers", "--add", *add_args, global_args=global_args)
+
+        list_output = workspace("manage", "modifiers", "--list", global_args=global_args)
+
+        assert "Workspace contains 2 modifiers" in list_output
+        assert f"Modifier scope: {mod_scope}" in list_output
+        assert "Name: intel" in list_output
+
+        with open(ws.config_file_path) as f:
+            data = f.read()
+            assert "modifiers" in data
+            assert "- name: intel" in data
+
+        workspace("manage", "modifiers", "--remove", *remove_args, global_args=global_args)
+
+        list_output = workspace("manage", "modifiers", "--list", global_args=global_args)
+
+        assert "Workspace contains 0 modifiers" in list_output
+
+        with open(ws.config_file_path) as f:
+            data = f.read()
+            assert "modifiers" not in data
+            assert "intel" not in data
+
+
+def test_manage_modifier_no_modifier_errors(workspace_name):
+    global_args = ["-w", workspace_name]
+    name_pattern = "no-matching-mod-name"
+
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+        err_str = f"Error: No modifiers found matching name pattern of {name_pattern}"
+        output = workspace(
+            "manage",
+            "modifiers",
+            "--add",
+            "-s",
+            "workspace",
+            "-n",
+            name_pattern,
+            global_args=global_args,
+        )
+        assert err_str in output
+
+
+@pytest.mark.parametrize(
+    "action,scope,error_message",
+    [
+        ("--add", "blarg", "No scope matches requested scope of blarg"),
+        ("--add", "foo:test_wl:generated", "No application matches requested scope foo"),
+        ("--add", "basic:foo", "No workload matches requested scope foo in application basic"),
+        (
+            "--add",
+            "basic:test_wl:foo",
+            "No experiment matches requested scope foo in application basic and workload test_wl",
+        ),
+        ("--remove", "blarg", "No existing modifiers match requested criteria"),
+        ("--remove", "foo:test_wl:generated", "No existing modifiers match requested criteria"),
+        ("--remove", "basic:foo", "No existing modifiers match requested criteria"),
+        ("--remove", "basic:test_wl:foo", "No existing modifiers match requested criteria"),
+    ],
+)
+def test_manage_modifier_invalid_scope_errors(workspace_name, action, scope, error_message):
+    global_args = ["-w", workspace_name]
+
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+        workspace(
+            "manage",
+            "experiments",
+            "basic",
+            "--wf",
+            "test_wl",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            global_args=global_args,
+        )
+        with pytest.raises(ramble.error.RambleCommandError) as err:
+            workspace(
+                "manage", "modifiers", action, "-s", scope, "-n", "lscpu", global_args=global_args
+            )
+            assert error_message in err

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -2417,6 +2417,93 @@ def test_manage_single_modifiers(workspace_name, mod_scope, mod_conf):
             assert mod_conf["name"] not in data
 
 
+def test_manage_modifier_index_remove(workspace_name):
+    global_args = ["-w", workspace_name]
+
+    with ramble.workspace.create(workspace_name):
+        workspace(
+            "manage",
+            "experiments",
+            "basic",
+            "--wf",
+            "test_wl",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            global_args=global_args,
+        )
+
+        output = workspace(
+            "manage",
+            "modifiers",
+            "--add",
+            "-s",
+            "workspace",
+            "-n",
+            "lscpu",
+            global_args=global_args,
+        )
+
+        assert "Added 1 modifier to workspace" in output
+
+        output = workspace(
+            "manage",
+            "modifiers",
+            "--remove",
+            "-i",
+            "0",
+            global_args=global_args,
+        )
+
+        assert "Removed 1 modifier from workspace" in output
+
+
+def test_manage_modifier_no_modifiers(workspace_name):
+    global_args = ["-w", workspace_name]
+
+    with ramble.workspace.create(workspace_name):
+
+        workspace(
+            "manage",
+            "experiments",
+            "basic",
+            "--wf",
+            "test_wl",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            global_args=global_args,
+        )
+
+        output = workspace(
+            "manage",
+            "modifiers",
+            "--add",
+            "-s",
+            "workspace",
+            "-n",
+            "not-a-modifier",
+            global_args=global_args,
+        )
+
+        assert "0 modifiers added" in output
+
+        output = workspace(
+            "manage",
+            "modifiers",
+            "--remove",
+            "-s",
+            "workspace",
+            "-n",
+            "not-a-modifier",
+            global_args=global_args,
+        )
+
+        assert "0 modifiers removed" in output
+
+
 def test_manage_modifier_remove_scope_globs(workspace_name):
     global_args = ["-w", workspace_name]
     mod_scope = "workspace"
@@ -2592,13 +2679,9 @@ def test_manage_modifier_no_modifier_errors(workspace_name):
             "basic:test_wl:foo",
             "No experiment matches requested scope foo in application basic and workload test_wl",
         ),
-        ("--remove", "blarg", "No existing modifiers match requested criteria"),
-        ("--remove", "foo:test_wl:generated", "No existing modifiers match requested criteria"),
-        ("--remove", "basic:foo", "No existing modifiers match requested criteria"),
-        ("--remove", "basic:test_wl:foo", "No existing modifiers match requested criteria"),
     ],
 )
-def test_manage_modifier_invalid_scope_errors(workspace_name, action, scope, error_message):
+def test_manage_modifier_add_invalid_scope_errors(workspace_name, action, scope, error_message):
     global_args = ["-w", workspace_name]
 
     with ramble.workspace.create(workspace_name) as ws:
@@ -2615,8 +2698,42 @@ def test_manage_modifier_invalid_scope_errors(workspace_name, action, scope, err
             "n_nodes=1",
             global_args=global_args,
         )
+
         with pytest.raises(ramble.error.RambleCommandError) as err:
             workspace(
                 "manage", "modifiers", action, "-s", scope, "-n", "lscpu", global_args=global_args
             )
             assert error_message in err
+
+
+@pytest.mark.parametrize(
+    "action,scope,error_message",
+    [
+        ("--remove", "blarg", "No modifiers matched criteria"),
+        ("--remove", "foo:test_wl:generated", "No modifiers matched criteria"),
+        ("--remove", "basic:foo", "No modifiers matched criteria"),
+        ("--remove", "basic:test_wl:foo", "No modifiers matched criteria"),
+    ],
+)
+def test_manage_modifier_remove_invalid_scope_errors(workspace_name, action, scope, error_message):
+    global_args = ["-w", workspace_name]
+
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+        workspace(
+            "manage",
+            "experiments",
+            "basic",
+            "--wf",
+            "test_wl",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            global_args=global_args,
+        )
+
+        output = workspace(
+            "manage", "modifiers", action, "-s", scope, "-n", "lscpu", global_args=global_args
+        )
+        assert error_message in output

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -14,11 +14,13 @@ import os
 import re
 import shutil
 from collections import defaultdict
+from typing import List
 
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 import llnl.util.tty.log as log
 
+import ramble.cmd.common.list as list_cmd
 import ramble.config
 import ramble.context
 import ramble.error
@@ -1989,6 +1991,253 @@ ramble:
             self._workspace_path_replacements = self.get_workspace_paths(self.root)
 
         return self._workspace_path_replacements
+
+    def _get_scope_section(self, scope):
+        base_section = None
+        if scope == "workspace":
+            base_section = self.config_sections["workspace"]["yaml"][namespace.ramble]
+
+        else:
+            scope_parts = scope.split(":")
+            base_section = self.config_sections["workspace"]["yaml"][namespace.ramble][
+                namespace.application
+            ]
+
+            if len(scope_parts) >= 1:  # Extract application section
+                if scope_parts[0] not in base_section:
+                    logger.die(f"No application matches requested scope {scope_parts[0]}")
+                base_section = base_section[scope_parts[0]]
+
+            if len(scope_parts) >= 2:  # Extract workload section
+                if scope_parts[1] not in base_section[namespace.workload]:
+                    logger.die(
+                        f"No workload matches requested scope {scope_parts[1]} "
+                        f"in application {scope_parts[0]}"
+                    )
+                base_section = base_section[namespace.workload][scope_parts[1]]
+
+            if len(scope_parts) >= 3:  # Extract experiment section
+                if scope_parts[2] not in base_section[namespace.experiment]:
+                    logger.die(
+                        f"No experiment matches requested scope {scope_parts[1]} in application "
+                        f"{scope_parts[0]} and workload {scope_parts[1]}"
+                    )
+
+                base_section = base_section[namespace.experiment][scope_parts[2]]
+        if base_section is None:
+            logger.die(f"No scope matches requested scope of {scope}")
+        return base_section
+
+    def index_modifiers(self):
+        """Construct a list of all modifiers in this workspace, and their associated scope.
+
+        Returns:
+            (list): List of tuples, of the form (scope, modifier_definition)
+        """
+        mod_list = []
+        base_section = self._get_scope_section("workspace")
+        ws_mods = base_section[namespace.modifiers] if namespace.modifiers in base_section else []
+
+        # Add workspace modifiers
+        for mod in ws_mods:
+            mod_list.append(("workspace", mod))
+
+        # Define scoped modifiers
+        for workloads, application_context in self.all_applications():
+            app_context = f"{application_context.context_name}"
+            for mod in application_context.modifiers:
+                mod_list.append((f"{app_context}", mod))
+
+            for experiments, workload_context in self.all_workloads(workloads):
+                wl_context = f"{app_context}:{workload_context.context_name}"
+                for mod in workload_context.modifiers:
+                    mod_list.append((f"{wl_context}", mod))
+
+                for _, experiment_context in self.all_experiments(experiments):
+                    exp_context = f"{wl_context}:{experiment_context.context_name}"
+                    for mod in experiment_context.modifiers:
+                        mod_list.append((f"{exp_context}", mod))
+
+        return mod_list
+
+    def print_modifiers(self):
+        """Print an indexed list of all modifiers in this workspace"""
+        mod_list = self.index_modifiers()
+
+        logger.all_msg(f"Workspace contains {len(mod_list)} modifiers.")
+        logger.all_msg("Additional modifiers may come from scopes outside of wokrspace")
+        logger.all_msg("To see a complete list of these, use:")
+        logger.all_msg("   ramble config get modifiers\n\n")
+
+        prev_scope = None
+        for idx, conf in enumerate(mod_list):
+            scope = conf[0]
+            entry = conf[1]
+            if scope != prev_scope:
+                if prev_scope is not None:
+                    logger.all_msg("")
+                logger.all_msg(f"Modifier scope: {scope}")
+                prev_scope = scope
+            name = entry["name"]
+            mode_str = ""
+            if "mode" in entry and entry["mode"] is not None:
+                mode_str = f" -- Mode: {entry['mode']}"
+
+            out_str = f"Name: {name}{mode_str}"
+
+            logger.all_msg(f"{idx}: {out_str}")
+
+    def remove_modifier(
+        self,
+        remove_index: int = None,
+        scope_pattern: str = None,
+        name_pattern: str = None,
+        mode_pattern: str = None,
+        dry_run: bool = False,
+    ):
+        """Remove an arbitrary number of modifiers from this workspace based
+        on some input arguments.
+
+        Args:
+            remove_index: Index of modifier to remove. Indices match ordering
+                          from the output of print_modifiers
+            scope_pattern: Pattern to select which scopes to remove modifiers from.
+                           If the pattern matches multiple scopes, each will
+                           have matching modifiers removed from them.
+            name_pattern: Pattern to select which modifier names should be removed.
+                          Modifiers with matching names that are in included
+                          scopes will be removed. If the scope doesn't match,
+                          but the name does, the modifier will not be removed.
+            mode_pattern: Pattern to select which modes should be removed. Only
+                          Modifiers which match the scope and name patterns will be
+                          considered for removal, but this can be used to downselect further.
+            dry_run: Whether to print the config instead of editing it, or to edit it directly.
+
+        Returns:
+            (int) Number of modifiers removed
+        """
+        mod_list = self.index_modifiers()
+        to_remove = []
+
+        if remove_index is not None:
+            if not isinstance(remove_index, int):
+                logger.error(
+                    "Cannot remove modifier index without an integer index. "
+                    f"Given index was {remove_index}"
+                )
+
+            if remove_index < 0 or remove_index > len(mod_list):
+                logger.error(
+                    f"Modifier index {remove_index} is outside of the range of modifiers."
+                    "Use `ramble worksapce manage modifiers --list` to see indices"
+                )
+
+            to_remove.append(mod_list[remove_index])
+
+        if scope_pattern is not None:
+            if name_pattern is None:
+                name_pattern = "*"
+            if mode_pattern is None:
+                mode_pattern = "*"
+
+            for mod_tup in mod_list:
+                scope = mod_tup[0]
+                mod_conf = mod_tup[1]
+                if fnmatch.fnmatch(scope, scope_pattern):
+                    if fnmatch.fnmatch(mod_conf["name"], name_pattern):
+                        if "mode" in mod_conf and fnmatch.fnmatch(mod_conf["mode"], mode_pattern):
+                            to_remove.append(mod_tup)
+                        else:
+                            to_remove.append(mod_tup)
+
+        if not to_remove:
+            logger.die("No existing modifiers match requested criteria.")
+
+        removed = 0
+        for mod_tup in to_remove:
+            base_section = self._get_scope_section(mod_tup[0])
+
+            if base_section is not None:
+                base_mods = base_section[namespace.modifiers]
+                remove_index = -1
+                for idx, ws_mod in enumerate(base_mods):
+                    if ws_mod == mod_tup[1]:
+                        remove_index = idx
+                        break
+                if remove_index != -1:
+                    removed += 1
+                    del base_mods[remove_index]
+
+                if not base_section[namespace.modifiers]:
+                    del base_section[namespace.modifiers]
+
+                if not dry_run:
+                    self._write_config(config_section)
+        return removed
+
+    def add_modifier(
+        self,
+        scope: str = None,
+        name_pattern: str = None,
+        mode: str = None,
+        on_executable: List[str] = None,
+        dry_run: bool = False,
+    ):
+        """Add an arbitrary number of modifiers to this workspace within a single scope
+
+        Args:
+            scope: Scope to add modifiers within.
+            name_pattern: Pattern to determine which modifiers should be added.
+                          If multiple modifiers match, all will be added with
+                          the additional arguments.
+            mode: Mode to set within the new modifier definitions
+            on_executable: List of strings to set for the on_executable
+                           attribute of the new modifier definitions.
+            dry_run: Whether to print the config instead of editing it, or to edit it directly.
+
+        Returns:
+            (int) Number of modifiers added to workspace
+        """
+
+        class Filters:
+            def __init__(self):
+                self.filter = []
+                self.search_description = False
+
+        on_exec_list = None
+        if on_executable is not None:
+            on_exec_list = syaml.syaml_list()
+            on_exec_list.extend(on_executable[1:-1].split(","))
+
+        base_section = self._get_scope_section(scope)
+
+        if namespace.modifiers not in base_section:
+            base_section[namespace.modifiers] = syaml.syaml_list()
+
+        filters = Filters()
+        filters.filter.append(name_pattern)
+
+        mod_type = ramble.repository.ObjectTypes.modifiers
+        objs = set(ramble.repository.all_object_names(mod_type))
+        mod_names = list_cmd.filter_by_name(objs, filters, mod_type)
+
+        if len(mod_names) < 1:
+            logger.error(f"No modifiers found matching name pattern of {name_pattern}")
+
+        added = 0
+        for mod_name in mod_names:
+            mod_def = syaml.syaml_dict()
+            mod_def["name"] = mod_name
+            if mode is not None:
+                mod_def["mode"] = mode
+            if on_exec_list is not None:
+                mod_def["on_executable"] = on_exec_list
+            base_section[namespace.modifiers].append(mod_def)
+            added += 1
+
+        if not dry_run:
+            self._write_config(config_section)
+        return added
 
     def add_include(self, new_include):
         """Add a new include to this workspace"""

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -2150,10 +2150,8 @@ ramble:
                         else:
                             to_remove.append(mod_tup)
 
-        if not to_remove:
-            logger.die("No existing modifiers match requested criteria.")
-
         removed = 0
+
         for mod_tup in to_remove:
             base_section = self._get_scope_section(mod_tup[0])
 
@@ -2173,6 +2171,7 @@ ramble:
 
                 if not dry_run:
                     self._write_config(config_section)
+
         return removed
 
     def add_modifier(

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -739,7 +739,7 @@ _ramble_workspace_manage() {
     then
         RAMBLE_COMPREPLY="-h --help"
     else
-        RAMBLE_COMPREPLY="experiments software includes"
+        RAMBLE_COMPREPLY="experiments software includes modifiers"
     fi
 }
 
@@ -758,4 +758,8 @@ _ramble_workspace_manage_software() {
 
 _ramble_workspace_manage_includes() {
     RAMBLE_COMPREPLY="-h --help --list -l --remove -r --remove-index --add -a"
+}
+
+_ramble_workspace_manage_modifiers() {
+    RAMBLE_COMPREPLY="-h --help --list -l --add --remove --mod-index -i --scope -s --name -n --mode -m --on-executable -e --dry-run"
 }


### PR DESCRIPTION
This merge adds a new front-end command for managing modifiers within a workspace. Supported functionality in this command includes:

 * Listing modifiers and their associated scopes
 * Adding modifiers to a specific scope
 * Removing one or more modifiers from a scope (or based on a globed name)
 
 Tests and documentation are added for this functionality as well.