### PR TITLE
Use `coverage run` for more accurate coverage numbers

### DIFF
--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -38,8 +38,6 @@ def _join_str(seq, sep=","):
 
 
 def _re_search(regex, s):
-    import re
-
     return re.search(regex, s) is not None
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,10 @@ known_third_party = ["ruamel", "jsonschema"]
 
 [tool.coverage.run]
 parallel = true
+# subprocess assumes parallel=true
+# This patch allows coverage.py to accurately capture
+# subprocess calls.
+patch = ["subprocess"]
 data_file = "./tests-coverage/.coverage"
 include = [
   "**/bin/ramble",
@@ -80,12 +84,6 @@ exclude_lines = [
     'if 0:',
     'if False:',
     'if __name__ == .__main__.:',
-
-    # Ignore import statements:
-    # Imports (and defs) are not counted due to coverage being run after
-    # these modules are already initialized.
-    '^import .*',
-    '^from .* import .*',
 ]
 ignore_errors = true
 include = [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,10 +2,10 @@
 pytest
 flake8
 black
-coverage
+coverage>=7.10;python_version>="3.9"
+coverage;python_version<"3.9"
 pre-commit
 pytest-xdist
-pytest-cov
 pytest-clarity
 line_profiler
 isort

--- a/share/ramble/cloud-build/ramble-pr-unit-tests.yaml
+++ b/share/ramble/cloud-build/ramble-pr-unit-tests.yaml
@@ -56,15 +56,21 @@ steps:
         # $$ characters are required for cloud-build:
         # https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values
         if [ $$coverage_err -gt 0 ]; then
-          if [ $$coverage_err == 2 ]; then
-            echo "Code coverage dropped below the minimum level."
-            echo " ***** Coverage decreased"
-          else
-            echo "Code coverage report generation failed."
-            echo " ***** Coverage report generic error"
-          fi
+          python3 -c 'import sys; exit(0 if sys.version_info >= (3, 9) else 1)'
+          py_version_check_err=$$?
+          if [ $$py_version_check_err -eq 0 ]; then
+            if [ $$coverage_err == 2 ]; then
+              echo "Code coverage dropped below the minimum level."
+              echo " ***** Coverage decreased"
+            else
+              echo "Code coverage report generation failed."
+              echo " ***** Coverage report generic error"
+            fi
 
-          error=1
+            error=1
+          else
+            echo "Skipping coverage check for python version < 3.9, as the coverage number is not accurate"
+          fi
         fi
 
         # $$ characters are required for cloud-build:

--- a/share/ramble/qa/run-unit-tests
+++ b/share/ramble/qa/run-unit-tests
@@ -47,9 +47,9 @@ if [ $? != 0 ]; then
     ERROR=1
 fi
 
-export UNIT_TEST_COVERAGE_ADDOPTS=""
+export UNIT_TEST_COVERAGE_PREFIX=""
 if [[ "$UNIT_TEST_COVERAGE" == "true" ]]; then
-  export UNIT_TEST_COVERAGE_ADDOPTS="--cov --cov-report= --cov-config=pyproject.toml"
+  export UNIT_TEST_COVERAGE_PREFIX="coverage run --rcfile=pyproject.toml"
 fi
 
 export PYTEST_ADDOPTS=""
@@ -65,12 +65,16 @@ fi
 #-----------------------------------------------------------
 
 if [[ "$LONG" == "true" ]]; then
-  $(which ramble) unit-test ${PYTEST_ADDOPTS} -x --verbose ${UNIT_TEST_COVERAGE_ADDOPTS}
+  ${UNIT_TEST_COVERAGE_PREFIX} $(which ramble) unit-test ${PYTEST_ADDOPTS} -x --verbose
 else
-  $(which ramble) unit-test ${PYTEST_ADDOPTS} -x --verbose ${UNIT_TEST_COVERAGE_ADDOPTS} --fast
+  ${UNIT_TEST_COVERAGE_PREFIX} $(which ramble) unit-test ${PYTEST_ADDOPTS} -x --verbose --fast
 fi
 if [ $? != 0 ]; then
     ERROR=1
+fi
+
+if [[ "$UNIT_TEST_COVERAGE" == "true" ]]; then
+  coverage combine
 fi
 
 if [[ "$PUSH_CODECOV" ]]; then


### PR DESCRIPTION
Previously when using `pytest-cov`, it does not capture lines that are executed as part of module initializations. One reason of relying on `pytest-cov` is becuase that handles subprocess calls properly. In newer versions of `coverage.py`, the "subprocess" patch config now handles this correctly, so we can use `coverage run` directly for a more accurate coverage report.