### PR TITLE
Convert families to class and fix info print issues

### DIFF
--- a/lib/ramble/ramble/cmd/common/info.py
+++ b/lib/ramble/ramble/cmd/common/info.py
@@ -163,11 +163,7 @@ def _unpack_when_set_if_needed(internal_attr: dict):
             # unpack to a list of dicts so dicts with same keys don't overwrite
             unpacked_dict = []
             for when_key, inner_dict in internal_attr.items():
-                if not when_key:
-                    unpacked_dict.append(inner_dict)
-                else:
-                    for when_condition in when_key:
-                        unpacked_dict.append(inner_dict)
+                unpacked_dict.append(inner_dict)
             return unpacked_dict
         elif isinstance(first_val, list):
             unpacked_list = []

--- a/lib/ramble/ramble/cmd/common/info.py
+++ b/lib/ramble/ramble/cmd/common/info.py
@@ -29,6 +29,7 @@ obj_attribute_map = {
     "builtins": None,
     "package_manager_configs": None,
     "required_packages": None,
+    "object_variants": None,
     "compilers": None,
     "software_specs": None,
     "archive_patterns": None,
@@ -197,7 +198,6 @@ def _print_verbose_dict_attr(internal_attr, pattern="*", indentation=(" " * 4)):
         i += 1
         if pattern and not fnmatch.fnmatch(name, pattern):
             continue
-
         if isinstance(vals, dict):
             color_name = ramble.util.colors.section_title(name)
             color.cprint(f"{color_name}:")
@@ -373,7 +373,10 @@ def print_single_attribute(obj, attr, verbose=False, pattern="*", format=support
                         color.cprint(colified(to_print, tty=True, indent=4))
                     color.cprint("")
         else:
-            color.cprint(f"{indentation}" + str(internal_attr) + "\n")
+            if hasattr(internal_attr, "as_str"):
+                color.cprint(f"{internal_attr.as_str(verbose=True)}")
+            else:
+                color.cprint(f"{indentation}" + str(internal_attr) + "\n")
 
 
 def print_attribute_header(attr, verbose=False):

--- a/lib/ramble/ramble/cmd/common/info.py
+++ b/lib/ramble/ramble/cmd/common/info.py
@@ -37,6 +37,7 @@ obj_attribute_map = {
     "templates": None,
     "validators": None,
     "object_variables": None,
+    "object_environment_variables": None,
     # Application specific:
     "workloads": None,
     "workload_groups": None,
@@ -227,11 +228,14 @@ def _print_verbose_dict_attr(internal_attr, pattern="*", indentation=(" " * 4)):
         elif isinstance(vals, list):
             for val in vals:
                 if hasattr(val, "as_str"):
-                    color.cprint(f"{val.as_str()}")
+                    color.cprint(f"{val.as_str(verbose=True)}")
                 else:
                     color.cprint(f"{str(val)}")
         else:
-            color.cprint(f"{str(vals)}")
+            if hasattr(vals, "as_str"):
+                color.cprint(f"{vals.as_str(verbose=True)}")
+            else:
+                color.cprint(f"{str(vals)}")
 
 
 # Attributes that need special print functions
@@ -350,12 +354,19 @@ def print_single_attribute(obj, attr, verbose=False, pattern="*", format=support
                     _print_verbose_dict_attr(attr_dict, pattern=pattern, indentation=indentation)
             # If the attribute is not a dict or list of dict, print using the existing format rules
             else:
-                to_print = fnmatch.filter(map(str, internal_attr), pattern)
-                if format == supported_formats.lists:
-                    color.cprint("    " + str(list(to_print)))
-                elif format == supported_formats.text:
-                    color.cprint(colified(to_print, tty=True, indent=4))
-                color.cprint("")
+                if hasattr(next(iter(internal_attr)), "as_str"):
+                    for obj in internal_attr:
+                        if pattern and not fnmatch.fnmatch(obj.name, pattern):
+                            continue
+
+                        color.cprint(f"{obj.as_str(verbose=True)}")
+                else:
+                    to_print = fnmatch.filter(map(str, internal_attr), pattern)
+                    if format == supported_formats.lists:
+                        color.cprint("    " + str(list(to_print)))
+                    elif format == supported_formats.text:
+                        color.cprint(colified(to_print, tty=True, indent=4))
+                    color.cprint("")
         else:
             color.cprint(f"{indentation}" + str(internal_attr))
 

--- a/lib/ramble/ramble/cmd/common/info.py
+++ b/lib/ramble/ramble/cmd/common/info.py
@@ -52,6 +52,8 @@ obj_attribute_map = {
     "env_var_modifications": None,
     "required_vars": None,
     "package_manager_requirements": None,
+    # Package / workflow manager specific:
+    "families": None,
 }
 
 

--- a/lib/ramble/ramble/cmd/common/info.py
+++ b/lib/ramble/ramble/cmd/common/info.py
@@ -192,7 +192,9 @@ def _print_verbose_dict_attr(internal_attr, pattern="*", indentation=(" " * 4)):
     sub items. These need to be iterated over, and we need to escape existing
     characters that would normally be used to color strings.
     """
+    i = 0
     for name, vals in internal_attr.items():
+        i += 1
         if pattern and not fnmatch.fnmatch(name, pattern):
             continue
 
@@ -236,6 +238,9 @@ def _print_verbose_dict_attr(internal_attr, pattern="*", indentation=(" " * 4)):
                 color.cprint(f"{vals.as_str(verbose=True)}")
             else:
                 color.cprint(f"{str(vals)}")
+                #  Necessary to add a line break after unformmated sections
+                if i == len(internal_attr.keys()):
+                    color.cprint("")
 
 
 # Attributes that need special print functions
@@ -368,7 +373,7 @@ def print_single_attribute(obj, attr, verbose=False, pattern="*", format=support
                         color.cprint(colified(to_print, tty=True, indent=4))
                     color.cprint("")
         else:
-            color.cprint(f"{indentation}" + str(internal_attr))
+            color.cprint(f"{indentation}" + str(internal_attr) + "\n")
 
 
 def print_attribute_header(attr, verbose=False):

--- a/lib/ramble/ramble/definitions/families.py
+++ b/lib/ramble/ramble/definitions/families.py
@@ -35,7 +35,7 @@ class Families:
             self._str_indent = 0
         return self.as_str(n_indent=self._str_indent)
 
-    def as_str(self, n_indent: int = 0):
+    def as_str(self, n_indent: int = 0, **kwargs):
         """String representation of this object's families
 
         Args:

--- a/lib/ramble/ramble/definitions/families.py
+++ b/lib/ramble/ramble/definitions/families.py
@@ -1,0 +1,58 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from typing import List
+
+
+class Families:
+    """Class representing object family membership"""
+
+    def __init__(
+        self,
+        origin_type: str,
+        families: List[str] = [],
+    ):
+        """Constructor for families object
+
+        Args:
+            origin_type: Base object type
+            families: List of families
+        """
+        self.family_type = f"{origin_type}_family"
+        self.families = families
+
+    def __iter__(self):
+        """Iterate over families"""
+        yield from self.families
+
+    def __str__(self):
+        if not hasattr(self, "_str_indent"):
+            self._str_indent = 0
+        return self.as_str(n_indent=self._str_indent)
+
+    def as_str(self, n_indent: int = 0):
+        """String representation of this object's families
+
+        Args:
+            n_indent: Number of spaces to indent string lines with
+
+        Returns:
+            (str): Representation of this variable
+        """
+        indentation = " " * n_indent
+
+        out_str = ""
+        for family in self.families:
+            out_str += f"{indentation}{self.family_type}={family}\n"
+
+        return out_str
+
+    def add_families(self, families: List[str]):
+        """Add new families to this object"""
+        updated_families = list(sorted(set(self.families + families)))
+        self.families = updated_families

--- a/lib/ramble/ramble/definitions/requirements.py
+++ b/lib/ramble/ramble/definitions/requirements.py
@@ -1,0 +1,66 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import ramble.util.colors as rucolor
+
+
+class PackageManagerRequirement:
+    """Class representing a package manager requirement for a modifier"""
+
+    def __init__(
+        self, command: str, validation_type: str, regex: str, package_manager: str, when: list
+    ):
+        """Constructor for PackageManagerRequirement object
+        Args:
+            command: Package manager command to execute, when evaluating the requirement
+            validation_type: Type of validation to perform on output of command
+            regex: Regular expression to use when validation_type is either 'contains_regex'
+                   or 'does_no_contain_regex'
+            package_manager: Name of the package manager this requirement should apply to
+            when: List of when conditions this requirement should apply to
+        """
+        self.name = command  # In order to print correctly from info, all obj need 'name'
+        self.command = command
+        self.validation_type = validation_type
+        self.regex = regex
+        self.package_manager = package_manager
+        self.when = when
+
+    def __str__(self):
+        if not hasattr(self, "_str_indent"):
+            self._str_indent = 0
+        return self.as_str(n_indent=self._str_indent)
+
+    def as_str(self, n_indent: int = 0, verbose: bool = False):
+        """String representation of this requirement
+
+        Args:
+            n_indent: Number of spaces to indent string lines with
+            verbose: Print verbose output
+
+        Returns:
+            (str): Representation of this requirement
+        """
+        indentation = " " * n_indent
+
+        if verbose:
+            print_attrs = ["command", "validation_type", "package_manager", "regex"]
+
+            out_str = f"{indentation}{rucolor.section_title('When:')} {self.when}\n"
+            for print_attr in print_attrs:
+                attr_val = getattr(self, print_attr, None)
+
+                if attr_val:
+                    out_str += (
+                        f"{indentation}    {rucolor.nested_1(print_attr)}: "
+                        f'{str(attr_val).replace("@", "@@")}\n'
+                    )
+        else:
+            out_str = f"{indentation}{self.when}"
+
+        return out_str

--- a/lib/ramble/ramble/language/modifier_language.py
+++ b/lib/ramble/ramble/language/modifier_language.py
@@ -8,6 +8,7 @@
 
 from typing import Optional
 
+import ramble.definitions.requirements
 import ramble.language.language_base
 import ramble.language.language_helpers
 import ramble.language.shared_language
@@ -394,13 +395,13 @@ def package_manager_requirement(
             mod.package_manager_requirements[when_set] = []
 
         mod.package_manager_requirements[when_set].append(
-            {
-                "command": command,
-                "validation_type": validation_type,
-                "regex": regex,
-                "package_manager": package_manager,
-                "when": when_list,
-            }
+            ramble.definitions.requirements.PackageManagerRequirement(
+                command=command,
+                validation_type=validation_type,
+                regex=regex,
+                package_manager=package_manager,
+                when=when_list,
+            )
         )
 
     return _new_package_manager_requirement

--- a/lib/ramble/ramble/language/package_manager_language.py
+++ b/lib/ramble/ramble/language/package_manager_language.py
@@ -8,6 +8,7 @@
 
 from typing import Optional
 
+import ramble.definitions.families
 import ramble.language.language_base
 import ramble.language.language_helpers
 import ramble.language.shared_language
@@ -70,7 +71,9 @@ def package_manager_family(*names: str, **kwargs):
     """
 
     def _define_package_manager_family(pm):
-        families_from_base = getattr(pm, "families", [])
-        pm.families = list(sorted(set(families_from_base + list(names))))
+        if not pm.families:
+            pm.families = ramble.definitions.families.Families(pm.origin_type, list(names))
+        else:
+            pm.families.add_families(list(names))
 
     return _define_package_manager_family

--- a/lib/ramble/ramble/language/workflow_manager_language.py
+++ b/lib/ramble/ramble/language/workflow_manager_language.py
@@ -68,7 +68,9 @@ def workflow_manager_family(*names: str, **kwargs):
     """
 
     def _define_workflow_manager_family(wm):
-        families_from_base = getattr(wm, "families", [])
-        wm.families = list(sorted(set(families_from_base + list(names))))
+        if not wm.families:
+            wm.families = ramble.definitions.families.Families(wm.origin_type, list(names))
+        else:
+            wm.families.add_families(list(names))
 
     return _define_workflow_manager_family

--- a/lib/ramble/ramble/util/spec_utils.py
+++ b/lib/ramble/ramble/util/spec_utils.py
@@ -70,9 +70,9 @@ class SoftwareSpec:
         for key, val in self_dict.items():
             yield f"software:packages:{self.name}:{key}:{val}"
 
-    def as_str(self, indent=0):
-        base_indent = " " * indent
-        indentation = " " * (indent + 4)
+    def as_str(self, n_indent: int = 0, verbose: bool = False):
+        base_indent = " " * n_indent
+        indentation = " " * (n_indent + 4)
         self_dict = self.to_dict()
         color_name = ramble.util.colors.section_title(self.name)
         output = f"{base_indent}{color_name}:\n"

--- a/lib/ramble/ramble/variants.py
+++ b/lib/ramble/ramble/variants.py
@@ -11,6 +11,7 @@ from enum import Enum
 from typing import Any, Callable, Optional, Union
 
 import ramble.error
+import ramble.util.colors as rucolor
 
 reserved_variants = {
     "modifier",
@@ -32,6 +33,39 @@ class VariantSet:
         self.multi_value_variants = {}
         self.experiment_variants = {}
         self._set_cache = None
+
+    def __str__(self):
+        if not hasattr(self, "_str_indent"):
+            self._str_indent = 0
+        return self.as_str(n_indent=self._str_indent)
+
+    def as_str(self, n_indent: int = 0, verbose: bool = False):
+        """String representation of this variant set
+
+        Args:
+            n_indent (int): Number of spaces to indent string with
+            verbose: Print verbose
+
+        Returns:
+            (str): Representation of this variant set
+        """
+        to_print = []
+        for variant in self.default_variants.values():
+            to_print.append(variant)
+
+        for variant_set in self.multi_value_variants.values():
+            for variant in variant_set:
+                to_print.append(variant)
+
+        for variant in self.experiment_variants.values():
+            to_print.append(variant)
+
+        if verbose:
+            out_str = "\n".join(v.as_str(verbose=True) for v in to_print)
+        else:
+            out_str = "  ".join(v.as_str(verbose=False) for v in to_print)
+
+        return out_str
 
     def copy(self):
         new_set = VariantSet()
@@ -284,28 +318,33 @@ class Variant:
                 return f"~{self.name}"
         return f"{self.name}={str(self.default)}"
 
-    def as_str(self, indent: int = 0, verbose: bool = False):
+    def as_str(self, n_indent: int = 0, verbose: bool = False):
         """String documentation of this variant
 
         Returns:
             str: String for information of this variant
         """
-        indentation = " " * indent
-        out_str = f"{indentation}Variant: {self.name}\n"
-        attrs = [
-            ("Description", "description"),
-            ("Default", "default"),
-            ("Values", "values"),
-        ]
-        for print_name, attr_name in attrs:
-            if hasattr(self, attr_name):
-                value = getattr(self, attr_name, None)
-                if value is not None:
-                    out_str += f"{indentation}  {print_name}: {value}"
+        indentation = " " * n_indent
+
+        if verbose:
+            out_str = rucolor.section_title(f"{indentation}{self.name}:\n")
+            attrs = [
+                ("Description", "description"),
+                ("Default", "default"),
+                ("Values", "values"),
+            ]
+            for print_name, attr_name in attrs:
+                if hasattr(self, attr_name):
+                    value = getattr(self, attr_name, None)
+                    if value is not None:
+                        out_str += f"{indentation}    {rucolor.nested_1(print_name)}: {value}\n"
+        else:
+            out_str = self.name
+
         return out_str
 
     def __str__(self):
-        return self.as_str(indent=0)
+        return self.as_str(n_indent=0)
 
 
 def validate_variant(variant: str):

--- a/lib/ramble/ramble/variants.py
+++ b/lib/ramble/ramble/variants.py
@@ -284,7 +284,7 @@ class Variant:
                 return f"~{self.name}"
         return f"{self.name}={str(self.default)}"
 
-    def as_str(self, indent=0):
+    def as_str(self, indent: int = 0, verbose: bool = False):
         """String documentation of this variant
 
         Returns:

--- a/lib/ramble/ramble/workload.py
+++ b/lib/ramble/ramble/workload.py
@@ -12,6 +12,16 @@ from typing import List, Optional
 import ramble.util.colors as rucolor
 
 
+def _title_color(title: str, n_indent: int = 0):
+    """Set the appropriate color for titles based on indentation"""
+    if n_indent == 0:  # When printing object var names
+        out_str = rucolor.section_title(f"{title}")
+    else:  # When printing nested workload var names
+        out_str = rucolor.nested_3(f"{title}")
+
+    return out_str
+
+
 class WorkloadVariable:
     """Class representing a variable definition"""
 
@@ -51,7 +61,7 @@ class WorkloadVariable:
             self._str_indent = 0
         return self.as_str(n_indent=self._str_indent)
 
-    def as_str(self, n_indent: int = 0):
+    def as_str(self, n_indent: int = 0, verbose: bool = False):
         """String representation of this variable
 
         Args:
@@ -62,18 +72,22 @@ class WorkloadVariable:
         """
         indentation = " " * n_indent
 
-        print_attrs = ["Description", "Default", "Values"]
+        if verbose:
+            print_attrs = ["Description", "Default", "Values"]
 
-        out_str = rucolor.nested_3(f"{indentation}{self.name}:\n")
-        for print_attr in print_attrs:
-            name = print_attr
-            if print_attr == "Values":
-                name = "Suggested Values"
-            attr_name = print_attr.lower()
+            out_str = _title_color(f"{indentation}{self.name}:\n", n_indent)
+            for print_attr in print_attrs:
+                name = print_attr
+                if print_attr == "Values":
+                    name = "Suggested Values"
+                attr_name = print_attr.lower()
 
-            attr_val = getattr(self, attr_name, None)
-            if attr_val:
-                out_str += f'{indentation}    {name}: {str(attr_val).replace("@", "@@")}\n'
+                attr_val = getattr(self, attr_name, None)
+                if attr_val:
+                    out_str += f'{indentation}    {name}: {str(attr_val).replace("@", "@@")}\n'
+        else:
+            out_str = f"{indentation}{self.name}"
+
         return out_str
 
     def copy(self):
@@ -120,7 +134,7 @@ class WorkloadVariableModification:
             self._str_indent = 0
         return self.as_str(n_indent=self._str_indent)
 
-    def as_str(self, n_indent: int = 0):
+    def as_str(self, n_indent: int = 0, verbose: bool = False):
         """String representation of this variable
 
         Args:
@@ -133,7 +147,7 @@ class WorkloadVariableModification:
 
         print_attrs = ["Modification", "Method", "Separator", "When"]
 
-        out_str = rucolor.nested_3(f"{indentation}{self.name}:\n")
+        out_str = _title_color(f"{indentation}{self.name}:\n", n_indent)
         for print_attr in print_attrs:
             name = print_attr
             attr_name = print_attr.lower()
@@ -173,7 +187,7 @@ class WorkloadEnvironmentVariable:
         self.description = description
         self.when = when.copy() if when else []
 
-    def as_str(self, n_indent: int = 0):
+    def as_str(self, n_indent: int = 0, verbose: bool = False):
         """String representation of environment variable
 
         Args:
@@ -184,14 +198,17 @@ class WorkloadEnvironmentVariable:
         """
         indentation = " " * n_indent
 
-        print_attrs = ["Description", "Value"]
+        if verbose:
+            print_attrs = ["Description", "Value"]
+            out_str = _title_color(f"{indentation}{self.name}:\n", n_indent)
+            for name in print_attrs:
+                attr_name = name.lower()
+                attr_val = getattr(self, attr_name, None)
+                if attr_val:
+                    out_str += f'{indentation}    {name}: {attr_val.replace("@", "@@")}\n'
+        else:
+            out_str = f"{indentation}{self.name}"
 
-        out_str = rucolor.nested_2(f"{indentation}{self.name}:\n")
-        for name in print_attrs:
-            attr_name = name.lower()
-            attr_val = getattr(self, attr_name, None)
-            if attr_val:
-                out_str += f'{indentation}    {name}: {attr_val.replace("@", "@@")}\n'
         return out_str
 
     def copy(self):
@@ -242,7 +259,7 @@ class Workload:
             self._str_indent = 0
         return self.as_str(n_indent=self._str_indent)
 
-    def as_str(self, n_indent: int = 0):
+    def as_str(self, n_indent: int = 0, verbose: bool = False):
         """String representation of this workload
 
         Args:
@@ -276,7 +293,7 @@ class Workload:
                 for var in var_list:
                     var_dict[var.name] = var
                 for var_name in sorted(var_dict.keys()):
-                    out_str += var_dict[var_name].as_str(n_indent + 12)
+                    out_str += var_dict[var_name].as_str(n_indent=(n_indent + 12), verbose=verbose)
 
         if self.environment_variables:
             out_str += rucolor.nested_1(f"{indentation}    Environment Variables:\n")
@@ -292,7 +309,9 @@ class Workload:
                 for env_var in env_var_list:
                     env_var_dict[var.name] = env_var
                 for env_var_name in sorted(env_var_dict.keys()):
-                    out_str += env_var_dict[env_var_name].as_str(n_indent + 12)
+                    out_str += env_var_dict[env_var_name].as_str(
+                        n_indent=(n_indent + 12), verbose=verbose
+                    )
 
         return out_str
 

--- a/lib/ramble/ramble/workload.py
+++ b/lib/ramble/ramble/workload.py
@@ -14,10 +14,16 @@ import ramble.util.colors as rucolor
 
 def _title_color(title: str, n_indent: int = 0):
     """Set the appropriate color for titles based on indentation"""
-    if n_indent == 0:  # When printing object var names
+    if n_indent == 0:
         out_str = rucolor.section_title(f"{title}")
-    else:  # When printing nested workload var names
+    elif n_indent == 4:
+        out_str = rucolor.nested_1(f"{title}")
+    elif n_indent == 8:
+        out_str = rucolor.nested_2(f"{title}")
+    elif n_indent == 12:
         out_str = rucolor.nested_3(f"{title}")
+    elif n_indent == 16:
+        out_str = rucolor.nested_4(f"{title}")
 
     return out_str
 
@@ -84,7 +90,10 @@ class WorkloadVariable:
 
                 attr_val = getattr(self, attr_name, None)
                 if attr_val:
-                    out_str += f'{indentation}    {name}: {str(attr_val).replace("@", "@@")}\n'
+                    out_str += (
+                        f"{indentation}    {_title_color(name, n_indent=n_indent + 4)}: "
+                        f'{str(attr_val).replace("@", "@@")}\n'
+                    )
         else:
             out_str = f"{indentation}{self.name}"
 
@@ -156,7 +165,10 @@ class WorkloadVariableModification:
             if attr_val:
                 if print_attr == "Separator":
                     attr_val = f"'{attr_val}'"
-                out_str += f'{indentation}    {name}: {str(attr_val).replace("@", "@@")}\n'
+                out_str += (
+                    f"{indentation}    {_title_color(name, n_indent=n_indent + 4)}: "
+                    f'{str(attr_val).replace("@", "@@")}\n'
+                )
         return out_str
 
     def copy(self):
@@ -187,6 +199,11 @@ class WorkloadEnvironmentVariable:
         self.description = description
         self.when = when.copy() if when else []
 
+    def __str__(self):
+        if not hasattr(self, "_str_indent"):
+            self._str_indent = 0
+        return self.as_str(n_indent=self._str_indent)
+
     def as_str(self, n_indent: int = 0, verbose: bool = False):
         """String representation of environment variable
 
@@ -205,7 +222,10 @@ class WorkloadEnvironmentVariable:
                 attr_name = name.lower()
                 attr_val = getattr(self, attr_name, None)
                 if attr_val:
-                    out_str += f'{indentation}    {name}: {attr_val.replace("@", "@@")}\n'
+                    out_str += (
+                        f"{indentation}    {_title_color(name, n_indent=n_indent + 4)}: "
+                        f'{str(attr_val).replace("@", "@@")}\n'
+                    )
         else:
             out_str = f"{indentation}{self.name}"
 
@@ -307,7 +327,7 @@ class Workload:
 
                 env_var_dict = {}
                 for env_var in env_var_list:
-                    env_var_dict[var.name] = env_var
+                    env_var_dict[env_var.name] = env_var
                 for env_var_name in sorted(env_var_dict.keys()):
                     out_str += env_var_dict[env_var_name].as_str(
                         n_indent=(n_indent + 12), verbose=verbose

--- a/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
@@ -10,6 +10,7 @@
 import os
 from typing import List
 
+import ramble.definitions.families
 import ramble.util.class_attributes
 import ramble.util.directives
 import ramble.variants
@@ -24,6 +25,8 @@ import spack.util.naming
 class PackageManagerBase(metaclass=PackageManagerMeta):
     name = None
     object_variants = None
+    families = None
+    origin_type = "package_manager"
     _builtin_name = NS_SEPARATOR.join(
         ("package_manager_builtin", "{obj_name}", "{name}")
     )
@@ -53,13 +56,17 @@ class PackageManagerBase(metaclass=PackageManagerMeta):
     #: Do not include @ here in order not to unnecessarily ping the users.
     maintainers: List[str] = []
     tags: List[str] = []
-    families: List[str] = []
 
     def __init__(self, file_path):
         super().__init__()
 
         if self.object_variants is None:
             self.object_variants = ramble.variants.VariantSet()
+
+        if self.families is None:
+            self.families = ramble.definitions.families.Families(
+                self.origin_type
+            )
 
         ramble.util.class_attributes.convert_class_attributes(self)
 
@@ -73,14 +80,14 @@ class PackageManagerBase(metaclass=PackageManagerMeta):
         ramble.util.directives.define_directive_methods(self)
 
         self.object_variants.default_variant(
-            "package_manager",
+            self.origin_type,
             default=self.name,
             description="Name of package manager for an experiment",
         )
 
         for family in self.families:
             self.object_variants.multi_value_variant(
-                "package_manager_family",
+                self.families.family_type,
                 value=family,
             )
 

--- a/var/ramble/repos/builtin/base_classes/workflow-manager-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/workflow-manager-base/base_class.py
@@ -9,6 +9,7 @@
 
 from typing import List
 
+import ramble.definitions.families
 import ramble.util.class_attributes
 import ramble.util.directives
 import ramble.variants
@@ -24,6 +25,7 @@ from ramble.util.naming import NS_SEPARATOR
 class WorkflowManagerBase(metaclass=WorkflowManagerMeta):
     name = None
     object_variants = None
+    families = None
     origin_type = "workflow_manager"
     _builtin_name = NS_SEPARATOR.join(
         ("workflow_manager_builtin", "{obj_name}", "{name}")
@@ -36,7 +38,6 @@ class WorkflowManagerBase(metaclass=WorkflowManagerMeta):
     ]
     maintainers: List[str] = []
     tags: List[str] = []
-    families: List[str] = []
 
     workflow_manager_variable(
         "workflow_banner",
@@ -68,6 +69,11 @@ class WorkflowManagerBase(metaclass=WorkflowManagerMeta):
         if self.object_variants is None:
             self.object_variants = ramble.variants.VariantSet()
 
+        if self.families is None:
+            self.families = ramble.definitions.families.Families(
+                self.origin_type
+            )
+
         ramble.util.class_attributes.convert_class_attributes(self)
 
         self._file_path = file_path
@@ -75,10 +81,16 @@ class WorkflowManagerBase(metaclass=WorkflowManagerMeta):
         ramble.util.directives.define_directive_methods(self)
 
         self.object_variants.default_variant(
-            "workflow_manager",
+            self.origin_type,
             default=self.name,
             description="Name of workflow manager for an experiment",
         )
+
+        for family in self.families:
+            self.object_variants.multi_value_variant(
+                self.families.family_type,
+                value=family,
+            )
 
         self.app_inst = None
         self.runner = None

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
@@ -270,7 +270,7 @@ class SpackLightweight(PackageManagerBase):
         for mod_inst in app_inst._modifier_instances:
             for req in mod_inst.all_package_manager_requirements():
                 expanded_req = {}
-                for key, val in req.items():
+                for key, val in vars(req).items():
                     expanded_req[key] = app_inst.expander.expand_var(val)
                 self.runner.validate_command(**expanded_req)
 


### PR DESCRIPTION
Converts families to class. Fixes printing of families from `info` to make it more useful for defining when clauses. Adds variants to info. Fixes duplicate prints of variable modifications from `info`. Adds object environment variables to `info`. Fixes formatting of variables and other misc info issues.