### PR TITLE
Fix cache push for spack compilers

### DIFF
--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -590,6 +590,9 @@ def workspace_push_to_cache(args):
     current_pipeline = ramble.pipeline.pipelines.pushtocache
     ws = ramble.cmd.require_active_workspace(cmd_name="workspace pushtocache")
 
+    if args.dry_run:
+        ws.dry_run = True
+
     filters = ramble.filters.Filters(
         phase_filters="*",
         include_where_filters=args.where,
@@ -606,6 +609,14 @@ def workspace_push_to_cache(args):
 
 def workspace_push_to_cache_setup_parser(subparser):
     """push workspace envs to a given buildcache"""
+
+    subparser.add_argument(
+        "--dry-run",
+        dest="dry_run",
+        action="store_true",
+        help="perform a dry run. Acts like it will push "
+        + "to a cache, but will not actually create a cache.",
+    )
 
     subparser.add_argument(
         "-d", dest="cache_path", default=None, required=True, help="Path to cache."

--- a/lib/ramble/ramble/pkgmankit.py
+++ b/lib/ramble/ramble/pkgmankit.py
@@ -16,6 +16,7 @@ from llnl.util.filesystem import *
 
 import ramble.language.package_manager_language
 import ramble.repository
+from ramble.error import PackageManagerError
 from ramble.language.package_manager_language import *
 from ramble.language.shared_language import *
 from ramble.software_environments import ExternalEnvironment

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -679,7 +679,7 @@ _ramble_workspace_analyze() {
 }
 
 _ramble_workspace_push_to_cache() {
-    RAMBLE_COMPREPLY="-h --help -d --where --exclude-where --filter-tags --profile-phase"
+    RAMBLE_COMPREPLY="-h --help --dry-run -d --where --exclude-where --filter-tags --profile-phase"
 }
 
 _ramble_workspace_info() {

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
@@ -61,7 +61,7 @@ class SpackLightweight(PackageManagerBase):
         # See if we cached this already, and if so return
         env_path = app_inst.expander.env_path
         if not env_path:
-            raise ApplicationError("Ramble env_path is set to None.")
+            raise PackageManagerError("Ramble env_path is set to None.")
         logger.msg("Installing compilers")
 
         cache_tupl = ("spack-compilers", env_path)
@@ -117,7 +117,7 @@ class SpackLightweight(PackageManagerBase):
         # See if we cached this already, and if so return
         env_path = app_inst.expander.env_path
         if not env_path:
-            raise ApplicationError("Ramble env_path is set to None.")
+            raise PackageManagerError("Ramble env_path is set to None.")
 
         cache_tupl = ("spack-env", env_path)
         if workspace.check_cache(cache_tupl):
@@ -288,12 +288,12 @@ class SpackLightweight(PackageManagerBase):
         # See if we cached this already, and if so return
         env_path = app_inst.expander.env_path
         if not env_path:
-            raise ApplicationError("Ramble env_path is set to None.")
+            raise PackageManagerError("Ramble env_path is set to None.")
 
         if not os.path.exists(env_path) or not os.path.isfile(
             os.path.join(env_path, "spack.lock")
         ):
-            raise ApplicationError(
+            raise PackageManagerError(
                 f"Spack environment {env_path} does not exist, or has not been concretized."
             )
 

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
@@ -378,9 +378,12 @@ class SpackLightweight(PackageManagerBase):
             software_env = software_envs.render_environment(
                 app_context, app_inst.expander, self, require=require_env
             )
-            compiler_specs = software_envs.compiler_specs_for_environment(
-                software_env
-            )
+            compiler_specs = [
+                spec
+                for spec, _ in software_envs.compiler_specs_for_environment(
+                    software_env
+                )
+            ]
 
             self.runner.push_to_spack_cache(
                 workspace.spack_cache_path, compiler_specs

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/test/spack_lightweight.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/test/spack_lightweight.py
@@ -118,3 +118,76 @@ def test_spack_auxiliary_files(request):
         data = f.read()
         assert "opt_target" not in data
         assert "x86_64" in data
+
+
+def test_spack_push_to_cache(workspace_name, mock_applications):
+    ws = ramble.workspace.create(workspace_name)
+    global_args = ["-w", workspace_name]
+
+    workspace(
+        "manage",
+        "experiments",
+        "zlib",
+        "--wf",
+        "ensure_installed",
+        "-p",
+        "spack",
+        "-v",
+        "n_nodes=1",
+        "-v",
+        "n_ranks=1",
+        "-v",
+        "processes_per_node=1",
+        "-v",
+        "batch_submit={execute_experiment}",
+        global_args=global_args,
+    )
+
+    # Add a gcc compiler package
+    workspace(
+        "manage",
+        "software",
+        "--pkg",
+        "gcc",
+        "--spec",
+        "gcc",
+        global_args=global_args,
+    )
+
+    # Add zlib package
+    workspace(
+        "manage",
+        "software",
+        "--pkg",
+        "zlib",
+        "--spec",
+        "zlib",
+        "--compiler",
+        "gcc",
+        global_args=global_args,
+    )
+
+    # Define zlib environment
+    workspace(
+        "manage",
+        "software",
+        "--env",
+        "zlib",
+        "--environment-packages",
+        "zlib",
+        global_args=global_args,
+    )
+
+    workspace(
+        "setup",
+        "--phases",
+        "software_create_env",
+        "software_configure",
+        global_args=global_args,
+    )
+
+    cache_path = os.path.join(ws.root, "test_cache")
+
+    workspace(
+        "push-to-cache", "-d", cache_path, "--dry-run", global_args=global_args
+    )


### PR DESCRIPTION
Recently, the compiler_specs_for_environment method was updated to separate the package and the compiler spec. The spack package manager was not updated correctly for this.

This merge fixes this issue.