### PR TITLE
Add `when` support to env var and promote

### DIFF
--- a/lib/ramble/ramble/language/application_language.py
+++ b/lib/ramble/ramble/language/application_language.py
@@ -304,57 +304,6 @@ def workload_variable(
     return _execute_workload_variable
 
 
-@application_directive("workload_group_env_vars")
-def environment_variable(
-    name, value, description, workload=None, workloads=None, workload_group=None, **kwargs
-):
-    """Define an environment variable to be used in experiments
-
-    Args:
-        name (str): Name of environment variable to define
-        value (str): Value to set env-var to
-        description (str): Description of the env-var
-        workload (str): Name of workload this env-var should be added to
-        workloads (list(str)): List of workload names this env-var should be
-                               added to
-    """
-
-    def _execute_environment_variable(app):
-        all_workloads = ramble.language.language_helpers.merge_definitions(
-            workload, workloads, app.workloads, "workload", "workloads", "environment_variable"
-        )
-
-        workload_env_var = ramble.workload.WorkloadEnvironmentVariable(
-            name, value=value, description=description
-        )
-
-        for when_set, app_workloads in app.workloads.items():
-            for wl_name in all_workloads:
-                if wl_name in app_workloads:
-                    app.workloads[when_set][wl_name].add_environment_variable(
-                        workload_env_var.copy()
-                    )
-
-        if workload_group is not None:
-            workload_group_list = app.workload_groups[workload_group]
-
-            if workload_group not in app.workload_group_env_vars:
-                app.workload_group_env_vars[workload_group] = []
-
-            app.workload_group_env_vars[workload_group].append(workload_env_var.copy())
-
-            for when_set, app_workloads in app.workloads.items():
-                for wl_name in workload_group_list:
-                    app.workloads[when_set][wl_name].add_environment_variable(
-                        workload_env_var.copy()
-                    )
-
-        if not all_workloads and workload_group is None:
-            raise DirectiveError("A workload or workload group is required")
-
-    return _execute_environment_variable
-
-
 @application_directive(dicts=())
 def license_name(name, **kwargs):
     """Add a new license name directive, to specify license name in a declarative way.

--- a/lib/ramble/ramble/language/language_base.py
+++ b/lib/ramble/ramble/language/language_base.py
@@ -238,6 +238,7 @@ class DirectiveMeta(type):
                         "modifier_variable",
                         "package_manager_variable",
                         "workflow_manager_variable",
+                        "environment_variable",
                         "workload",
                         "executable",
                         "input_file",

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -814,6 +814,83 @@ def variable(
     return _define_variable
 
 
+@shared_directive(dicts=("workload_group_env_vars", "object_environment_variables"))
+def environment_variable(
+    name,
+    value,
+    description,
+    workload=None,
+    workloads=None,
+    workload_group=None,
+    when=None,
+    **kwargs,
+):
+    """Define an environment variable to be used in experiments. Workload args
+    are only applicable to application definitions.
+
+    Args:
+        name (str): Name of environment variable to define
+        value (str): Value to set env-var to
+        description (str): Description of the env-var
+        workload (str): Name of app workload this env-var should be added to
+        workloads (list(str)): List of app workload names this env-var should be
+                               added to
+        workload_group (str): Name of app workload group this env-var should be
+                               added to
+        when (list | None): List of when conditions to apply to directive
+    """
+
+    def _execute_environment_variable(obj):
+        when_list = ramble.language.language_helpers.build_when_list(
+            when, obj, name, "environment_variable"
+        )
+
+        workload_env_var = ramble.workload.WorkloadEnvironmentVariable(
+            name, value=value, description=description, when=when_list, **kwargs
+        )
+
+        if workload or workloads or workload_group:
+            if obj.origin_type != "application":
+                raise ramble.language.language_base.DirectiveError(
+                    f"A workload argument was provided for environment variable {name} in object "
+                    f"{obj.name}. Workload arguments are only valid in an application definition."
+                )
+
+            all_workloads = ramble.language.language_helpers.merge_definitions(
+                workload, workloads, obj.workloads, "workload", "workloads", "environment_variable"
+            )
+
+            for when_set, app_workloads in obj.workloads.items():
+                for wl_name in all_workloads:
+                    if wl_name in app_workloads:
+                        obj.workloads[when_set][wl_name].add_environment_variable(
+                            workload_env_var.copy()
+                        )
+
+            if workload_group is not None:
+                workload_group_list = obj.workload_groups[workload_group]
+
+                if workload_group not in obj.workload_group_env_vars:
+                    obj.workload_group_env_vars[workload_group] = []
+
+                obj.workload_group_env_vars[workload_group].append(workload_env_var.copy())
+
+                for when_set, app_workloads in obj.workloads.items():
+                    for wl_name in workload_group_list:
+                        if wl_name in app_workloads:
+                            obj.workloads[when_set][wl_name].add_environment_variable(
+                                workload_env_var.copy()
+                            )
+        else:
+            when_set = frozenset(when_list)
+            if when_set not in obj.object_environment_variables:
+                obj.object_environment_variables[when_set] = []
+
+            obj.object_environment_variables[when_set].append(workload_env_var.copy())
+
+    return _execute_environment_variable
+
+
 @shared_directive(dicts=())
 def variant(
     name: str,

--- a/lib/ramble/ramble/test/end_to_end/env_var_builtin.py
+++ b/lib/ramble/ramble/test/end_to_end/env_var_builtin.py
@@ -17,12 +17,11 @@ from ramble.main import RambleCommand
 # everything here uses the mock_workspace_path
 pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_path")
 
+config = RambleCommand("config")
 workspace = RambleCommand("workspace")
 
 
-def test_env_var_builtin(
-    mutable_config, mutable_mock_workspace_path, mock_applications, workspace_name
-):
+def test_env_var_builtin(mock_applications, workspace_name):
     test_config = """
 ramble:
   config:
@@ -125,9 +124,7 @@ ramble:
             assert cmd_found and export_found
 
 
-def test_env_var_from_app_only(
-    mutable_config, mutable_mock_workspace_path, mock_applications, workspace_name
-):
+def test_env_var_from_app_only(mock_applications, workspace_name):
     test_config = """
 ramble:
   variables:
@@ -164,3 +161,75 @@ ramble:
 
         with open(os.path.join(exp1_dir, "execute_experiment")) as f:
             assert "FROM_DIRECTIVE" in f.read()
+
+
+def test_object_env_var_order(
+    workspace_name,
+    mutable_mock_apps_repo,
+    mutable_mock_mods_repo,
+    mutable_mock_pkg_mans_repo,
+    mutable_mock_wms_repo,
+):
+    global_args = ["-w", workspace_name]
+
+    with ramble.workspace.create(workspace_name) as ws:
+        workspace(
+            "manage",
+            "experiments",
+            "when-directives",
+            "--wf",
+            "test_wl",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "processes_per_node=1",
+            "-p",
+            "when-package-manager",
+            "--wm",
+            "when-workflow-manager",
+            global_args=global_args,
+        )
+
+        mod_config_path = os.path.join(ws.config_dir, "modifiers.yaml")
+        with open(mod_config_path, "w+") as f:
+            f.write("modifiers:\n")
+            f.write(" - name: when-modifier\n")
+
+        config("add", "variants:app_env_var_included:true", global_args=global_args)
+        config("add", "variants:workflow_manager_included:true", global_args=global_args)
+        config("add", "variants:workflow_manager_env_var_included:true", global_args=global_args)
+        config("add", "variants:package_manager_included:true", global_args=global_args)
+        config("add", "variants:package_manager_env_var_included:true", global_args=global_args)
+        config("add", "variants:mod_env_var_included:true", global_args=global_args)
+
+        ws._re_read()
+        workspace("setup", "--dry-run", global_args=global_args)
+
+        regex_order = [
+            re.compile(r"export APP_ENV_VAR=APP_ENV_VAR_SET;"),
+            re.compile(r"export PACKAGE_ENV_VAR=PKG_ENV_VAR_SET;"),
+            re.compile(r"export WORKFLOW_ENV_VAR=WF_ENV_VAR_SET;"),
+            re.compile(r"export MOD_ENV_VAR=MOD_ENV_VAR_SET;"),
+        ]
+
+        found_order = [False for _ in regex_order]
+
+        found_idx = 0
+
+        rendered_script = os.path.join(
+            ws.experiment_dir, "when-directives", "test_wl", "generated", "execute_experiment"
+        )
+
+        with open(rendered_script) as f:
+            for line in f.readlines():
+                cur_regex = regex_order[found_idx]
+                if cur_regex.search(line):
+                    found_order[found_idx] = True
+                    found_idx += 1
+
+                if found_idx == len(found_order):
+                    break
+
+        assert all(found_order)

--- a/lib/ramble/ramble/test/when.py
+++ b/lib/ramble/ramble/test/when.py
@@ -1187,3 +1187,73 @@ def test_workload_errors_when_overlapping_conditions(request):
 
             captured = workspace("setup", global_args=global_args)
             assert "test_wl is defined for overlapping `when` conditions" in captured
+
+
+@pytest.mark.parametrize("obj", ["app", "mod", "wf_man", "pkg_man"])
+def test_obj_env_var_when(workspace_name, obj, mutable_mock_wms_repo, mutable_mock_pkg_mans_repo):
+    global_args = ["-w", workspace_name]
+
+    exec_test_str = {
+        "app": "export APP_ENV_VAR=APP_ENV_VAR_SET;",
+        "mod": "export MOD_ENV_VAR=MOD_ENV_VAR_SET;",
+        "wf_man": "export WORKFLOW_ENV_VAR=WF_ENV_VAR_SET;",
+        "pkg_man": "export PACKAGE_ENV_VAR=PKG_ENV_VAR_SET;",
+    }
+
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+        args = [
+            "when-directives",
+            "--wf",
+            "test_wl",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "processes_per_node=1",
+            "-p",
+            "when-package-manager",
+            "--wm",
+            "when-workflow-manager",
+        ]
+
+        if obj == "app":
+            config("add", "variants:app_env_var_included:true", global_args=global_args)
+        elif obj == "mod":
+            mod_config_path = os.path.join(ws.config_dir, "modifiers.yaml")
+            with open(mod_config_path, "w+") as f:
+                f.write("modifiers:\n")
+                f.write(" - name: when-modifier\n")
+            config("add", "variants:mod_env_var_included:true", global_args=global_args)
+        elif obj == "wf_man":
+            config("add", "variants:workflow_manager_included:true", global_args=global_args)
+            config(
+                "add",
+                "variants:workflow_manager_env_var_included:true",
+                global_args=global_args,
+            )
+        elif obj == "pkg_man":
+            config("add", "variants:package_manager_included:true", global_args=global_args)
+            config(
+                "add",
+                "variants:package_manager_env_var_included:true",
+                global_args=global_args,
+            )
+
+        workspace("manage", "experiments", *args, global_args=global_args)
+        workspace("setup", "--dry-run", global_args=global_args)
+
+        exec_file = os.path.join(
+            ws.experiment_dir,
+            "when-directives",
+            "test_wl",
+            "generated",
+            "execute_experiment",
+        )
+
+        with open(exec_file) as f:
+            data = f.read()
+
+            for obj_under_test, exec_test_str in exec_test_str.items():
+                assert (exec_test_str in data) == (obj_under_test == obj)

--- a/lib/ramble/ramble/workload.py
+++ b/lib/ramble/ramble/workload.py
@@ -83,17 +83,26 @@ class WorkloadVariable:
 class WorkloadEnvironmentVariable:
     """Class representing an environment variable in a workload"""
 
-    def __init__(self, name: str, value=None, description: str = None):
+    def __init__(
+        self,
+        name: str,
+        value=None,
+        description: str = None,
+        when=None,
+        **kwargs,
+    ):
         """WorkloadEnvironmentVariable constructor
 
         Args:
             name (str): Name of environment variable
             value: Value to set environment variable to
             description (str): Description of the environment variable
+            when (list | None): List of when conditions to apply to directive
         """
         self.name = name
         self.value = value
         self.description = description
+        self.when = when.copy() if when else []
 
     def as_str(self, n_indent: int = 0):
         """String representation of environment variable
@@ -202,8 +211,19 @@ class Workload:
 
         if self.environment_variables:
             out_str += rucolor.nested_1(f"{indentation}    Environment Variables:\n")
-            for env_var in self.environment_variables.values():
-                out_str += env_var.as_str(n_indent + 4)
+            for when_set, env_var_list in self.environment_variables.items():
+                if when_set:
+                    out_str += rucolor.nested_2(f"{indentation}        When conditions:\n")
+                    for variant in when_set:
+                        out_str += f"{indentation}            {variant}\n"
+                else:
+                    out_str += rucolor.nested_2(f"{indentation}        Unconditional\n")
+
+                env_var_dict = {}
+                for env_var in env_var_list:
+                    env_var_dict[var.name] = env_var
+                for env_var_name in sorted(env_var_dict.keys()):
+                    out_str += env_var_dict[env_var_name].as_str(n_indent + 12)
 
         return out_str
 
@@ -224,7 +244,10 @@ class Workload:
         Args:
             env_var (WorkloadEnvironmentVariable): New environment variable to add to this workload
         """
-        self.environment_variables[env_var.name] = env_var
+        when_key = frozenset(env_var.when)
+        if when_key not in self.environment_variables:
+            self.environment_variables[when_key] = []
+        self.environment_variables[when_key].append(env_var)
 
     def add_executable(self, executable: str):
         """Add an executable to this workload
@@ -315,7 +338,8 @@ class Workload:
             (WorkloadEnvironmentVariable | None): Environment variable instance
                                                   if it exists, None if it is not found
         """
-        if name in self.environment_variables:
-            return self.environment_variables[name]
-        else:
-            return None
+        named_env_vars = []
+        for env_var_list in self.environment_variables.values():
+            for env_var in env_var_list:
+                named_env_vars.append(env_var)
+        return named_env_vars

--- a/var/ramble/repos/builtin.mock/applications/when-directives/application.py
+++ b/var/ramble/repos/builtin.mock/applications/when-directives/application.py
@@ -17,6 +17,7 @@ class WhenDirectives(ExecutableApplication):
     executable("test_exec", "echo '{test_variable}'", use_mpi=False)
 
     workload("test_wl", executable="test_exec")
+    workload_group("test_wl_group", workloads=["test_wl"])
 
     with default_args(workload="test_wl"):
         workload_variable(
@@ -299,3 +300,18 @@ class WhenDirectives(ExecutableApplication):
         executables=["test_exec"],
         when=["+workload_defined_twice"],
     )
+
+    variant(
+        "app_env_var_included",
+        default=False,
+        values=[True, False],
+        description="Test app object env variable",
+    )
+
+    with when("+app_env_var_included"):
+        environment_variable(
+            "APP_ENV_VAR",
+            value="APP_ENV_VAR_SET",
+            description="Test app environment variable",
+            workload_group="test_wl_group",
+        )

--- a/var/ramble/repos/builtin.mock/modifiers/when-modifier/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/when-modifier/modifier.py
@@ -29,3 +29,17 @@ class WhenModifier(BasicModifier):
             default="included",
             description="Test variable",
         )
+
+    variant(
+        "mod_env_var_included",
+        default=False,
+        values=[True, False],
+        description="Test mod env var",
+    )
+
+    with when("+mod_env_var_included"):
+        environment_variable(
+            "MOD_ENV_VAR",
+            value="MOD_ENV_VAR_SET",
+            description="Test environment variable",
+        )

--- a/var/ramble/repos/builtin.mock/package_managers/when-package-manager/package_manager.py
+++ b/var/ramble/repos/builtin.mock/package_managers/when-package-manager/package_manager.py
@@ -23,3 +23,17 @@ class WhenPackageManager(PackageManagerBase):
         package_manager_variable(
             "pm_var_test", default="included", description="Test variable"
         )
+
+    variant(
+        "package_manager_env_var_included",
+        default=False,
+        values=[True, False],
+        description="Test package manager env vars",
+    )
+
+    with when("+package_manager_env_var_included"):
+        environment_variable(
+            "PACKAGE_ENV_VAR",
+            value="PKG_ENV_VAR_SET",
+            description="Test env variable",
+        )

--- a/var/ramble/repos/builtin.mock/workflow_managers/when-workflow-manager/workflow_manager.py
+++ b/var/ramble/repos/builtin.mock/workflow_managers/when-workflow-manager/workflow_manager.py
@@ -23,3 +23,17 @@ class WhenWorkflowManager(WorkflowManagerBase):
         workflow_manager_variable(
             "wm_var_test", default="included", description="Test variable"
         )
+
+    variant(
+        "workflow_manager_env_var_included",
+        default=False,
+        values=[True, False],
+        description="Test workflow manager env vars",
+    )
+
+    with when("+workflow_manager_env_var_included"):
+        environment_variable(
+            "WORKFLOW_ENV_VAR",
+            value="WF_ENV_VAR_SET",
+            description="Test env variable",
+        )

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -536,15 +536,12 @@ class ApplicationBase(metaclass=ApplicationMeta):
                     )
 
     def set_env_variable_sets(self, env_variable_sets):
-        """Set internal reference to environment variable sets"""
+        """Set internal reference to application environment variable sets"""
 
         self._env_variable_sets = env_variable_sets.copy()
 
-        # Extract workload environment variable sets
-        workload = self.get_workload()
-
         new_env_vars = {}
-        for env_var in workload.environment_variables.values():
+        for env_var in self.selected_environment_variables().values():
             action = "set"
             value = env_var.value
 
@@ -1347,6 +1344,65 @@ class ApplicationBase(metaclass=ApplicationMeta):
                     wl_vars[var.name] = var
 
         return wl_vars
+
+    def selected_environment_variables(self):
+        """Extract all environment variables which would be included based
+        on the current variants.
+
+        Returns:
+            (dict) Keys are environment variable names, values are environment
+            variable instances
+        """
+
+        selected_env_vars = {}
+
+        workloads = self.get_workloads()
+        for workload in workloads:
+            for (
+                when_set,
+                env_var_list,
+            ) in workload.environment_variables.items():
+                if self.expander.satisfies(when_set, self.object_variants):
+                    for env_var in env_var_list:
+                        selected_env_vars[env_var.name] = env_var
+
+        for (
+            when_set,
+            env_var_list,
+        ) in self.object_environment_variables.items():
+            if self.expander.satisfies(when_set, self.object_variants):
+                for env_var in env_var_list:
+                    selected_env_vars[env_var.name] = env_var
+
+        return selected_env_vars
+
+    def get_environment_variable_sets(self):
+        """Get environment variable sets for all objects.
+
+        Returns:
+            (list) List of environment variable sets from all objects
+        """
+        obj_env_var_sets = self._env_variable_sets.copy()
+
+        env_var_objs = []
+        if self.package_manager is not None:
+            env_var_objs.append(self.package_manager)
+        if self.workflow_manager is not None:
+            env_var_objs.append(self.workflow_manager)
+        for mod_inst in self._modifier_instances:
+            env_var_objs.append(mod_inst)
+
+        for env_var_obj in env_var_objs:
+            obj_env_vars = {}
+            for (
+                env_var
+            ) in env_var_obj.selected_environment_variables().values():
+                obj_env_vars[env_var.name] = env_var.value
+
+            if obj_env_vars:
+                obj_env_var_sets.append({"set": obj_env_vars})
+
+        return obj_env_var_sets
 
     def _define_commands(self, exec_graph, success_list=None):
         """Populate the internal list of commands based on executables
@@ -3079,7 +3135,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
                         )
 
         # Process environment variable actions
-        for env_var_set in self._env_variable_sets:
+        for env_var_set in self.get_environment_variable_sets():
             for action, conf in env_var_set.items():
                 (env_cmds, _) = action_funcs[action](
                     conf, self.expander, set(), shell=shell

--- a/var/ramble/repos/builtin/base_classes/modifier-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/modifier-base/base_class.py
@@ -304,6 +304,29 @@ class ModifierBase(metaclass=ModifierMeta):
 
         return mod_variables
 
+    def selected_environment_variables(self):
+        """Extract all environment variables which would be included based
+        on the current variants.
+
+        Returns:
+            (dict) Keys are environment variable names, values are environment
+            variable instances
+        """
+
+        mod_environment_variables = {}
+
+        for (
+            when_key,
+            env_var_list,
+        ) in self.object_environment_variables.items():
+            if not self.expander.satisfies(when_key, self.object_variants):
+                continue
+
+            for env_var in env_var_list:
+                mod_environment_variables[env_var.name] = env_var
+
+        return mod_environment_variables
+
     def artifact_inventory(self, workspace, app_inst=None):
         """Return an inventory of modifier artifacts
 

--- a/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
@@ -139,6 +139,28 @@ class PackageManagerBase(metaclass=PackageManagerMeta):
                 all_vars[var.name] = var
         return all_vars
 
+    def selected_environment_variables(self):
+        """Extract all environment variables which would be included based
+        on the current variants.
+
+        Returns:
+            (dict) Keys are environment variable names, values are environment
+            variable instances
+        """
+        all_env_vars = {}
+        for (
+            when_key,
+            env_var_list,
+        ) in self.object_environment_variables.items():
+            if not self.app_inst.expander.satisfies(
+                when_key, self.app_inst.object_variants
+            ):
+                continue
+
+            for env_var in env_var_list:
+                all_env_vars[env_var.name] = env_var
+        return all_env_vars
+
     def get_spec_str(self, pkg, all_pkgs, compiler):
         """Return a spec string for the given pkg
 

--- a/var/ramble/repos/builtin/base_classes/workflow-manager-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/workflow-manager-base/base_class.py
@@ -143,3 +143,26 @@ class WorkflowManagerBase(metaclass=WorkflowManagerMeta):
             for var in var_list:
                 all_vars[var.name] = var
         return all_vars
+
+    def selected_environment_variables(self):
+        """Extract all environment variables which would be included based
+        on the current variants.
+
+        Returns:
+            (dict) Keys are environment variable names, values are environment
+            variable instances
+        """
+
+        all_env_vars = {}
+        for (
+            when_key,
+            env_var_list,
+        ) in self.object_environment_variables.items():
+            if not self.app_inst.expander.satisfies(
+                when_key, self.app_inst.object_variants
+            ):
+                continue
+
+            for env_var in env_var_list:
+                all_env_vars[env_var.name] = env_var
+        return all_env_vars


### PR DESCRIPTION
Adds `when` support to the environment_variable directive and promotes to shared language, adding env vars to modifiers, workflow managers, and package managers.