### PR TITLE
Delay initialize runner for package managers

### DIFF
--- a/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
@@ -69,7 +69,6 @@ class PackageManagerBase(metaclass=PackageManagerMeta):
 
         self._verbosity = "short"
 
-        self.runner = None
         self.app_inst = None
         self.keywords = None
 
@@ -88,6 +87,11 @@ class PackageManagerBase(metaclass=PackageManagerMeta):
             )
 
         self.output_prefix = self.name
+
+    @property
+    def runner(self):
+        # Turn `runner` into a property for delayed init
+        return None
 
     def copy(self):
         """Deep copy a package manager instance"""

--- a/var/ramble/repos/builtin/package_managers/pip/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/pip/package_manager.py
@@ -42,7 +42,13 @@ class Pip(PackageManagerBase):
     def __init__(self, file_path):
         super().__init__(file_path)
 
-        self.runner = PipRunner()
+        self._runner = None
+
+    @property
+    def runner(self):
+        if self._runner is None:
+            self._runner = PipRunner()
+        return self._runner
 
     register_builtin(
         "pip_activate", required=True, depends_on=["builtin::env_vars"]

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
@@ -45,7 +45,13 @@ class SpackLightweight(PackageManagerBase):
         super().__init__(file_path)
         self.output_prefix = self._spec_prefix
 
-        self.runner = SpackRunner()
+        self._runner = None
+
+    @property
+    def runner(self):
+        if self._runner is None:
+            self._runner = SpackRunner()
+        return self._runner
 
     register_phase(
         "software_install_requested_compilers",


### PR DESCRIPTION
The motivation comes from `ramble list --type package_managers` reporting "missing Spack" in an environment where spack is not installed (for example in doc-build,) even though technically spack is not required for `ramble list` purpose. Changing it to be a property so that the "missing in path" error only gets reported upon first-use.