### PR TITLE
Search `experiment_run_dir` for `ramble on` executor

### DIFF
--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -584,7 +584,19 @@ class ExecutePipeline(Pipeline):
             exec_name = exec_parts[0]
             exec_args = exec_parts[1:]
 
-            executor = Executable(exec_name)
+            executor = which(exec_name)
+            if executor is None:
+                # attempt searching inside the run directory
+                if not os.path.isabs(exec_name):
+                    alt_exec_path = os.path.join(app_inst.expander.experiment_run_dir, exec_name)
+                    executor = which(alt_exec_path)
+
+            if executor is None:
+                # Attempt the execution, even though it won't succeed.
+                # The raised os error gives better reason for troubleshooting
+                # (like whether the exec doesn't exist, or due to missing permission.)
+                executor = Executable(exec_name)
+
             executor(*exec_args)
 
 

--- a/lib/ramble/ramble/test/cmd/on.py
+++ b/lib/ramble/ramble/test/cmd/on.py
@@ -89,3 +89,43 @@ def test_on_executor():
         assert os.path.exists(ws.root + "/all_experiments")
 
         on("--executor", 'echo "Index = {experiment_index}"', global_args=["-w", ws_name])
+
+
+def test_on_executor_in_run_dir(workspace_name):
+    global_args = ["-w", workspace_name]
+    ws = ramble.workspace.create(workspace_name)
+    workspace(
+        "manage",
+        "experiments",
+        "basic",
+        "--wf",
+        "working_wl",
+        "-v",
+        "n_nodes=1",
+        "-v",
+        "processes_per_node=1",
+        "-v",
+        "batch_submit={execute_experiment}",
+        "-v",
+        "my_var=10",
+        global_args=global_args,
+    )
+
+    # Assert executor not found
+    with pytest.raises(Exception, match="my_exit: No such file or directory"):
+        on("--executor", "my_exit", global_args=global_args)
+
+    # Now set up the executor template
+    tpl_path = os.path.join(ws.config_dir, "my_exit.tpl")
+    with open(tpl_path, "w") as f:
+        f.write("#!/bin/bash\n\nexit {my_var}")
+    ws._re_read()
+    workspace("setup", global_args=global_args)
+
+    # Assert no executable permission against the template
+    with pytest.raises(Exception, match="my_exit.tpl: Permission denied"):
+        on("--executor", tpl_path, global_args=global_args)
+
+    # Assert the executable is invoked
+    with pytest.raises(Exception, match="Command exited with status 10"):
+        on("--executor", "my_exit", global_args=global_args)

--- a/lib/ramble/ramble/test/cmd/unit_test.py
+++ b/lib/ramble/ramble/test/cmd/unit_test.py
@@ -48,7 +48,6 @@ def test_pytest_help():
 )
 def test_failed_import(extra_flag):
     out = ramble_test(extra_flag, "-p", "fake-pytest", fail_on_error=False)
-    assert ramble_test.returncode == 1
     assert "Ensure requirements-dev.txt are installed" in out
 
 


### PR DESCRIPTION
This is mostly for convenience, such that any executor templates specified inside the config directory can be invoked without explicitly specifying the full path.