### PR TITLE
Update merged config section with more config sections

### DIFF
--- a/lib/ramble/ramble/schema/merged.py
+++ b/lib/ramble/ramble/schema/merged.py
@@ -14,25 +14,42 @@
 from llnl.util.lang import union_dicts
 
 import ramble.schema.applications
+import ramble.schema.base_application_repos
+import ramble.schema.base_class_repos
+import ramble.schema.base_modifier_repos
+import ramble.schema.base_package_manager_repos
+import ramble.schema.base_workflow_manager_repos
 import ramble.schema.config
 import ramble.schema.env_vars
 import ramble.schema.formatted_executables
 import ramble.schema.internals
 import ramble.schema.licenses
+import ramble.schema.mirrors
+import ramble.schema.modifier_repos
 import ramble.schema.modifiers
+import ramble.schema.package_manager_repos
 import ramble.schema.repos
 import ramble.schema.software
 import ramble.schema.success_criteria
 import ramble.schema.variables
 import ramble.schema.variants
+import ramble.schema.workflow_manager_repos
 import ramble.schema.zips
 
 #: Properties for inclusion in other schemas
 properties = union_dicts(
     ramble.schema.applications.properties,
+    ramble.schema.base_application_repos.properties,
+    ramble.schema.base_class_repos.properties,
+    ramble.schema.base_modifier_repos.properties,
+    ramble.schema.base_package_manager_repos.properties,
+    ramble.schema.base_workflow_manager_repos.properties,
     ramble.schema.config.properties,
     ramble.schema.formatted_executables.properties,
     ramble.schema.licenses.properties,
+    ramble.schema.mirrors.properties,
+    ramble.schema.modifier_repos.properties,
+    ramble.schema.package_manager_repos.properties,
     ramble.schema.repos.properties,
     ramble.schema.software.properties,
     ramble.schema.success_criteria.properties,
@@ -41,6 +58,7 @@ properties = union_dicts(
     ramble.schema.env_vars.properties,
     ramble.schema.internals.properties,
     ramble.schema.modifiers.properties,
+    ramble.schema.workflow_manager_repos.properties,
     ramble.schema.zips.properties,
 )
 

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1128,10 +1128,6 @@ ramble:
                     if fnmatch.fnmatch(section, pattern):
                         keep = False
 
-            # Disallow all repo configuration sections, as they are not valid
-            if fnmatch.fnmatch(section, "*repos"):
-                keep = False
-
             if keep:
                 section_dict = ramble.config.get(section)
                 if section_dict:


### PR DESCRIPTION
This merge adds more configuration sections to the merged configuration section. This allows workspaces to include more in-lined configuration sections and be more self contained.

Additionally, the logic that disallowed `*repos` from the workspace squash and print config method was removed, as these are now allowed.