### PR TITLE
Support top-level command aliasing

### DIFF
--- a/lib/ramble/ramble/cmd/commands.py
+++ b/lib/ramble/ramble/cmd/commands.py
@@ -18,6 +18,7 @@ from llnl.util.argparsewriter import ArgparseCompletionWriter, ArgparseRstWriter
 from llnl.util.tty.colify import colify
 
 import ramble.cmd
+import ramble.config
 import ramble.main
 import ramble.paths
 from ramble.main import section_descriptions
@@ -249,7 +250,9 @@ def names(args, out):
     commands = copy.copy(ramble.cmd.all_commands())
 
     if args.aliases:
-        commands.extend(ramble.main.aliases.keys())
+        aliases = ramble.config.get("config:aliases")
+        if aliases:
+            commands.extend(aliases.keys())
 
     colify(commands, output=out)
 

--- a/lib/ramble/ramble/main.py
+++ b/lib/ramble/ramble/main.py
@@ -51,9 +51,6 @@ from spack.util.executable import CommandNotFoundError
 #: names of profile statistics
 stat_names = pstats.Stats.sort_arg_dict_default
 
-#: top-level aliases for Ramble commands
-aliases = {"rm": "remove"}
-
 #: help levels in order of detail (i.e., number of commands shown)
 levels = ["short", "long"]
 
@@ -789,6 +786,46 @@ def print_setup_info(*info):
             logger.die("shell must be sh or csh")
 
 
+def resolve_alias(cmd_name, cmd):
+    """Resolves aliases in the given command.
+
+    Args:
+        cmd_name: command name.
+        cmd: command line arguments.
+
+    Returns:
+        new command name and arguments.
+    """
+    all_commands = ramble.cmd.all_commands()
+    aliases = ramble.config.get("config:aliases")
+
+    if aliases:
+        for key, value in aliases.items():
+            if " " in key:
+                logger.warn(
+                    f"Alias '{key}' (mapping to '{value}') contains a space"
+                    ", which is not supported."
+                )
+            if key in all_commands:
+                logger.warn(
+                    f"Alias '{key}' (mapping to '{value}') attempts to override"
+                    " built-in command."
+                )
+
+    if cmd_name not in all_commands:
+        if aliases:
+            alias = aliases.get(cmd_name)
+        else:
+            alias = None
+
+        if alias is not None:
+            alias_parts = shlex.split(alias)
+            cmd_name = alias_parts[0]
+            cmd = alias_parts + cmd[1:]
+
+    return cmd_name, cmd
+
+
 def _main(argv=None):
     """Logic for the main entry point for the Ramble command.
 
@@ -897,7 +934,7 @@ def _main(argv=None):
 
     # Try to load the particular command the caller asked for.
     cmd_name = args.command[0]
-    cmd_name = aliases.get(cmd_name, cmd_name)
+    cmd_name, args.command = resolve_alias(cmd_name, args.command)
 
     # set up a bootstrap context, if asked.
     # bootstrap context needs to include parsing the command, b/c things
@@ -910,14 +947,14 @@ def _main(argv=None):
     #   # bootstrap_context = bootstrap.ensure_bootstrap_configuration()
 
     with bootstrap_context:
-        return finish_parse_and_run(parser, cmd_name, workspace_format_error)
+        return finish_parse_and_run(parser, cmd_name, args, workspace_format_error)
 
 
-def finish_parse_and_run(parser, cmd_name, workspace_format_error):
+def finish_parse_and_run(parser, cmd_name, main_args, workspace_format_error):
     """Finish parsing after we know the command to run."""
     # add the found command to the parser and re-run then re-parse
     command = parser.add_command(cmd_name)
-    args, unknown = parser.parse_known_args()
+    args, unknown = parser.parse_known_args(main_args.command)
 
     # Now that we know what command this is and what its args are, determine
     # whether we can continue with a bad workspace and raise if not.
@@ -946,9 +983,9 @@ def finish_parse_and_run(parser, cmd_name, workspace_format_error):
     set_working_dir()
 
     # now we can actually execute the command.
-    if args.ramble_profile or args.sorted_profile:
+    if main_args.ramble_profile or main_args.sorted_profile:
         _profile_wrapper(command, parser, args, unknown)
-    elif args.pdb:
+    elif main_args.pdb:
         import pdb
 
         pdb.runctx("_invoke_command(command, parser, args, unknown)", globals(), locals())

--- a/lib/ramble/ramble/test/cmd/config.py
+++ b/lib/ramble/ramble/test/cmd/config.py
@@ -884,3 +884,35 @@ def test_config_edit_file(mutable_config, config_section, mock_editor):
     args = section_args(config_section)
 
     assert ramble.cmd.config.config_edit(args)
+
+
+def test_command_alias(mutable_empty_config):
+    import io
+    from contextlib import redirect_stdout
+
+    from ramble import main
+
+    # Test alias 'l' -> 'list'
+    config("add", "config:aliases:l:list")
+    f = io.StringIO()
+    with redirect_stdout(f):
+        ret = main.main(argv=["l"])
+    assert ret == 0
+    output = f.getvalue()
+    assert "gromacs" in output
+
+    # Test that an alias cannot override a built-in command
+    config("add", "config:aliases:list:info")
+    # `list` should run `list`, not `info`
+    f = io.StringIO()
+    with redirect_stdout(f):
+        ret = main.main(argv=["list"])
+    output = f.getvalue()
+    assert ret == 0
+    assert "ramble info" not in output
+
+    # Test alias to non-existent command
+    config("add", "config:aliases:bad:nonexistent")
+    with pytest.raises(SystemExit) as e:
+        main.main(argv=["bad"])
+    assert e.value.code != 0

--- a/lib/ramble/ramble/test/commands.py
+++ b/lib/ramble/ramble/test/commands.py
@@ -10,9 +10,12 @@ import os
 
 import pytest
 
+import ramble.config
 from ramble.error import RambleCommandError
 from ramble.main import RambleCommand
 from ramble.util.logger import logger
+
+command = RambleCommand("commands")
 
 
 def test_missing_command():
@@ -32,8 +35,6 @@ def test_available_command():
 
 
 def test_command_output(tmpdir):
-    command = RambleCommand("commands")
-
     formats = ["subcommands", "rst", "names", "bash"]
     for f in formats:
         file = os.path.join(tmpdir, f"outfile.{f}")
@@ -43,3 +44,10 @@ def test_command_output(tmpdir):
     target = os.path.join(tmpdir, "outfile.names")
     header = os.path.join(tmpdir, "outfile.subcommands")
     command("--update", target, "--header", header, "-a")
+
+
+def test_command_alias_output(mutable_config):
+    with ramble.config.override("config:aliases", {"ws": "workspace"}):
+        out = command("-a", output=str)
+        assert "ws" in out
+        assert "workspace" in out


### PR DESCRIPTION
Main changes:

* Remove the hard-coded top-level `ramble.main.aliases` dict
* Support top-level aliasing via the `aliases` config. This follows what Spack is doing.
* Ensure `ramble commands -a` recognizes the aliases config.

Example usage:

```
$ ramble config add "config:aliases:ls:list"
$ ramble config add "config:aliases:ws:workspace"
$ ramble ws ls
==> 2 workspaces
    hostname-test  test
```