### PR TITLE
Fix class naming in py-nemo classes

### DIFF
--- a/var/ramble/repos/builtin/applications/py-nemo-2/application.py
+++ b/var/ramble/repos/builtin/applications/py-nemo-2/application.py
@@ -10,7 +10,7 @@
 import os
 
 from ramble.appkit import *
-from ramble.base_app.builtin.py_nemo import BasePyNemo
+from ramble.base_app.builtin.py_nemo import PyNemo as BasePyNemo
 
 from spack.util.path import canonicalize_path
 

--- a/var/ramble/repos/builtin/applications/py-nemo/application.py
+++ b/var/ramble/repos/builtin/applications/py-nemo/application.py
@@ -13,7 +13,7 @@ import ruamel.yaml as yaml
 
 import ramble.util.yaml_generation
 from ramble.appkit import *
-from ramble.base_app.builtin.py_nemo import BasePyNemo
+from ramble.base_app.builtin.py_nemo import PyNemo as BasePyNemo
 
 import spack.util.spack_yaml as syaml
 from spack.util.path import canonicalize_path

--- a/var/ramble/repos/builtin/base_applications/py-nemo/base_application.py
+++ b/var/ramble/repos/builtin/base_applications/py-nemo/base_application.py
@@ -15,7 +15,7 @@ from ramble.appkit import *
 from spack.util.path import canonicalize_path
 
 
-class BasePyNemo(ExecutableApplication):
+class PyNemo(ExecutableApplication):
     """Define a base class for PyNemo applications."""
 
     tags(


### PR DESCRIPTION
Previously, the base application py-nemo had a class named BasePyNemo which isn't the correct format for Ramble.

This merge fixes this to use the correct format.