### PR TITLE
Remove uploading of foms and data

### DIFF
--- a/lib/ramble/ramble/uploader.py
+++ b/lib/ramble/ramble/uploader.py
@@ -99,9 +99,16 @@ class Experiment:
         import copy
 
         j = copy.deepcopy(self.__dict__)
+        data_copy = copy.deepcopy(self.data)
 
-        j["foms"] = json.dumps(self.foms)
-        j["data"] = json.dumps(self.data, default=vars)
+        # These two fields will be deprecated in an upcoming release.
+        # For now we avoid setting them to a reduced set of information to
+        # maintain backwards database compatibiilty but also avoiding
+        # large un-needed uploads
+        data_copy["CONTEXTS"] = []
+
+        j["foms"] = json.dumps(None)
+        j["data"] = json.dumps(data_copy, default=vars)
         return j
 
 


### PR DESCRIPTION
This PR is the first step in deprecated `experiment.foms` and `experiment.data`

This change avoids the setting `foms` and removes `foms` from data. This significantly decreases the size of the pushed data, and is required for large workspaces to upload to BQ

A future change will remove these fields entirely, but that will be a backwards breaking change for the db schema. This change is safe and just avoids writing data that should not be consumed today  