### PR TITLE
Fix info printing `when` for executable_modifier

### DIFF
--- a/lib/ramble/ramble/language/modifier_language.py
+++ b/lib/ramble/ramble/language/modifier_language.py
@@ -185,7 +185,9 @@ def executable_modifier(name, when=None, **kwargs):
         if when_set not in mod.executable_modifiers:
             mod.executable_modifiers[when_set] = {}
 
-        mod.executable_modifiers[when_set][name] = name
+        mod.executable_modifiers[when_set][name] = {
+            "when": when_list,
+        }
 
     return _executable_modifier
 

--- a/lib/ramble/ramble/test/cmd/info.py
+++ b/lib/ramble/ramble/test/cmd/info.py
@@ -242,7 +242,7 @@ def _get_modifier_outputs():
             "var_mod_name",
             ["test var modified", "['+variable_modification_active', 'info_mode=test']"],
         ),
-        ("executable_modifiers", "exec_modifier_name", ""),
+        ("executable_modifiers", "exec_modifier_name", "+exec_modifier_active"),
         ("env_var_modifications", "", ""),  # TODO: Fix this test once info is fixed
         (
             "package_manager_requirements",

--- a/lib/ramble/ramble/test/modifier_language.py
+++ b/lib/ramble/ramble/test/modifier_language.py
@@ -416,7 +416,6 @@ def test_executable_modifier_directive(mod_class):
         mod_name = test_def
 
         assert mod_name in mod_inst.executable_modifiers[frozenset()]
-        assert mod_name == mod_inst.executable_modifiers[frozenset()][mod_name]
 
 
 def add_env_var_modification(mod_inst, env_var_mod_num=1):


### PR DESCRIPTION
Fixes an issue where `when` conditions did not print for executable_modifier using the info command