### PR TITLE
Fix results level argument in required_variable directive

### DIFF
--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -975,9 +975,20 @@ def required_variable(
                 when, obj, var, "required_variable"
             )
 
+        if results_level not in ["key", "variable"]:
+            raise ramble.language.language_base.DirectiveError(
+                "The results_level argument for required variable "
+                f"{var} is set to {results_level}.\n"
+                "Valid options are 'key' or 'variable'."
+            )
+
+        output_level = ramble.keywords.output_level.variable
+        if results_level == "key":
+            output_level = ramble.keywords.output_level.key
+
         obj.required_vars[var] = {
             "type": ramble.keywords.key_type.required,
-            "level": ramble.keywords.output_level.variable,
+            "level": output_level,
             "description": description,
             # Extra prop that's only used for filtering
             "when": when_list,

--- a/lib/ramble/ramble/test/when.py
+++ b/lib/ramble/ramble/test/when.py
@@ -6,6 +6,7 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+import json
 import os
 
 import pytest
@@ -1490,3 +1491,74 @@ def test_obj_required_var_when(
         workspace("setup", "--dry-run", global_args=global_args)
 
         assert os.path.exists(exec_file)
+
+
+@pytest.mark.parametrize("obj", ["app", "mod", "wf_man", "pkg_man"])
+def test_obj_required_key_when(
+    workspace_name, obj, mutable_mock_wms_repo, mutable_mock_pkg_mans_repo
+):
+    global_args = ["-w", workspace_name]
+
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+        args = [
+            "when-directives",
+            "--wf",
+            "test_wl",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "processes_per_node=1",
+            "-p",
+            "when-package-manager",
+            "--wm",
+            "when-workflow-manager",
+        ]
+
+        config("add", f"variants:{obj}_required_key:true", global_args=global_args)
+        if obj == "mod":
+            mod_config_path = os.path.join(ws.config_dir, "modifiers.yaml")
+            with open(mod_config_path, "w+") as f:
+                f.write("modifiers:\n")
+                f.write(" - name: when-modifier\n")
+                f.write("   mode: test")
+        elif obj == "wf_man":
+            config("add", "variants:workflow_manager_included:true", global_args=global_args)
+        elif obj == "pkg_man":
+            config("add", "variants:package_manager_included:true", global_args=global_args)
+
+        workspace("manage", "experiments", *args, global_args=global_args)
+
+        with pytest.raises(ramble.experiment_set.RambleVariableDefinitionError):
+            workspace("setup", "--dry-run", global_args=global_args)
+
+        exec_file = os.path.join(
+            ws.experiment_dir,
+            "when-directives",
+            "test_wl",
+            "generated",
+            "execute_experiment",
+        )
+
+        assert not os.path.exists(exec_file)
+
+        config("add", f"variables:test_{obj}_required_key:'test'", global_args=global_args)
+
+        ws._re_read()
+        workspace("setup", "--dry-run", global_args=global_args)
+
+        assert os.path.exists(exec_file)
+
+        workspace("analyze", "-f", "json", global_args=global_args)
+
+        results_file = os.path.join(ws.root, "results.latest.json")
+
+        assert os.path.exists(results_file)
+
+        with open(results_file) as f:
+            data = json.load(f)
+
+        for exp in data["experiments"]:
+            assert f"test_{obj}_required_key" in exp

--- a/var/ramble/repos/builtin.mock/applications/when-directives/application.py
+++ b/var/ramble/repos/builtin.mock/applications/when-directives/application.py
@@ -325,7 +325,21 @@ class WhenDirectives(ExecutableApplication):
 
     required_variable(
         "test_app_required_variable",
-        results_level="key",
+        results_level="variable",
         description="Test required variable",
         when=["+app_required_variable"],
+    )
+
+    variant(
+        "app_required_key",
+        default=False,
+        values=[True, False],
+        description="Test required key",
+    )
+
+    required_variable(
+        "test_app_required_key",
+        results_level="key",
+        description="Test required key",
+        when=["+app_required_key"],
     )

--- a/var/ramble/repos/builtin.mock/modifiers/when-modifier/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/when-modifier/modifier.py
@@ -126,3 +126,17 @@ class WhenModifier(BasicModifier):
             "test_mod_required_variable",
             description="Test modifier required variable",
         )
+
+    variant(
+        "mod_required_key",
+        default=False,
+        values=[True, False],
+        description="Test modifier required key",
+    )
+
+    with when("+mod_required_key"):
+        required_variable(
+            "test_mod_required_key",
+            results_level="key",
+            description="Test modifier required key",
+        )

--- a/var/ramble/repos/builtin.mock/package_managers/when-package-manager/package_manager.py
+++ b/var/ramble/repos/builtin.mock/package_managers/when-package-manager/package_manager.py
@@ -50,3 +50,17 @@ class WhenPackageManager(PackageManagerBase):
         description="Test required variable",
         when=["+pkg_man_required_variable"],
     )
+
+    variant(
+        "pkg_man_required_key",
+        default=False,
+        values=[True, False],
+        description="Test required key",
+    )
+
+    required_variable(
+        "test_pkg_man_required_key",
+        results_level="key",
+        description="Test required key",
+        when=["+pkg_man_required_key"],
+    )

--- a/var/ramble/repos/builtin.mock/workflow_managers/when-workflow-manager/workflow_manager.py
+++ b/var/ramble/repos/builtin.mock/workflow_managers/when-workflow-manager/workflow_manager.py
@@ -50,3 +50,17 @@ class WhenWorkflowManager(WorkflowManagerBase):
         description="Test required variable",
         when=["+wf_man_required_variable"],
     )
+
+    variant(
+        "wf_man_required_key",
+        default=False,
+        values=[True, False],
+        description="Test required key",
+    )
+
+    required_variable(
+        "test_wf_man_required_key",
+        results_level="key",
+        description="Test required key",
+        when=["+wf_man_required_key"],
+    )


### PR DESCRIPTION
The `required_variable` directive has an argument named `results_level` that is expected to promote variables to be keys in the experiment results. Previously, this did not happen appropriately and all required variables were marked as just `variables` in the results level.

This merge adds tests to ensure the expected behavior is happening, and fixes the behavior to function how it should.