### PR TITLE
Tweak to non-aggregated FOM's summary output

### DIFF
--- a/lib/ramble/ramble/test/end_to_end/experiment_repeats.py
+++ b/lib/ramble/ramble/test/end_to_end/experiment_repeats.py
@@ -233,3 +233,4 @@ ramble:
             # Assert that the last experiment is not included in the stats
             assert "summary::max = 2.0 minutes" in data
             assert "summary::mean = 1.5 minutes" in data
+            assert "mode:\n      value = Sleep" in data

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1714,10 +1714,13 @@ ramble:
                                     if name not in fom_summary.keys():
                                         fom_summary[name] = []
                                     stat_name = fom["origin_type"]
+                                    if not stat_name.startswith("summary::"):
+                                        display_name = "value"
+                                    else:
+                                        display_name = stat_name
                                     value = fom["value"]
                                     units = fom["units"]
-
-                                    output = f"{stat_name} = {value} {units}\n"
+                                    output = f"{display_name} = {value} {units}\n"
                                     fom_summary[name].append(output)
 
                                 for fom_name, fom_val_list in fom_summary.items():

--- a/var/ramble/repos/builtin/applications/sleep/application.py
+++ b/var/ramble/repos/builtin/applications/sleep/application.py
@@ -100,4 +100,12 @@ class Sleep(ExecutableApplication):
         units="ms",
     )
 
+    figure_of_merit(
+        "mode",
+        fom_regex=r"\s*(?P<mode>(Sleep|Wake)) for.*",
+        group_name="mode",
+        units="",
+        fom_type=FomType.INFO,
+    )
+
     success_criteria("printed_sleep_time", mode="string", match=echo_regex)


### PR DESCRIPTION
Before this change, such non-aggregated FOMs use their `origin_type` as the stat's name, which feels somewhat confusing:

```
Level 0 Groups (cluster):
    modifier = 1
Level 1 Groups (rack):
    modifier = 1
Level 2 Groups (host):
    modifier = 1
```

Instead, just use `value =` for display.