### PR TITLE
Skip harmonic mean upon stats error

### DIFF
--- a/lib/ramble/ramble/test/util/stats.py
+++ b/lib/ramble/ramble/test/util/stats.py
@@ -23,6 +23,12 @@ import ramble.util.stats
             "s",
             (3.0, "s", "summary::harmonic_mean"),
         ),
+        (
+            ramble.util.stats.StatsHarmonicMean(),
+            [2, 3, 5, -1],
+            "s",
+            ("NA", "s", "summary::harmonic_mean"),
+        ),
         (ramble.util.stats.StatsMedian(), [-2, 0, 2, 5.5], "s", (1.0, "s", "summary::median")),
         (ramble.util.stats.StatsVar(), [-2, 0, 2, 5.5], "s", (10.2, "s^2", "summary::variance")),
         (ramble.util.stats.StatsVar(), [3], "s", ("NA", "", "summary::variance")),

--- a/lib/ramble/ramble/util/stats.py
+++ b/lib/ramble/ramble/util/stats.py
@@ -71,7 +71,10 @@ class StatsHarmonicMean(StatsBase):
     name = "harmonic_mean"
 
     def compute(self, values):
-        return round(statistics.harmonic_mean(values), max_decimal_places(values))
+        try:
+            return round(statistics.harmonic_mean(values), max_decimal_places(values))
+        except statistics.StatisticsError:
+            return "NA"
 
 
 class StatsMedian(StatsBase):


### PR DESCRIPTION
The harmonic_mean routine fails upon encountering negative values, in which case we can just return NA.