### PR TITLE
Ensure `simplify-variables` considers compilers

### DIFF
--- a/lib/ramble/ramble/software_environments.py
+++ b/lib/ramble/ramble/software_environments.py
@@ -327,6 +327,7 @@ class TemplatePackage(SoftwarePackage):
         new_pkg = RenderedPackage(name, pkg_info, package_manager, spec, compiler, compiler_spec)
 
         if new_pkg.name in self._rendered_packages[pm_name]:
+            expander.merge_used_variable_stage()
             if new_pkg != self._rendered_packages[pm_name][name]:
                 new_info = new_pkg.info(only_used=False, color_level=-1).replace("@", "")
                 old_info = (

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1843,7 +1843,7 @@ ramble:
                 if not scope_section[namespace.variables]:
                     del scope_section[namespace.variables]
 
-        # Build experiment sets to determine which variables are used
+        # Build software environments to determine which variables are used
         self.software_environments = ramble.software_environments.SoftwareEnvironments(self)
         experiment_set = self.build_experiment_set()
 

--- a/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
@@ -246,9 +246,13 @@ class PackageManagerBase(metaclass=PackageManagerMeta):
         )
 
         software_environments = workspace.software_environments
-        software_environments.render_environment(
+        software_env = software_environments.render_environment(
             app_context, self.app_inst.expander, self, require=False
         )
+        if software_env is not None:
+            software_environments.define_compiler_packages(
+                software_env, self.app_inst.expander
+            )
 
         return self.app_inst.expander._used_variables
 


### PR DESCRIPTION
This merge fixes an issue where simplifying variables would remove used variables that were needed for compiler definitions within the experiment.