### PR TITLE
Do not include in inmem FOM that's not present

### DIFF
--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -2213,6 +2213,8 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                 # TODO: this can be extended to support derived FOMs,
                 # since the `fom_values` contains resolved file-based FOMs
                 fom_map_key = fom_conf["fom_map_key"]
+                if fom_map_key not in self._fom_map:
+                    continue
                 fom_value = self._fom_map.get(fom_map_key)
                 expanded_fom_value = self.expander.expand_var(fom_value)
                 fom_values[context][fom_name] = {

--- a/var/ramble/repos/builtin/modifiers/tunables/test/tunables.py
+++ b/var/ramble/repos/builtin/modifiers/tunables/test/tunables.py
@@ -91,3 +91,5 @@ nodeset-0: fom:hugepage-size:    2048 kB
                 "modifier::tunables::thp-enabled = {'always': nodeset-0, 'madvise': nodeset-1}"
                 in content
             )
+            # Assert FOMs that are not present don't get included (as None)
+            assert "modifier::tunables::numa-balancing" not in content


### PR DESCRIPTION
Currently it includes the FOM even if it's None.