### PR TITLE
Add harmonic_mean to repeated stats

### DIFF
--- a/lib/ramble/ramble/test/end_to_end/experiment_repeats.py
+++ b/lib/ramble/ramble/test/end_to_end/experiment_repeats.py
@@ -171,7 +171,11 @@ ramble:
                 assert "Core Time = 11.111 s" in data
                 assert "Core Time = 22.222 s" in data
                 assert "summary::mean = 16.666 s" in data
+                assert "summary::harmonic_mean = 14.815 s" in data
+                assert "summary::median = 16.666 s" in data
                 assert "summary::variance = 61.727 s^2" in data
+                assert "summary::stdev = 7.857 s" in data
+                assert "summary::cv = 0.471" in data
 
         # When --summary-only, only the base experiments are included
         workspace("analyze", "-s", global_args=["-w", workspace_name])  # noqa: E501

--- a/lib/ramble/ramble/test/util/stats.py
+++ b/lib/ramble/ramble/test/util/stats.py
@@ -17,6 +17,12 @@ import ramble.util.stats
         (ramble.util.stats.StatsMin(), [-2, 0, 2, 5.5], "s", (-2, "s", "summary::min")),
         (ramble.util.stats.StatsMax(), [-2, 0, 2, 5.5], "s", (5.5, "s", "summary::max")),
         (ramble.util.stats.StatsMean(), [-2, 0, 2, 5.5], "s", (1.4, "s", "summary::mean")),
+        (
+            ramble.util.stats.StatsHarmonicMean(),
+            [2, 3, 5],
+            "s",
+            (3.0, "s", "summary::harmonic_mean"),
+        ),
         (ramble.util.stats.StatsMedian(), [-2, 0, 2, 5.5], "s", (1.0, "s", "summary::median")),
         (ramble.util.stats.StatsVar(), [-2, 0, 2, 5.5], "s", (10.2, "s^2", "summary::variance")),
         (ramble.util.stats.StatsVar(), [3], "s", ("NA", "", "summary::variance")),

--- a/lib/ramble/ramble/util/stats.py
+++ b/lib/ramble/ramble/util/stats.py
@@ -67,6 +67,13 @@ class StatsMean(StatsBase):
         return round(statistics.mean(values), max_decimal_places(values))
 
 
+class StatsHarmonicMean(StatsBase):
+    name = "harmonic_mean"
+
+    def compute(self, values):
+        return round(statistics.harmonic_mean(values), max_decimal_places(values))
+
+
 class StatsMedian(StatsBase):
     name = "median"
 
@@ -118,6 +125,7 @@ all_stats = [
     StatsMin(),
     StatsMax(),
     StatsMean(),
+    StatsHarmonicMean(),
     StatsMedian(),
     StatsVar(),
     StatsStdev(),


### PR DESCRIPTION
This can be useful for summarizing rates that perform a fixed amount of work across samples, such as MIPS of a given benchmark.