### PR TITLE
Fix up the "overline too short" sphinx warning

### DIFF
--- a/lib/ramble/docs/base_application_list.rst
+++ b/lib/ramble/docs/base_application_list.rst
@@ -8,9 +8,9 @@
 
 .. _base-application-list:
 
-================
+=====================
 Base Application List
-================
+=====================
 
 This is a list of base applications you can inherit from within other  for using Ramble.  It is
 automatically generated based on the base applications in this Ramble

--- a/lib/ramble/docs/base_modifiers_list.rst
+++ b/lib/ramble/docs/base_modifiers_list.rst
@@ -8,9 +8,9 @@
 
 .. _base-modifier-list:
 
-================
+==================
 Base Modifier List
-================
+==================
 
 This is a list of base modifiers you can inherit from when creating new
 modifiers for use in Ramble. This list is automatically generated based on the

--- a/lib/ramble/docs/package_manager_list.rst
+++ b/lib/ramble/docs/package_manager_list.rst
@@ -8,9 +8,9 @@
 
 .. _package-manager-list:
 
-================
+====================
 Package Manager List
-================
+====================
 
 This is a list of package managers available within Ramble, for managing
 experiment software stacks.  It is automatically generated based on the


### PR DESCRIPTION
This shows up as warnings in our doc build. Sphinx expects the overline to be at least the same length as the section texts.