### PR TITLE
Allow workspace replacements in variable definitions

### DIFF
--- a/lib/ramble/docs/workspace_config.rst
+++ b/lib/ramble/docs/workspace_config.rst
@@ -996,6 +996,17 @@ Ramble automatically generates definitions for the following variables:
   the experiment. Unformatted so it can be formatted for various experiments.
 * ``unformatted_command_without_logs`` - The same as ``unformatted_command`` but
   has no log removal, creation, or redirection.
+* ``workspace`` - Path to the root of the workspace
+* ``workspace_root`` - Path to the root of the workspace
+* ``workspace_configs`` - Path to the workspace configs directory
+* ``workspace_software`` - Path to the workspace software directory
+* ``workspace_logs`` - Path to the workspace logs directory
+* ``workspace_inputs`` - Path to the workspace inputs directory
+* ``workspace_experiments`` - Path to the workspace experiments directory
+* ``workspace_shared`` - Path to the workspace shared directory
+* ``workspace_archives`` - Path to the workspace archives directory
+* ``workspace_deployments`` - Path to the workspace deployments directory
+
 
 Package Manager Specific Generated Variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -19,6 +19,7 @@ from typing import Dict, FrozenSet, List, Union
 import ramble.error
 import ramble.keywords
 from ramble.util.logger import logger
+from ramble.util.path import substitute_path_variables
 
 import spack.util.naming
 
@@ -393,6 +394,7 @@ class Expander:
         self._used_variable_stage = set()
 
         self._experiment_set = experiment_set
+        self.replacement_paths = {}
 
         self._application_name = None
         self._workload_name = None
@@ -669,7 +671,10 @@ class Expander:
         if merge_used_stage:
             self.merge_used_variable_stage()
 
-        return value
+        if isinstance(value, str):
+            return substitute_path_variables(value, local_replacements=self.replacement_paths)
+        else:
+            return value
 
     def evaluate_predicate(self, in_str, extra_vars=None, merge_used_stage: bool = True):
         """Evaluate a predicate by expanding and evaluating math contained in a string

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -365,6 +365,9 @@ class ExperimentSet:
             ),
         )
 
+        for name, value in self._workspace.workspace_paths().items():
+            app_inst.define_variable(name, value)
+
         app_inst.add_expand_vars(self._workspace)
         app_inst.read_status()
 

--- a/lib/ramble/ramble/keywords.py
+++ b/lib/ramble/ramble/keywords.py
@@ -15,6 +15,16 @@ key_type = Enum("type", ["reserved", "optional", "required"])
 output_level = Enum("level", ["key", "variable"])
 default_keys = {
     "workspace_name": {"type": key_type.reserved, "level": output_level.variable},
+    "workspace": {"type": key_type.reserved, "level": output_level.variable},
+    "workspace_root": {"type": key_type.reserved, "level": output_level.variable},
+    "workspace_configs": {"type": key_type.reserved, "level": output_level.variable},
+    "workspace_software": {"type": key_type.reserved, "level": output_level.variable},
+    "workspace_logs": {"type": key_type.reserved, "level": output_level.variable},
+    "workspace_inputs": {"type": key_type.reserved, "level": output_level.variable},
+    "workspace_experiments": {"type": key_type.reserved, "level": output_level.variable},
+    "workspace_shared": {"type": key_type.reserved, "level": output_level.variable},
+    "workspace_archives": {"type": key_type.reserved, "level": output_level.variable},
+    "workspace_deployments": {"type": key_type.reserved, "level": output_level.variable},
     "application_name": {"type": key_type.reserved, "level": output_level.key},
     "application_run_dir": {"type": key_type.reserved, "level": output_level.variable},
     "application_input_dir": {"type": key_type.reserved, "level": output_level.variable},

--- a/lib/ramble/ramble/test/end_to_end/workspace_path_replacements.py
+++ b/lib/ramble/ramble/test/end_to_end/workspace_path_replacements.py
@@ -1,0 +1,58 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.workspace
+from ramble.main import RambleCommand
+
+# everything here uses the mock_workspace_path
+pytestmark = pytest.mark.usefixtures(
+    "mutable_config",
+    "mutable_mock_workspace_path",
+)
+
+workspace = RambleCommand("workspace")
+
+
+def test_workspace_dollar_paths(workspace_name):
+    ws = ramble.workspace.create(workspace_name)
+    global_args = ["-w", workspace_name]
+
+    replacement_paths = ws.workspace_paths()
+
+    path_args = []
+    for name in replacement_paths:
+        path_args.append("-v")
+        path_args.append(f"test_{name}=${name}/unit_test")
+
+    workspace(
+        "manage", "experiments", "hostname", "--wf", "local", *path_args, global_args=global_args
+    )
+
+    with open(os.path.join(ws.config_dir, "execute_experiment.tpl"), "a") as f:
+        for name in replacement_paths:
+            f.write(f"{{test_{name}}}\n")
+
+    ws._re_read()
+
+    workspace(
+        "setup",
+        "--dry-run",
+        global_args=global_args,
+    )
+
+    exec_path = os.path.join(
+        ws.experiment_dir, "hostname", "local", "generated", "execute_experiment"
+    )
+    with open(exec_path) as f:
+        data = f.read()
+        for path in replacement_paths.values():
+            assert path in data

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -578,6 +578,10 @@ class ApplicationBase(metaclass=ApplicationMeta):
                 self.define_variable(var, val.default)
 
         self.expander.set_no_expand_vars(self.no_expand_vars)
+        if experiment_set and experiment_set._workspace:
+            self.expander.replacement_paths = (
+                experiment_set._workspace.workspace_paths()
+            )
 
     def set_internals(self, internals):
         """Set internal reference to application internals"""
@@ -1954,7 +1958,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
         for var in variables:
             if isinstance(variables[var], str):
                 variables[var] = variables[var].replace(
-                    workspace.root + os.path.sep, ""
+                    workspace.root, "$workspace_root"
                 )
 
     def populate_inventory(


### PR DESCRIPTION
This merge allows workspace replacements (i.e. ``$workspace_root``) in variable definitions, just as they are supported in include paths currently.

Additionally, variables are defined as an alternative for these references which can be used in other variable definitions.