### PR TITLE
Allow referencing math functions directly

### DIFF
--- a/lib/ramble/docs/workspace_config.rst
+++ b/lib/ramble/docs/workspace_config.rst
@@ -186,6 +186,9 @@ Supported functions are:
 * ``re_search(regex, str)`` (determine if ``str`` contains pattern ``regex``, based on ``re.search``)
 * ``maybe(var_name, default="")`` (returns the expanded ``var_name`` if it is defined, otherwise returns ``default``)
 
+Besides the above listed, any functions from the ``math`` module can be used in Ramble by referencing ``math_<function_name>``.
+For instance, ``math_log(<num>, <base>)`` invokes the ``math.log(<num>, <base>)`` function.
+
 String slicing is supported:
 
 * ``str[start:end:step]`` (string slicing)

--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -112,6 +112,11 @@ supported_list_function_pointers = {
 }
 
 
+supported_modules = {
+    "math": math,
+}
+
+
 formatter = string.Formatter()
 
 
@@ -937,6 +942,15 @@ class Expander:
             func = supported_scalar_function_with_self_arg_pointers[node.func.id]
             return func(self, *args, **kwargs)
         else:
+            parts = node.func.id.split("_", 1)
+            if len(parts) == 2:
+                module_name, func_name = parts
+                if module_name in supported_modules:
+                    module = supported_modules[module_name]
+                    if hasattr(module, func_name):
+                        func = getattr(module, func_name)
+                        return func(*args, **kwargs)
+
             raise MathEvaluationError(
                 f"Undefined function {node.func.id} used.\n" "returning unexapanded string"
             )

--- a/lib/ramble/ramble/test/expander.py
+++ b/lib/ramble/ramble/test/expander.py
@@ -142,6 +142,10 @@ def build_variant_set():
         ("log2(8)", "3.0", set(), 1),
         ("log10(100)", "2.0", set(), 1),
         ("sqrt(16)", "4.0", set(), 1),
+        # Can also reference functions available in the math module directly
+        ("math_sqrt(64)", "8.0", set(), 1),
+        ("math_log(9, 3)", "2.0", set(), 1),
+        ("math_not_exist(1)", "math_not_exist(1)", set(), 1),
     ],
 )
 def test_expansions(input, output, no_expand_vars, passes):


### PR DESCRIPTION
This allows using `math_<function_name>` to call any functions available in the `math` module.