### PR TITLE
Fix squash of multiline strings

### DIFF
--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -2858,6 +2858,9 @@ def test_workspace_config_squash(workspace_name, capsys):
   foo: bar
   n_ranks: 1
   test_var: test_value
+  test_multiline_str: |-
+    This is a multi-line
+    String in YAML
 """
 
     test_software_include = """software:
@@ -2949,6 +2952,7 @@ def test_workspace_config_squash(workspace_name, capsys):
         assert "test_var: test_value" in config_output
         assert "gcc" in config_output
         assert "pkg_spec: gcc@9.3.0" in config_output
+        assert "test_multiline_str: |-" in config_output
 
         with open(ws.config_file_path, "w+") as f:
             f.write(config_output)

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1133,7 +1133,7 @@ ramble:
                 if section_dict:
                     workspace_dict["ramble"][section] = section_dict
 
-        print(f"\n{syaml.dump(workspace_dict)}")
+        print(f"\n{syaml.dump(workspace_dict, Dumper=syaml.OrderedLineDumper)}")
 
     def add_experiments(
         self,


### PR DESCRIPTION
This merge fixes the formatting of multiline strings when squashing a workspace config.