### PR TITLE
Add support for multiple package-manager experiments

### DIFF
--- a/lib/ramble/ramble/experiment_result.py
+++ b/lib/ramble/ramble/experiment_result.py
@@ -84,12 +84,7 @@ class ExperimentResult:
             if var not in app_inst.keywords.keys or not app_inst.keywords.is_key_level(var):
                 self.variables[var] = app_inst.expander.expand_var(val)
 
-        self.variants = set()
-        for _, obj_inst in app_inst._objects():
-            if hasattr(obj_inst, "object_variants"):
-                obj_var_set = obj_inst.object_variants.as_set()
-                self.variants = self.variants.union(obj_var_set)
-        self.variants = list(self.variants)
+        self.variants = sorted(list(app_inst.experiment_variants().as_set()))
 
     def to_dict(self):
         """Generate a dict for encoders (json, yaml) and uploaders.

--- a/lib/ramble/ramble/software_environments.py
+++ b/lib/ramble/ramble/software_environments.py
@@ -16,8 +16,13 @@ from ramble.util.logger import logger
 SUB_INDENT = 2
 
 
-def _get_spec(pkg_info: dict, spec_name: str, prefix: str, default=None) -> str:
-    return pkg_info.get(f"{prefix}_{spec_name}", pkg_info.get(spec_name, default))
+def _get_spec(
+    pkg_info: dict, spec_name: str, prefix: str, allow_unprefixed=True, default=None
+) -> str:
+    if allow_unprefixed:
+        return pkg_info.get(f"{prefix}_{spec_name}", pkg_info.get(spec_name, default))
+    else:
+        return pkg_info.get(f"{prefix}_{spec_name}", default)
 
 
 def _is_dict_empty(rendered: defaultdict):
@@ -306,14 +311,18 @@ class TemplatePackage(SoftwarePackage):
         pm_name = package_manager.name
         pkg_info = self.pkg_info
         pm_prefix = package_manager.spec_prefix
+        pm_allow_unprefixed = package_manager.allow_unprefixed_specs
 
-        raw_spec = _get_spec(pkg_info, "pkg_spec", pm_prefix)
-        raw_compiler = _get_spec(pkg_info, "compiler", pm_prefix)
-        raw_compiler_spec = _get_spec(pkg_info, "compiler_spec", pm_prefix)
+        raw_spec = _get_spec(pkg_info, "pkg_spec", pm_prefix, pm_allow_unprefixed)
+        raw_compiler = _get_spec(pkg_info, "compiler", pm_prefix, pm_allow_unprefixed)
+        raw_compiler_spec = _get_spec(pkg_info, "compiler_spec", pm_prefix, pm_allow_unprefixed)
 
         spec = expander.expand_var(raw_spec, merge_used_stage=False) if raw_spec else None
         if not spec:
-            raise RambleSoftwareEnvironmentError(f"Package {name} is missing a valid spec")
+            if pm_allow_unprefixed:
+                raise RambleSoftwareEnvironmentError(f"Package {name} is missing a valid spec")
+            else:
+                return None
 
         compiler = (
             expander.expand_var(raw_compiler, merge_used_stage=False) if raw_compiler else None
@@ -622,20 +631,21 @@ class TemplateEnvironment(SoftwareEnvironment):
                 )
             expander.flush_used_variable_stage()
             rendered_pkg = matching_template.render_package(expander, package_manager)
-            if rendered_pkg.spec is not None:
-                expander.merge_used_variable_stage()
-                if rendered_pkg.name in all_packages[pm_name]:
-                    if rendered_pkg != all_packages[pm_name][rendered_pkg.name]:
-                        raise RambleSoftwareEnvironmentError(
-                            f"Environment {name} defined multiple "
-                            "times in inconsistent ways.\n"
-                            f"Package with differences is {rendered_pkg.name}"
-                        )
-                    rendered_pkg = all_packages[pm_name][rendered_pkg.name]
-                else:
-                    all_packages[pm_name][rendered_pkg.name] = rendered_pkg
-            matching_template.add_rendered_package(rendered_pkg, all_packages, pm_name)
-            new_env.add_package(rendered_pkg)
+            if rendered_pkg is not None:
+                if rendered_pkg.spec is not None:
+                    expander.merge_used_variable_stage()
+                    if rendered_pkg.name in all_packages[pm_name]:
+                        if rendered_pkg != all_packages[pm_name][rendered_pkg.name]:
+                            raise RambleSoftwareEnvironmentError(
+                                f"Environment {name} defined multiple "
+                                "times in inconsistent ways.\n"
+                                f"Package with differences is {rendered_pkg.name}"
+                            )
+                        rendered_pkg = all_packages[pm_name][rendered_pkg.name]
+                    else:
+                        all_packages[pm_name][rendered_pkg.name] = rendered_pkg
+                matching_template.add_rendered_package(rendered_pkg, all_packages, pm_name)
+                new_env.add_package(rendered_pkg)
 
         return new_env
 

--- a/lib/ramble/ramble/test/application.py
+++ b/lib/ramble/ramble/test/application.py
@@ -429,7 +429,7 @@ def test_set_variables_and_variants(mutable_mock_apps_repo):
 
     assert executable_application_instance.variables["n_ranks"] == "1"
 
-    variant_set = executable_application_instance.object_variants.as_set()
+    variant_set = executable_application_instance.experiment_variants().as_set()
     assert "workflow_manager=slurm" in variant_set
     assert "package_manager=spack" not in variant_set
 

--- a/lib/ramble/ramble/util/spec_utils.py
+++ b/lib/ramble/ramble/util/spec_utils.py
@@ -52,8 +52,8 @@ class SoftwareSpec:
         self.compiler_spec = compiler_spec
         self.when = when.copy()
 
-    def to_dict(self, prefix: str = None):
-        prefix_base = prefix if prefix is not None else self.prefix
+    def to_dict(self, apply_prefix: bool = False):
+        prefix_base = self.prefix if apply_prefix else ""
         prefix_str = f"{prefix_base}_" if prefix_base else ""
 
         attrs = ["pkg_spec", "compiler", "compiler_spec"]
@@ -87,7 +87,7 @@ class SoftwareSpec:
         return output
 
     def __str__(self):
-        self_dict = self.to_dict(prefix="")
+        self_dict = self.to_dict()
         self_dict["prefix"] = self.prefix
         return str(self_dict)
 

--- a/lib/ramble/ramble/variants.py
+++ b/lib/ramble/ramble/variants.py
@@ -78,11 +78,16 @@ class VariantSet:
                 dest_attr_set[name] = variant.copy()
 
         for name, var_list in self.multi_value_variants.items():
-            new_set.multi_value_variants[name] = []
+            new_set.multi_value_variants[name] = set()
             for variant in var_list:
-                new_set.multi_value_variants[name].append(variant.copy())
+                new_set.multi_value_variants[name].add(variant.copy())
 
         return new_set
+
+    def merge_variants(self, in_set):
+        self.merge_default_variants(in_set)
+        self.merge_experiment_variants(in_set)
+        self.merge_multi_value_variants(in_set)
 
     def merge_default_variants(self, in_set):
         """Merge another variant set's default variants into this variant set.
@@ -95,6 +100,18 @@ class VariantSet:
         for name, variant in in_set.default_variants.items():
             if name not in self.default_variants:
                 self.default_variants[name] = variant.copy()
+
+    def merge_experiment_variants(self, in_set):
+        """Merge another variant set's experiment variants into this variant set.
+
+        Args:
+            in_set: VariantSet to merge into self
+        """
+
+        self._set_cache = None
+        for name, variant in in_set.experiment_variants.items():
+            if name not in self.experiment_variants:
+                self.experiment_variants[name] = variant.copy()
 
     def merge_multi_value_variants(self, in_set):
         """Merge another variant set's multi value variants into this variant set.

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1456,12 +1456,16 @@ ramble:
 
         experiment_set = self.build_experiment_set(die_on_validate_error=False)
 
+        force_prefix = False
         pkgman_prefixes = set()
         for _, app_inst, _ in experiment_set.all_experiments():
             app_inst.build_modifier_instances()
             app_inst.add_expand_vars(self)
             if app_inst.package_manager is not None:
                 pkgman_prefixes.add(app_inst.package_manager.spec_prefix)
+                force_prefix = force_prefix or not app_inst.package_manager.allow_unprefixed_specs
+
+        force_prefix = force_prefix or len(pkgman_prefixes) > 1
 
         for _, app_inst, _ in experiment_set.all_experiments():
             app_inst.build_modifier_instances()
@@ -1469,47 +1473,33 @@ ramble:
             env_name_str = app_inst.expander.expansion_str(ramble.keywords.keywords.env_name)
             env_name = app_inst.expander.expand_var(env_name_str)
 
-            spec_prefix = (
-                f"{app_inst.package_manager.spec_prefix}" if len(pkgman_prefixes) > 1 else ""
-            )
-
             if app_inst.package_manager is None:
                 continue
 
-            compiler_packages = {}
-            compiler_dicts = [app_inst.compilers]
-            for mod_inst in app_inst._modifier_instances:
-                compiler_dicts.append(mod_inst.compilers)
-
-            for compiler_dict in compiler_dicts:
-                for comp, definitions in compiler_dict.items():
-                    for info in definitions:
-                        keep_comp = app_inst.expander.satisfies(
-                            info.when, variant_set=app_inst.object_variants
+            compiler_packages = app_inst.package_manager.get_experiment_compilers(
+                app_inst=app_inst, prefixed=force_prefix
+            )
+            for comp, definitions in compiler_packages.items():
+                for info in definitions:
+                    if (
+                        not quiet
+                        and comp in packages_dict
+                        and info.conflict_dict(packages_dict[comp])
+                    ):
+                        logger.debug(f"  Spec 1: {str(info)}")
+                        logger.debug(f"  Spec 2: {str(packages_dict[comp])}")
+                        raise RambleConflictingDefinitionError(
+                            f"Compiler {comp} would be defined " "in multiple conflicting ways"
                         )
-                        if keep_comp:
-                            if (
-                                not quiet
-                                and comp in packages_dict
-                                and info.conflict_dict(packages_dict[comp])
-                            ):
-                                logger.debug(f"  Spec 1: {str(info)}")
-                                logger.debug(f"  Spec 2: {str(packages_dict[comp])}")
-                                raise RambleConflictingDefinitionError(
-                                    f"Compiler {comp} would be defined "
-                                    "in multiple conflicting ways"
-                                )
 
-                            if comp not in packages_dict or (
-                                force and comp not in newly_created_packages
-                            ):
-                                newly_created_packages.add(comp)
-                                packages_dict[comp] = syaml.syaml_dict()
+                    if comp not in packages_dict or (force and comp not in newly_created_packages):
+                        newly_created_packages.add(comp)
+                        packages_dict[comp] = syaml.syaml_dict()
 
-                            compiler_packages[comp] = False
-                            packages_dict[comp].update(info.to_dict(prefix=spec_prefix))
-                            for conf in info.config_opts():
-                                ramble.config.add(conf, scope=self.ws_file_config_scope_name())
+                    compiler_packages[comp] = False
+                    packages_dict[comp].update(info.to_dict(apply_prefix=force_prefix))
+                    for conf in info.config_opts():
+                        ramble.config.add(conf, scope=self.ws_file_config_scope_name())
 
             logger.debug(f"Trying to define packages for {env_name}")
             app_packages = []
@@ -1517,43 +1507,36 @@ ramble:
                 if namespace.packages in environments_dict[env_name]:
                     app_packages = environments_dict[env_name][namespace.packages].copy()
 
-            software_dicts = [app_inst.software_specs]
-            for mod_inst in app_inst._modifier_instances:
-                software_dicts.append(mod_inst.software_specs)
-
-            for software_dict in software_dicts:
-                for spec_name, definitions in software_dict.items():
-                    for info in definitions:
-                        keep_pkg = app_inst.expander.satisfies(
-                            info.when, variant_set=app_inst.object_variants
+            software_packages = app_inst.package_manager.get_experiment_specs(
+                app_inst=app_inst, prefixed=force_prefix
+            )
+            for spec_name, definitions in software_packages.items():
+                for info in definitions:
+                    logger.debug(f"    Found spec: {spec_name}")
+                    if (
+                        not quiet
+                        and spec_name in packages_dict
+                        and info.conflict_dict(packages_dict[spec_name])
+                    ):
+                        logger.debug(f"  Spec 1: {str(info)}")
+                        logger.debug(f"  Spec 2: {str(packages_dict[spec_name])}")
+                        raise RambleConflictingDefinitionError(
+                            f"Package {spec_name} would be defined in multiple " "conflicting ways"
                         )
-                        if keep_pkg:
-                            logger.debug(f"    Found spec: {spec_name}")
-                            if (
-                                not quiet
-                                and spec_name in packages_dict
-                                and info.conflict_dict(packages_dict[spec_name])
-                            ):
-                                logger.debug(f"  Spec 1: {str(info)}")
-                                logger.debug(f"  Spec 2: {str(packages_dict[spec_name])}")
-                                raise RambleConflictingDefinitionError(
-                                    f"Package {spec_name} would be defined in multiple "
-                                    "conflicting ways"
-                                )
 
-                            if spec_name not in packages_dict or (
-                                force and spec_name not in newly_created_packages
-                            ):
-                                packages_dict[spec_name] = syaml.syaml_dict()
+                    if spec_name not in packages_dict or (
+                        force and spec_name not in newly_created_packages
+                    ):
+                        packages_dict[spec_name] = syaml.syaml_dict()
 
-                            # Check for usage of compilers
-                            if info.compiler in compiler_packages:
-                                compiler_packages[info.compiler] = True
+                    # Check for usage of compilers
+                    if info.compiler in compiler_packages:
+                        compiler_packages[info.compiler] = True
 
-                            packages_dict[spec_name].update(info.to_dict(prefix=spec_prefix))
+                    packages_dict[spec_name].update(info.to_dict(apply_prefix=force_prefix))
 
-                            if spec_name not in app_packages:
-                                app_packages.append(spec_name)
+                    if spec_name not in app_packages:
+                        app_packages.append(spec_name)
 
             if app_packages:
                 if env_name not in environments_dict:

--- a/var/ramble/repos/builtin.mock/applications/multi-package-manager-specs/application.py
+++ b/var/ramble/repos/builtin.mock/applications/multi-package-manager-specs/application.py
@@ -1,0 +1,55 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+from ramble.appkit import *
+
+
+class MultiPackageManagerSpecs(ExecutableApplication):
+    name = "multi-package-manager-specs"
+
+    executable("list_env", "ls {env_path}", use_mpi=False)
+
+    workload("check_environments", executables=["list_env"])
+
+    with when("package_manager_family=spack"):
+        software_spec("zlib", pkg_spec="zlib")
+
+        figure_of_merit(
+            "zlib_configured",
+            fom_regex=r".*(?P<pkg_name>zlib\S*)",
+            group_name="pkg_name",
+            units="",
+            log_file="{env_path}" + os.sep + "spack.yaml",
+        )
+
+        success_criteria(
+            "zlib_configured",
+            mode="string",
+            match=r".*- zlib",
+            file="{env_path}" + os.sep + "spack.yaml",
+        )
+
+    with when("package_manager_family=pip"):
+        software_spec("requests", pkg_spec="requests>=2.31.0")
+
+        figure_of_merit(
+            "requests_configured",
+            fom_regex=r".*(?P<pkg_name>requests\S*)",
+            group_name="pkg_name",
+            units="",
+            log_file="{env_path}" + os.sep + "requirements.txt",
+        )
+
+        success_criteria(
+            "requests_configured",
+            mode="string",
+            match=r".*requests",
+            file="{env_path}" + os.sep + "requirements.txt",
+        )

--- a/var/ramble/repos/builtin/applications/intel-mlc/application.py
+++ b/var/ramble/repos/builtin/applications/intel-mlc/application.py
@@ -18,9 +18,8 @@ class IntelMlc(ExecutableApplication):
 
     tags("memory-benchmark", "intel-tool")
 
-    required_package("intel-mlc")
-
     with when("package_manager_family=spack"):
+        required_package("intel-mlc")
         software_spec(
             "intel-mlc",
             pkg_spec="intel-mlc",

--- a/var/ramble/repos/builtin/applications/spack-stack/application.py
+++ b/var/ramble/repos/builtin/applications/spack-stack/application.py
@@ -208,6 +208,9 @@ class SpackStack(ExecutableApplication):
     def evaluate_success(self):
         import spack.util.spack_yaml as syaml
 
+        if not self.expander.satisfies("package_manager_family=spack"):
+            return True
+
         spack_file = self.expander.expand_var("{env_path}/spack.yaml")
         spec_list = []
 

--- a/var/ramble/repos/builtin/base_applications/hpl/base_application.py
+++ b/var/ramble/repos/builtin/base_applications/hpl/base_application.py
@@ -401,7 +401,9 @@ class Hpl(ExecutableApplication):
             for when_key, var_list in self.get_workload(
                 "standard"
             ).variables.items():
-                if self.expander.satisfies(when_key, self.object_variants):
+                if self.expander.satisfies(
+                    when_key, self.experiment_variants()
+                ):
                     for var in var_list:
                         if var.name not in self.variables:
                             self.define_variable(var.name, var.default)

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -366,7 +366,9 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         all_workloads_names = set()
         found = False
         for when_set, workloads in self.workloads.items():
-            if self.expander.satisfies(when_set, self.experiment_variants()):
+            if self.expander.satisfies(
+                when_set, self.experiment_variants(allow_caching=False)
+            ):
                 for workload_name, workload in workloads.items():
                     if workload_name in all_workloads_names:
                         logger.die(
@@ -381,12 +383,14 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         if not found:
             logger.die(
                 "No workloads satisfy the current `when` conditions: \n"
-                f"  {self.experiment_variants().as_set()}"
+                f"  {self.experiment_variants(allow_caching=False).as_set()}"
             )
 
     def _set_package_manager(self):
         pkgman_name = conversions.canonical_none(
-            self.experiment_variants().value(namespace.package_manager)
+            self.experiment_variants(allow_caching=False).value(
+                namespace.package_manager
+            )
         )
 
         if pkgman_name is not None:
@@ -406,7 +410,8 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         if self.package_manager is not None:
             for pkgname, config in self.required_packages.items():
                 if self.expander.satisfies(
-                    config["when"], variant_set=self.experiment_variants()
+                    config["when"],
+                    variant_set=self.experiment_variants(allow_caching=False),
                 ):
                     self.keywords.update_keys(
                         {
@@ -419,7 +424,9 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
     def _set_workflow_manager(self):
         workflow_name = conversions.canonical_none(
-            self.experiment_variants().value(namespace.workflow_manager)
+            self.experiment_variants(allow_caching=False).value(
+                namespace.workflow_manager
+            )
         )
 
         # Map None to the default of user-managed
@@ -560,7 +567,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         for workload in workloads:
             for var_when_set, var_list in workload.variables.items():
                 if self.expander.satisfies(
-                    var_when_set, self.experiment_variants()
+                    var_when_set, self.experiment_variants(allow_caching=False)
                 ):
                     for var in var_list:
                         if not var.expandable:

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -291,7 +291,9 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         for when_set, workloads in self.workloads.items():
             if workload_name in workloads:
                 workload_found = True
-                if self.expander.satisfies(when_set, self.object_variants):
+                if self.expander.satisfies(
+                    when_set, self.experiment_variants()
+                ):
                     if workload:
                         logger.die(
                             f"Workload {workload_name} is defined with "
@@ -364,7 +366,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         all_workloads_names = set()
         found = False
         for when_set, workloads in self.workloads.items():
-            if self.expander.satisfies(when_set, self.object_variants):
+            if self.expander.satisfies(when_set, self.experiment_variants()):
                 for workload_name, workload in workloads.items():
                     if workload_name in all_workloads_names:
                         logger.die(
@@ -379,12 +381,12 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         if not found:
             logger.die(
                 "No workloads satisfy the current `when` conditions: \n"
-                f"  {self.object_variants.as_set()}"
+                f"  {self.experiment_variants().as_set()}"
             )
 
     def _set_package_manager(self):
         pkgman_name = conversions.canonical_none(
-            self.object_variants.value(namespace.package_manager)
+            self.experiment_variants().value(namespace.package_manager)
         )
 
         if pkgman_name is not None:
@@ -404,7 +406,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         if self.package_manager is not None:
             for pkgname, config in self.required_packages.items():
                 if self.expander.satisfies(
-                    config["when"], variant_set=self.object_variants
+                    config["when"], variant_set=self.experiment_variants()
                 ):
                     self.keywords.update_keys(
                         {
@@ -417,7 +419,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
     def _set_workflow_manager(self):
         workflow_name = conversions.canonical_none(
-            self.object_variants.value(namespace.workflow_manager)
+            self.experiment_variants().value(namespace.workflow_manager)
         )
 
         # Map None to the default of user-managed
@@ -538,16 +540,6 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         self._set_package_manager()
         self._set_workflow_manager()
 
-        for _, obj in self._objects(
-            exclude_types=[ramble.repository.ObjectTypes.applications]
-        ):
-            obj_variants = getattr(obj, "object_variants", None)
-            if obj_variants is not None:
-                self.object_variants.merge_default_variants(
-                    getattr(obj, "object_variants")
-                )
-                self.object_variants.merge_multi_value_variants(obj_variants)
-
         base_chain = self.__class__.__mro__
         for cls in base_chain:
             if hasattr(cls, "name") and getattr(cls, "name") is not None:
@@ -567,7 +559,9 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
         for workload in workloads:
             for var_when_set, var_list in workload.variables.items():
-                if self.expander.satisfies(var_when_set, self.object_variants):
+                if self.expander.satisfies(
+                    var_when_set, self.experiment_variants()
+                ):
                     for var in var_list:
                         if not var.expandable:
                             self.no_expand_vars.add(var.name)
@@ -668,7 +662,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
         for i, phase in enumerate(ordered_phases):
             if self.expander.satisfies(
-                phase.when, variant_set=self.object_variants
+                phase.when, variant_set=self.experiment_variants()
             ) and any(fnmatch.fnmatch(phase.key, pf) for pf in phase_filters):
                 selected_phases.add(phase)
                 last_match_idx = i
@@ -1138,11 +1132,6 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                 self.expander.add_no_expand_var(var)
                 mod_inst.expander.add_no_expand_var(var)
 
-            # Set standard variants for all modifiers
-            obj_variants = getattr(mod_inst, "object_variants", None)
-            if obj_variants is not None:
-                self.object_variants.merge_multi_value_variants(obj_variants)
-
             # Define any missing modifier variables
             for var, val in mod_inst.selected_variables.items():
                 if var not in self.variables:
@@ -1165,7 +1154,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         for _, obj in self._objects():
             for when_set, validator_defs in obj.validators.items():
                 if not self.expander.satisfies(
-                    when_set, variant_set=self.object_variants
+                    when_set, variant_set=self.experiment_variants()
                 ):
                     continue
 
@@ -1234,7 +1223,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         for when_set, executables in all_executables.items():
             full_executables.update(executables)
             if self.expander.satisfies(
-                when_set, variant_set=self.object_variants
+                when_set, variant_set=self.experiment_variants()
             ):
                 for executable in executables:
                     if executable in filtered_executables:
@@ -1286,7 +1275,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         for _, obj in self._objects():
             for when_set, builtins in obj.builtins.items():
                 if self.expander.satisfies(
-                    when_set, variant_set=self.object_variants
+                    when_set, variant_set=self.experiment_variants()
                 ):
                     builtin_objects.append(obj)
                     all_builtins.append(builtins)
@@ -1369,12 +1358,14 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         workloads = self.get_workloads()
         for workload in workloads:
             for var_when_set, var_list in workload.variables.items():
-                if self.expander.satisfies(var_when_set, self.object_variants):
+                if self.expander.satisfies(
+                    var_when_set, self.experiment_variants()
+                ):
                     for var in var_list:
                         wl_vars[var.name] = var
 
         for when_key, var_list in self.object_variables.items():
-            if self.expander.satisfies(when_key, self.object_variants):
+            if self.expander.satisfies(when_key, self.experiment_variants()):
                 for var in var_list:
                     wl_vars[var.name] = var
 
@@ -1399,7 +1390,9 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                 when_set,
                 env_var_list,
             ) in workload.environment_variables.items():
-                if self.expander.satisfies(when_set, self.object_variants):
+                if self.expander.satisfies(
+                    when_set, self.experiment_variants()
+                ):
                     for env_var in env_var_list:
                         selected_env_vars[env_var.name] = env_var
 
@@ -1407,7 +1400,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             when_set,
             env_var_list,
         ) in self.object_environment_variables.items():
-            if self.expander.satisfies(when_set, self.object_variants):
+            if self.expander.satisfies(when_set, self.experiment_variants()):
                 for env_var in env_var_list:
                     selected_env_vars[env_var.name] = env_var
 
@@ -1627,7 +1620,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         for formatted_exec_group in formatted_exec_groups:
             for when_set, formatted_exec_defs in formatted_exec_group.items():
                 if not self.expander.satisfies(
-                    when_set, variant_set=self.object_variants
+                    when_set, variant_set=self.experiment_variants()
                 ):
                     continue
 
@@ -1730,7 +1723,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             when_set
             for when_set in self.inputs.keys()
             if self.expander.satisfies(
-                when_set, variant_set=self.object_variants
+                when_set, variant_set=self.experiment_variants()
             )
         }
 
@@ -2850,7 +2843,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         for success_scope, success_list in success_lists:
             for criteria, conf in success_list.items():
                 if not self.expander.satisfies(
-                    conf["when"], variant_set=self.object_variants
+                    conf["when"], variant_set=self.experiment_variants()
                 ):
                     continue
 
@@ -2922,7 +2915,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                 source_context_defs,
             ) in source.figure_of_merit_contexts.items():
                 if self.expander.satisfies(
-                    when_fs, variant_set=self.object_variants
+                    when_fs, variant_set=self.experiment_variants()
                 ):
                     for context, context_def in source_context_defs.items():
                         all_contexts[context] = context_def
@@ -2934,7 +2927,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             # figures_of_merit[frozenset(when_list)][frozenset(context_list)][fom_name]
             for when_fs, source_contexts in source.figures_of_merit.items():
                 if not self.expander.satisfies(
-                    when_fs, variant_set=self.object_variants
+                    when_fs, variant_set=self.experiment_variants()
                 ):
                     continue
 
@@ -3330,7 +3323,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         for obj_type, obj in self._objects():
             for when_set, tpl in obj.templates.items():
                 if not self.expander.satisfies(
-                    when_set, variant_set=self.object_variants
+                    when_set, variant_set=self.experiment_variants()
                 ):
                     continue
 

--- a/var/ramble/repos/builtin/base_classes/modifier-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/modifier-base/base_class.py
@@ -85,7 +85,7 @@ class ModifierBase(ObjectMixin, metaclass=ModifierMeta):
         return new_copy
 
     def satisfy_when(self, when_key):
-        return self.expander.satisfies(when_key, self.object_variants)
+        return self.expander.satisfies(when_key, self.experiment_variants())
 
     def set_usage_mode(self, mode):
         """Set the usage mode for this modifier.
@@ -151,17 +151,15 @@ class ModifierBase(ObjectMixin, metaclass=ModifierMeta):
             self._on_executables = ["*"]
 
     def inherit_from_application(self, app):
+        self.app_inst = app
         self.expander = app.expander.copy()
-        self.object_variants.merge_default_variants(app.object_variants)
 
         for name, value in app.variants.items():
             expanded_value = self.expander.expand_var(value, typed=True)
             self.object_variants.experiment_variant(name, expanded_value)
 
-        self.object_variants.merge_multi_value_variants(app.object_variants)
         modded_vars = self.modded_variables(app)
         self.expander._variables.update(modded_vars)
-        self.app_inst = app
 
     def define_variable(self, var_name, var_value):
         """Define a variable within this modifier's expander instance"""
@@ -183,7 +181,7 @@ class ModifierBase(ObjectMixin, metaclass=ModifierMeta):
             extra_vars = {}
 
         for when_set, var_mod_dict in self.variable_modifications.items():
-            if self.expander.satisfies(when_set, self.object_variants):
+            if self.expander.satisfies(when_set, self.experiment_variants()):
                 for var, var_mods in var_mod_dict.items():
                     for var_mod in var_mods:
                         if var_mod.method in ["append", "prepend"]:
@@ -230,7 +228,7 @@ class ModifierBase(ObjectMixin, metaclass=ModifierMeta):
         pre_execs = []
         post_execs = []
         for when_set, exec_mods in self.executable_modifiers.items():
-            if self.expander.satisfies(when_set, self.object_variants):
+            if self.expander.satisfies(when_set, self.experiment_variants()):
                 for exec_mod in exec_mods:
                     mod_func = getattr(self, exec_mod)
 
@@ -245,14 +243,18 @@ class ModifierBase(ObjectMixin, metaclass=ModifierMeta):
 
     def all_env_var_modifications(self):
         for when_set, env_var_mods in self.env_var_modifications.items():
-            if not self.expander.satisfies(when_set, self.object_variants):
+            if not self.expander.satisfies(
+                when_set, self.experiment_variants()
+            ):
                 continue
 
             yield from env_var_mods.values()
 
     def all_package_manager_requirements(self):
         for when_set in self.package_manager_requirements:
-            if not self.expander.satisfies(when_set, self.object_variants):
+            if not self.expander.satisfies(
+                when_set, self.experiment_variants()
+            ):
                 continue
 
             yield from self.package_manager_requirements[when_set]
@@ -265,7 +267,9 @@ class ModifierBase(ObjectMixin, metaclass=ModifierMeta):
         """
 
         for when_key, var_list in self.object_variables.items():
-            if not self.expander.satisfies(when_key, self.object_variants):
+            if not self.expander.satisfies(
+                when_key, self.experiment_variants()
+            ):
                 continue
 
             for var in var_list:

--- a/var/ramble/repos/builtin/base_classes/modifier-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/modifier-base/base_class.py
@@ -181,7 +181,9 @@ class ModifierBase(ObjectMixin, metaclass=ModifierMeta):
             extra_vars = {}
 
         for when_set, var_mod_dict in self.variable_modifications.items():
-            if self.expander.satisfies(when_set, self.experiment_variants()):
+            if self.expander.satisfies(
+                when_set, self.experiment_variants(allow_caching=False)
+            ):
                 for var, var_mods in var_mod_dict.items():
                     for var_mod in var_mods:
                         if var_mod.method in ["append", "prepend"]:

--- a/var/ramble/repos/builtin/base_classes/object_mixin/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/object_mixin/base_class.py
@@ -67,7 +67,7 @@ class ObjectMixin:
         experiment_variants = self.experiment_variants()
         return app_inst.expander.satisfies(when_key, experiment_variants)
 
-    def experiment_variants(self, single_modifier=None):
+    def experiment_variants(self, include_modifier=None):
         """Construct a VariantSet for this experiment.
 
         Apply some merging logic to VariantSet combination, in order to
@@ -86,9 +86,9 @@ class ObjectMixin:
 
         exclude_types = [self_type]
 
-        if single_modifier is not None:
+        if include_modifier is not None:
             exclude_types.append(ObjectTypes.modifiers)
-            new_set.merge_variants(single_modifier.object_variants)
+            new_set.merge_variants(include_modifier.object_variants)
 
         for _, obj in app_inst._objects(exclude_types=exclude_types):
             new_set.merge_variants(obj.object_variants)

--- a/var/ramble/repos/builtin/base_classes/object_mixin/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/object_mixin/base_class.py
@@ -7,6 +7,7 @@
 # except according to those terms.
 from html import escape
 
+from ramble.repository import ObjectTypes, get_base_class
 from ramble.util import format
 
 
@@ -45,9 +46,54 @@ class ObjectMixin:
             return self.app_inst
         return self
 
-    def satisfy_when(self, when_key):
+    def _get_object_type(self):
+        ApplicationBase = get_base_class("application-base")
+        PackageManagerBase = get_base_class("package-manager-base")
+        WorkflowManagerBase = get_base_class("workflow-manager-base")
+        ModifierBase = get_base_class("modifier-base")
+
+        if isinstance(self, ApplicationBase):
+            return ObjectTypes.applications
+        elif isinstance(self, PackageManagerBase):
+            return ObjectTypes.package_managers
+        elif isinstance(self, WorkflowManagerBase):
+            return ObjectTypes.workflow_managers
+        elif isinstance(self, ModifierBase):
+            return ObjectTypes.modifiers
+        return None
+
+    def satisfy_when(self, when_key, variant_set=None):
         app_inst = self._get_app_inst()
-        return app_inst.expander.satisfies(when_key, app_inst.object_variants)
+        experiment_variants = self.experiment_variants()
+        return app_inst.expander.satisfies(when_key, experiment_variants)
+
+    def experiment_variants(self, single_modifier=None):
+        """Construct a VariantSet for this experiment.
+
+        Apply some merging logic to VariantSet combination, in order to
+        provide scoped variant definitions.
+
+        Args:
+            include_modifier (ModifierBase): A single modifier to merge in to resulting set
+
+        Returns:
+            VariantSet: Merged variants for the experiment.
+        """
+        app_inst = self._get_app_inst()
+
+        self_type = self._get_object_type()
+        new_set = self.object_variants.copy()
+
+        exclude_types = [self_type]
+
+        if single_modifier is not None:
+            exclude_types.append(ObjectTypes.modifiers)
+            new_set.merge_variants(single_modifier.object_variants)
+
+        for _, obj in app_inst._objects(exclude_types=exclude_types):
+            new_set.merge_variants(obj.object_variants)
+
+        return new_set
 
     @property
     def required_variables(self):

--- a/var/ramble/repos/builtin/base_classes/object_mixin/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/object_mixin/base_class.py
@@ -7,7 +7,7 @@
 # except according to those terms.
 from html import escape
 
-from ramble.repository import ObjectTypes, get_base_class
+from ramble.repository import ObjectTypes
 from ramble.util import format
 
 
@@ -47,18 +47,13 @@ class ObjectMixin:
         return self
 
     def _get_object_type(self):
-        ApplicationBase = get_base_class("application-base")
-        PackageManagerBase = get_base_class("package-manager-base")
-        WorkflowManagerBase = get_base_class("workflow-manager-base")
-        ModifierBase = get_base_class("modifier-base")
-
-        if isinstance(self, ApplicationBase):
+        if self.origin_type == "application":
             return ObjectTypes.applications
-        elif isinstance(self, PackageManagerBase):
+        elif self.origin_type == "package_manager":
             return ObjectTypes.package_managers
-        elif isinstance(self, WorkflowManagerBase):
+        elif self.origin_type == "workflow_manager":
             return ObjectTypes.workflow_managers
-        elif isinstance(self, ModifierBase):
+        elif self.origin_type == "modifier":
             return ObjectTypes.modifiers
         return None
 

--- a/var/ramble/repos/builtin/base_classes/object_mixin/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/object_mixin/base_class.py
@@ -67,7 +67,7 @@ class ObjectMixin:
         experiment_variants = self.experiment_variants()
         return app_inst.expander.satisfies(when_key, experiment_variants)
 
-    def experiment_variants(self, include_modifier=None):
+    def experiment_variants(self, include_modifier=None, allow_caching=True):
         """Construct a VariantSet for this experiment.
 
         Apply some merging logic to VariantSet combination, in order to
@@ -79,6 +79,18 @@ class ObjectMixin:
         Returns:
             VariantSet: Merged variants for the experiment.
         """
+
+        if allow_caching:
+            if not hasattr(self, "_variant_cache"):
+                setattr(self, "_variant_cache", {})
+
+            cache_key = f"{self.origin_type}::{self.name}"
+            if include_modifier is not None:
+                cache_key += f"-{include_modifier.origin_type}::{include_modifier.name}::{include_modifier._usage_mode}"
+
+            if cache_key in self._variant_cache:
+                return self._variant_cache[cache_key]
+
         app_inst = self._get_app_inst()
 
         self_type = self._get_object_type()
@@ -92,6 +104,9 @@ class ObjectMixin:
 
         for _, obj in app_inst._objects(exclude_types=exclude_types):
             new_set.merge_variants(obj.object_variants)
+
+        if allow_caching:
+            self._variant_cache[cache_key] = new_set
 
         return new_set
 

--- a/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
@@ -165,6 +165,16 @@ class PackageManagerBase(ObjectMixin, metaclass=PackageManagerMeta):
         self.app_inst = app_inst
         self.keywords = app_inst.keywords
 
+        self.object_variants.merge_default_variants(app_inst.object_variants)
+
+        for name, value in app_inst.variants.items():
+            expanded_value = app_inst.expander.expand_var(value, typed=True)
+            self.object_variants.experiment_variant(name, expanded_value)
+
+        self.object_variants.merge_multi_value_variants(
+            app_inst.object_variants
+        )
+
     def build_used_variables(self, workspace):
         """Build a set of all used variables
 
@@ -261,3 +271,38 @@ class PackageManagerBase(ObjectMixin, metaclass=PackageManagerMeta):
         """Stub method for acquiring the commands to unload an
         experiment's execution environment"""
         return []
+
+    def _extract_specs(
+        self, attr_name="software_specs", app_inst=None, prefixed=False
+    ):
+        specs = {}
+        for _, obj in app_inst._objects():
+            software_dict = getattr(obj, attr_name, {})
+            for name, definitions in software_dict.items():
+                for info in definitions:
+                    if app_inst.expander.satisfies(
+                        info.when, variant_set=self.object_variants
+                    ):
+                        if name not in specs:
+                            specs[name] = []
+
+                        new_info = info.copy()
+                        if prefixed:
+                            new_info.prefix = self._spec_prefix
+
+                        specs[name].append(new_info)
+        return specs
+
+    def get_experiment_specs(self, app_inst=None, prefixed=False):
+        if app_inst is None:
+            return {}
+        return self._extract_specs(
+            attr_name="software_specs", app_inst=app_inst, prefixed=prefixed
+        )
+
+    def get_experiment_compilers(self, app_inst=None, prefixed=False):
+        if app_inst is None:
+            return {}
+        return self._extract_specs(
+            attr_name="compilers", app_inst=app_inst, prefixed=prefixed
+        )

--- a/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
@@ -41,6 +41,7 @@ class PackageManagerBase(ObjectMixin, metaclass=PackageManagerMeta):
         "execute",
         "logs",
     ]
+    _allow_unprefixed_specs = True
 
     _spec_groups = [
         ("compilers", "Compilers"),
@@ -98,6 +99,10 @@ class PackageManagerBase(ObjectMixin, metaclass=PackageManagerMeta):
     def runner(self):
         # Turn `runner` into a property for delayed init
         return None
+
+    @property
+    def allow_unprefixed_specs(self):
+        return getattr(self, "_allow_unprefixed_specs", True)
 
     def package_manager_dir(self, workspace):
         """Get the path to the package manager's software environment directory

--- a/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
@@ -272,7 +272,7 @@ class PackageManagerBase(ObjectMixin, metaclass=PackageManagerMeta):
             if obj_type == ramble.repository.ObjectTypes.modifiers:
                 include_modifier = obj
             spec_variants = self.experiment_variants(
-                include_modifier=include_modifier
+                include_modifier=include_modifier, allow_caching=False
             )
 
             software_dict = getattr(obj, attr_name, {})

--- a/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
@@ -125,7 +125,7 @@ class PackageManagerBase(ObjectMixin, metaclass=PackageManagerMeta):
 
         return any(
             self.app_inst.expander.satisfies(
-                info.when, variant_set=self.object_variants
+                info.when, variant_set=self.experiment_variants()
             )
             for definitions in app_inst.software_specs.values()
             for info in definitions
@@ -164,16 +164,6 @@ class PackageManagerBase(ObjectMixin, metaclass=PackageManagerMeta):
         """
         self.app_inst = app_inst
         self.keywords = app_inst.keywords
-
-        self.object_variants.merge_default_variants(app_inst.object_variants)
-
-        for name, value in app_inst.variants.items():
-            expanded_value = app_inst.expander.expand_var(value, typed=True)
-            self.object_variants.experiment_variant(name, expanded_value)
-
-        self.object_variants.merge_multi_value_variants(
-            app_inst.object_variants
-        )
 
     def build_used_variables(self, workspace):
         """Build a set of all used variables
@@ -276,12 +266,19 @@ class PackageManagerBase(ObjectMixin, metaclass=PackageManagerMeta):
         self, attr_name="software_specs", app_inst=None, prefixed=False
     ):
         specs = {}
-        for _, obj in app_inst._objects():
+        for obj_type, obj in app_inst._objects():
+            single_modifier = None
+            if obj_type == ramble.repository.ObjectTypes.modifiers:
+                single_modifier = obj
+            spec_variants = self.experiment_variants(
+                single_modifier=single_modifier
+            )
+
             software_dict = getattr(obj, attr_name, {})
             for name, definitions in software_dict.items():
                 for info in definitions:
                     if app_inst.expander.satisfies(
-                        info.when, variant_set=self.object_variants
+                        info.when, variant_set=spec_variants
                     ):
                         if name not in specs:
                             specs[name] = []

--- a/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
@@ -41,7 +41,6 @@ class PackageManagerBase(ObjectMixin, metaclass=PackageManagerMeta):
         "execute",
         "logs",
     ]
-    _allow_unprefixed_specs = True
 
     _spec_groups = [
         ("compilers", "Compilers"),
@@ -79,6 +78,8 @@ class PackageManagerBase(ObjectMixin, metaclass=PackageManagerMeta):
         self.app_inst = None
         self.keywords = None
 
+        self._allow_unprefixed_specs = True
+
         ramble.util.directives.define_directive_methods(self)
 
         self.object_variants.default_variant(
@@ -102,7 +103,7 @@ class PackageManagerBase(ObjectMixin, metaclass=PackageManagerMeta):
 
     @property
     def allow_unprefixed_specs(self):
-        return getattr(self, "_allow_unprefixed_specs", True)
+        return self._allow_unprefixed_specs
 
     def package_manager_dir(self, workspace):
         """Get the path to the package manager's software environment directory
@@ -267,11 +268,11 @@ class PackageManagerBase(ObjectMixin, metaclass=PackageManagerMeta):
     ):
         specs = {}
         for obj_type, obj in app_inst._objects():
-            single_modifier = None
+            include_modifier = None
             if obj_type == ramble.repository.ObjectTypes.modifiers:
-                single_modifier = obj
+                include_modifier = obj
             spec_variants = self.experiment_variants(
-                single_modifier=single_modifier
+                include_modifier=include_modifier
             )
 
             software_dict = getattr(obj, attr_name, {})

--- a/var/ramble/repos/builtin/base_modifiers/container-base/base_modifier.py
+++ b/var/ramble/repos/builtin/base_modifiers/container-base/base_modifier.py
@@ -163,7 +163,9 @@ class ContainerBase(BasicModifier):
         ):
             add_mod = True
             for when_set, var_mod_dict in self.variable_modifications.items():
-                if self.expander.satisfies(when_set, self.object_variants):
+                if self.expander.satisfies(
+                    when_set, self.experiment_variants()
+                ):
                     if "container_mounts" in var_mod_dict:
                         add_mod = False
                         break

--- a/var/ramble/repos/builtin/package_managers/environment-modules/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/environment-modules/package_manager.py
@@ -85,6 +85,7 @@ class EnvironmentModules(PackageManagerBase):
         self.app_inst.hash_inventory["software"].append(
             {
                 "name": env_path.replace(workspace.root + os.path.sep, ""),
+                "package_manager": self.name,
                 "digest": env_hash,
             }
         )

--- a/var/ramble/repos/builtin/package_managers/pip/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/pip/package_manager.py
@@ -154,7 +154,7 @@ class Pip(PackageManagerBase):
                         app_inst.expander.satisfies(
                             conf["when"],
                             variant_set=self.experiment_variants(
-                                single_modifier=mod_inst
+                                include_modifier=mod_inst
                             ),
                         )
                         and pkg not in installed_pkgs

--- a/var/ramble/repos/builtin/package_managers/pip/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/pip/package_manager.py
@@ -20,6 +20,7 @@ import ramble.software_info
 import ramble.stage
 from ramble.error import ApplicationError
 from ramble.pkgmankit import *
+from ramble.util.executable import which
 from ramble.util.hashing import hash_string
 from ramble.util.logger import logger
 from ramble.util.shell_utils import source_str
@@ -124,7 +125,8 @@ class Pip(PackageManagerBase):
             workspace.add_to_cache(cache_tupl)
 
         env_context = app_inst.expander.expand_var_name(self.keywords.env_name)
-        if self.environment_required:
+        logger.debug(f" Required environment: {self.environment_required}")
+        try:
             self.runner.set_dry_run(workspace.dry_run)
             self.runner.configure_env(env_path)
             self.runner.install()
@@ -133,22 +135,27 @@ class Pip(PackageManagerBase):
             for pkg, conf in app_inst.required_packages.items():
                 if (
                     app_inst.expander.satisfies(
-                        conf["when"], variant_set=app_inst.object_variants
+                        conf["when"], variant_set=self.experiment_variants()
                     )
                     and pkg not in installed_pkgs
                 ):
                     logger.die(
                         f"Package {pkg} is not installed "
                         f"in environment {env_context}, but is "
-                        f"required by the {self.name} application "
-                        "definition"
+                        f"required by the {app_inst.name} application "
+                        "definition\n",
+                        f"{self.experiment_variants().as_set()}\n",
+                        f"{conf['when']}",
                     )
 
             for mod_inst in app_inst._modifier_instances:
                 for pkg, conf in mod_inst.required_packages.items():
                     if (
                         app_inst.expander.satisfies(
-                            conf["when"], variant_set=app_inst.object_variants
+                            conf["when"],
+                            variant_set=self.experiment_variants(
+                                single_modifier=mod_inst
+                            ),
                         )
                         and pkg not in installed_pkgs
                     ):
@@ -158,6 +165,10 @@ class Pip(PackageManagerBase):
                             f"required by the {mod_inst.name} modifier "
                             "definition"
                         )
+        except RunnerError as e:
+            if self.environment_required:
+                logger.die(e)
+            pass
 
     register_phase(
         "define_package_paths",
@@ -215,6 +226,7 @@ class Pip(PackageManagerBase):
                 "name": self.runner.env_path.replace(
                     workspace.root + os.path.sep, ""
                 ),
+                "package_manager": self.name,
                 "digest": self.runner.inventory_hash(),
             }
         )
@@ -337,6 +349,14 @@ class PipRunner(CommandRunner):
         # Ensure subsequent commands use the created env now.
         self.env_path = env_path
 
+    def reset_bs_python(self, exec=None, path=None):
+        if isinstance(exec, Executable):
+            self.bs_python = exec
+        elif isinstance(path, str):
+            self.bs_python = which("python", path=path)
+        else:
+            self.bs_python = which("python")
+
     def _get_venv_python(self):
         if self.dry_run:
             return self.bs_python.copy()
@@ -368,9 +388,6 @@ class PipRunner(CommandRunner):
             with open(lock_file, "w") as f:
                 f.write(out)
         self.installed = True
-
-    def get_bootstrap_python(self):
-        return self.bs_python
 
     def _get_activate_script_path(self):
         return os.path.join(self.env_path, self._venv_name, "bin", "activate")

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
@@ -207,7 +207,7 @@ class SpackLightweight(PackageManagerBase):
                             app_inst.expander.satisfies(
                                 conf["when"],
                                 variant_set=self.experiment_variants(
-                                    single_modifier=mod_inst
+                                    include_modifier=mod_inst
                                 ),
                             )
                             and pkg not in added_packages

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
@@ -10,6 +10,7 @@ import os
 import re
 import shlex
 import shutil
+import sys
 
 import llnl.util.filesystem as fs
 
@@ -17,7 +18,7 @@ from ramble.pkgmankit import *
 from ramble.util.logger import logger
 
 import spack.util.spack_yaml as syaml
-from spack.util.executable import ProcessError
+from spack.util.executable import ProcessError, which
 
 
 class SpackLightweight(PackageManagerBase):
@@ -135,7 +136,7 @@ class SpackLightweight(PackageManagerBase):
         for config_dict in package_manager_config_dicts:
             for _, config in config_dict.items():
                 keep_config = app_inst.expander.satisfies(
-                    config["when"], variant_set=app_inst.object_variants
+                    config["when"], variant_set=self.experiment_variants()
                 )
                 if keep_config:
                     self.runner.add_config(config["config"])
@@ -188,7 +189,8 @@ class SpackLightweight(PackageManagerBase):
                 for pkg, conf in app_inst.required_packages.items():
                     if (
                         app_inst.expander.satisfies(
-                            conf["when"], variant_set=app_inst.object_variants
+                            conf["when"],
+                            variant_set=self.experiment_variants(),
                         )
                         and pkg not in added_packages
                     ):
@@ -204,7 +206,9 @@ class SpackLightweight(PackageManagerBase):
                         if (
                             app_inst.expander.satisfies(
                                 conf["when"],
-                                variant_set=app_inst.object_variants,
+                                variant_set=self.experiment_variants(
+                                    single_modifier=mod_inst
+                                ),
                             )
                             and pkg not in added_packages
                         ):
@@ -423,6 +427,7 @@ class SpackLightweight(PackageManagerBase):
                 "name": self.runner.env_path.replace(
                     workspace.root + os.path.sep, ""
                 ),
+                "package_manager": self.name,
                 "digest": self.runner.inventory_hash(),
             }
         )
@@ -718,6 +723,9 @@ class SpackRunner(CommandRunner):
             self.spack_dir, "share", "spack", script
         )
 
+        self.bs_python = CommandRunner(
+            "python", command=sys.executable, dry_run=dry_run
+        )
         self.concretized = False
         self.hash = None
         self.env_path = None
@@ -741,6 +749,14 @@ class SpackRunner(CommandRunner):
             ramble.config.get(f"{self.concretize_config_name}:prefix")
         )
         self.concretizer.add_default_arg("concretize")
+
+    def get_spack_python(self):
+        if self.dry_run:
+            return self.bs_python
+        return which(
+            "python",
+            path=os.path.join(self.env_path, "ramble", "bin"),
+        )
 
     def get_version(self):
         """Get spack's version"""

--- a/var/ramble/repos/builtin/package_managers/spack-pip/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-pip/package_manager.py
@@ -23,8 +23,6 @@ class SpackPip(PackageManagerBase):
 
     maintainers("douglasjacobsen")
 
-    _allow_unprefixed_specs = False
-
     package_manager_family("spack")
     package_manager_family("pip")
 
@@ -36,10 +34,11 @@ class SpackPip(PackageManagerBase):
     def __init__(self, file_path):
         # Let parents run first; then we enforce our runner.
         super().__init__(file_path)
+        self._allow_unprefixed_specs = False
 
         self.spack_mgr = Spack(file_path)
-        self.spack_mgr._allow_unprefixed_specs = False
         self.pip_mgr = Pip(file_path)
+        self.spack_mgr._allow_unprefixed_specs = False
         self.pip_mgr._allow_unprefixed_specs = False
 
     def set_application(self, app_inst):

--- a/var/ramble/repos/builtin/package_managers/spack-pip/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-pip/package_manager.py
@@ -1,0 +1,301 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+from ramble.pkg_man.builtin.pip import Pip
+from ramble.pkg_man.builtin.spack import Spack
+from ramble.pkgmankit import *
+
+
+class SpackPip(PackageManagerBase):
+    """Chained spack + pip package manager
+
+    This package manager uses spack to install a spack environment, then using the python that is installed within this environment (or whichever one is available in your path) will install pip packages into a python virtual environment. Experiments will load both environments, in the order of spack then pip.
+    """
+
+    name = "spack-pip"
+
+    maintainers("douglasjacobsen")
+
+    _allow_unprefixed_specs = False
+
+    package_manager_family("spack")
+    package_manager_family("pip")
+
+    archive_pattern(os.path.join("{env_path}", "spack.yaml"))
+    archive_pattern(os.path.join("{env_path}", "spack.lock"))
+    archive_pattern(os.path.join("{env_path}", "requirements.txt"))
+    archive_pattern(os.path.join("{env_path}", "requirements.lock"))
+
+    def __init__(self, file_path):
+        # Let parents run first; then we enforce our runner.
+        super().__init__(file_path)
+
+        self.spack_mgr = Spack(file_path)
+        self.spack_mgr._allow_unprefixed_specs = False
+        self.pip_mgr = Pip(file_path)
+        self.pip_mgr._allow_unprefixed_specs = False
+
+    def set_application(self, app_inst):
+        self.spack_mgr.set_application(app_inst)
+        self.pip_mgr.set_application(app_inst)
+
+    def build_used_variables(self, workspace):
+        self.spack_mgr.build_used_variables(workspace)
+        self.pip_mgr.build_used_variables(workspace)
+
+    def populate_inventory(
+        self, workspace, force_compute=False, require_exist=False
+    ):
+        """Inject spack and pip software inventory information
+
+        Args:
+            workspace (ramble.workspace.Workspace): Reference to the workspace that is currently
+                                   being acted on.
+            force_compute (bool): Whether to force computation of hashes or not
+            require_exist (bool): Whether to require environment hashes exist or not.
+        """
+
+        self.spack_mgr.populate_inventory(
+            workspace, force_compute=force_compute, require_exist=require_exist
+        )
+        self.pip_mgr.populate_inventory(
+            workspace, force_compute=force_compute, require_exist=require_exist
+        )
+
+    def _add_software_to_results(self, workspace, app_inst=None):
+        self.spack_mgr._add_software_to_results(workspace, app_inst)
+        self.pip_mgr._add_software_to_results(workspace, app_inst)
+
+    # Spack phases
+    register_phase("software_create_env_spack", pipeline="setup")
+    register_phase("software_create_env_spack", pipeline="pushdeployment")
+    register_phase(
+        "software_create_env_spack",
+        pipeline="mirror",
+        run_before=["software_configure_spack"],
+    )
+
+    def _software_create_env_spack(self, workspace, app_inst=None):
+        self.spack_mgr._software_create_env(workspace, app_inst)
+
+    register_phase(
+        "software_install_requested_compilers",
+        pipeline="setup",
+        run_after=["software_create_env_spack"],
+    )
+
+    def _software_install_requested_compilers(self, workspace, app_inst=None):
+        self.spack_mgr._software_install_requested_compilers(
+            workspace, app_inst
+        )
+
+    register_phase(
+        "software_configure_spack",
+        pipeline="setup",
+        run_after=[
+            "software_create_env_spack",
+            "software_install_requested_compilers",
+        ],
+    )
+
+    def _software_configure_spack(self, workspace, app_inst=None):
+        self.spack_mgr._software_configure(workspace, app_inst)
+
+    register_phase(
+        "software_install_spack",
+        pipeline="setup",
+        run_after=["software_configure_spack"],
+        run_before=["evaluate_requirements_spack"],
+    )
+
+    def _software_install_spack(self, workspace, app_inst=None):
+        self.spack_mgr._software_install(workspace, app_inst)
+        self.pip_mgr.runner.reset_bs_python(
+            self.spack_mgr.runner.get_spack_python()
+        )
+
+    register_phase(
+        "define_package_paths_spack",
+        pipeline="setup",
+        run_after=["software_install_spack", "evaluate_requirements_spack"],
+        run_before=["make_experiments"],
+    )
+
+    def _define_package_paths_spack(self, workspace, app_inst=None):
+        self.spack_mgr._define_package_paths(workspace, app_inst)
+
+    register_phase(
+        "evaluate_requirements_spack",
+        pipeline="setup",
+        run_before=["make_experiments"],
+    )
+
+    def _evaluate_requirements_spack(self, workspace, app_inst=None):
+        self.spack_mgr._evaluate_requirements(workspace, app_inst)
+
+    register_phase("mirror_software_spack", pipeline="mirror")
+
+    def _mirror_software_spack(self, workspace, app_inst=None):
+        self.spack_mgr._mirror_software(workspace, app_inst)
+
+    register_phase("push_to_spack_cache", pipeline="pushtocache", run_after=[])
+
+    def _push_to_spack_cache(self, workspace, app_inst=None):
+        self.spack_mgr._push_to_spack_cache(workspace, app_inst)
+
+    register_phase(
+        "deploy_spack_artifacts",
+        pipeline="pushdeployment",
+        run_after=["software_create_env_spack", "deploy_artifacts"],
+    )
+
+    def _deploy_spack_artifacts(self, workspace, app_inst=None):
+        self.spack_mgr._deploy_spack_artifacts(workspace, app_inst)
+
+    register_phase(
+        "software_configure_spack",
+        pipeline="mirror",
+        run_before=["mirror_software_spack"],
+    )
+
+    register_phase(
+        "software_create_env_spack",
+        pipeline="mirror",
+        run_before=["software_configure_spack"],
+    )
+
+    register_builtin(
+        "spack_source",
+        required=True,
+    )
+
+    register_builtin(
+        "spack_activate",
+        required=True,
+        depends_on=["spack_source"],
+    )
+    register_builtin(
+        "spack_deactivate",
+        required=False,
+        depends_on=["spack_source"],
+    )
+
+    def spack_source(self):
+        return self.spack_mgr.spack_source()
+
+    def spack_activate(self):
+        return self.spack_mgr.spack_activate()
+
+    def spack_deactivate(self):
+        return self.spack_mgr.spack_deactivate()
+
+    # Pip Phases
+    register_builtin(
+        "pip_activate",
+        required=True,
+        depends_on=["builtin::env_vars", "spack_activate"],
+    )
+
+    def pip_activate(self):
+        return self.pip_mgr.pip_activate()
+
+    register_builtin(
+        "pip_deactivate",
+        required=False,
+        depends_on=["pip_activate"],
+    )
+
+    def pip_deactivate(self):
+        return self.pip_mgr.pip_deactivate()
+
+    # TODO: This needs to happen after loading the spack environment in the environment pip is run in.
+    register_phase(
+        "software_create_env_pip",
+        pipeline="setup",
+        run_after=["software_install_spack"],
+    )
+
+    def _software_create_env_pip(self, workspace, app_inst=None):
+        self.pip_mgr._software_create_env(workspace, app_inst)
+
+    register_phase(
+        "software_install_pip",
+        pipeline="setup",
+        run_after=["software_create_env_pip"],
+    )
+
+    def _software_install_pip(self, workspace, app_inst=None):
+        self.pip_mgr._software_install(workspace, app_inst)
+
+    register_phase(
+        "define_package_paths_pip",
+        pipeline="setup",
+        run_after=["software_install_pip"],
+        run_before=["make_experiments"],
+    )
+
+    def _define_package_paths_pip(self, workspace, app_inst=None):
+        self.pip_mgr._define_package_paths(workspace, app_inst)
+
+    register_phase("warn_mirror_support_pip", pipeline="mirror")
+
+    def _warn_mirror_support_pip(self, workspace, app_inst=None):
+        self.pip_mgr._warn_mirror_support_pip(workspace, app_inst)
+
+    register_phase(
+        "configure_for_analyze",
+        pipeline="analyze",
+        run_before=["analyze_experiments"],
+    )
+
+    def _configure_for_analyze(self, workspace, app_inst=None):
+        self.spack_mgr._software_create_env(workspace, app_inst)
+        self.pip_mgr.runner.reset_bs_python(
+            self.spack_mgr.runner.get_spack_python()
+        )
+        self.pip_mgr._software_create_env(workspace, app_inst)
+
+    def get_package_list(self, workspace):
+        pkg_list = self.spack_mgr.get_package_list()
+        pkg_list.extend(self.pip_mgr.get_package_list())
+
+    def environment_load_commands(self):
+        commands = self.spack_mgr.environment_load_commands()
+        commands.extend(self.pip_mgr.environment_load_commands())
+        return commands
+
+    def environment_unload_commands(self):
+        commands = self.spack_mgr.environment_unload_commands()
+        commands.extend(self.pip_mgr.environment_unload_commands())
+        return commands
+
+    def get_experiment_specs(self, app_inst=None, prefixed=False):
+        specs = self.spack_mgr.get_experiment_specs(
+            app_inst=app_inst, prefixed=True
+        )
+        for name, definitions in self.pip_mgr.get_experiment_specs(
+            app_inst=app_inst, prefixed=True
+        ).items():
+            if name not in specs:
+                specs[name] = []
+            specs[name].extend(definitions)
+        return specs
+
+    def get_experiment_compilers(self, app_inst=None, prefixed=False):
+        specs = self.spack_mgr.get_experiment_compilers(
+            app_inst=app_inst, prefixed=True
+        )
+        for name, definitions in self.pip_mgr.get_experiment_compilers(
+            app_inst=app_inst, prefixed=True
+        ).items():
+            if name not in specs:
+                specs[name] = []
+            specs[name].extend(definitions)
+        return specs

--- a/var/ramble/repos/builtin/package_managers/spack-pip/test/spack_pip.py
+++ b/var/ramble/repos/builtin/package_managers/spack-pip/test/spack_pip.py
@@ -1,0 +1,146 @@
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.workspace
+from ramble.main import RambleCommand
+
+pytestmark = pytest.mark.usefixtures(
+    "mutable_config",
+    "mutable_mock_workspace_path",
+)
+
+config = RambleCommand("config")
+workspace = RambleCommand("workspace")
+
+
+def test_spack_pip_multi_prefix(request, mock_applications):
+    ws_name = request.node.name
+    ws = ramble.workspace.create(ws_name)
+    global_args = ["-w", ws_name]
+    workspace(
+        "manage",
+        "experiments",
+        "multi-package-manager-specs",
+        "-p",
+        "spack-pip",
+        "-v",
+        "n_nodes=1",
+        "-v",
+        "processes_per_node=1",
+        global_args=global_args,
+    )
+    ws._re_read()
+    workspace("concretize", global_args=global_args)
+    with open(ws.config_file_path) as f:
+        data = f.read()
+        assert "spack_pkg_spec: zlib" in data
+        assert "pip_pkg_spec: requests" in data
+
+    workspace("setup", "--dry-run", global_args=global_args)
+
+    workspace("analyze", global_args=global_args)
+
+    with open(os.path.join(ws.root, "results.latest.txt")) as f:
+        data = f.read()
+        assert "SUCCESS" in data
+        assert "FAILED" not in data
+
+
+def test_spack_pip_ignores_unprefixed_spec(request, mock_applications):
+    ws_name = request.node.name
+    ws = ramble.workspace.create(ws_name)
+    global_args = ["-w", ws_name]
+    workspace(
+        "manage",
+        "experiments",
+        "multi-package-manager-specs",
+        "-p",
+        "spack-pip",
+        "-v",
+        "n_nodes=1",
+        "-v",
+        "processes_per_node=1",
+        global_args=global_args,
+    )
+
+    workspace(
+        "manage",
+        "software",
+        "--pkg",
+        "zlib",
+        "--prefix",
+        "spack",
+        "--spec",
+        "zlib",
+        global_args=global_args,
+    )
+
+    workspace(
+        "manage",
+        "software",
+        "--pkg",
+        "requests",
+        "--prefix",
+        "pip",
+        "--spec",
+        "requests",
+        global_args=global_args,
+    )
+
+    workspace(
+        "manage",
+        "software",
+        "--pkg",
+        "gcc",
+        "--spec",
+        "gcc",
+        global_args=global_args,
+    )
+
+    workspace(
+        "manage",
+        "software",
+        "--env",
+        "multi-package-manager-specs",
+        "--environment-packages",
+        "zlib,requests,gcc",
+        global_args=global_args,
+    )
+
+    ws._re_read()
+    with open(ws.config_file_path) as f:
+        data = f.read()
+        assert "spack_pkg_spec: zlib" in data
+        assert "pip_pkg_spec: requests" in data
+        assert "pkg_spec: gcc" in data
+
+    workspace("setup", "--dry-run", global_args=global_args)
+
+    env_path = os.path.join(
+        ws.software_dir, "spack-pip", "multi-package-manager-specs"
+    )
+    with open(os.path.join(env_path, "spack.yaml")) as f:
+        data = f.read()
+        assert "zlib" in data
+        assert "requests" not in data
+        assert "gcc" not in data
+
+    with open(os.path.join(env_path, "requirements.txt")) as f:
+        data = f.read()
+        assert "zlib" not in data
+        assert "requests" in data
+        assert "gcc" not in data
+
+    workspace("analyze", global_args=global_args)
+
+    with open(os.path.join(ws.root, "results.latest.txt")) as f:
+        data = f.read()
+        assert "SUCCESS" in data
+        assert "FAILED" not in data

--- a/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
@@ -190,7 +190,7 @@ class Slurm(WorkflowManagerBase):
         ]
         if expander.satisfies(
             "+slurm_include_default_sbatch_headers",
-            variant_set=app_inst.object_variants,
+            variant_set=app_inst.experiment_variants(),
         ):
             pragmas.extend(
                 [


### PR DESCRIPTION
This merge performs a lot of internal tasks to enable experiments to have multiple package managers attached to them. An example implementation of this is provided in the `spack-pip` package manager, though in the future this could be abstracted into a base class to make it easier to implement for additional use cases.

Generally, more of the ownership is pushed into the package manager class for the software spec and compiler spec definitions / formatting.

Tests for the spack-pip package manager are added as well.