### PR TITLE
Add a missing pytest marker

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -20,6 +20,7 @@ filterwarnings =
   ignore:.*use of fork:DeprecationWarning
 markers =
   db: tests that require creating a DB
+  network: tests that use networking
   maybeslow: tests that may be slow (e.g. access a lot the filesystem, etc.)
   regression: tests that fix a reported bug
   requires_executables: tests that requires certain executables in PATH to run


### PR DESCRIPTION
This marker is used in gcs_fetch test.