### PR TITLE
Fix `spack compiler info` call

### DIFF
--- a/lib/ramble/ramble/software_environments.py
+++ b/lib/ramble/ramble/software_environments.py
@@ -844,7 +844,8 @@ class SoftwareEnvironments:
             environment (SoftwareEnvironment): Environment to extract compiler specs for
 
         Yields:
-            (str) Spec string for each compiler
+            (str) Package spec string for each compiler
+            (str) Compiler spec string for each compiler
         """
 
         root_compilers = []
@@ -874,7 +875,9 @@ class SoftwareEnvironments:
 
         for comp in reversed(root_compilers + dep_compilers):
             comp_pkg = self._rendered_packages[pm_name][comp]
-            yield comp_pkg.spec_str(all_packages=self._rendered_packages, compiler=False)
+            yield comp_pkg.spec_str(
+                all_packages=self._rendered_packages, compiler=False
+            ), comp_pkg.spec_str(all_packages=self._rendered_packages, compiler=True)
 
     def package_specs_for_environment(self, environment: object):
         """Iterator over package specs for a given environment

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
@@ -89,12 +89,15 @@ class SpackLightweight(PackageManagerBase):
 
             if software_env is not None:
                 for (
-                    compiler_spec
+                    pkg_spec,
+                    compiler_spec,
                 ) in software_envs.compiler_specs_for_environment(
                     software_env
                 ):
-                    logger.debug(f"Installing compiler: {compiler_spec}")
-                    self.runner.install_compiler(compiler_spec)
+                    logger.debug(
+                        f"Installing compiler: {compiler_spec} with pkg_spec {pkg_spec}"
+                    )
+                    self.runner.install_compiler(pkg_spec, compiler_spec)
 
         except RunnerError as e:
             logger.die(e)
@@ -889,7 +892,7 @@ class SpackRunner(CommandRunner):
                         env_var.group("var"), env_var.group("val")
                     )
 
-    def install_compiler(self, spec):
+    def install_compiler(self, pkg_spec, compiler_spec):
         """
         Ensure a compiler is installed, before using it to install packages
         within an environment.
@@ -914,7 +917,7 @@ class SpackRunner(CommandRunner):
         comp_info_args = []
         if self.compiler_config_dir:
             comp_info_args.extend(["-C", self.env_path])
-        comp_info_args.extend(["compiler", "info", spec])
+        comp_info_args.extend(["compiler", "info", compiler_spec])
 
         compiler_find_flags = ramble.config.get(
             f"{self.compiler_find_config_name}:flags"
@@ -930,7 +933,7 @@ class SpackRunner(CommandRunner):
             self._cmd_start(self.spack, comp_info_args)
             self.spack(*comp_info_args, output=os.devnull, error=os.devnull)
             self._cmd_end(self.spack, comp_info_args)
-            logger.msg(f"{spec} is already an available compiler")
+            logger.msg(f"{compiler_spec} is already an available compiler")
             return
         except ProcessError:
 
@@ -943,16 +946,16 @@ class SpackRunner(CommandRunner):
                 for flag in shlex.split(install_flags):
                     args.append(flag)
 
-            args.append(spec)
+            args.append(pkg_spec)
 
             self.execute(self.installer, args)
 
-            self.load_compiler(spec)
+            self.load_compiler(pkg_spec)
 
             self.execute(self.spack, compiler_find_args)
 
             if not self.dry_run:
-                self.compilers.append(spec)
+                self.compilers.append(pkg_spec)
 
                 if self.active:
                     self.spack.add_default_env(self.env_key, active_env)

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/test/spack_runner.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/test/spack_runner.py
@@ -384,7 +384,7 @@ packages:
                 sr.add_include_file(packages_path)
                 sr.add_include_file(compilers_path)
                 sr.generate_env_file()
-                sr.install_compiler("gcc@12.1.0")
+                sr.install_compiler("gcc@12.1.0", "gcc@12.1.0")
                 captured = capsys.readouterr()
 
                 assert (
@@ -567,7 +567,7 @@ compilers::
                     sr.create_env(os.getcwd())
                     sr.activate()
                     sr.add_include_file(compilers_path)
-                    sr.install_compiler("gcc@12.2.0")
+                    sr.install_compiler("gcc@12.2.0", "gcc@12.2.0")
                     captured = capsys.readouterr()
 
                     assert expected_str in captured.out

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/test/spack_runner.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/test/spack_runner.py
@@ -378,19 +378,23 @@ packages:
             "config:spack", {"global": {"flags": f"-C {config_path}"}}
         ):
             try:
+                pkg_spec = "gcc@12.1.0 +binutils"
+                compiler_spec = "gcc@12.1.0"
                 sr = SpackRunner(dry_run=True)
                 sr.create_env(os.getcwd())
                 sr.activate()
                 sr.add_include_file(packages_path)
                 sr.add_include_file(compilers_path)
                 sr.generate_env_file()
-                sr.install_compiler("gcc@12.1.0", "gcc@12.1.0")
+                sr.install_compiler("gcc@12.1.0 +binutils", "gcc@12.1.0")
                 captured = capsys.readouterr()
 
                 assert (
-                    "gcc@12.1.0 is already an available compiler"
+                    f"{compiler_spec} is already an available compiler"
                     in captured.out
                 )
+
+                assert f"{pkg_spec}" not in captured.out
             except RunnerError as e:
                 pytest.skip("%s" % e)
 
@@ -563,11 +567,13 @@ compilers::
                 "config:spack", {"compiler_find": {attr: value}}
             ):
                 try:
+                    pkg_spec = "gcc@12.2.0 +binutils"
+                    compiler_spec = "gcc@12.2.0"
                     sr = SpackRunner(dry_run=True)
                     sr.create_env(os.getcwd())
                     sr.activate()
                     sr.add_include_file(compilers_path)
-                    sr.install_compiler("gcc@12.2.0", "gcc@12.2.0")
+                    sr.install_compiler(pkg_spec, compiler_spec)
                     captured = capsys.readouterr()
 
                     assert expected_str in captured.out


### PR DESCRIPTION
This merge fixes an issue where we pass spack the incorrect spec for compilers. This results in spack trying to re-install compilers, even if they are already installed, making repeat calls to `ramble workspace setup` take longer than needed.