### PR TITLE
Fix up workflow_manager doc list

### DIFF
--- a/lib/ramble/ramble/test/util/format.py
+++ b/lib/ramble/ramble/test/util/format.py
@@ -1,0 +1,40 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import pytest
+
+from ramble.util import format
+
+
+@pytest.mark.parametrize(
+    "doc_str, kwargs, expected",
+    [
+        ("", {}, ""),
+        (None, {}, ""),
+        (
+            "This is a short docstring.",
+            {"indent": 4},
+            "    This is a short docstring.\n",
+        ),
+        (
+            "This  is   a\tdocstring\nwith    extra whitespace.",
+            {},
+            "This is a docstring with extra whitespace.\n",
+        ),
+        (
+            "This is a very long docstring that should definitely be wrapped "
+            "because it exceeds the seventy-two character limit for a single line.",
+            {"indent": 2},
+            "  This is a very long docstring that should definitely be wrapped because\n"
+            "  it exceeds the seventy-two character limit for a single line.\n",
+        ),
+    ],
+)
+def test_format_doc(doc_str, kwargs, expected):
+    """Test the format_doc function with various inputs."""
+    assert format.format_doc(doc_str, **kwargs) == expected

--- a/lib/ramble/ramble/util/format.py
+++ b/lib/ramble/ramble/util/format.py
@@ -1,0 +1,25 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+
+import io
+import re
+import textwrap
+
+
+def format_doc(doc_str, **kwargs):
+    """Wrap doc string at 72 characters and format nicely"""
+    if not doc_str:
+        return ""
+    indent = kwargs.get("indent", 0)
+    doc = re.sub(r"\s+", " ", doc_str)
+    lines = textwrap.wrap(doc, 72)
+    results = io.StringIO()
+    for line in lines:
+        results.write((" " * indent) + line + "\n")
+    return results.getvalue()

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -9,14 +9,12 @@
 
 import copy
 import fnmatch
-import io
 import operator
 import os
 import re
 import shutil
 import stat
 import string
-import textwrap
 import time
 from typing import List
 
@@ -59,7 +57,7 @@ from ramble.language.shared_language import (
     register_builtin,
     register_phase,
 )
-from ramble.util import constants, conversions
+from ramble.util import constants, conversions, format
 from ramble.util.foms import FomType
 from ramble.util.logger import logger
 from ramble.util.naming import NS_SEPARATOR
@@ -831,18 +829,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
             color.cprint(f"{indent}- {exp}")
 
     def format_doc(self, **kwargs):
-        """Wrap doc string at 72 characters and format nicely"""
-        indent = kwargs.get("indent", 0)
-
-        if not self.__doc__:
-            return ""
-
-        doc = re.sub(r"\s+", " ", self.__doc__)
-        lines = textwrap.wrap(doc, 72)
-        results = io.StringIO()
-        for line in lines:
-            results.write((" " * indent) + line + "\n")
-        return results.getvalue()
+        return format.format_doc(self.__doc__, **kwargs)
 
     # Phase execution helpers
     def run_phase(self, pipeline, phase, workspace):

--- a/var/ramble/repos/builtin/base_classes/modifier-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/modifier-base/base_class.py
@@ -8,9 +8,7 @@
 """Define base classes for modifier definitions"""
 
 import fnmatch
-import io
 import re
-import textwrap
 from typing import List
 
 import ramble.util.class_attributes
@@ -19,6 +17,7 @@ import ramble.variants
 from ramble.error import InvalidModeError, ModifierError
 from ramble.language.modifier_language import ModifierMeta, mode
 from ramble.language.shared_language import SharedMeta
+from ramble.util import format
 from ramble.util.logger import logger
 from ramble.util.naming import NS_SEPARATOR
 
@@ -173,18 +172,7 @@ class ModifierBase(metaclass=ModifierMeta):
         return self.name
 
     def format_doc(self, **kwargs):
-        """Wrap doc string at 72 characters and format nicely"""
-        indent = kwargs.get("indent", 0)
-
-        if not self.__doc__:
-            return ""
-
-        doc = re.sub(r"\s+", " ", self.__doc__)
-        lines = textwrap.wrap(doc, 72)
-        results = io.StringIO()
-        for line in lines:
-            results.write((" " * indent) + line + "\n")
-        return results.getvalue()
+        return format.format_doc(self.__doc__, **kwargs)
 
     def modded_variables(self, app, extra_vars=None):
         mods = {}

--- a/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
@@ -7,10 +7,7 @@
 # except according to those terms.
 """Define base classes for package manager definitions"""
 
-import io
 import os
-import re
-import textwrap
 from typing import List
 
 import ramble.util.class_attributes
@@ -18,6 +15,7 @@ import ramble.util.directives
 import ramble.variants
 from ramble.language.package_manager_language import PackageManagerMeta
 from ramble.language.shared_language import SharedMeta, register_phase
+from ramble.util import format
 from ramble.util.naming import NS_SEPARATOR
 
 import spack.util.naming
@@ -188,18 +186,7 @@ class PackageManagerBase(metaclass=PackageManagerMeta):
         return self.name
 
     def format_doc(self, **kwargs):
-        """Wrap doc string at 72 characters and format nicely"""
-        indent = kwargs.get("indent", 0)
-
-        if not self.__doc__:
-            return ""
-
-        doc = re.sub(r"\s+", " ", self.__doc__)
-        lines = textwrap.wrap(doc, 72)
-        results = io.StringIO()
-        for line in lines:
-            results.write((" " * indent) + line + "\n")
-        return results.getvalue()
+        return format.format_doc(self.__doc__, **kwargs)
 
     def all_pipeline_phases(self, pipeline):
         """Iterator over all phases within a specified pipeline

--- a/var/ramble/repos/builtin/base_classes/workflow-manager-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/workflow-manager-base/base_class.py
@@ -7,6 +7,9 @@
 # except according to those terms.
 """Define base classes for workflow manager definitions"""
 
+import io
+import re
+import textwrap
 from typing import List
 
 import ramble.util.class_attributes
@@ -166,3 +169,17 @@ class WorkflowManagerBase(metaclass=WorkflowManagerMeta):
             for env_var in env_var_list:
                 all_env_vars[env_var.name] = env_var
         return all_env_vars
+
+    def format_doc(self, **kwargs):
+        """Wrap doc string at 72 characters and format nicely"""
+        indent = kwargs.get("indent", 0)
+
+        if not self.__doc__:
+            return ""
+
+        doc = re.sub(r"\s+", " ", self.__doc__)
+        lines = textwrap.wrap(doc, 72)
+        results = io.StringIO()
+        for line in lines:
+            results.write((" " * indent) + line + "\n")
+        return results.getvalue()

--- a/var/ramble/repos/builtin/base_classes/workflow-manager-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/workflow-manager-base/base_class.py
@@ -7,9 +7,6 @@
 # except according to those terms.
 """Define base classes for workflow manager definitions"""
 
-import io
-import re
-import textwrap
 from typing import List
 
 import ramble.util.class_attributes
@@ -171,15 +168,4 @@ class WorkflowManagerBase(metaclass=WorkflowManagerMeta):
         return all_env_vars
 
     def format_doc(self, **kwargs):
-        """Wrap doc string at 72 characters and format nicely"""
-        indent = kwargs.get("indent", 0)
-
-        if not self.__doc__:
-            return ""
-
-        doc = re.sub(r"\s+", " ", self.__doc__)
-        lines = textwrap.wrap(doc, 72)
-        results = io.StringIO()
-        for line in lines:
-            results.write((" " * indent) + line + "\n")
-        return results.getvalue()
+        return format.format_doc(self.__doc__, **kwargs)

--- a/var/ramble/repos/builtin/workflow_managers/google-batch/workflow_manager.py
+++ b/var/ramble/repos/builtin/workflow_managers/google-batch/workflow_manager.py
@@ -8,7 +8,7 @@
 
 import os
 
-import yaml
+import ruamel.yaml as yaml
 
 from ramble.experiment_result import ExperimentStatus
 from ramble.util import shell_utils


### PR DESCRIPTION
Previously the workflow_manager object is missing the `format_doc` method. Also the `yaml` module imported by google-batch may not exist.

Extract `format_doc` into a standalone util.