### PR TITLE
Refactor experiment result class

### DIFF
--- a/lib/ramble/ramble/experiment_result.py
+++ b/lib/ramble/ramble/experiment_result.py
@@ -47,27 +47,38 @@ class ExperimentResult:
 
     def __init__(self, app_inst):
         """Build up the result from the given app instance"""
+        self._app_inst = app_inst
+        self.name = None
+        self.status = ExperimentStatus.UNKNOWN
+        self.n_repeats = None
+        self.experiment_chain = []
+        self.tags = []
+        self.contexts = []
+        self.success_criteria = {}
+        self.software = {}
+        self.keys = {}
+        self.raw_variables = {}
+        self.variables = {}
+        self.variants = []
+
+    def finalize(self):
+        app_inst = self._app_inst
         self.name = app_inst.expander.experiment_namespace
 
         self.status = app_inst.get_ramble_status()
 
-        # Most libs can handle this str enum, but convert it to help out
-        self.status = self.status.value
-
         self.n_repeats = app_inst.repeats.n_repeats
         self.experiment_chain = app_inst.chain_order.copy()
         self.tags = list(app_inst.experiment_tags)
-        self.contexts = []
-        self.success_criteria = {}
-        self.software = {}
 
-        self.keys = {}
+        # Most libs can handle this str enum, but convert it to help out
+        self.status = self.status.value
+
         for key in app_inst.keywords.keys:
             if app_inst.keywords.is_key_level(key):
                 self.keys[key] = app_inst.expander.expand_var_name(key)
 
         self.raw_variables = {}
-        self.variables = {}
         for var, val in app_inst.variables.items():
             self.raw_variables[var] = val
             if var not in app_inst.keywords.keys or not app_inst.keywords.is_key_level(var):
@@ -91,6 +102,10 @@ class ExperimentResult:
         output = {}
         obj_keys = {}
 
+        # Remove app_inst to prevent pickle issues
+        app_inst = self._app_inst
+        delattr(self, "_app_inst")
+
         obj_dict = copy.deepcopy(self.__dict__)
 
         if "keys" in obj_dict:
@@ -101,5 +116,8 @@ class ExperimentResult:
                 output.update(obj_keys)
             else:
                 output[output_val] = obj_dict[lookup_key]
+
+        # Add app_inst back into object
+        self._app_inst = app_inst
 
         return output

--- a/lib/ramble/ramble/test/experiment_result.py
+++ b/lib/ramble/ramble/test/experiment_result.py
@@ -20,6 +20,7 @@ def test_to_dict(mutable_mock_apps_repo):
     )
     basic_app_inst.set_status("UNKNOWN")
     exp_res = ExperimentResult(basic_app_inst)
+    exp_res.finalize()
     res_dict = exp_res.to_dict()
 
     assert "name" in res_dict

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -226,6 +226,8 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
         self.workflow_manager = None
 
+        self.result = ExperimentResult(self)
+
         ramble.util.directives.define_directive_methods(self)
 
     @property
@@ -2264,6 +2266,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             logger.warn(
                 f"Experiment has status {self.get_status()}. Skipping analysis..\n"
             )
+            self.result.finalize()
             return
 
         def format_context(context_match, context_format):
@@ -2454,7 +2457,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
         self.set_status(status)
 
-        self._init_result()
+        self.result.finalize()
 
         for criteria_obj in criteria_list.all_criteria():
             if criteria_obj.ok():
@@ -2588,7 +2591,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         else:
             self.set_status(status=ExperimentStatus.FAILED)
 
-        self._init_result()
+        self.result.finalize()
 
         logger.debug(
             f"Calculating statistics for {self.repeats.n_repeats} repeats of {base_exp_name}"
@@ -2742,10 +2745,6 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             self.result.contexts = results
 
         workspace.insert_result(self.result.to_dict(), first_repeat_exp)
-
-    def _init_result(self):
-        if self.result is None:
-            self.result = ExperimentResult(self)
 
     def _new_file_dict(self):
         """Create a dictionary to represent a new log file"""


### PR DESCRIPTION
This merge splits the init method of the experiment result class into an init (which doesn't do anything beyond creating the attributes of the result class), and a finalize method (which correctly sets the attributes). This gets around issues where experiments (namely, repeats under parent experiments) were not setup / run and are considered invalid because they didn't have a valid results object.