### PR TITLE
Set default vars in user-managed workflow manager

### DIFF
--- a/lib/ramble/ramble/test/cmd/config.py
+++ b/lib/ramble/ramble/test/cmd/config.py
@@ -343,8 +343,7 @@ def test_config_get_gets_ramble_yaml(mutable_mock_workspace_path, mutable_mock_a
             "variables",
             "env_vars",
             "software",
-            "mpi_command",
-            "batch_submit",
+            "processes_per_node",
         ]
 
         for key in expected_keys:

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -453,7 +453,6 @@ def test_workspace_info_complete(workspace_name):
     assert "package_manager: spack" in output
 
     assert "Variables from Workspace" in output
-    assert "mpi_command = mpirun -n {n_ranks} ==> mpirun -n 1" in output
     assert "Variables from Experiment" in output
     assert "n_ranks = 1 ==> 1" in output
 

--- a/lib/ramble/ramble/test/cmd/workspace_manage.py
+++ b/lib/ramble/ramble/test/cmd/workspace_manage.py
@@ -59,3 +59,23 @@ def test_manage_variable_multiple_equals(workspace_name, tmpdir):
                     results[idx] = True
 
     assert all(results)
+
+
+def test_manage_experiments_no_overwrite_wm_vars(workspace_name):
+    ws = ramble.workspace.create(workspace_name)
+    global_args = ["-w", workspace_name]
+    workspace(
+        "manage",
+        "experiments",
+        "hostname",
+        "--wf",
+        "parallel",
+        "--wm",
+        "user-managed",
+        global_args=global_args,
+    )
+    with open(ws.config_file_path) as f:
+        content = f.read()
+        assert "processes_per_node:" in content
+        assert "batch_submit" not in content
+        assert "mpi_command" not in content

--- a/lib/ramble/ramble/test/experiment_set.py
+++ b/lib/ramble/ramble/test/experiment_set.py
@@ -822,24 +822,19 @@ def test_reserved_keywords_error_in_experiment(mutable_mock_workspace_path, var)
         assert "is reserved by ramble" in captured
 
 
-@pytest.mark.parametrize("var", ["batch_submit", "mpi_command"])
-def test_missing_required_keyword_errors(mutable_mock_workspace_path, var, capsys):
+def test_missing_required_keyword_errors(mutable_mock_workspace_path, capsys):
     workspace("create", "test")
 
     assert "test" in workspace("list")
 
     with ramble.workspace.read("test") as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
-        for context in exp_set._contexts:
-            if exp_set._context[context].variables and var in exp_set._context[context].variables:
-                del exp_set._context[context].variables[var]
 
         application_context = ramble.context.Context()
         application_context.context_name = "basic"
         application_context.variables = {
             "app_var1": "1",
             "app_var2": "2",
-            "n_ranks": ["4", "6"],
         }
 
         workload_context = ramble.context.Context()
@@ -849,28 +844,23 @@ def test_missing_required_keyword_errors(mutable_mock_workspace_path, var, capsy
             "wl_var2": "2",
         }
         experiment_context = ramble.context.Context()
-        experiment_context.context_name = "series1_{n_ranks}_{processes_per_node}"
+        experiment_context.context_name = "series1"
         experiment_context.variables = {
             "exp_var1": "1",
             "exp_var2": "2",
-            "n_nodes": ["2", "3"],
             "batch_submit": "",
             "mpi_command": "",
         }
-
-        if var in experiment_context.variables.keys():
-            del experiment_context.variables[var]
 
         exp_set.set_application_context(application_context)
         exp_set.set_workload_context(workload_context)
         with pytest.raises(ramble.experiment_set.RambleVariableDefinitionError):
             exp_set.set_experiment_context(experiment_context)
         captured = capsys.readouterr()
-        assert f'Required key "{var}" is not defined' in captured.err
-        assert "in basic.test_wl.series1_{n_ranks}_{processes_per_node}" in captured.err
+        assert 'Required key "n_ranks" is not defined' in captured.err
 
 
-def test_chained_experiments_populate_new_experiments(mutable_mock_workspace_path, capsys):
+def test_chained_experiments_populate_new_experiments(mutable_mock_workspace_path):
     workspace("create", "test")
 
     assert "test" in workspace("list")
@@ -932,7 +922,7 @@ def test_chained_experiments_populate_new_experiments(mutable_mock_workspace_pat
         assert "basic.test_wl.test1" in exp_set.experiments
 
 
-def test_chained_experiment_has_correct_directory(mutable_mock_workspace_path, capsys):
+def test_chained_experiment_has_correct_directory(mutable_mock_workspace_path):
     workspace("create", "test")
 
     assert "test" in workspace("list")
@@ -1091,7 +1081,7 @@ def test_chained_invalid_order_errors(mutable_mock_workspace_path):
             exp_set.build_experiment_chains()
 
 
-def test_modifiers_set_correctly(mutable_mock_workspace_path, mock_modifiers, capsys):
+def test_modifiers_set_correctly(mutable_mock_workspace_path, mock_modifiers):
     workspace("create", "test")
 
     assert "test" in workspace("list")

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -390,22 +390,26 @@ def get_workspace(args, cmd_name, required=False):
         )
 
 
-def _get_all_wm_var_names(wm):
-    """Return a set of all workflow manager's variables names."""
-    if wm is None:
+def _get_all_obj_var_names(obj, obj_type):
+    """Return a set of all variables names defined in the given object."""
+    if obj is None:
+        if obj_type == ramble.repository.ObjectTypes.package_managers:
+            variant_name = namespace.package_manager
+        elif obj_type == ramble.repository.ObjectTypes.workflow_managers:
+            variant_name = namespace.workflow_manager
+        else:
+            raise ValueError("Only package manager and workflow manager types are supported")
         variants_dict = ramble.config.get(namespace.variants)
-        wm_name = variants_dict.get(namespace.workflow_manager)
-        if wm_name is None:
+        obj_name = variants_dict.get(variant_name)
+        if obj_name is None:
             return set()
     else:
-        wm_name = wm
+        obj_name = obj
     try:
-        wm_inst = ramble.repository.get(
-            wm_name, object_type=ramble.repository.ObjectTypes.workflow_managers
-        )
+        obj_inst = ramble.repository.get(obj_name, object_type=obj_type)
     except ramble.repository.UnknownObjectError:
         return set()
-    vars = list(itertools.chain.from_iterable(wm_inst.object_variables.values()))
+    vars = list(itertools.chain.from_iterable(obj_inst.object_variables.values()))
     return {var.name for var in vars}
 
 
@@ -1317,7 +1321,11 @@ ramble:
             var_def_dict[workload_name_variable] = workload_names.copy()
             workload_names = [ramble.expander.Expander.expansion_str(workload_name_variable)]
 
-        wm_all_var_names = _get_all_wm_var_names(workflow_manager)
+        obj_var_names = _get_all_obj_var_names(
+            workflow_manager, obj_type=ramble.repository.ObjectTypes.package_managers
+        ) | _get_all_obj_var_names(
+            workflow_manager, obj_type=ramble.repository.ObjectTypes.workflow_managers
+        )
 
         for workload_name in workload_names:
             edited = True
@@ -1347,11 +1355,11 @@ ramble:
             # Ensure required variables are defined
             for key in app_inst.keywords.all_required_keys():
                 # Do not define missing required variables that are defined in
-                # the associated workflow manager.
+                # the associated package and workflow managers.
                 # TODO: should include consideration for when clause, right now
                 # the `selected_variables` method cannot be used due to no associated
                 # expander at this stage.
-                if key not in workspace_vars and key not in wm_all_var_names:
+                if key not in workspace_vars and key not in obj_var_names:
                     vars_dict[key] = ""
 
             # Only extract variable defaults if requested.

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -10,6 +10,7 @@ import contextlib
 import copy
 import datetime
 import fnmatch
+import itertools
 import os
 import re
 import shutil
@@ -387,6 +388,25 @@ def get_workspace(args, cmd_name, required=False):
             "or use:",
             f"    ramble -w WRKSPC {cmd_name} ...",
         )
+
+
+def _get_all_wm_var_names(wm):
+    """Return a set of all workflow manager's variables names."""
+    if wm is None:
+        variants_dict = ramble.config.get(namespace.variants)
+        wm_name = variants_dict.get(namespace.workflow_manager)
+        if wm_name is None:
+            return set()
+    else:
+        wm_name = wm
+    try:
+        wm_inst = ramble.repository.get(
+            wm_name, object_type=ramble.repository.ObjectTypes.workflow_managers
+        )
+    except ramble.repository.UnknownObjectError:
+        return set()
+    vars = list(itertools.chain.from_iterable(wm_inst.object_variables.values()))
+    return {var.name for var in vars}
 
 
 class Workspace:
@@ -1297,6 +1317,8 @@ ramble:
             var_def_dict[workload_name_variable] = workload_names.copy()
             workload_names = [ramble.expander.Expander.expansion_str(workload_name_variable)]
 
+        wm_all_var_names = _get_all_wm_var_names(workflow_manager)
+
         for workload_name in workload_names:
             edited = True
             if workload_name not in workloads_dict:
@@ -1324,7 +1346,12 @@ ramble:
 
             # Ensure required variables are defined
             for key in app_inst.keywords.all_required_keys():
-                if key not in workspace_vars:
+                # Do not define missing required variables that are defined in
+                # the associated workflow manager.
+                # TODO: should include consideration for when clause, right now
+                # the `selected_variables` method cannot be used due to no associated
+                # expander at this stage.
+                if key not in workspace_vars and key not in wm_all_var_names:
                     vars_dict[key] = ""
 
             # Only extract variable defaults if requested.

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -601,7 +601,10 @@ cd "{experiment_run_dir}"
         # Construct string for default variants
         variant_string = ""
 
-        all_variants = {}
+        # Set default workflow_manager to the user-managed one,
+        # which provides defaults for required variables such as
+        # batch_submit and mpi_command.
+        all_variants = {"workflow_manager": "user-managed"}
         for scope in ramble.config.scopes():
             if namespace.workspace not in scope:
                 variant_dict = ramble.config.get(namespace.variants, scope=scope)
@@ -644,8 +647,6 @@ ramble:
       OMP_NUM_THREADS: '{{n_threads}}'
 {variant_string}
   {namespace.variables}:
-    mpi_command: mpirun -n {{n_ranks}}
-    batch_submit: '{{execute_experiment}}'
     processes_per_node: 1
   {namespace.application}: {{}}
   {namespace.software}:

--- a/var/ramble/repos/builtin/workflow_managers/user-managed/workflow_manager.py
+++ b/var/ramble/repos/builtin/workflow_managers/user-managed/workflow_manager.py
@@ -25,3 +25,15 @@ class UserManaged(WorkflowManagerBase):
 """,
         description="Banner to describe the workflow within execution templates",
     )
+
+    workflow_manager_variable(
+        name="mpi_command",
+        default="mpirun -n {n_ranks}",
+        description="mpirun prefix, mostly served as an overridable default",
+    )
+
+    workflow_manager_variable(
+        name="batch_submit",
+        default="{execute_experiment}",
+        description="batch_submit script, mostly served as an overridable default",
+    )


### PR DESCRIPTION
The default config template sets `workflow_manager` to `user-managed`, and the `mpi_commands` and `batch_submit` variables are set inside that workflow manager. The intent is to avoid the default config template to set these variables and potentially in conflict with workflow managers like slurm.