### PR TITLE
Fix up subcommands that rely on global options

### DIFF
--- a/lib/ramble/ramble/main.py
+++ b/lib/ramble/ramble/main.py
@@ -955,6 +955,10 @@ def finish_parse_and_run(parser, cmd_name, main_args, workspace_format_error):
     # add the found command to the parser and re-run then re-parse
     command = parser.add_command(cmd_name)
     args, unknown = parser.parse_known_args(main_args.command)
+    # Copy global options that are accessed by subcommands
+    args.workspace_dir = main_args.workspace_dir
+    args.workspace = main_args.workspace
+    args.no_workspace = main_args.no_workspace
 
     # Now that we know what command this is and what its args are, determine
     # whether we can continue with a bad workspace and raise if not.


### PR DESCRIPTION
This was a bug introduced by https://github.com/GoogleCloudPlatform/ramble/pull/1238. Before that PR, global options were passed into args supplied to subcommands, and the PR broke that behavior by passing only subcommand-scoped args.

The fix is to explicitly pass down global options that are accessed by subcommands.