### PR TITLE
Update impi package definitions

### DIFF
--- a/examples/basic_expansion_config.yaml
+++ b/examples/basic_expansion_config.yaml
@@ -46,8 +46,8 @@ ramble:
       ompi412:
         pkg_spec: openmpi@4.1.2 +legacylaunchers +pmi +thread_multiple +cxx target=x86_64
         compiler: gcc9
-      impi2021:
-        pkg_spec: intel-oneapi-mpi@2021.11.0
+      intel-mpi:
+        pkg_spec: intel-oneapi-mpi@2021.13.1
         compiler: gcc9
       openfoam:
         pkg_spec: openfoam-org@7
@@ -66,5 +66,5 @@ ramble:
         - openfoam
       wrfv4:
         packages:
-        - impi2021
+        - intel-mpi
         - wrfv4

--- a/examples/basic_gromacs_config.yaml
+++ b/examples/basic_gromacs_config.yaml
@@ -52,8 +52,8 @@ ramble:
       gcc9:
         pkg_spec: gcc@9.4.0 target=x86_64
         compiler_spec: gcc@9.4.0
-      impi2021:
-        pkg_spec: intel-oneapi-mpi@2021.11.0 target=x86_64
+      intel-mpi:
+        pkg_spec: intel-oneapi-mpi@2021.13.1 target=x86_64
         compiler: gcc9
       gromacs:
         pkg_spec: gromacs@2021.6
@@ -62,4 +62,4 @@ ramble:
       gromacs:
         packages:
         - gromacs
-        - impi2021
+        - intel-mpi

--- a/examples/tutorial_10_aps_error_config.yaml
+++ b/examples/tutorial_10_aps_error_config.yaml
@@ -33,7 +33,7 @@ ramble:
       gcc9:
         pkg_spec: gcc@9.4.0
       intel-mpi:
-        pkg_spec: intel-oneapi-mpi@2021.11.0
+        pkg_spec: intel-oneapi-mpi@2021.13.1
         compiler: gcc9
       wrfv4:
         pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem

--- a/examples/tutorial_10_aps_final_config.yaml
+++ b/examples/tutorial_10_aps_final_config.yaml
@@ -33,7 +33,7 @@ ramble:
       gcc9:
         pkg_spec: gcc@9.4.0
       intel-mpi:
-        pkg_spec: intel-oneapi-mpi@2021.11.0
+        pkg_spec: intel-oneapi-mpi@2021.13.1
         compiler: gcc9
       aps:
         pkg_spec: intel-oneapi-vtune

--- a/examples/tutorial_10_lscpu_config.yaml
+++ b/examples/tutorial_10_lscpu_config.yaml
@@ -32,7 +32,7 @@ ramble:
       gcc9:
         pkg_spec: gcc@9.4.0
       intel-mpi:
-        pkg_spec: intel-oneapi-mpi@2021.11.0
+        pkg_spec: intel-oneapi-mpi@2021.13.1
         compiler: gcc9
       wrfv4:
         pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem

--- a/examples/tutorial_11_exec_injection_config.yaml
+++ b/examples/tutorial_11_exec_injection_config.yaml
@@ -46,7 +46,7 @@ ramble:
       gcc9:
         pkg_spec: gcc@9.4.0
       intel-mpi:
-        pkg_spec: intel-oneapi-mpi@2021.11.0
+        pkg_spec: intel-oneapi-mpi@2021.13.1
         compiler: gcc9
       wrfv4:
         pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem

--- a/examples/tutorial_11_exec_order_config.yaml
+++ b/examples/tutorial_11_exec_order_config.yaml
@@ -52,7 +52,7 @@ ramble:
       gcc9:
         pkg_spec: gcc@9.4.0
       intel-mpi:
-        pkg_spec: intel-oneapi-mpi@2021.11.0
+        pkg_spec: intel-oneapi-mpi@2021.13.1
         compiler: gcc9
       wrfv4:
         pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem

--- a/examples/tutorial_11_new_exec_config.yaml
+++ b/examples/tutorial_11_new_exec_config.yaml
@@ -42,7 +42,7 @@ ramble:
       gcc9:
         pkg_spec: gcc@9.4.0
       intel-mpi:
-        pkg_spec: intel-oneapi-mpi@2021.11.0
+        pkg_spec: intel-oneapi-mpi@2021.13.1
         compiler: gcc9
       wrfv4:
         pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem

--- a/examples/tutorial_6_config.yaml
+++ b/examples/tutorial_6_config.yaml
@@ -30,7 +30,7 @@ ramble:
       gcc9:
         pkg_spec: gcc@9.4.0
       intel-mpi:
-        pkg_spec: intel-oneapi-mpi@2021.11.0
+        pkg_spec: intel-oneapi-mpi@2021.13.1
         compiler: gcc9
       wrfv4:
         pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem

--- a/examples/tutorial_7_base_config.yaml
+++ b/examples/tutorial_7_base_config.yaml
@@ -35,7 +35,7 @@ ramble:
       gcc9:
         pkg_spec: gcc@9.4.0
       intel-mpi:
-        pkg_spec: intel-oneapi-mpi@2021.11.0
+        pkg_spec: intel-oneapi-mpi@2021.13.1
         compiler: gcc9
       wrfv4:
         pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem

--- a/examples/tutorial_7_final_config.yaml
+++ b/examples/tutorial_7_final_config.yaml
@@ -38,7 +38,7 @@ ramble:
       gcc9:
         pkg_spec: gcc@9.4.0
       intel-mpi:
-        pkg_spec: intel-oneapi-mpi@2021.11.0
+        pkg_spec: intel-oneapi-mpi@2021.13.1
         compiler: gcc9
       wrfv4:
         pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem

--- a/examples/tutorial_7_matrix_config.yaml
+++ b/examples/tutorial_7_matrix_config.yaml
@@ -38,7 +38,7 @@ ramble:
       gcc9:
         pkg_spec: gcc@9.4.0
       intel-mpi:
-        pkg_spec: intel-oneapi-mpi@2021.11.0
+        pkg_spec: intel-oneapi-mpi@2021.13.1
         compiler: gcc9
       wrfv4:
         pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem

--- a/examples/tutorial_8_base_config.yaml
+++ b/examples/tutorial_8_base_config.yaml
@@ -38,7 +38,7 @@ ramble:
       gcc9:
         pkg_spec: gcc@9.4.0
       intel-mpi:
-        pkg_spec: intel-oneapi-mpi@2021.11.0
+        pkg_spec: intel-oneapi-mpi@2021.13.1
         compiler: gcc9
       wrfv4:
         pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem

--- a/examples/tutorial_8_expansion_indirection_config.yaml
+++ b/examples/tutorial_8_expansion_indirection_config.yaml
@@ -46,7 +46,7 @@ ramble:
       gcc9:
         pkg_spec: gcc@9.4.0
       intel-mpi:
-        pkg_spec: intel-oneapi-mpi@2021.11.0
+        pkg_spec: intel-oneapi-mpi@2021.13.1
         compiler: gcc9
       openmpi:
         pkg_spec: openmpi@3.1.6 +orterunprefix

--- a/examples/tutorial_8_mpi_config.yaml
+++ b/examples/tutorial_8_mpi_config.yaml
@@ -39,7 +39,7 @@ ramble:
       gcc9:
         pkg_spec: gcc@9.4.0
       intel-mpi:
-        pkg_spec: intel-oneapi-mpi@2021.11.0
+        pkg_spec: intel-oneapi-mpi@2021.13.1
         compiler: gcc9
       openmpi:
         pkg_spec: openmpi@3.1.6 +orterunprefix

--- a/examples/tutorial_8_mpi_matrix_config.yaml
+++ b/examples/tutorial_8_mpi_matrix_config.yaml
@@ -40,7 +40,7 @@ ramble:
       gcc9:
         pkg_spec: gcc@9.4.0
       intel-mpi:
-        pkg_spec: intel-oneapi-mpi@2021.11.0
+        pkg_spec: intel-oneapi-mpi@2021.13.1
         compiler: gcc9
       openmpi:
         pkg_spec: openmpi@3.1.6 +orterunprefix

--- a/examples/tutorial_8_software_environments_config.yaml
+++ b/examples/tutorial_8_software_environments_config.yaml
@@ -47,7 +47,7 @@ ramble:
       gcc9:
         pkg_spec: gcc@9.4.0
       intel-mpi:
-        pkg_spec: intel-oneapi-mpi@2021.11.0
+        pkg_spec: intel-oneapi-mpi@2021.13.1
         compiler: gcc9
       openmpi:
         pkg_spec: openmpi@3.1.6 +orterunprefix

--- a/examples/tutorial_9_fom_criteria_config.yaml
+++ b/examples/tutorial_9_fom_criteria_config.yaml
@@ -37,7 +37,7 @@ ramble:
       gcc9:
         pkg_spec: gcc@9.4.0
       intel-mpi:
-        pkg_spec: intel-oneapi-mpi@2021.11.0
+        pkg_spec: intel-oneapi-mpi@2021.13.1
         compiler: gcc9
       wrfv4:
         pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem

--- a/examples/tutorial_9_regex_criteria_config.yaml
+++ b/examples/tutorial_9_regex_criteria_config.yaml
@@ -32,7 +32,7 @@ ramble:
       gcc9:
         pkg_spec: gcc@9.4.0
       intel-mpi:
-        pkg_spec: intel-oneapi-mpi@2021.11.0
+        pkg_spec: intel-oneapi-mpi@2021.13.1
         compiler: gcc9
       wrfv4:
         pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem

--- a/examples/vector_gromacs_software_config.yaml
+++ b/examples/vector_gromacs_software_config.yaml
@@ -40,8 +40,8 @@ ramble:
       gcc9:
         pkg_spec: gcc@9.4.0 target=x86_64
         compiler_spec: gcc@9.4.0
-      impi2021:
-        pkg_spec: intel-oneapi-mpi@2021.11.0 target=x86_64
+      intel-mpi:
+        pkg_spec: intel-oneapi-mpi@2021.13.1 target=x86_64
         compiler: gcc9
       gromacs-{gromacs_version}:
         pkg_spec: gromacs@{gromacs_version}
@@ -50,4 +50,4 @@ ramble:
       gromacs-{gromacs_version}:
         packages:
         - gromacs-{gromacs_version}
-        - impi2021
+        - intel-mpi

--- a/examples/vector_matrix_gromacs_config.yaml
+++ b/examples/vector_matrix_gromacs_config.yaml
@@ -37,8 +37,8 @@ ramble:
       gcc9:
         pkg_spec: gcc@9.4.0 target=x86_64
         compiler_spec: gcc@9.4.0
-      impi2021:
-        pkg_spec: intel-oneapi-mpi@2021.11.0 target=x86_64
+      intel-mpi:
+        pkg_spec: intel-oneapi-mpi@2021.13.1 target=x86_64
         compiler: gcc9
       gromacs:
         pkg_spec: gromacs@2021.6
@@ -47,4 +47,4 @@ ramble:
       gromacs:
         packages:
         - gromacs
-        - impi2021
+        - intel-mpi

--- a/examples/wrf_scaling_config.yaml
+++ b/examples/wrf_scaling_config.yaml
@@ -30,7 +30,7 @@ ramble:
       gcc9:
         pkg_spec: gcc@9.4.0
       intel-mpi:
-        pkg_spec: intel-oneapi-mpi@2021.11.0
+        pkg_spec: intel-oneapi-mpi@2021.13.1
         compiler: gcc9
       wrfv4:
         pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem

--- a/lib/ramble/docs/dev_guides/application_dev_guide.rst
+++ b/lib/ramble/docs/dev_guides/application_dev_guide.rst
@@ -296,18 +296,18 @@ package manager variant:
         define_compiler("gcc9", pkg_spec="gcc@9.3.0")
 
         software_spec(
-            "impi2018",
-            pkg_spec="intel-mpi@2018.4.274",
+            "impi",
+            pkg_spec="intel-oneapi-mpi@2021.13.1",
         )
 
         with default_args(compiler="gcc9"):
             software_spec(
-                "spack_gromacs",
+                "gromacs",
                 pkg_spec="gromacs@2020.5",
             )
 
     software_spec(
-        "eessi_gromacs",
+        "gromacs",
         pkg_spec="GROMACS/2024.1-foss-2023b",
         when=["package_manager_family=eessi"],
     )

--- a/lib/ramble/docs/tutorials/2_running_a_simple_gromacs_experiment.rst
+++ b/lib/ramble/docs/tutorials/2_running_a_simple_gromacs_experiment.rst
@@ -44,33 +44,35 @@ Under the workloads marked by ``Workload: water_bare`` and
         Inputs: ['water_gmx50_bare']
         Tags: []
         Variables:
-            size:
-                Description: Workload size
-                Default: 1536
-                Suggested Values: ['0000.65', '0000.96', '0001.5', '0003', '0006', '0012', '0024', '0048', '0096', '0192', '0384', '0768', '1536', '3072']
-            type:
-                Description: Workload type.
-                Default: pme
-                Suggested Values: ['pme', 'rf']
-            input_path:
-                Description: Input path for water GMX50
-                Default: {water_gmx50_bare}/{size}
+            Unconditional:
+                size:
+                    Description: Workload size
+                    Default: 1536
+                    Suggested Values: ['0000.65', '0000.96', '0001.5', '0003', '0006', '0012', '0024', '0048', '0096', '0192', '0384', '0768', '1536', '3072']
+                type:
+                    Description: Workload type.
+                    Default: pme
+                    Suggested Values: ['pme', 'rf']
+                input_path:
+                    Description: Input path for water GMX50
+                    Default: {water_gmx50_bare}/{size}
     Workload: water_bare
         Executables: ['pre-process', 'execute-gen']
         Inputs: ['water_bare_hbonds']
         Tags: []
         Variables:
-            size:
-                Description: Workload size
-                Default: 1536
-                Suggested Values: ['0000.65', '0000.96', '0001.5', '0003', '0006', '0012', '0024', '0048', '0096', '0192', '0384', '0768', '1536', '3072']
-            type:
-                Description: Workload type.
-                Default: pme
-                Suggested Values: ['pme', 'rf']
-            input_path:
-                Description: Input path for water bare hbonds
-                Default: {water_bare_hbonds}/{size}
+            Unconditional:
+                size:
+                    Description: Workload size
+                    Default: 1536
+                    Suggested Values: ['0000.65', '0000.96', '0001.5', '0003', '0006', '0012', '0024', '0048', '0096', '0192', '0384', '0768', '1536', '3072']
+                type:
+                    Description: Workload type.
+                    Default: pme
+                    Suggested Values: ['pme', 'rf']
+                input_path:
+                    Description: Input path for water bare hbonds
+                    Default: {water_bare_hbonds}/{size}
 
 Here we see that both of these workloads have a ``type`` variable (with
 possible values of ``pme`` and ``rf``) and a ``size`` variable with a variety
@@ -89,32 +91,34 @@ With this command, you should see output similar to the following:
   ##################
   # software_specs #
   ##################
-  impi2018:
-      pkg_spec: intel-mpi@2018.4.274
-      compiler_spec: None
-      compiler: None
-      package_manager: spack*
-  
-  spack_gromacs:
+  intel-mpi:
+      pkg_spec: intel-oneapi-mpi@2021.13.1
+
+      When:
+          package_manager_family=spack
+
+  gromacs:
       pkg_spec: gromacs@2020.5
-      compiler_spec: None
       compiler: gcc9
-      package_manager: spack*
-  
-  eessi_gromacs:
+
+      When:
+          package_manager_family=spack
+
+  gromacs:
       pkg_spec: GROMACS/2024.1-foss-2023b
-      compiler_spec: None
-      compiler: None
-      package_manager: eessi
-  
+
+      When:
+          package_manager_family=eessi
+
   #############
   # compilers #
   #############
   gcc9:
       pkg_spec: gcc@9.3.0
-      compiler_spec: None
-      compiler: None
-      package_manager: spack*
+
+      When:
+          package_manager_family=spack
+
 
 This output does not represent the only possible configuration that works for
 this application, it only presents a good starting point. When using Ramble,

--- a/lib/ramble/docs/tutorials/3_modifying_a_gromacs_experiment.rst
+++ b/lib/ramble/docs/tutorials/3_modifying_a_gromacs_experiment.rst
@@ -139,33 +139,35 @@ Which should contain the following information:
         Inputs: ['water_gmx50_bare']
         Tags: []
         Variables:
-            size:
-                Description: Workload size
-                Default: 1536
-                Suggested Values: ['0000.65', '0000.96', '0001.5', '0003', '0006', '0012', '0024', '0048', '0096', '0192', '0384', '0768', '1536', '3072']
-            type:
-                Description: Workload type.
-                Default: pme
-                Suggested Values: ['pme', 'rf']
-            input_path:
-                Description: Input path for water GMX50
-                Default: {water_gmx50_bare}/{size}
+            Unconditional:
+                size:
+                    Description: Workload size
+                    Default: 1536
+                    Suggested Values: ['0000.65', '0000.96', '0001.5', '0003', '0006', '0012', '0024', '0048', '0096', '0192', '0384', '0768', '1536', '3072']
+                type:
+                    Description: Workload type.
+                    Default: pme
+                    Suggested Values: ['pme', 'rf']
+                input_path:
+                    Description: Input path for water GMX50
+                    Default: {water_gmx50_bare}/{size}
     Workload: water_bare
         Executables: ['pre-process', 'execute-gen']
         Inputs: ['water_bare_hbonds']
         Tags: []
         Variables:
-            size:
-                Description: Workload size
-                Default: 1536
-                Suggested Values: ['0000.65', '0000.96', '0001.5', '0003', '0006', '0012', '0024', '0048', '0096', '0192', '0384', '0768', '1536', '3072']
-            type:
-                Description: Workload type.
-                Default: pme
-                Suggested Values: ['pme', 'rf']
-            input_path:
-                Description: Input path for water bare hbonds
-                Default: {water_bare_hbonds}/{size}
+            Unconditional:
+                size:
+                    Description: Workload size
+                    Default: 1536
+                    Suggested Values: ['0000.65', '0000.96', '0001.5', '0003', '0006', '0012', '0024', '0048', '0096', '0192', '0384', '0768', '1536', '3072']
+                type:
+                    Description: Workload type.
+                    Default: pme
+                    Suggested Values: ['pme', 'rf']
+                input_path:
+                    Description: Input path for water bare hbonds
+                    Default: {water_bare_hbonds}/{size}
 
 
 Within each of the workloads your workspace has experiments for, you can see

--- a/lib/ramble/docs/tutorials/EESSI_package_manager.rst
+++ b/lib/ramble/docs/tutorials/EESSI_package_manager.rst
@@ -46,33 +46,35 @@ Under the workloads marked by ``Workload: water_bare`` and
         Inputs: ['water_gmx50_bare']
         Tags: []
         Variables:
-            size:
-                Description: Workload size
-                Default: 1536
-                Suggested Values: ['0000.65', '0000.96', '0001.5', '0003', '0006', '0012', '0024', '0048', '0096', '0192', '0384', '0768', '1536', '3072']
-            type:
-                Description: Workload type.
-                Default: pme
-                Suggested Values: ['pme', 'rf']
-            input_path:
-                Description: Input path for water GMX50
-                Default: {water_gmx50_bare}/{size}
+            Unconditional:
+                size:
+                    Description: Workload size
+                    Default: 1536
+                    Suggested Values: ['0000.65', '0000.96', '0001.5', '0003', '0006', '0012', '0024', '0048', '0096', '0192', '0384', '0768', '1536', '3072']
+                type:
+                    Description: Workload type.
+                    Default: pme
+                    Suggested Values: ['pme', 'rf']
+                input_path:
+                    Description: Input path for water GMX50
+                    Default: {water_gmx50_bare}/{size}
     Workload: water_bare
         Executables: ['pre-process', 'execute-gen']
         Inputs: ['water_bare_hbonds']
         Tags: []
         Variables:
-            size:
-                Description: Workload size
-                Default: 1536
-                Suggested Values: ['0000.65', '0000.96', '0001.5', '0003', '0006', '0012', '0024', '0048', '0096', '0192', '0384', '0768', '1536', '3072']
-            type:
-                Description: Workload type.
-                Default: pme
-                Suggested Values: ['pme', 'rf']
-            input_path:
-                Description: Input path for water bare hbonds
-                Default: {water_bare_hbonds}/{size}
+            Unconditional:
+                size:
+                    Description: Workload size
+                    Default: 1536
+                    Suggested Values: ['0000.65', '0000.96', '0001.5', '0003', '0006', '0012', '0024', '0048', '0096', '0192', '0384', '0768', '1536', '3072']
+                type:
+                    Description: Workload type.
+                    Default: pme
+                    Suggested Values: ['pme', 'rf']
+                input_path:
+                    Description: Input path for water bare hbonds
+                    Default: {water_bare_hbonds}/{size}
 
 Here we see that both of these workloads have a ``type`` variable (with
 possible values of ``pme`` and ``rf``) and a ``size`` variable with a variety
@@ -91,32 +93,34 @@ With this command, you should see output similar to the following:
   ##################
   # software_specs #
   ##################
-  impi2018:
-      pkg_spec: intel-mpi@2018.4.274
-      compiler_spec: None
-      compiler: None
-      package_manager: spack*
-  
-  spack_gromacs:
+  intel-mpi:
+      pkg_spec: intel-oneapi-mpi@2021.13.1
+
+      When:
+          package_manager_family=spack
+
+  gromacs:
       pkg_spec: gromacs@2020.5
-      compiler_spec: None
       compiler: gcc9
-      package_manager: spack*
-  
-  eessi_gromacs:
+
+      When:
+          package_manager_family=spack
+
+  gromacs:
       pkg_spec: GROMACS/2024.1-foss-2023b
-      compiler_spec: None
-      compiler: None
-      package_manager: eessi
-  
+
+      When:
+          package_manager_family=eessi
+
   #############
   # compilers #
   #############
   gcc9:
       pkg_spec: gcc@9.3.0
-      compiler_spec: None
-      compiler: None
-      package_manager: spack*
+
+      When:
+          package_manager_family=spack
+
 
 
 Package Manager Information
@@ -153,17 +157,25 @@ This should print a summary of the ``eessi`` definition, as follows:
       douglasjacobsen
 
   pipelines:
-      analyze  archive  mirror  setup  pushdeployment  pushtocache  execute
+      analyze  archive  mirror  setup  pushdeployment  pushtocache  execute  logs
 
   builtins:
-      package_manager_builtin::eessi::module_load  package_manager_builtin::eessi::eessi_init
+      package_manager_builtin::eessi::module_load  package_manager_builtin::eessi::module_list  package_manager_builtin::eessi::eessi_init
+
+  object_variables:
+      eessi_version:
+      Description: Version of EESSI to use
+      Default: 2023.06
+      Suggested Values: [None]
+
 
   registered_phases:
+      analyze:
+          add_software_to_results
+
       setup:
           write_module_commands
 
-  package_manager_variables:
-      eessi_version
 
 Examining the ``package_manager_variables`` section, you can see that ``eessi``
 has a defined variable named ``eessi_version``. To get more information about
@@ -171,16 +183,16 @@ this portion of the package manager definition, you can execute the following:
 
 .. code-block:: console
 
-  $ ramble info --type package_managers --attrs package_manager_variables -v eessi
+  $ ramble info --type package_managers --attrs object_variables -v eessi
 
 Which should print something like the following output:
 
 .. code-block:: console
 
-  #############################
-  # package_manager_variables #
-  #############################
-  eessi_version:
+  ####################
+  # object_variables #
+  ####################
+      eessi_version:
       Description: Version of EESSI to use
       Default: 2023.06
       Suggested Values: [None]

--- a/lib/ramble/ramble/test/end_to_end/chained_experiment_var_inheritance.py
+++ b/lib/ramble/ramble/test/end_to_end/chained_experiment_var_inheritance.py
@@ -94,8 +94,8 @@ ramble:
     packages:
       gcc:
         pkg_spec: gcc@9.3.0 target=x86_64
-      impi2018:
-        pkg_spec: intel-mpi@2018.4.274
+      intel-mpi:
+        pkg_spec: intel-oneapi-mpi@2021.13.1
         compiler: gcc
       imb:
         pkg_spec: intel-mpi-benchmarks
@@ -107,11 +107,11 @@ ramble:
       intel-mpi-benchmarks:
         packages:
         - imb
-        - impi2018
+        - intel-mpi
       gromacs:
         packages:
         - gromacs
-        - impi2018
+        - intel-mpi
 """
 
     setup_type = ramble.pipeline.pipelines.setup

--- a/lib/ramble/ramble/test/end_to_end/chained_experiment_variant_propagation.py
+++ b/lib/ramble/ramble/test/end_to_end/chained_experiment_variant_propagation.py
@@ -94,8 +94,8 @@ ramble:
     packages:
       gcc:
         pkg_spec: gcc@9.3.0 target=x86_64
-      impi2018:
-        pkg_spec: intel-mpi@2018.4.274
+      intel-mpi:
+        pkg_spec: intel-oneapi-mpi@2021.13.1
         compiler: gcc
       imb:
         pkg_spec: intel-mpi-benchmarks
@@ -107,11 +107,11 @@ ramble:
       intel-mpi-benchmarks:
         packages:
         - imb
-        - impi2018
+        - intel-mpi
       gromacs:
         packages:
         - gromacs
-        - impi2018
+        - intel-mpi
 """
 
     setup_type = ramble.pipeline.pipelines.setup

--- a/lib/ramble/ramble/test/end_to_end/configvar_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/configvar_dry_run.py
@@ -56,7 +56,7 @@ ramble:
       gcc:
         pkg_spec: gcc@8.5.0
       intel:
-        pkg_spec: intel-mpi@2018.4.274
+        pkg_spec: intel-oneapi-mpi@2021.13.1
         compiler: gcc
       openfoam:
         pkg_spec: openfoam

--- a/lib/ramble/ramble/test/end_to_end/dryrun_chained_experiments.py
+++ b/lib/ramble/ramble/test/end_to_end/dryrun_chained_experiments.py
@@ -84,8 +84,8 @@ ramble:
     packages:
       gcc:
         pkg_spec: gcc@9.3.0 target=x86_64
-      impi2018:
-        pkg_spec: intel-mpi@2018.4.274
+      intel-mpi:
+        pkg_spec: intel-oneapi-mpi@2021.13.1
         compiler: gcc
       imb:
         pkg_spec: intel-mpi-benchmarks
@@ -97,11 +97,11 @@ ramble:
       intel-mpi-benchmarks:
         packages:
         - imb
-        - impi2018
+        - intel-mpi
       gromacs:
         packages:
         - gromacs
-        - impi2018
+        - intel-mpi
 """
 
     mock_output_data = """

--- a/lib/ramble/ramble/test/end_to_end/experiment_excludes.py
+++ b/lib/ramble/ramble/test/end_to_end/experiment_excludes.py
@@ -89,7 +89,7 @@ ramble:
       gcc:
         pkg_spec: gcc@8.5.0
       intel-mpi:
-        pkg_spec: intel-mpi@2018.4.274
+        pkg_spec: intel-oneapi-mpi@2021.13.1
         compiler: gcc
       wrfv4:
         pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf

--- a/lib/ramble/ramble/test/end_to_end/experiment_repeats.py
+++ b/lib/ramble/ramble/test/end_to_end/experiment_repeats.py
@@ -64,7 +64,7 @@ ramble:
       gcc:
         pkg_spec: gcc@8.5.0
       intel-mpi:
-        pkg_spec: intel-mpi@2018.4.274
+        pkg_spec: intel-oneapi-mpi@2021.13.1
         compiler: gcc
       gromacs:
         pkg_spec: gromacs@2021.6

--- a/lib/ramble/ramble/test/end_to_end/explicit_zips.py
+++ b/lib/ramble/ramble/test/end_to_end/explicit_zips.py
@@ -88,7 +88,7 @@ ramble:
       gcc:
         pkg_spec: gcc@8.5.0
       intel-mpi:
-        pkg_spec: intel-mpi@2018.4.274
+        pkg_spec: intel-oneapi-mpi@2021.13.1
         compiler: gcc
       wrfv4:
         pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf

--- a/lib/ramble/ramble/test/end_to_end/gromacs_size_expansion.py
+++ b/lib/ramble/ramble/test/end_to_end/gromacs_size_expansion.py
@@ -44,7 +44,7 @@ ramble:
       gcc:
         pkg_spec: gcc@8.5.0
       intel-mpi:
-        pkg_spec: intel-mpi@2018.4.274
+        pkg_spec: intel-oneapi-mpi@2021.13.1
         compiler: gcc
       gromacs:
         pkg_spec: gromacs

--- a/lib/ramble/ramble/test/end_to_end/included_configuration_files.py
+++ b/lib/ramble/ramble/test/end_to_end/included_configuration_files.py
@@ -89,7 +89,7 @@ software:
     gcc:
       pkg_spec: gcc@8.5.0
     intel-mpi:
-      pkg_spec: intel-mpi@2018.4.274
+      pkg_spec: intel-oneapi-mpi@2021.13.1
       compiler: gcc
     wrfv4:
       pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf

--- a/lib/ramble/ramble/test/end_to_end/missing_required_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/missing_required_dry_run.py
@@ -45,8 +45,8 @@ ramble:
       gcc8:
         pkg_spec: gcc@8.2.0 target=x86_64
         compiler_spec: gcc@8.2.0
-      impi2018:
-        pkg_spec: intel-mpi@2018.4.274 target=x86_64
+      intel-mpi:
+        pkg_spec: intel-oneapi-mpi@2021.13.1
         compiler: gcc8
       wrfv3:
         pkg_spec: my_wrf@3.9.1.1 build_type=dm+sm compile_type=em_real nesting=basic ~pnetcdf
@@ -54,7 +54,7 @@ ramble:
     environments:
       wrfv3:
         packages:
-        - impi2018
+        - intel-mpi
         - wrfv3
 """
 

--- a/lib/ramble/ramble/test/end_to_end/nested_compilers_are_installed.py
+++ b/lib/ramble/ramble/test/end_to_end/nested_compilers_are_installed.py
@@ -55,7 +55,7 @@ ramble:
         pkg_spec: gcc@10.1.0
         compiler: gcc9
       intel:
-        pkg_spec: intel-mpi@2018.4.274
+        pkg_spec: intel-oneapi-mpi@2021.13.1
         compiler: gcc10
       wrf:
         pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf

--- a/lib/ramble/ramble/test/end_to_end/phase_selection.py
+++ b/lib/ramble/ramble/test/end_to_end/phase_selection.py
@@ -83,7 +83,7 @@ ramble:
       gcc:
         pkg_spec: gcc@8.5.0
       intel-mpi:
-        pkg_spec: intel-mpi@2018.4.274
+        pkg_spec: intel-oneapi-mpi@2021.13.1
         compiler: gcc
       wrfv4:
         pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf

--- a/lib/ramble/ramble/test/end_to_end/phase_selection_with_dependencies.py
+++ b/lib/ramble/ramble/test/end_to_end/phase_selection_with_dependencies.py
@@ -83,7 +83,7 @@ ramble:
       gcc:
         pkg_spec: gcc@8.5.0
       intel-mpi:
-        pkg_spec: intel-mpi@2018.4.274
+        pkg_spec: intel-oneapi-mpi@2021.13.1
         compiler: gcc
       wrfv4:
         pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf

--- a/lib/ramble/ramble/test/end_to_end/unused_compilers_are_skipped.py
+++ b/lib/ramble/ramble/test/end_to_end/unused_compilers_are_skipped.py
@@ -53,7 +53,7 @@ ramble:
       gcc10:
         pkg_spec: gcc@10.1.0
       intel:
-        pkg_spec: intel-mpi@2018.4.274
+        pkg_spec: intel-oneapi-mpi@2021.13.1
         compiler: gcc8
       wrf:
         pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf

--- a/lib/ramble/ramble/test/modifier_application.py
+++ b/lib/ramble/ramble/test/modifier_application.py
@@ -48,7 +48,7 @@ ramble:
       gcc:
         pkg_spec: gcc@8.5.0
       intel-mpi:
-        pkg_spec: intel-mpi@2018.4.274
+        pkg_spec: intel-oneapi-mpi@2021.13.1
         compiler: gcc
       wrfv4:
         pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf

--- a/var/ramble/repos/builtin/applications/gromacs/application.py
+++ b/var/ramble/repos/builtin/applications/gromacs/application.py
@@ -25,8 +25,8 @@ class Gromacs(ExecutableApplication):
         define_compiler("gcc9", pkg_spec="gcc@9.3.0")
 
         software_spec(
-            "impi2018",
-            pkg_spec="intel-mpi@2018.4.274",
+            "intel-mpi",
+            pkg_spec="intel-oneapi-mpi@2021.13.1",
         )
 
         with default_args(compiler="gcc9"):

--- a/var/ramble/repos/builtin/applications/hmmer/application.py
+++ b/var/ramble/repos/builtin/applications/hmmer/application.py
@@ -32,7 +32,7 @@ class Hmmer(ExecutableApplication):
     with when("package_manager_family=spack"):
         define_compiler("gcc9", pkg_spec="gcc@9.3.0")
 
-        software_spec("impi_2018", pkg_spec="intel-mpi@2018.4.274")
+        software_spec("impi_2018", pkg_spec="intel-oneapi-mpi@2021.13.1")
 
         software_spec(
             "hmmer",

--- a/var/ramble/repos/builtin/applications/hpcc/application.py
+++ b/var/ramble/repos/builtin/applications/hpcc/application.py
@@ -32,7 +32,7 @@ class Hpcc(ExecutableApplication):
     with when("package_manager_family=spack"):
         define_compiler("gcc9", pkg_spec="gcc@9.3.0")
 
-        software_spec("impi2018", pkg_spec="intel-mpi@2018.4.274")
+        software_spec("intel-mpi", pkg_spec="intel-oneapi-mpi@2021.13.1")
 
         software_spec(
             "hpcc",

--- a/var/ramble/repos/builtin/applications/hpcg/application.py
+++ b/var/ramble/repos/builtin/applications/hpcg/application.py
@@ -29,7 +29,7 @@ class Hpcg(BaseHpcg):
     with when("package_manager_family=spack"):
         define_compiler("gcc9", pkg_spec="gcc@9.3.0")
 
-        software_spec("impi2018", pkg_spec="intel-mpi@2018.4.274")
+        software_spec("intel-mpi", pkg_spec="intel-oneapi-mpi@2021.13.1")
 
         software_spec(
             "hpcg",

--- a/var/ramble/repos/builtin/applications/hpl/application.py
+++ b/var/ramble/repos/builtin/applications/hpl/application.py
@@ -20,7 +20,7 @@ class Hpl(HplBase):
     with when("package_manager_family=spack"):
         define_compiler("gcc9", pkg_spec="gcc@9.3.0")
 
-        software_spec("impi_2018", pkg_spec="intel-mpi@2018.4.274")
+        software_spec("impi_2018", pkg_spec="intel-oneapi-mpi@2021.13.1")
 
         software_spec(
             "hpl",

--- a/var/ramble/repos/builtin/applications/intel-mpi-benchmarks/application.py
+++ b/var/ramble/repos/builtin/applications/intel-mpi-benchmarks/application.py
@@ -32,7 +32,7 @@ class IntelMpiBenchmarks(ExecutableApplication):
 
     with when("package_manager_family"):
         define_compiler("gcc9", pkg_spec="gcc@9.3.0")
-        software_spec("impi2018", pkg_spec="intel-mpi@2018.4.274")
+        software_spec("intel-mpi", pkg_spec="intel-oneapi-mpi@2021.13.1")
         software_spec(
             "intel-mpi-benchmarks",
             pkg_spec="intel-mpi-benchmarks@2019.6",

--- a/var/ramble/repos/builtin/applications/lammps/application.py
+++ b/var/ramble/repos/builtin/applications/lammps/application.py
@@ -23,7 +23,7 @@ class Lammps(ExecutableApplication):
     define_compiler("gcc9", pkg_spec="gcc@9.3.0")
 
     with when("package_manager_family=spack"):
-        software_spec("impi2018", pkg_spec="intel-mpi@2018.4.274")
+        software_spec("intel-mpi", pkg_spec="intel-oneapi-mpi@2021.13.1")
 
         software_spec(
             "lammps",

--- a/var/ramble/repos/builtin/applications/lulesh/application.py
+++ b/var/ramble/repos/builtin/applications/lulesh/application.py
@@ -24,7 +24,7 @@ class Lulesh(ExecutableApplication):
     with when("package_manager_family"):
         define_compiler("gcc13", pkg_spec="gcc@13.1.0")
 
-        software_spec("impi2018", pkg_spec="intel-mpi@2018.4.274")
+        software_spec("intel-mpi", pkg_spec="intel-oneapi-mpi@2021.13.1")
 
         software_spec(
             "lulesh",

--- a/var/ramble/repos/builtin/applications/openfoam-org/application.py
+++ b/var/ramble/repos/builtin/applications/openfoam-org/application.py
@@ -20,7 +20,7 @@ class OpenfoamOrg(OpenfoamBase):
     with when("package_manager_family=spack"):
         define_compiler("gcc9", pkg_spec="gcc@9.3.0")
 
-        software_spec("impi2018", pkg_spec="intel-mpi@2018.4.274")
+        software_spec("intel-mpi", pkg_spec="intel-oneapi-mpi@2021.13.1")
 
         software_spec(
             "openfoam-org",

--- a/var/ramble/repos/builtin/applications/openfoam/application.py
+++ b/var/ramble/repos/builtin/applications/openfoam/application.py
@@ -20,7 +20,7 @@ class Openfoam(OpenfoamBase):
     with when("package_manager_family=spack"):
         define_compiler("gcc9", pkg_spec="gcc@9.3.0")
 
-        software_spec("impi2018", pkg_spec="intel-mpi@2018.4.274")
+        software_spec("intel-mpi", pkg_spec="intel-oneapi-mpi@2021.13.1")
 
         software_spec(
             "openfoam",

--- a/var/ramble/repos/builtin/applications/wrfv3/application.py
+++ b/var/ramble/repos/builtin/applications/wrfv3/application.py
@@ -24,7 +24,7 @@ class Wrfv3(ExecutableApplication):
     with when("package_manager_family=spack"):
         define_compiler("gcc8", pkg_spec="gcc@8.2.0")
 
-        software_spec("impi2018", pkg_spec="intel-mpi@2018.4.274")
+        software_spec("intel-mpi", pkg_spec="intel-oneapi-mpi@2021.13.1")
 
         software_spec(
             "wrfv3",

--- a/var/ramble/repos/builtin/applications/wrfv4/application.py
+++ b/var/ramble/repos/builtin/applications/wrfv4/application.py
@@ -26,8 +26,7 @@ class Wrfv4(ExecutableApplication):
 
         software_spec(
             "intel-mpi",
-            pkg_spec="intel-mpi@2018.4.274",
-            compiler="gcc9",
+            pkg_spec="intel-oneapi-mpi@2021.13.1",
         )
 
         software_spec(


### PR DESCRIPTION
This merge updates references to Intel MPI to use non-deprecated versions.

Tutorials and examples are also updated based on formatting changes from the info command.