### PR TITLE
Fix invalid success_list reference in experiment logs

### DIFF
--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -635,7 +635,7 @@ class LogsPipeline(Pipeline):
             logger.all_msg(f"Experiment: {exp}")
             logger.all_msg(f"    Experiment log file: {log_file}")
 
-            analysis_logs, _, _ = app_inst._analysis_dicts(self.workspace.success_list)
+            analysis_logs, _, _ = app_inst._analysis_dicts(app_inst.success_list)
 
             logger.all_msg("    Auxiliary experiment logs:")
             for log in analysis_logs:

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -2890,3 +2890,29 @@ def test_workspace_config_squash(workspace_name, capsys):
             data = f.read()
             assert "foo: bar" not in data
             assert "test_var: test_value" not in data
+
+
+def test_workspace_experiment_logs(workspace_name):
+    global_args = ["-w", workspace_name]
+
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+        workspace(
+            "manage",
+            "experiments",
+            "basic",
+            "--wf",
+            "test_wl",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            global_args=global_args,
+        )
+
+        output = workspace("experiment-logs", global_args=global_args)
+
+        expected_output = os.sep.join(
+            ["experiments", "basic", "test_wl", "generated", "generated.out"]
+        )
+        assert expected_output in output


### PR DESCRIPTION
This merge fixes an issue where the experiment-logs command would reference an invalid success list attribute.

A test is also added to help ensure experiment-logs works in the future.