### PR TITLE
 Disable expansion of environment references

### DIFF
--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -19,7 +19,7 @@ from typing import Dict, FrozenSet, List, Union
 import ramble.error
 import ramble.keywords
 from ramble.util.logger import logger
-from ramble.util.path import substitute_path_variables
+from ramble.util.path import substitute_config_variables
 
 import spack.util.naming
 
@@ -672,7 +672,7 @@ class Expander:
             self.merge_used_variable_stage()
 
         if isinstance(value, str):
-            return substitute_path_variables(value, local_replacements=self.replacement_paths)
+            return substitute_config_variables(value, local_replacements=self.replacement_paths)
         else:
             return value
 

--- a/lib/ramble/ramble/test/expander.py
+++ b/lib/ramble/ramble/test/expander.py
@@ -137,6 +137,8 @@ def build_variant_set():
         ("0b10 >> 1", "1", set(), 1),
         # Can be a handy way to select experiments to run
         ("(1 << {experiment_index} & 0b1011010) == 0", "True", set(), 1),
+        ("$HOSTNAME", "$HOSTNAME", set(), 1),
+        ("${HOSTNAME}", "${HOSTNAME}", set(), 1),
     ],
 )
 def test_expansions(input, output, no_expand_vars, passes):


### PR DESCRIPTION
This merge disables expansion (by the expander class) of refernces defined in the user's environment. This includes things like `${HOME}` and `~`.

