### PR TITLE
Add executable print option to workspace info

### DIFF
--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -653,6 +653,10 @@ def workspace_info_setup_parser(subparser):
         "--variants", action="store_true", help="If set, experiment variants will be printed"
     )
 
+    subparser.add_argument(
+        "--executables", action="store_true", help="If set, experiment executables will be printed"
+    )
+
     arguments.add_common_arguments(subparser, ["where", "exclude_where", "filter_tags"])
 
     subparser.add_argument(
@@ -663,7 +667,7 @@ def workspace_info_setup_parser(subparser):
         help="level of verbosity. Add flags to "
         + "increase description of workspace\n"
         + "level 1 enables software, tags, templates, and variants\n"
-        + "level 2 enables expansions and phases\n",
+        + "level 2 enables executables, expansions, and phases\n",
     )
 
 
@@ -680,6 +684,7 @@ def workspace_info(args):
     if args.verbose >= 2:
         args.expansions = True
         args.phases = True
+        args.executables = True
 
     color.cprint(rucolor.section_title("Workspace: ") + ws.name)
     color.cprint("")
@@ -811,6 +816,13 @@ def workspace_info(args):
                         color.cprint(rucolor.nested_4("        Variants: "))
                         for key, value in app_inst.variants.items():
                             color.cprint(f"          {key}: {value}")
+
+                    if args.executables:
+                        color.cprint(rucolor.nested_4("        Executables: "))
+                        app_inst.add_expand_vars(ws)
+                        exec_graph = app_inst._executable_graph
+                        for executable in exec_graph.walk():
+                            color.cprint(f"          {executable.key}")
 
                     if args.expansions:
                         var_groups = [

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -409,6 +409,71 @@ ramble:
     assert "zlib.ensure_installed.test_experiment" not in output
 
 
+def test_workspace_info_complete(workspace_name):
+    global_args = ["-w", workspace_name]
+    ws = ramble.workspace.create(workspace_name)
+    ws.write()
+
+    workspace(
+        "manage",
+        "experiments",
+        "zlib",
+        "-p",
+        "spack",
+        "--wf",
+        "ensure_installed",
+        "-v",
+        "n_nodes=1",
+        "-v",
+        "n_ranks=1",
+        global_args=global_args,
+    )
+    workspace("concretize", global_args=global_args)
+
+    ws._re_read()
+
+    output = workspace(
+        "info",
+        "-vv",
+        global_args=["-w", workspace_name],
+    )
+
+    assert "All experiment tags" in output
+
+    assert "zlib.ensure_installed.generated" in output
+    for pipeline in [
+        "analyze",
+        "archive",
+        "execute",
+        "logs",
+        "mirror",
+        "pushdeployment",
+        "pushtocache",
+        "setup",
+    ]:
+        assert f"Phases for {pipeline}" in output
+
+    assert "Variants:" in output
+    assert "package_manager: spack" in output
+
+    assert "Variables from Workspace" in output
+    assert "mpi_command = mpirun -n {n_ranks} ==> mpirun -n 1" in output
+    assert "Variables from Experiment" in output
+    assert "n_ranks = 1 ==> 1" in output
+
+    assert "Executables" in output
+    assert "builtin::env_vars" in output
+    assert "package_manager_builtin::spack::spack_source" in output
+    assert "list_lib" in output
+
+    assert "Software Stack" in output
+    assert "Template package: zlib" in output
+    assert "Template package: zlib" in output
+    assert "Spec: zlib" in output
+    assert "Template environment: zlib" in output
+    assert "- zlib = zlib" in output
+
+
 def test_workspace_dir(tmpdir):
     with tmpdir.as_cwd():
         workspace("create", "-d", ".")

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -679,7 +679,7 @@ _ramble_workspace_push_to_cache() {
 }
 
 _ramble_workspace_info() {
-    RAMBLE_COMPREPLY="-h --help --software --all-software --templates --expansions --tags --phases --variants --where --exclude-where --filter-tags -v --verbose"
+    RAMBLE_COMPREPLY="-h --help --software --all-software --templates --expansions --tags --phases --variants --executables --where --exclude-where --filter-tags -v --verbose"
 }
 
 _ramble_workspace_edit() {


### PR DESCRIPTION
This merge adds the ability for workspace info to print the executables that are used in experiments.

Additionally, tests are added to more completely exercise workspace info.