### PR TITLE
Update variant object attribute to prevent leakage

### DIFF
--- a/lib/ramble/ramble/language/package_manager_language.py
+++ b/lib/ramble/ramble/language/package_manager_language.py
@@ -71,7 +71,7 @@ def package_manager_family(*names: str, **kwargs):
     """
 
     def _define_package_manager_family(pm):
-        if not pm.families:
+        if getattr(pm, "families", None) is None:
             pm.families = ramble.definitions.families.Families(pm.origin_type, list(names))
         else:
             pm.families.add_families(list(names))

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -912,7 +912,7 @@ def variant(
         """
         ramble.variants.validate_variant(name)
 
-        if obj.object_variants is None:
+        if not hasattr(obj, "object_variants") or obj.object_variants is None:
             obj.object_variants = ramble.variants.VariantSet()
 
         obj.object_variants.default_variant(

--- a/lib/ramble/ramble/language/workflow_manager_language.py
+++ b/lib/ramble/ramble/language/workflow_manager_language.py
@@ -68,7 +68,7 @@ def workflow_manager_family(*names: str, **kwargs):
     """
 
     def _define_workflow_manager_family(wm):
-        if not wm.families:
+        if getattr(wm, "families", None) is None:
             wm.families = ramble.definitions.families.Families(wm.origin_type, list(names))
         else:
             wm.families.add_families(list(names))

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -125,7 +125,6 @@ def _get_phase_func_wrapper(workspace, phase_func, phase_name):
 
 class ApplicationBase(metaclass=ApplicationMeta):
     name = None
-    object_variants = None
     origin_type = "application"
     _builtin_name = NS_SEPARATOR.join(("builtin", "{name}"))
     _builtin_required_key = "required"
@@ -153,7 +152,7 @@ class ApplicationBase(metaclass=ApplicationMeta):
     def __init__(self, file_path):
         super().__init__()
 
-        if self.object_variants is None:
+        if getattr(self, "object_variants", None) is None:
             self.object_variants = ramble.variants.VariantSet()
 
         ramble.util.class_attributes.convert_class_attributes(self)

--- a/var/ramble/repos/builtin/base_classes/modifier-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/modifier-base/base_class.py
@@ -24,7 +24,6 @@ from ramble.util.naming import NS_SEPARATOR
 
 class ModifierBase(metaclass=ModifierMeta):
     name = None
-    object_variants = None
     origin_type = "modifier"
     _builtin_name = NS_SEPARATOR.join(
         ("modifier_builtin", "{obj_name}", "{name}")
@@ -55,7 +54,7 @@ class ModifierBase(metaclass=ModifierMeta):
     def __init__(self, file_path):
         super().__init__()
 
-        if self.object_variants is None:
+        if getattr(self, "object_variants", None) is None:
             self.object_variants = ramble.variants.VariantSet()
 
         ramble.util.class_attributes.convert_class_attributes(self)

--- a/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
@@ -24,8 +24,6 @@ import spack.util.naming
 
 class PackageManagerBase(metaclass=PackageManagerMeta):
     name = None
-    object_variants = None
-    families = None
     origin_type = "package_manager"
     _builtin_name = NS_SEPARATOR.join(
         ("package_manager_builtin", "{obj_name}", "{name}")
@@ -60,10 +58,10 @@ class PackageManagerBase(metaclass=PackageManagerMeta):
     def __init__(self, file_path):
         super().__init__()
 
-        if self.object_variants is None:
+        if getattr(self, "object_variants", None) is None:
             self.object_variants = ramble.variants.VariantSet()
 
-        if self.families is None:
+        if getattr(self, "families", None) is None:
             self.families = ramble.definitions.families.Families(
                 self.origin_type
             )

--- a/var/ramble/repos/builtin/base_classes/workflow-manager-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/workflow-manager-base/base_class.py
@@ -24,8 +24,6 @@ from ramble.util.naming import NS_SEPARATOR
 
 class WorkflowManagerBase(metaclass=WorkflowManagerMeta):
     name = None
-    object_variants = None
-    families = None
     origin_type = "workflow_manager"
     _builtin_name = NS_SEPARATOR.join(
         ("workflow_manager_builtin", "{obj_name}", "{name}")
@@ -66,10 +64,10 @@ class WorkflowManagerBase(metaclass=WorkflowManagerMeta):
     def __init__(self, file_path):
         super().__init__()
 
-        if self.object_variants is None:
+        if getattr(self, "object_variants", None) is None:
             self.object_variants = ramble.variants.VariantSet()
 
-        if self.families is None:
+        if getattr(self, "families", None) is None:
             self.families = ramble.definitions.families.Families(
                 self.origin_type
             )


### PR DESCRIPTION
This merge migrates the `object_variants` attributes to be a instance attributes instead of class attributes to prevent leakage.