### PR TITLE
Add a job-status success_criteria for slurm workflow manager

### DIFF
--- a/lib/ramble/ramble/success_criteria.py
+++ b/lib/ramble/ramble/success_criteria.py
@@ -29,11 +29,13 @@ class ScopedCriteriaList:
 
     _valid_scopes = [
         "application_definition",
+        "workflow_manager_definition",
         "modifier_definition",
         "experiment",
     ]
     _flush_scopes = {
         "experiment": ["experiment"],
+        "workflow_manager_definition": ["workflow_manager_definition"],
         "modifier_definition": ["modifier_definition"],
         "application_definition": ["application_definition"],
     }

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -2780,6 +2780,15 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         for mod in self._modifier_instances:
             success_lists.append(("modifier_definition", mod.success_criteria))
 
+        if self.workflow_manager is not None:
+            criteria_list.flush_scope("workflow_manager_definition")
+            success_lists.append(
+                (
+                    "workflow_manager_definition",
+                    self.workflow_manager.success_criteria,
+                )
+            )
+
         for success_scope, success_list in success_lists:
             for criteria, conf in success_list.items():
                 if not self.expander.satisfies(

--- a/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
@@ -331,6 +331,13 @@ class Slurm(WorkflowManagerBase):
             fom_type=FomType.INFO,
         )
 
+    success_criteria(
+        "job-status-check",
+        mode="fom_comparison",
+        fom_name="job-status",
+        formula="'{value}' == 'COMPLETE'",
+    )
+
 
 class SlurmRunner:
     """Runner for executing slurm commands"""


### PR DESCRIPTION
This requires adding success_criteria support for workflow manager.

The intent is to include job-status as part of the success_criteria list:

```
Success criteria summary:
    wrote_anything = PASSED
    _application_function = PASSED
    job-status-check = PASSED
```