### PR TITLE
Switching Between Two Rambles

### DIFF
--- a/share/ramble/setup-env.sh
+++ b/share/ramble/setup-env.sh
@@ -198,7 +198,7 @@ _ramble_pathadd() {
 
     _pa_canonical=":$_pa_oldvalue:"
     if [ -d "$_pa_new_path" ] && \
-       [ "${_pa_canonical#*:${_pa_new_path}:}" = "${_pa_canonical}" ];
+       [ "${_pa_canonical#${_pa_new_path}:}" = "${_pa_canonical}" ];
     then
         if [ -n "$_pa_oldvalue" ]; then
             eval "export $_pa_varname=\"$_pa_new_path:$_pa_oldvalue\""


### PR DESCRIPTION
### Problem
Currently, if I:
   1. Use `dir1/ramble` 
   2. switch to `dir2/ramble`
   3. Try to switch back to `dir1/ramble`
 
Sourcing the script in `ramble/share/ramble/setup-env.sh` will not prepend the path of `dir1/ramble` since it already exists, and my `PATH` will still point at `dir2/ramble`

### Example
```
$ . wkp/ramble/share/ramble/setup-env.sh
$ echo $PATH
/usr/workspace/mckinsey/bp_rp_caliper_none/wkp/ramble/bin:...

$ . wkp2/ramble/share/ramble/setup-env.sh
$ echo $PATH
/usr/workspace/mckinsey/bp_rp_caliper_none/wkp2/ramble/bin:/usr/workspace/mckinsey/bp_rp_caliper_none/wkp/ramble/bin:...

$ . wkp/ramble/share/ramble/setup-env.sh
$ echo $PATH
/usr/workspace/mckinsey/bp_rp_caliper_none/wkp2/ramble/bin:/usr/workspace/mckinsey/bp_rp_caliper_none/wkp/ramble/bin:...

# ^ Note: cannot switch back to "wkp/ramble" since the path already exists, "wkp2/ramble" will be used for "ramble ..."
```
After the change in this PR #1108
```
$ . wkp/ramble/share/ramble/setup-env.sh 
$ echo $PATH
/usr/workspace/mckinsey/bp_rp_caliper_none/wkp/ramble/bin:/usr/workspace/mckinsey/bp_rp_caliper_none/wkp2/ramble/bin:/usr/workspace/mckinsey/bp_rp_caliper_none/wkp/ramble/bin:...

# ^ Note: notice duplicate "wkp/ramble", but path is prepended
```

For full context, the use case for me is two different benchpark workspaces `wkp` and `wkp2`.
FYI: This change would match the behavior by `spack/share/spack/setup-env.sh`