### PR TITLE
Move command / formatted executable generation to make_experiments

### DIFF
--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -892,7 +892,9 @@ def workspace_info(args):
                     if args.executables:
                         color.cprint(rucolor.nested_4("        Executables: "))
                         app_inst.add_expand_vars(ws)
-                        exec_graph = app_inst._executable_graph
+                        exec_graph = app_inst._get_executable_graph(
+                            app_inst.expander.workload_name
+                        )
                         for executable in exec_graph.walk():
                             color.cprint(f"          {executable.key}")
 

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -891,7 +891,7 @@ def workspace_info(args):
 
                     if args.executables:
                         color.cprint(rucolor.nested_4("        Executables: "))
-                        app_inst.add_expand_vars(ws)
+                        app_inst.define_variables_for_template_path(ws)
                         exec_graph = app_inst._get_executable_graph(
                             app_inst.expander.workload_name
                         )

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -373,7 +373,7 @@ class ExperimentSet:
         for name, value in self._workspace.workspace_paths().items():
             app_inst.define_variable(name, value)
 
-        app_inst.add_expand_vars(self._workspace)
+        app_inst.define_variables_for_template_path(self._workspace)
         app_inst.read_status()
 
         experiment_namespace = app_inst.expander.experiment_namespace

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -576,7 +576,7 @@ class ExecutePipeline(Pipeline):
                 logger.debug(f"{app_inst.name} is a repeat base. Skipping execution.")
                 continue
 
-            app_inst.add_expand_vars(self.workspace)
+            app_inst.define_variables_for_template_path(self.workspace)
             exec_str = app_inst.expander.expand_var(self.executor)
             if resolve_env_vars:
                 exec_str = os.path.expandvars(exec_str)

--- a/lib/ramble/ramble/test/application.py
+++ b/lib/ramble/ramble/test/application.py
@@ -463,7 +463,7 @@ def test_define_commands(mutable_mock_apps_repo):
     assert "mpirun" in executable_application_instance.variables["command"]
 
 
-def test_derive_variables_for_template_path(mutable_mock_apps_repo, workspace_name):
+def test_define_variables_for_template_path(mutable_mock_apps_repo, workspace_name):
     """_set_default_variables_for_template_path"""
     test_config = """
 ramble:
@@ -524,7 +524,7 @@ ramble:
     executable_application_instance._define_formatted_executables()
 
     test_answer = "/workspace/experiments/bar/test_wl2/baz/execute_experiment"
-    executable_application_instance._derive_variables_for_template_path(ws1)
+    executable_application_instance.define_variables_for_template_path(ws1)
     assert executable_application_instance.variables["execute_experiment"] == test_answer
 
 

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1459,13 +1459,13 @@ ramble:
         pkgman_prefixes = set()
         for _, app_inst, _ in experiment_set.all_experiments():
             app_inst.build_modifier_instances()
-            app_inst.add_expand_vars(self)
+            app_inst.define_variables_for_template_path(self)
             if app_inst.package_manager is not None:
                 pkgman_prefixes.add(app_inst.package_manager.spec_prefix)
 
         for _, app_inst, _ in experiment_set.all_experiments():
             app_inst.build_modifier_instances()
-            app_inst.add_expand_vars(self)
+            app_inst.define_variables_for_template_path(self)
             env_name_str = app_inst.expander.expansion_str(ramble.keywords.keywords.env_name)
             env_name = app_inst.expander.expand_var(env_name_str)
 

--- a/var/ramble/repos/builtin/applications/intel-mlc/application.py
+++ b/var/ramble/repos/builtin/applications/intel-mlc/application.py
@@ -221,30 +221,19 @@ class IntelMlc(ExecutableApplication):
             cur_node = (cur_node + 1) % spread_divisions
         return threads
 
-    def add_expand_vars(self, workspace):
-        if not self._vars_are_expanded:
-            self._generate_input_file(workspace, self)
-            super().add_expand_vars(workspace)
+    register_phase(
+        "generate_input_variables",
+        pipeline="setup",
+        run_before=["make_experiments"],
+    )
 
-    def _generate_input_file(self, workspace, app_inst=None):
-        workload = app_inst.get_workload()
-
-        thread_dist = app_inst.expander.expand_var_name("thread_distribution")
-        if thread_dist == "{thread_distribution}":
-            possible_vars = workload.find_variable("thread_distribution")
-            assert len(possible_vars) == 1
-            thread_dist = possible_vars[0].default
-
+    def _generate_input_variables(self, workspace, app_inst=None):
         ppn = int(app_inst.expander.expand_var_name("processes_per_node"))
         n_threads = int(app_inst.expander.expand_var_name("n_threads"))
-
+        thread_dist = app_inst.expander.expand_var_name("thread_distribution")
         spread_divisions = app_inst.expander.expand_var_name(
             "spread_divisions"
         )
-        if spread_divisions == "{spread_divisions}":
-            possible_vars = workload.find_variable("spread_divisions")
-            assert len(possible_vars) == 1
-            spread_divisions = possible_vars[0].default
 
         try:
             spread_divisions = int(spread_divisions)

--- a/var/ramble/repos/builtin/base_applications/openfoam/base_application.py
+++ b/var/ramble/repos/builtin/base_applications/openfoam/base_application.py
@@ -483,7 +483,11 @@ class Openfoam(ExecutableApplication):
                         stat.compute(timestep_times),
                     )
 
-    def _define_commands(self, exec_graph, success_list):
+    register_phase(
+        "define_exports", pipeline="setup", run_before=["make_experiments"]
+    )
+
+    def _define_exports(self, workspace, app_inst=None):
         export_prefix = self.expander.expand_var_name("export_prefix")
         export_vars = self.expander.expand_var_name("export_variables").split(
             ","
@@ -496,5 +500,3 @@ class Openfoam(ExecutableApplication):
         export_str = " ".join(export_args)
 
         self.define_variable("workload_exports", export_str)
-
-        super()._define_commands(exec_graph, success_list)

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -774,7 +774,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
         backup_variables = self.variables.copy()
 
-        self._define_commands(self._executable_graph, self.success_list)
+        self._define_commands(success_list=self.success_list)
         self._define_formatted_executables()
 
         ########################
@@ -1495,7 +1495,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
         return obj_env_var_sets
 
-    def _define_commands(self, exec_graph, success_list=None):
+    def _define_commands(self, exec_graph=None, success_list=None):
         """Populate the internal list of commands based on executables
 
         Populates self._command_list with a list of the executable commands that
@@ -1503,6 +1503,13 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         """
         if len(self._command_list) > 0:
             return
+
+        exec_graph = getattr(self, "_executable_graph", exec_graph)
+        if exec_graph is None:
+            self._executable_graph = self._get_executable_graph(
+                self.expander.workload_name
+            )
+            exec_graph = self._executable_graph
 
         # Do not replace escaped braces here, to allow them to
         # be replace properly when templates are written.
@@ -1742,7 +1749,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             self.variables[node.key] = join_separator.join(formatted_lines)
 
     def _derive_variables_for_template_path(self, workspace):
-        """Define variables for template paths (for add_expand_vars)"""
+        """Define variables for all workspace and object template paths"""
         for template_name, _ in workspace.all_templates():
             expand_path = os.path.join(
                 self.expander.expand_var("{experiment_run_dir}"),
@@ -1750,22 +1757,33 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             )
             self.variables[template_name] = expand_path
 
+        var_attr = {
+            "type": ramble.keywords.key_type.reserved,
+            "level": ramble.keywords.output_level.variable,
+        }
+        for obj, tpl_config in self._object_templates(workspace):
+            var_name = tpl_config["var_name"]
+            if var_name is not None:
+                if var_name in self.variables:
+                    old_var = f"_old_{var_name}"
+                    self.variables[old_var] = self.variables[var_name]
+                    self.keywords.update_keys({old_var: var_attr})
+                self.variables[var_name] = tpl_config["dest_path"]
+                self.keywords.update_keys({var_name: var_attr})
+            if hasattr(obj, "template_render_vars"):
+                render_vars = obj.template_render_vars
+                self.variables.update(render_vars)
+                for name in render_vars.keys():
+                    self.keywords.update_keys({name: var_attr})
+
     def add_expand_vars(self, workspace):
         """Add application specific expansion variables
 
         Applications require several variables to be defined to function properly.
-        This method defines these variables, including:
-        - command: set to the commands needed to execute the experiment
-        - spack_setup: set to an empty string, so spack applications can override this
         """
         if not self._vars_are_expanded:
-            self._executable_graph = self._get_executable_graph(
-                self.expander.workload_name
-            )
-            self._set_input_path()
 
             self._derive_variables_for_template_path(workspace)
-            self._define_object_template_vars(workspace)
             self._vars_are_expanded = True
 
     def _inputs_and_fetchers(self, workload=None):
@@ -2017,7 +2035,8 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
         exp_lock = self.experiment_lock
 
-        self._define_commands(self._executable_graph, self.success_list)
+        self._set_input_path()
+        self._define_commands(success_list=self.success_list)
         self._define_formatted_executables()
 
         with lk.WriteTransaction(exp_lock):
@@ -3427,26 +3446,6 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                 f_out.write(rendered)
                 f_out.write("\n")
             os.chmod(out_path, perm)
-
-    def _define_object_template_vars(self, workspace):
-        var_attr = {
-            "type": ramble.keywords.key_type.reserved,
-            "level": ramble.keywords.output_level.variable,
-        }
-        for obj, tpl_config in self._object_templates(workspace):
-            var_name = tpl_config["var_name"]
-            if var_name is not None:
-                if var_name in self.variables:
-                    old_var = f"_old_{var_name}"
-                    self.variables[old_var] = self.variables[var_name]
-                    self.keywords.update_keys({old_var: var_attr})
-                self.variables[var_name] = tpl_config["dest_path"]
-                self.keywords.update_keys({var_name: var_attr})
-            if hasattr(obj, "template_render_vars"):
-                render_vars = obj.template_render_vars
-                self.variables.update(render_vars)
-                for name in render_vars.keys():
-                    self.keywords.update_keys({name: var_attr})
 
     def _objects(self, exclude_types=None):
         """Return a tuple for each object instance associated with the app_inst.

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -770,7 +770,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             (set): All variable names used by this experiment.
         """
         self.build_modifier_instances()
-        self.add_expand_vars(workspace)
+        self.define_variables_for_template_path(workspace)
 
         backup_variables = self.variables.copy()
 
@@ -882,7 +882,6 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
     # Phase execution helpers
     def run_phase(self, pipeline, phase, workspace):
         """Run a phase, by getting its function pointer"""
-        self.add_expand_vars(workspace)
         if self.is_template:
             logger.debug(f"{self.name} is a template. Skipping phases")
             return
@@ -1078,7 +1077,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                             ]
 
                     # Expand the chained experiment vars, so we can build the execution command
-                    new_inst.add_expand_vars(workspace)
+                    new_inst.define_variables_for_template_path(workspace)
                     chain_cmd = new_inst.expander.expand_var(
                         cur_exp_def[namespace.command]
                     )
@@ -1329,7 +1328,13 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                 )
 
     def _get_executable_graph(self, workload_name):
-        """Return executables for add_expand_vars"""
+        """Construct and return an executable graph
+
+        Builds an executable graph for a given workload.
+
+        Returns:
+            ExecutableGraph: Graph of executables for workload
+        """
         self._define_custom_executables()
         exec_order = self.get_workload(workload_name).executables
         # Use yaml defined executable order, if defined
@@ -1391,7 +1396,11 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         return executable_graph
 
     def _set_input_path(self):
-        """Put input_path into self.variables[input_file] for add_expand_vars"""
+        """Define input file path variables
+
+        Define variables for each input file, of the format:
+            '{input_file_name}' = <path_to_input>
+        """
         self._inputs_and_fetchers(self.expander.workload_name)
 
         for input_file, input_conf in self._input_fetchers.items():
@@ -1748,7 +1757,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
             self.variables[node.key] = join_separator.join(formatted_lines)
 
-    def _derive_variables_for_template_path(self, workspace):
+    def define_variables_for_template_path(self, workspace):
         """Define variables for all workspace and object template paths"""
         for template_name, _ in workspace.all_templates():
             expand_path = os.path.join(
@@ -1775,16 +1784,6 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                 self.variables.update(render_vars)
                 for name in render_vars.keys():
                     self.keywords.update_keys({name: var_attr})
-
-    def add_expand_vars(self, workspace):
-        """Add application specific expansion variables
-
-        Applications require several variables to be defined to function properly.
-        """
-        if not self._vars_are_expanded:
-
-            self._derive_variables_for_template_path(workspace)
-            self._vars_are_expanded = True
 
     def _inputs_and_fetchers(self, workload=None):
         """Extract all inputs for a given workload


### PR DESCRIPTION
This merge is mostly cleanup, but it reorganizes the creation of executable commands and formatted_executables within an experiment to be inside the make_experiments phase.

This allows other phases to define variables that are necessary for the actual commands / executables, and have them render properly. It also removes the `add_expand_vars` method, as it is no longer needed.