### PR TITLE
Add front-end command to manage ramble configs

### DIFF
--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -47,6 +47,7 @@ subcommands = [
     "deactivate",
     "create",
     "concretize",
+    "config",
     "setup",
     "analyze",
     "push-to-cache",
@@ -435,7 +436,7 @@ def workspace_concretize(args):
 
     if args.simplify:
         logger.debug("Simplifying workspace config")
-        ws.simplify()
+        ws.simplify_software()
     else:
         logger.debug("Concretizing workspace")
         ws.concretize(force=args.force_concretize, quiet=args.quiet)
@@ -616,6 +617,66 @@ def workspace_push_to_cache_setup_parser(subparser):
     arguments.add_common_arguments(
         subparser, ["where", "exclude_where", "filter_tags", "profile_phases"]
     )
+
+
+def workspace_config_setup_parser(subparser):
+    """Squashed workspace config"""
+
+    actions = subparser.add_mutually_exclusive_group(required=True)
+
+    actions.add_argument(
+        "--print-squash",
+        "-p",
+        action="store_true",
+        help="Print a squashed workspace configuration",
+    )
+
+    actions.add_argument(
+        "--simplify-software",
+        "--ss",
+        action="store_true",
+        help="Simplify the software configuration section of this workspace",
+    )
+
+    actions.add_argument(
+        "--simplify-variables",
+        "--sv",
+        action="store_true",
+        help="Simplify the variables configuration section of this workspace",
+    )
+
+    subparser.add_argument(
+        "--include-section",
+        "-i",
+        dest="included_section",
+        nargs="+",
+        default=["*"],
+        help="list of patterns to include configuration section, "
+        + "when printing the squashed config",
+        required=False,
+    )
+
+    subparser.add_argument(
+        "--exclude-section",
+        "-e",
+        dest="excluded_section",
+        nargs="+",
+        default=[],
+        help="list of patterns to exclude configuration section, "
+        + "when printing the squashed config. Overrides included section.",
+        required=False,
+    )
+
+
+def workspace_config(args):
+    ws = ramble.cmd.require_active_workspace(cmd_name="workspace squashed-config")
+
+    if args.print_squash:
+        ws.squash_and_print_config(args.included_section, args.excluded_section)
+    elif args.simplify_software:
+        ws.simplify_software()
+    elif args.simplify_variables:
+        ws.simplify_variables()
 
 
 def workspace_info_setup_parser(subparser):

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -262,6 +262,7 @@ class ExperimentSet:
 
     def _prepare_experiment(
         self,
+        workload_template_name,
         exp_template_name,
         variables,
         context,
@@ -273,7 +274,8 @@ class ExperimentSet:
         repeats, and template name.
 
         Args:
-            exp_template_name (str): Template name for experiments
+            workload_template_name (str): Template name for workload
+            experiment_template_name (str): Template name for experiments
             variables (dict): Dictionary of variables for this experiment
             context (Context): Context object for this experiment
             repeats (Repeats): Repeats object for this experiment
@@ -319,10 +321,12 @@ class ExperimentSet:
         final_wl_name = expander.expand_var_name(
             self.keywords.workload_name, allow_passthrough=False
         )
+
         final_exp_name = expander.expand_var(
             exp_template_name + experiment_suffix, allow_passthrough=False
         )
 
+        app_inst.define_variable(self.keywords.workload_template_name, workload_template_name)
         app_inst.define_variable(
             self.keywords.experiment_template_name, exp_template_name + experiment_suffix
         )
@@ -426,6 +430,7 @@ class ExperimentSet:
             Expander.expansion_str(self.keywords.experiment_name),
         )
 
+        workload_template_name = final_context.variables[self.keywords.workload_name]
         experiment_template_name = final_context.variables[self.keywords.experiment_name]
 
         renderer = ramble.renderer.Renderer()
@@ -473,6 +478,7 @@ class ExperimentSet:
             tracking_group, exclude_where=exclude_where, ignore_used=False, fatal=False
         ):
             app_inst = self._prepare_experiment(
+                workload_template_name,
                 experiment_template_name,
                 tracking_vars,
                 final_context,
@@ -490,6 +496,7 @@ class ExperimentSet:
             render_group, exclude_where=exclude_where
         ):
             app_inst = self._prepare_experiment(
+                workload_template_name,
                 experiment_template_name,
                 experiment_vars,
                 final_context,

--- a/lib/ramble/ramble/keywords.py
+++ b/lib/ramble/ramble/keywords.py
@@ -49,6 +49,7 @@ default_keys = {
     "n_threads": {"type": key_type.optional, "level": output_level.key},
     "batch_submit": {"type": key_type.required, "level": output_level.variable},
     "mpi_command": {"type": key_type.required, "level": output_level.variable},
+    "workload_template_name": {"type": key_type.reserved, "level": output_level.key},
     "experiment_template_name": {"type": key_type.reserved, "level": output_level.key},
     "unformatted_command": {"type": key_type.reserved, "level": output_level.variable},
     "unformatted_command_without_logs": {

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -2802,3 +2802,96 @@ def test_manage_modifier_remove_invalid_scope_errors(workspace_name, action, sco
             "manage", "modifiers", action, "-s", scope, "-n", "lscpu", global_args=global_args
         )
         assert error_message in output
+
+
+def test_workspace_config_squash(workspace_name, capsys):
+    test_vars_include = """variables:
+  foo: bar
+  n_ranks: 1
+  test_var: test_value
+"""
+
+    test_software_include = """software:
+  packages:
+    gcc:
+      pkg_spec: gcc@9.3.0 target=x86_64
+  environments:
+    gcc:
+      packages:
+      - gcc
+"""
+
+    global_args = ["-w", workspace_name]
+
+    with ramble.workspace.create(workspace_name) as ws:
+        with open(f"{os.path.join(ws.root, 'variables.yaml')}", "w+") as f:
+            f.write(test_vars_include)
+
+        with open(f"{os.path.join(ws.root, 'software.yaml')}", "w+") as f:
+            f.write(test_software_include)
+
+        ws.write()
+        workspace(
+            "manage",
+            "experiments",
+            "zlib",
+            "--wf",
+            "ensure_installed",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            "-p",
+            "spack",
+            global_args=global_args,
+        )
+
+        workspace("concretize", global_args=global_args)
+
+        workspace(
+            "manage",
+            "includes",
+            "--add",
+            "$workspace_root/variables.yaml",
+            global_args=global_args,
+        )
+
+        workspace(
+            "manage", "includes", "--add", "$workspace_root/software.yaml", global_args=global_args
+        )
+
+        config_output = config("get", "variables", global_args=global_args)
+
+        assert "foo: bar" in config_output
+
+        ws.write()
+
+        # Can't call with the front-end command, because included config scopes
+        # are not processed correctly in tests.
+        ws.squash_and_print_config(excluded_section=["*repos", "config"])
+
+        config_output = capsys.readouterr().out
+
+        assert "foo: bar" in config_output
+        assert "test_var: test_value" in config_output
+        assert "gcc" in config_output
+        assert "pkg_spec: gcc@9.3.0" in config_output
+
+        with open(ws.config_file_path, "w+") as f:
+            f.write(config_output)
+
+        ws._re_read()
+
+        workspace("config", "--simplify-software", global_args=global_args)
+
+        with open(ws.config_file_path) as f:
+            data = f.read()
+            assert "pkg_spec: gcc@9.3.0" not in data
+            assert "gcc" not in data
+
+        workspace("config", "--simplify-variables", global_args=global_args)
+
+        with open(ws.config_file_path) as f:
+            data = f.read()
+            assert "foo: bar" not in data
+            assert "test_var: test_value" not in data

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -14,7 +14,7 @@ import os
 import re
 import shutil
 from collections import defaultdict
-from typing import List
+from typing import List, Set
 
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
@@ -1088,6 +1088,34 @@ ramble:
             workspace_dict = self._get_workspace_dict()
             workspace_dict[namespace.software] = software_dict
 
+    def squash_and_print_config(self, included_section=None, excluded_section=None):
+        workspace_dict = self._get_workspace_dict()
+
+        # Remove includes if they were defined before.
+        if "include" in workspace_dict["ramble"]:
+            del workspace_dict["ramble"]["include"]
+
+        for section in ramble.config.section_schemas:
+            keep = True
+
+            if included_section:
+                keep = False
+                for pattern in included_section:
+                    if fnmatch.fnmatch(section, pattern):
+                        keep = True
+
+            if excluded_section:
+                for pattern in excluded_section:
+                    if fnmatch.fnmatch(section, pattern):
+                        keep = False
+
+            if keep:
+                section_dict = ramble.config.get(section)
+                if section_dict:
+                    workspace_dict["ramble"][section] = section_dict
+
+        print(f"\n{syaml.dump(workspace_dict)}")
+
     def add_experiments(
         self,
         application,
@@ -1752,7 +1780,92 @@ ramble:
         self.input_mirror_cache = ramble.caches.MirrorCache(self.input_mirror_path)
         self.software_mirror_cache = ramble.caches.MirrorCache(self.software_mirror_path)
 
-    def simplify(self):
+    def simplify_variables(self):
+        """Simplify variable sections in workspace configuration file"""
+
+        def _remove_scoped_variables(scope_name: str, used_variables: Set):
+            """Remove unused variables from a specific workspace scope.
+
+            Args:
+                scope_name (str): Name of scope to remove definitions from.
+                used_variables (set): Set of used definitions that should be kept.
+            """
+
+            if scope_name is None:
+                return
+
+            # Delete unused variables from requested scope.
+            to_remove = set()
+            scope_section = self._get_scope_section(scope_name)
+            if namespace.variables in scope_section:
+                for var in scope_section[namespace.variables]:
+                    if var not in used_variables:
+                        to_remove.add(var)
+                for var in to_remove:
+                    del scope_section[namespace.variables][var]
+
+                if not scope_section[namespace.variables]:
+                    del scope_section[namespace.variables]
+
+        # Build experiment sets to determine which variables are used
+        self.software_environments = ramble.software_environments.SoftwareEnvironments(self)
+        experiment_set = self.build_experiment_set()
+
+        workspace_used_variables = set()
+
+        prev_app = None
+        prev_wl = None
+        prev_exp = None
+
+        app_used_vars = set()
+        wl_used_vars = set()
+        exp_used_vars = set()
+
+        for _, app_inst, _ in experiment_set.all_experiments():
+            app_inst.build_used_variables(self)
+
+            if prev_exp != app_inst.variables[app_inst.keywords.experiment_template_name]:
+                if prev_exp is not None:
+                    _remove_scoped_variables(f"{prev_app}:{prev_wl}:{prev_exp}", exp_used_vars)
+
+                prev_exp = app_inst.variables[app_inst.keywords.experiment_template_name]
+                exp_used_vars = set()
+
+            if prev_wl != app_inst.variables[app_inst.keywords.workload_template_name]:
+                if prev_wl is not None:
+                    _remove_scoped_variables(f"{prev_app}:{prev_wl}", wl_used_vars)
+
+                prev_wl = app_inst.variables[app_inst.keywords.workload_template_name]
+                wl_used_vars = set()
+
+            if prev_app != app_inst.variables[app_inst.keywords.application_name]:
+                if prev_app is not None:
+                    _remove_scoped_variables(prev_app, app_used_vars)
+
+                prev_app = app_inst.variables[app_inst.keywords.application_name]
+                app_used_vars = set()
+
+            workspace_used_variables = workspace_used_variables.union(
+                app_inst.expander._used_variables
+            )
+            app_used_vars = app_used_vars.union(app_inst.expander._used_variables)
+            wl_used_vars = wl_used_vars.union(app_inst.expander._used_variables)
+            exp_used_vars = exp_used_vars.union(app_inst.expander._used_variables)
+
+        if prev_exp is not None:
+            _remove_scoped_variables(f"{prev_app}:{prev_wl}:{prev_exp}", exp_used_vars)
+
+        if prev_wl is not None:
+            _remove_scoped_variables(f"{prev_app}:{prev_wl}", wl_used_vars)
+
+        if prev_app is not None:
+            _remove_scoped_variables(prev_app, app_used_vars)
+
+        _remove_scoped_variables("workspace", workspace_used_variables)
+
+        self._write_config(config_section)
+
+    def simplify_software(self):
         # First drop unused experiment templates from app dict so environments aren't rendered
         app_dict = ramble.config.config.get_config(
             namespace.application, scope=self.ws_file_config_scope_name()
@@ -2017,13 +2130,14 @@ ramble:
                 base_section = base_section[namespace.workload][scope_parts[1]]
 
             if len(scope_parts) >= 3:  # Extract experiment section
-                if scope_parts[2] not in base_section[namespace.experiment]:
+                joined_scope_part = ":".join(scope_parts[2:])
+                if joined_scope_part not in base_section[namespace.experiment]:
                     logger.die(
-                        f"No experiment matches requested scope {scope_parts[1]} in application "
-                        f"{scope_parts[0]} and workload {scope_parts[1]}"
+                        f"No experiment matches requested scope {joined_scope_part} "
+                        f"in application{scope_parts[0]} and workload {scope_parts[1]}"
                     )
 
-                base_section = base_section[namespace.experiment][scope_parts[2]]
+                base_section = base_section[namespace.experiment][joined_scope_part]
         if base_section is None:
             logger.die(f"No scope matches requested scope of {scope}")
         return base_section

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -632,7 +632,7 @@ _ramble_workspace() {
     then
         RAMBLE_COMPREPLY="-h --help"
     else
-        RAMBLE_COMPREPLY="activate archive deactivate create concretize setup analyze push-to-cache info edit mirror experiment-logs list ls remove rm generate-config manage"
+        RAMBLE_COMPREPLY="activate archive deactivate create concretize config setup analyze push-to-cache info edit mirror experiment-logs list ls remove rm generate-config manage"
     fi
 }
 
@@ -664,6 +664,10 @@ _ramble_workspace_create() {
 
 _ramble_workspace_concretize() {
     RAMBLE_COMPREPLY="-h --help -f --force-concretize --simplify --quiet -q"
+}
+
+_ramble_workspace_config() {
+    RAMBLE_COMPREPLY="-h --help --print-squash -p --simplify-software --ss --simplify-variables --sv --include-section -i --exclude-section -e"
 }
 
 _ramble_workspace_setup() {


### PR DESCRIPTION
This merge adds the ability for `ramble workspace` to squash all config sections into a ramble.yaml, and print it to the screen. Additionally, in the `ramble workspace config` command, features are added to support simplifying (removing unused) software, and variables.