### PR TITLE
add app names to fix documentation

### DIFF
--- a/var/ramble/repos/builtin/base_applications/openfoam/base_application.py
+++ b/var/ramble/repos/builtin/base_applications/openfoam/base_application.py
@@ -15,7 +15,7 @@ from ramble.expander import Expander
 class Openfoam(ExecutableApplication):
     """Base application definition for OpenFoam"""
 
-    name = "openfoamorg"
+    name = "openfoam"
 
     maintainers("douglasjacobsen")
 

--- a/var/ramble/repos/builtin/base_applications/py-nemo/base_application.py
+++ b/var/ramble/repos/builtin/base_applications/py-nemo/base_application.py
@@ -18,6 +18,8 @@ from spack.util.path import canonicalize_path
 class PyNemo(ExecutableApplication):
     """Define a base class for PyNemo applications."""
 
+    name = "py-nemo"
+
     tags(
         "machine-learning",
         "llm",


### PR DESCRIPTION
I noticed that our documentation relies on apps having names and currently generates incorrect information for these two apps, 

ie base openfoam thinks its actually called openfoamorg links to a non existant source file:

```
openfoamorg[¶](https://ramble.readthedocs.io/en/latest/base_application_list.html#openfoamorg)
Ramble base_applications:
[openfoamorg/base_application.py](https://github.com/GoogleCloudPlatform/ramble/blob/develop/var/ramble/repos/builtin/base_applications/openfoamorg/base_application.py)
```

(see https://ramble.readthedocs.io/en/latest/base_application_list.html#openfoamorg) 

I think this is a reasonable fix *if* base apps are OK to have the same name as dependent apps

Alternate fix is to change how documentation is generates