### PR TITLE
Add checking for unused compiler definitions

### DIFF
--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -1,7 +1,11 @@
 name: ramble spelling
 
 on:
-  pull_request: []
+  pull_request:
+   types:
+   - 'opened'
+   - 'reopened'
+   - 'synchronize'
   push:
     branches-ignore:
     - main

--- a/lib/ramble/ramble/cmd/software_definitions.py
+++ b/lib/ramble/ramble/cmd/software_definitions.py
@@ -18,6 +18,7 @@ description = "inspect software definitions in object definitions"
 section = "developer"
 level = "long"
 
+unused_compilers = {}
 definitions = {}
 conflicts = {}
 used_by = {}
@@ -56,7 +57,12 @@ def collect_definitions():
     """
     top_level_attrs = ["compilers", "software_specs"]
 
-    types_to_print = [ramble.repository.ObjectTypes.applications]
+    types_to_print = [
+        ramble.repository.ObjectTypes.applications,
+        ramble.repository.ObjectTypes.modifiers,
+        ramble.repository.ObjectTypes.workflow_managers,
+        ramble.repository.ObjectTypes.package_managers,
+    ]
 
     for object_type in types_to_print:
         obj_path = ramble.repository.paths[object_type]
@@ -64,6 +70,20 @@ def collect_definitions():
             obj_repo = obj_path.repo_for_obj(obj_inst.name)
 
             obj_namespace = f"{obj_repo.full_namespace}.{obj_inst.name}"
+
+            for compiler_name in obj_inst.compilers:
+                used = False
+                for pkg_defs in obj_inst.software_specs.values():
+                    for pkg_def in pkg_defs:
+                        if (
+                            getattr(pkg_def, "compiler", "__rmb_no_compiler_attr__")
+                            == compiler_name
+                        ):
+                            used = True
+                if not used:
+                    if compiler_name not in unused_compilers:
+                        unused_compilers[compiler_name] = []
+                    unused_compilers[compiler_name].append(obj_namespace)
 
             for top_level_attr in top_level_attrs:
                 if hasattr(obj_inst, top_level_attr):
@@ -110,26 +130,36 @@ def count_conflicts():
     num_conflicts = 0
     for pkg_name in conflicts:
         num_conflicts += len(conflicts[pkg_name])
+    for object_names in unused_compilers.values():
+        num_conflicts += len(object_names)
     return num_conflicts
 
 
 def print_conflicts():
     """Print conflict information, if any exist"""
-    if len(conflicts) > 0:
-        color.cprint(section_title("Software Definition Conflicts:"))
-        for pkg_name in conflicts:
+    if len(conflicts) > 0 or len(unused_compilers) > 0:
+        if len(conflicts) > 0:
+            color.cprint(section_title("Software Definition Conflicts:"))
+            for pkg_name in conflicts:
 
-            color.cprint(f'{nested_1("Package")}: {pkg_name}:')
-            color.cprint("\tDefined as:")
-            for attr in ["pkg_spec", "compiler_spec", "compiler"]:
-                if hasattr(definitions[pkg_name], attr):
-                    attr_def = getattr(definitions[pkg_name], attr)
-                    if attr_def:
-                        color.cprint(f'\t\t{attr} = {attr_def.replace("@", "@@")}')
-            color.cprint("\tIn objects:")
-            colify(used_by[pkg_name], indent=24, output=sys.stdout)
-            color.cprint("\tConflicts with objects:")
-            colify(conflicts[pkg_name], indent=24, output=sys.stdout)
+                color.cprint(f'{nested_1("Package")}: {pkg_name}:')
+                color.cprint("\tDefined as:")
+                for attr in ["pkg_spec", "compiler_spec", "compiler"]:
+                    if hasattr(definitions[pkg_name], attr):
+                        attr_def = getattr(definitions[pkg_name], attr)
+                        if attr_def:
+                            color.cprint(f'\t\t{attr} = {attr_def.replace("@", "@@")}')
+                color.cprint("\tIn objects:")
+                colify(used_by[pkg_name], indent=24, output=sys.stdout)
+                color.cprint("\tConflicts with objects:")
+                colify(conflicts[pkg_name], indent=24, output=sys.stdout)
+
+        if len(unused_compilers) > 0:
+            color.cprint(section_title("Unused Compilers:"))
+            for compiler_name, object_names in unused_compilers.items():
+                color.cprint(nested_1(f"    Compiler {compiler_name} is not used in packages:"))
+                colify(object_names, indent=8, output=sys.stdout)
+                color.cprint("\n")
     else:
         color.cprint(section_title("No Conflicts Detected"))
 
@@ -164,5 +194,8 @@ def software_definitions(parser, args, unknown_args):
 
     if args.error_on_conflict:
         num_conflicts = count_conflicts()
-        color.cprint(f"{num_conflicts} conflicts detected.")
+        if num_conflicts == 1:
+            color.cprint(f"{num_conflicts} conflict detected.")
+        else:
+            color.cprint(f"{num_conflicts} conflicts detected.")
         sys.exit(num_conflicts)

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1481,6 +1481,7 @@ ramble:
             if app_inst.package_manager is None:
                 continue
 
+            compiler_packages = {}
             compiler_dicts = [app_inst.compilers]
             for mod_inst in app_inst._modifier_instances:
                 compiler_dicts.append(mod_inst.compilers)
@@ -1510,6 +1511,7 @@ ramble:
                                 newly_created_packages.add(comp)
                                 packages_dict[comp] = syaml.syaml_dict()
 
+                            compiler_packages[comp] = False
                             packages_dict[comp].update(info.to_dict(prefix=spec_prefix))
                             for conf in info.config_opts():
                                 ramble.config.add(conf, scope=self.ws_file_config_scope_name())
@@ -1549,6 +1551,10 @@ ramble:
                             ):
                                 packages_dict[spec_name] = syaml.syaml_dict()
 
+                            # Check for usage of compilers
+                            if info.compiler in compiler_packages:
+                                compiler_packages[info.compiler] = True
+
                             packages_dict[spec_name].update(info.to_dict(prefix=spec_prefix))
 
                             if spec_name not in app_packages:
@@ -1559,6 +1565,18 @@ ramble:
                     environments_dict[env_name] = syaml.syaml_dict()
 
                 environments_dict[env_name][namespace.packages] = app_packages.copy()
+
+            # Ensure all compilers in this experiment are used.
+            comp_list = []
+            for name, used in compiler_packages.items():
+                if not used:
+                    comp_list.append(name)
+            if comp_list:
+                logger.warn(
+                    "Unused compiler(s) found in experiment: "
+                    + app_inst.expander.experiment_namespace
+                )
+                logger.warn(f"   {comp_list}")
 
         ramble.config.config.update_config(
             namespace.software, full_software_dict, scope=self.ws_file_config_scope_name()


### PR DESCRIPTION
This merge adds support to both the software-definitions command, and `workspace concretize` to detect (and warn / error) about unused compilers defined in the objects.