### PR TITLE
Update documentation with variant logic

### DIFF
--- a/lib/ramble/docs/dev_guides/application_dev_guide.rst
+++ b/lib/ramble/docs/dev_guides/application_dev_guide.rst
@@ -276,6 +276,51 @@ that should be used when referencing file paths in application definitions. This
 helps with Ramble to properly mock out these paths during unit testing, where the
 files may not exist under the dry-run setting.
 
+
+.. _application-dev-variant-directive:
+
+^^^^^^^^^^^^^^^^^^^^
+Application Variants
+^^^^^^^^^^^^^^^^^^^^
+
+Ramble supports objects defining variants to help control their conditional
+behavior. Variants can be used to control most aspects of an application
+definition in Ramble, and their usage within an application will be
+described in :ref:`application-dev-conditional-logic`.
+
+To define a new variant within an application, developers can use the
+``variant`` directive. An example can be seen below:
+
+.. code-block:: python
+
+  variant(
+    "gpu",
+    default=False,
+    description="Enables the usage of GPU features in this application.",
+    values=[True, False]
+  )
+
+The previous example would define a new variant named ``gpu`` within
+an application. The allowed values are either ``True`` or ``False``
+(implying it is a boolean variant), and the default is ``False``.
+
+Users will be able to control this variants value by using
+:ref:`variants<variants-config>`. Within the application, this
+variant can be used in ``when`` arguments. This will be discussed in
+more detail later, but an example of this specific variant would be:
+
+.. code-block:: python
+
+  workload_variable("gpu_flag", default="-g", description="Flag that controls GPU features", when="+gpu")
+  workload_variable("gpu_flag", default="", description="Flag that controls GPU features", when="~gpu")
+
+In this case, the variable ``gpu_flag`` will be defined, and will have
+a value of ``-g`` or an empty string, depending on the value of the
+``gpu`` variant.
+
+
+.. _application-dev-conditional-logic:
+
 ^^^^^^^^^^^^^^^^^
 Conditional Logic
 ^^^^^^^^^^^^^^^^^
@@ -322,6 +367,8 @@ along with any variants created in definition files:
     workflow_manager_family  
     modifier  
     <mod-name>_mode 
+
+Most of the directives in Ramble support 
 
 --------------------------
 Package Manager Directives

--- a/lib/ramble/docs/dev_guides/modifier_dev_guide.rst
+++ b/lib/ramble/docs/dev_guides/modifier_dev_guide.rst
@@ -222,3 +222,14 @@ correctly by using ``ramble workspace setup --dry-run``. The output from the
 preparation steps can be copied into the experiment directory to verify the
 ``ramble workspace analyze`` pipeline works, without having to execute the
 experiment itself.
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Variants and Conditional Logic
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Ramble modifiers support variants, just as applications do (see
+:ref:`application-dev-variant-directive`).
+
+Variants can be used to control the behavior of many of the
+directives within a modifier, and their use follows the discussion
+in :ref:`application-dev-conditional-logic`.

--- a/lib/ramble/docs/dev_guides/package_manager_dev_guide.rst
+++ b/lib/ramble/docs/dev_guides/package_manager_dev_guide.rst
@@ -180,3 +180,14 @@ package managers can be used as a reference.
 This unit test by default will dry-run every possible application with every
 possible package manager. As a result, it is unlikely that a package manager
 without dry-run support would pass Ramble's unit tests.
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Variants and Conditional Logic
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Ramble package managers support variants, just as applications do
+(see :ref:`application-dev-variant-directive`).
+
+Variants can be used to control the behavior of many of the
+directives within a package manager, and their use follows the
+discussion in :ref:`application-dev-conditional-logic`.


### PR DESCRIPTION
This merge adds documentation to the developers guides around defining new variants, and using the variants to create conditional logic within other directives.