### PR TITLE
Add confidence intervals to repeats stats

### DIFF
--- a/lib/ramble/ramble/test/util/stats.py
+++ b/lib/ramble/ramble/test/util/stats.py
@@ -42,6 +42,79 @@ import ramble.util.stats
             "s",
             (0.18, "", "summary::cv"),
         ),
+        (
+            ramble.util.stats.StatsConfidenceIntervalLower95(),
+            [1, 2, 3, 4, 5],
+            "s",
+            (1.0, "s", "summary::ci_95_lower"),
+        ),
+        (
+            ramble.util.stats.StatsConfidenceIntervalUpper95(),
+            [1, 2, 3, 4, 5],
+            "s",
+            (5.0, "s", "summary::ci_95_upper"),
+        ),
+        (
+            ramble.util.stats.StatsConfidenceIntervalLower95(),
+            [1],
+            "s",
+            ("NA", "", "summary::ci_95_lower"),
+        ),
+        (
+            ramble.util.stats.StatsConfidenceIntervalUpper95(),
+            [1],
+            "s",
+            ("NA", "", "summary::ci_95_upper"),
+        ),
+        # Test case with a larger sample size to verify z-score approximation
+        (
+            ramble.util.stats.StatsConfidenceIntervalLower95(),
+            list(range(1, 31)),
+            "s",
+            (12.0, "s", "summary::ci_95_lower"),
+        ),
+        (
+            ramble.util.stats.StatsConfidenceIntervalUpper95(),
+            list(range(1, 31)),
+            "s",
+            (19.0, "s", "summary::ci_95_upper"),
+        ),
+        (
+            ramble.util.stats.StatsConfidenceIntervalLower99(),
+            list(range(1, 31)),
+            "s",
+            (11.0, "s", "summary::ci_99_lower"),
+        ),
+        (
+            ramble.util.stats.StatsConfidenceIntervalUpper99(),
+            list(range(1, 31)),
+            "s",
+            (20.0, "s", "summary::ci_99_upper"),
+        ),
+        (
+            ramble.util.stats.StatsConfidenceIntervalLower90(),
+            list(range(1, 31)),
+            "s",
+            (13.0, "s", "summary::ci_90_lower"),
+        ),
+        (
+            ramble.util.stats.StatsConfidenceIntervalUpper90(),
+            list(range(1, 31)),
+            "s",
+            (18.0, "s", "summary::ci_90_upper"),
+        ),
+        (
+            ramble.util.stats.StatsConfidenceIntervalLower50(),
+            list(range(1, 31)),
+            "s",
+            (14.0, "s", "summary::ci_50_lower"),
+        ),
+        (
+            ramble.util.stats.StatsConfidenceIntervalUpper50(),
+            list(range(1, 31)),
+            "s",
+            (17.0, "s", "summary::ci_50_upper"),
+        ),
     ],
 )
 def test_stats_for_repeat_foms(statistic, input_values, input_units, output):

--- a/lib/ramble/ramble/util/stats.py
+++ b/lib/ramble/ramble/util/stats.py
@@ -6,7 +6,10 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+import math
 import statistics
+
+from scipy.stats import t
 
 
 def decimal_places(value):
@@ -124,6 +127,112 @@ class StatsCoefficientOfVariation(StatsBase):
         return ""
 
 
+def _calculate_margin_of_error(values, confidence_level):
+    """Calculates the margin of error for a given confidence interval."""
+    n = len(values)
+    stdev = statistics.stdev(values)
+
+    # For small sample sizes (n < 30), a t-distribution is more accurate.
+    # For larger samples, the z-score is a good approximation.
+    if n < 30:
+        degrees_freedom = n - 1
+        t_score = float(t.ppf(1 - (1 - confidence_level) / 2, degrees_freedom))
+        return t_score * (stdev / math.sqrt(n))
+    else:
+        # Using z-score for confidence.
+        if confidence_level == 0.99:
+            z_score = 2.576
+        elif confidence_level == 0.95:
+            z_score = 1.96
+        elif confidence_level == 0.90:
+            z_score = 1.645
+        elif confidence_level == 0.50:
+            z_score = 0.674
+        else:
+            z_score = None
+        return z_score * (stdev / math.sqrt(n))
+
+
+class StatsConfidenceIntervalLower99(StatsBase):
+    name = "ci_99_lower"
+    min_count = 2
+
+    def compute(self, values):
+        mean = statistics.mean(values)
+        margin_of_error = _calculate_margin_of_error(values, 0.99)
+        return round(mean - margin_of_error, max_decimal_places(values))
+
+
+class StatsConfidenceIntervalUpper99(StatsBase):
+    name = "ci_99_upper"
+    min_count = 2
+
+    def compute(self, values):
+        mean = statistics.mean(values)
+        margin_of_error = _calculate_margin_of_error(values, 0.99)
+        return round(mean + margin_of_error, max_decimal_places(values))
+
+
+class StatsConfidenceIntervalLower95(StatsBase):
+    name = "ci_95_lower"
+    min_count = 2
+
+    def compute(self, values):
+        mean = statistics.mean(values)
+        margin_of_error = _calculate_margin_of_error(values, 0.95)
+        return round(mean - margin_of_error, max_decimal_places(values))
+
+
+class StatsConfidenceIntervalUpper95(StatsBase):
+    name = "ci_95_upper"
+    min_count = 2
+
+    def compute(self, values):
+        mean = statistics.mean(values)
+        margin_of_error = _calculate_margin_of_error(values, 0.95)
+        return round(mean + margin_of_error, max_decimal_places(values))
+
+
+class StatsConfidenceIntervalLower90(StatsBase):
+    name = "ci_90_lower"
+    min_count = 2
+
+    def compute(self, values):
+        mean = statistics.mean(values)
+        margin_of_error = _calculate_margin_of_error(values, 0.90)
+        return round(mean - margin_of_error, max_decimal_places(values))
+
+
+class StatsConfidenceIntervalUpper90(StatsBase):
+    name = "ci_90_upper"
+    min_count = 2
+
+    def compute(self, values):
+        mean = statistics.mean(values)
+        margin_of_error = _calculate_margin_of_error(values, 0.90)
+        return round(mean + margin_of_error, max_decimal_places(values))
+
+
+class StatsConfidenceIntervalLower50(StatsBase):
+    name = "ci_50_lower"
+    min_count = 2
+
+    def compute(self, values):
+        mean = statistics.mean(values)
+        margin_of_error = _calculate_margin_of_error(values, 0.50)
+        return round(mean - margin_of_error, max_decimal_places(values))
+
+
+class StatsConfidenceIntervalUpper50(StatsBase):
+    name = "ci_50_upper"
+    min_count = 2
+
+    def compute(self, values):
+        mean = statistics.mean(values)
+        margin_of_error = _calculate_margin_of_error(values, 0.50)
+        return round(mean + margin_of_error, max_decimal_places(values))
+
+
 all_stats = [
     StatsMin(),
     StatsMax(),
@@ -133,4 +242,12 @@ all_stats = [
     StatsVar(),
     StatsStdev(),
     StatsCoefficientOfVariation(),
+    StatsConfidenceIntervalLower99(),
+    StatsConfidenceIntervalUpper99(),
+    StatsConfidenceIntervalLower95(),
+    StatsConfidenceIntervalUpper95(),
+    StatsConfidenceIntervalLower90(),
+    StatsConfidenceIntervalUpper90(),
+    StatsConfidenceIntervalLower50(),
+    StatsConfidenceIntervalUpper50(),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ deprecation
 pandas
 matplotlib
 setuptools
+scipy


### PR DESCRIPTION
This merge adds 50%, 90%, 95%, and 99% confidence intervals to the statistical output computed for repeats.