### PR TITLE
Add a config to control the showing of workspace prompt

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -23,6 +23,7 @@ import ramble.config
 import ramble.paths
 import ramble.repository
 import ramble.stage
+import ramble.workspace
 from ramble.fetch_strategy import FetchError, FetchStrategyComposite, URLFetchStrategy
 from ramble.util.file_util import is_dry_run_path
 
@@ -565,6 +566,14 @@ def mutable_mock_workspace_path(tmpdir_factory, mutable_config):
     mock_path = tmpdir_factory.mktemp("mock-workspace-path")
     with ramble.config.override("config:workspace_dirs", str(mock_path)):
         yield mock_path
+
+
+@pytest.fixture()
+def workspace_deactivate():
+    """Deactivates any active workspace after a test."""
+    yield
+    ramble.workspace._active_workspace = None
+    os.environ.pop("RAMBLE_WORKSPACE", None)
 
 
 @pytest.fixture

--- a/lib/ramble/docs/workspace.rst
+++ b/lib/ramble/docs/workspace.rst
@@ -178,6 +178,21 @@ will activate a workspace until it is deactivated, while
 
 will activate a workspace for the specific command.
 
+To indicate the activated workspace, an option ``-p`` can be supplied to the ``activate`` command.
+This updates the shell prompt to display the name of the currently active workspace.
+
+.. code-block:: console
+
+    $ ramble workspace activate -p <name_or_path>
+
+Alternatively, a config ``enable_workspace_prompt`` exists, to allow controlling for this behavior
+at the desired configuration granularity.
+
+.. code-block:: console
+
+    $ ramble config add 'config:enable_workspace_prompt:true'
+
+
 ------------------------------
 Printing Workspace Information
 ------------------------------

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -172,8 +172,11 @@ def workspace_activate(args):
 
     # Activate new workspace
     active_workspace = ramble.workspace.Workspace(workspace_path)
+    enable_prompt = args.prompt or ramble.config.get("config:enable_workspace_prompt")
     cmds += ramble.workspace.shell.activate_header(
-        ws=active_workspace, shell=args.shell, prompt=workspace_prompt if args.prompt else None
+        ws=active_workspace,
+        shell=args.shell,
+        prompt=workspace_prompt if enable_prompt else None,
     )
     env_mods.extend(ramble.workspace.shell.activate(ws=active_workspace))
     cmds += env_mods.shell_modifications(args.shell)

--- a/lib/ramble/ramble/schema/config.py
+++ b/lib/ramble/ramble/schema/config.py
@@ -181,6 +181,8 @@ properties["config"]["n_repeats"] = {"type": "string", "default": "0"}
 
 properties["config"]["repeat_success_strict"] = {"type": "boolean", "default": True}
 
+properties["config"]["enable_workspace_prompt"] = {"type": "boolean", "default": False}
+
 
 #: Full schema with metadata
 schema = {

--- a/lib/ramble/ramble/test/cmd/config.py
+++ b/lib/ramble/ramble/test/cmd/config.py
@@ -910,9 +910,3 @@ def test_command_alias(mutable_empty_config):
     output = f.getvalue()
     assert ret == 0
     assert "ramble info" not in output
-
-    # Test alias to non-existent command
-    config("add", "config:aliases:bad:nonexistent")
-    with pytest.raises(SystemExit) as e:
-        main.main(argv=["bad"])
-    assert e.value.code != 0

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -28,19 +28,15 @@ import spack.util.spack_yaml as syaml
 
 # everything here uses the mock_workspace_path
 pytestmark = pytest.mark.usefixtures(
-    "mutable_config", "mutable_mock_workspace_path", "mutable_mock_apps_repo"
+    "mutable_config",
+    "mutable_mock_workspace_path",
+    "mutable_mock_apps_repo",
+    "workspace_deactivate",
 )
 
 config = RambleCommand("config")
 workspace = RambleCommand("workspace")
 on = RambleCommand("on")
-
-
-@pytest.fixture()
-def workspace_deactivate():
-    yield
-    ramble.workspace._active_workspace = None
-    os.environ.pop("RAMBLE_WORKSPACE", None)
 
 
 def add_basic(ws):
@@ -152,6 +148,64 @@ def test_workspace_activate_fails(mutable_mock_workspace_path):
     workspace("create", "foo")
     out = workspace("activate", "foo")
     assert "To set up shell support" in out
+
+
+def test_workspace_activate_prompt(workspace_name):
+    ws = ramble.workspace.create(workspace_name)
+    ws.write()
+
+    # Assert no prompt modification
+    output = workspace("activate", workspace_name, "--sh")
+    assert "PS1" not in output
+
+    # Assert prompt mod with --prompt
+    output = workspace("activate", workspace_name, "--sh", "--prompt")
+    assert "export RAMBLE_OLD_PS1=" in output
+    assert f'PS1="[{workspace_name}] ${{PS1}}";' in output
+
+    # Assert prompt mod with config value
+    with ramble.config.override("config:enable_workspace_prompt", True):
+        output = workspace("activate", workspace_name, "--sh")
+        assert "export RAMBLE_OLD_PS1=" in output
+        assert f'PS1="[{workspace_name}] ${{PS1}}";' in output
+
+
+def test_workspace_activate_by_name(workspace_name):
+    ws = ramble.workspace.create(workspace_name)
+    ws.write()
+
+    output = workspace("activate", workspace_name, "--sh")
+    assert f"export RAMBLE_WORKSPACE={ws.root}" in output
+
+
+def test_workspace_activate_by_dir(tmpdir):
+    with tmpdir.as_cwd():
+        workspace("create", "-d", "foo")
+        output = workspace("activate", "--dir", "foo", "--sh")
+        ws_path = os.path.abspath("foo")
+        assert f"export RAMBLE_WORKSPACE={ws_path}" in output
+
+
+def test_workspace_activate_temp():
+    """Test `ramble workspace activate --temp`."""
+    # Test without prompt decoration
+    output = workspace("activate", "--temp", "--sh")
+
+    match = re.search(r"export RAMBLE_WORKSPACE=([^;]+)", output)
+    workspace_path = match.group(1)
+
+    assert os.path.isdir(workspace_path)
+    assert ramble.workspace.is_workspace_dir(workspace_path)
+
+
+def test_workspace_activate_non_existent():
+    output = workspace("activate", "non-existent-ws", "--sh", fail_on_error=False)
+    assert "No such workspace: 'non-existent-ws'" in output
+
+
+def test_workspace_activate_no_args():
+    output = workspace("activate", fail_on_error=False)
+    assert "ramble workspace activate requires a workspace name, directory, or --temp" in output
 
 
 def test_workspace_list(mutable_mock_workspace_path):

--- a/lib/ramble/ramble/test/workspace.py
+++ b/lib/ramble/ramble/test/workspace.py
@@ -14,15 +14,11 @@ import ramble.workspace
 
 # everything here uses the mock_workspace_path
 pytestmark = pytest.mark.usefixtures(
-    "mutable_mock_workspace_path", "config", "mutable_mock_apps_repo"
+    "mutable_mock_workspace_path",
+    "config",
+    "mutable_mock_apps_repo",
+    "workspace_deactivate",
 )
-
-
-@pytest.fixture()
-def workspace_deactivate():
-    yield
-    ramble.workspace._active_workspace = None
-    os.environ.pop("RAMBLE_WORKSPACE", None)
 
 
 def test_re_read(tmpdir):


### PR DESCRIPTION
I've always wanted this behavior more globally, and sometimes it's easy to forget using `-p` in activation.

Also since we support `ramble workspace create -a`, currently there isn't a good way to pass the `-p` there.