### PR TITLE
Add FOMs around SLURM configs and termination overhead

### DIFF
--- a/var/ramble/repos/builtin/workflow_managers/slurm/test/slurm.py
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/test/slurm.py
@@ -166,6 +166,7 @@ ramble:
         with open(os.path.join(path, "slurm_experiment_sbatch")) as f:
             content = f.read()
             assert "scontrol show hostnames" in content
+            assert "scontrol show config" in content
             assert "#SBATCH -N 1" in content
             assert "#SBATCH -J hostname_local_test_slurm" in content
             assert "#SBATCH --ntasks-per-node 1" in content
@@ -201,7 +202,7 @@ ramble:
             content = f.read()
             # Since it uses the default execute_experiment tpl, no slurm content is present
             assert "#SBATCH" not in content
-            assert "scontrol" not in content
+            assert "scontrol show hostnames" not in content
 
 
 def test_slurm_workflow_variant(request):

--- a/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
@@ -257,6 +257,26 @@ class Slurm(WorkflowManagerBase):
             fom_type=FomType.INFO,
         )
 
+    # Capture slurm configs before the workload runs, just so that the configs
+    # match closer when the job is submitted.
+    register_builtin(
+        "capture_slurm_config", required=True, injection_method="prepend"
+    )
+
+    def capture_slurm_config(self):
+        return [
+            "scontrol show config > {experiment_run_dir}/.slurm_config",
+        ]
+
+    for fom in ["TopologyParam", "TopologyPlugin"]:
+        figure_of_merit(
+            f"slurm-config-{fom}",
+            fom_regex=rf"\s*{fom}\s*=\s*(?P<val>\S+)",
+            group_name="val",
+            log_file="{experiment_run_dir}/.slurm_config",
+            fom_type=FomType.INFO,
+        )
+
 
 class SlurmRunner:
     """Runner for executing slurm commands"""

--- a/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
@@ -6,6 +6,7 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+import datetime
 import os
 
 from ramble.experiment_result import ExperimentStatus
@@ -213,6 +214,39 @@ class Slurm(WorkflowManagerBase):
             "workflow_hostfile_cmd": self.runner.get_hostfile_cmd(),
         }
 
+    def _get_job_termination_overhead(self):
+        # Get the duration between script end time and job termination time.
+        run_dir = self.app_inst.expander.experiment_run_dir
+        end_time_file = os.path.join(run_dir, ".slurm_script_end_time")
+        job_id_file = os.path.join(run_dir, ".slurm_job")
+        if not os.path.isfile(end_time_file) or not os.path.isfile(
+            job_id_file
+        ):
+            return
+        with open(end_time_file) as f:
+            script_end_time = float(f.read().strip())
+        with open(job_id_file) as f:
+            job_id = f.read().strip()
+        sacct_cmd = Executable("sacct")
+        try:
+            job_end_time_str = sacct_cmd(
+                "-j", job_id, "-X", "-n", "--format=End", output=str
+            ).strip()
+            # sacct by default reports timestamp in local timezone
+            # TODO: can use more convenient method with python 3.7+
+            job_end_time = datetime.datetime.strptime(
+                job_end_time_str, "%Y-%m-%dT%H:%M:%S"
+            ).timestamp()
+            duration = int(job_end_time - script_end_time)
+        except (ProcessError, ValueError) as e:
+            logger.warn(f"Failed to get job end time with error {e}")
+        else:
+            fom_key = "slurm-job-termination-overhead"
+            self.figure_of_merit(
+                "job-termination-overhead", units="s", fom_map_key=fom_key
+            )
+            self.add_inmem_fom_value(fom_key, duration)
+
     def _prepare_analysis(self, workspace):
         if workspace.dry_run:
             return
@@ -224,6 +258,7 @@ class Slurm(WorkflowManagerBase):
         except ProcessError as e:
             # Only log a warning as this is not considered a critical step
             logger.warn(f"batch_query returns error {e}")
+        self._get_job_termination_overhead()
 
     def get_status(self, workspace):
         expander = self.app_inst.expander
@@ -256,6 +291,16 @@ class Slurm(WorkflowManagerBase):
             log_file="{experiment_run_dir}/.slurm_job_info",
             fom_type=FomType.INFO,
         )
+
+    # Capture sbatch script end time, in epoch seconds
+    register_builtin(
+        "capture_sbatch_script_end_time",
+        required=True,
+        injection_method="append",
+    )
+
+    def capture_sbatch_script_end_time(self):
+        return ["date +%s > {experiment_run_dir}/.slurm_script_end_time"]
 
     # Capture slurm configs before the workload runs, just so that the configs
     # match closer when the job is submitted.


### PR DESCRIPTION
* Add a couple FOMs around topology.
* Add a FOM to track the duration between script finishing execution and the final job termination time.