### PR TITLE
Fix rendering auxiliary software files

### DIFF
--- a/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
@@ -213,6 +213,9 @@ class PackageManagerBase(ObjectMixin, metaclass=PackageManagerMeta):
                 software_env, self.app_inst.expander
             )
 
+        for _, contents in workspace.all_auxiliary_software_files():
+            self.app_inst.expander.expand_var(contents)
+
         return self.app_inst.expander._used_variables
 
     def populate_inventory(

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/test/spack_lightweight.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/test/spack_lightweight.py
@@ -72,3 +72,49 @@ def test_container_push_cache_script(request):
         assert "spack buildcache push" in script
         assert '--base-image "base-linux"' in script
         assert '--tag "my-tag" --private' in script
+
+
+def test_spack_auxiliary_files(request):
+    ws_name = request.node.name
+    ws = ramble.workspace.create(ws_name)
+    global_args = ["-w", ws_name]
+    workspace(
+        "manage",
+        "experiments",
+        "gromacs",
+        "-p",
+        "spack-lightweight",
+        "--wf",
+        "water_bare",
+        "-v",
+        "n_nodes=1",
+        "-v",
+        "processes_per_node=1",
+        "-v",
+        "opt_target=x86_64",
+        global_args=global_args,
+    )
+
+    os.makedirs(ws.auxiliary_software_dir)
+    with open(
+        os.path.join(ws.auxiliary_software_dir, "packages.yaml"), "w+"
+    ) as f:
+        f.write(
+            """packages:
+  all:
+    target: ['{opt_target}']"""
+        )
+
+    ws._re_read()
+
+    workspace("concretize", global_args=["-w", ws_name])
+
+    workspace("setup", "--dry-run", global_args=["-w", ws_name])
+    rendered_package_path = os.path.join(
+        ws.software_dir, "spack-lightweight", "gromacs", "packages.yaml"
+    )
+
+    with open(rendered_package_path) as f:
+        data = f.read()
+        assert "opt_target" not in data
+        assert "x86_64" in data


### PR DESCRIPTION
This merge adds variables in auxiliary software files to the used variable list. This prevents auxiliary software files from being rendered with un-expanded variables.

A test for spack-lightweight is added to help cover this as well.