### PR TITLE
Add language feature to detect conflicting modifier definitions

### DIFF
--- a/lib/ramble/docs/dev_guides/modifier_dev_guide.rst
+++ b/lib/ramble/docs/dev_guides/modifier_dev_guide.rst
@@ -233,3 +233,26 @@ Ramble modifiers support variants, just as applications do (see
 Variants can be used to control the behavior of many of the
 directives within a modifier, and their use follows the discussion
 in :ref:`application-dev-conditional-logic`.
+
+^^^^^^^^^^^^^^^^^^^^^^^^
+Multi-modifier Conflicts
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Ramble supports repeating modifier definitions within the ``modifiers``
+configuration section. This can be useful (when applying varying modes of the
+same modifier) but can also present a challenge to modifier developers.
+Modifiers are not inherently able to be replicated multiple times on the same
+experiment without providing some unexpected behaviors.
+
+In the modifier language, Ramble allows modifiers to define how they should
+conflict with other modifier definitions when aspects of their definitions
+overlap.
+
+The ``modifier_conflict`` language feature can be used to control what Ramble's
+behavior should be when repeated definitions of the same modifier exist. An
+enum is provided in ``ramble.util.conflicts`` named ``MODIFIER_CONFLICT`` to
+understand what options exist.
+
+This language feature supports the ``when`` and variant logic that was
+previously described, which can allow the conflict behavior to change based on
+variant settings.

--- a/lib/ramble/ramble/error.py
+++ b/lib/ramble/ramble/error.py
@@ -150,6 +150,12 @@ class ModifierError(RambleError):
     """
 
 
+class ConflictingModifiersError(ModifierError):
+    """
+    Exception raised when two modifiers on the same experiment conflict
+    """
+
+
 class InvalidModeError(ModifierError):
     """
     Exception raised when an invalid mode is passed

--- a/lib/ramble/ramble/language/modifier_language.py
+++ b/lib/ramble/ramble/language/modifier_language.py
@@ -418,10 +418,10 @@ def modifier_conflict(
                 else:
                     conflict_value = MODIFIER_CONFLICT[conflict_type]
             elif isinstance(conflict_type, int):
-                if conflict_type not in MODIFIER_CONFLICT._value2member_map_:
+                try:
+                    conflict_value = MODIFIER_CONFLICT(conflict_type)
+                except ValueError:
                     usage_error = True
-                else:
-                    conflict_value = MODIFIER_CONFLICT._value2member_map_[conflict_type]
             elif isinstance(conflict_type, MODIFIER_CONFLICT):
                 conflict_value = conflict_type
             else:

--- a/lib/ramble/ramble/language/modifier_language.py
+++ b/lib/ramble/ramble/language/modifier_language.py
@@ -389,3 +389,61 @@ def package_manager_requirement(
         )
 
     return _new_package_manager_requirement
+
+
+@modifier_directive("modifier_conflicts")
+def modifier_conflict(
+    conflict_type,
+    when=None,
+    **kwargs,
+):
+    """Define a conflict with other modifiers on the same experiment.
+
+    Allowed values are defined in the MODIFIER_CONFLICT class in conflicts.py
+
+    Args:
+        conflict_type: Either a string or integer based on the options in
+                       ramble.util.conflicts.MODIFIER_CONFLICT
+    """
+
+    def _define_modifier_conflict(mod):
+        from ramble.util.conflicts import MODIFIER_CONFLICT
+
+        conflict_value = None
+        usage_error = False
+        if conflict_type is not None:
+            if isinstance(conflict_type, str):
+                if conflict_type not in MODIFIER_CONFLICT._member_names_:
+                    usage_error = True
+                else:
+                    conflict_value = MODIFIER_CONFLICT[conflict_type]
+            elif isinstance(conflict_type, int):
+                if conflict_type not in MODIFIER_CONFLICT._value2member_map_:
+                    usage_error = True
+                else:
+                    conflict_value = MODIFIER_CONFLICT._value2member_map_[conflict_type]
+            elif isinstance(conflict_type, MODIFIER_CONFLICT):
+                conflict_value = conflict_type
+            else:
+                usage_error = True
+
+        if usage_error:
+            raise DirectiveError(
+                f"modifier_conflict directive on modifier {mod.name} was given "
+                f"an invalid value for the conflict_type argument."
+                "This argument needs to be an integer or string based on the "
+                "MODIFIER_CONFLICT enum.\n"
+                f"The provided value was {conflict_type}"
+            )
+
+        when_list = ramble.language.language_helpers.build_when_list(
+            when, mod, mod.name, "modifier_conflict"
+        )
+        when_set = frozenset(when_list)
+
+        if conflict_value is None and when_set in mod.modifier_conflicts:
+            del mod.modifier_conflicts[when_set]
+        else:
+            mod.modifier_conflicts[when_set] = conflict_value
+
+    return _define_modifier_conflict

--- a/lib/ramble/ramble/modkit.py
+++ b/lib/ramble/ramble/modkit.py
@@ -23,6 +23,7 @@ from ramble.util.command_runner import (
     RunnerError,
     ValidationFailedError,
 )
+from ramble.util.conflicts import MODIFIER_CONFLICT
 from ramble.util.file_util import get_file_path
 from ramble.util.logger import logger
 from ramble.util.output_capture import OUTPUT_CAPTURE

--- a/lib/ramble/ramble/test/modifier_functionality/modifier_conflicts.py
+++ b/lib/ramble/ramble/test/modifier_functionality/modifier_conflicts.py
@@ -1,0 +1,130 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import pytest
+
+import ramble.workspace
+from ramble.error import ConflictingModifiersError
+from ramble.main import RambleCommand
+
+workspace = RambleCommand("workspace")
+
+
+def define_experiments(global_args):
+    workspace(
+        "manage",
+        "experiments",
+        "hostname",
+        "--wf",
+        "local",
+        "-v",
+        "n_nodes=1",
+        "-v",
+        "n_ranks=1",
+        global_args=global_args,
+    )
+
+
+def test_name_modifier_conflict(mutable_mock_workspace_path, mock_modifiers, workspace_name):
+    global_args = ["-w", workspace_name]
+    ramble.workspace.create(workspace_name)
+
+    define_experiments(global_args)
+
+    for _ in range(0, 2):
+        workspace(
+            "manage",
+            "modifiers",
+            "--add",
+            "--name",
+            "conflict-name-modifier",
+            "--scope",
+            "workspace",
+            global_args=global_args,
+        )
+
+    with pytest.raises(ConflictingModifiersError) as err:
+        workspace("setup", global_args=global_args)
+        assert "by having the same name." in str(err)
+
+
+def test_name_mode_modifier_conflict(mutable_mock_workspace_path, mock_modifiers, workspace_name):
+    global_args = ["-w", workspace_name]
+    ramble.workspace.create(workspace_name)
+
+    define_experiments(global_args)
+
+    for _ in range(0, 2):
+        workspace(
+            "manage",
+            "modifiers",
+            "--add",
+            "--name",
+            "conflict-name-mode-modifier",
+            "--scope",
+            "workspace",
+            global_args=global_args,
+        )
+
+    with pytest.raises(ConflictingModifiersError) as err:
+        workspace("setup", global_args=global_args)
+        assert "by having the same name and mode." in err
+
+
+def test_name_executables_modifier_conflict(
+    mutable_mock_workspace_path, mock_modifiers, workspace_name
+):
+    global_args = ["-w", workspace_name]
+    ramble.workspace.create(workspace_name)
+
+    define_experiments(global_args)
+
+    for _ in range(0, 2):
+        workspace(
+            "manage",
+            "modifiers",
+            "--add",
+            "--name",
+            "conflict-name-executables-modifier",
+            "--scope",
+            "workspace",
+            "-e",
+            "foo",
+            global_args=global_args,
+        )
+
+    with pytest.raises(ConflictingModifiersError) as err:
+        workspace("setup", global_args=global_args)
+        assert "by having the same name and overlapping on_executable." in err
+
+
+def test_name_mode_executables_modifier_conflict(
+    mutable_mock_workspace_path, mock_modifiers, workspace_name
+):
+    global_args = ["-w", workspace_name]
+    ramble.workspace.create(workspace_name)
+
+    define_experiments(global_args)
+
+    for _ in range(0, 2):
+        workspace(
+            "manage",
+            "modifiers",
+            "--add",
+            "--name",
+            "conflict-name-mode-executables-modifier",
+            "--scope",
+            "workspace",
+            "-e",
+            "foo",
+            global_args=global_args,
+        )
+
+    with pytest.raises(ConflictingModifiersError) as err:
+        workspace("setup", global_args=global_args)
+        assert "by having the same name, mode, and overlapping on_executable." in err

--- a/lib/ramble/ramble/test/modifier_language.py
+++ b/lib/ramble/ramble/test/modifier_language.py
@@ -521,3 +521,19 @@ def test_require_condition_creates_when_list(mod_class):
 
     for i in range(4):
         assert f"test-mod_mode=mode_{i}" in when_list
+
+
+def test_modifier_conflict_usage_error():
+    class BrokenModifier(BasicModifier):  # noqa: F405
+        name = "broken-modifier"
+
+    broken_mod = BrokenModifier("/not/a/path")
+
+    err_str = (
+        "modifier_conflict directive on modifier broken-modifier was given "
+        "an invalid value for the conflict_type argument."
+        "This argument needs to be an integer or string based on the MODIFIER_CONFLICT enum.\n"
+        "The provided value was 80"
+    )
+    with pytest.raises(DirectiveError, match=err_str):
+        broken_mod.modifier_conflict(80)

--- a/lib/ramble/ramble/util/conflicts.py
+++ b/lib/ramble/ramble/util/conflicts.py
@@ -1,0 +1,24 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from enum import Enum
+
+
+class MODIFIER_CONFLICT(Enum):
+    # Conflict on identical name only
+    name = 0
+
+    # Conflict on name, and mode
+    name_mode = 1
+
+    # Conflict on name, and overlapping executables
+    name_executables = 2
+
+    # Conflict on name, mode, and overlapping executables
+    name_mode_executables = 3
+    name_executables_mode = 3

--- a/var/ramble/repos/builtin.mock/modifiers/conflict-name-executables-modifier/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/conflict-name-executables-modifier/modifier.py
@@ -1,0 +1,20 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.modkit import *
+
+
+class ConflictNameExecutablesModifier(BasicModifier):
+
+    name = "conflict-name-executables-modifier"
+
+    mode("standard", description="Standard modifier mode")
+
+    default_mode("standard")
+
+    modifier_conflict(MODIFIER_CONFLICT.name_executables)

--- a/var/ramble/repos/builtin.mock/modifiers/conflict-name-mode-executables-modifier/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/conflict-name-mode-executables-modifier/modifier.py
@@ -1,0 +1,20 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.modkit import *
+
+
+class ConflictNameModeExecutablesModifier(BasicModifier):
+
+    name = "conflict-name-mode-executables-modifier"
+
+    mode("standard", description="Standard modifier mode")
+
+    default_mode("standard")
+
+    modifier_conflict("name_mode_executables")

--- a/var/ramble/repos/builtin.mock/modifiers/conflict-name-mode-modifier/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/conflict-name-mode-modifier/modifier.py
@@ -1,0 +1,20 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.modkit import *
+
+
+class ConflictNameModeModifier(BasicModifier):
+
+    name = "conflict-name-mode-modifier"
+
+    mode("standard", description="Standard modifier mode")
+
+    default_mode("standard")
+
+    modifier_conflict("name_mode")

--- a/var/ramble/repos/builtin.mock/modifiers/conflict-name-modifier/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/conflict-name-modifier/modifier.py
@@ -1,0 +1,20 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.modkit import *
+
+
+class ConflictNameModifier(BasicModifier):
+
+    name = "conflict-name-modifier"
+
+    mode("standard", description="Standard modifier mode")
+
+    default_mode("standard")
+
+    modifier_conflict("name")

--- a/var/ramble/repos/builtin.mock/modifiers/conflict-none-modifier/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/conflict-none-modifier/modifier.py
@@ -1,0 +1,20 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.modkit import *
+
+
+class ConflictNoneModifier(BasicModifier):
+
+    name = "conflict-none-modifier"
+
+    mode("standard", description="Standard modifier mode")
+
+    default_mode("standard")
+
+    modifier_conflict(None)

--- a/var/ramble/repos/builtin.mock/modifiers/test-mod/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/test-mod/modifier.py
@@ -22,6 +22,8 @@ class TestMod(BasicModifier):
     mode("test", description="This is a test mode")
     default_mode("test")
 
+    modifier_conflict(MODIFIER_CONFLICT.name_mode_executables)
+
     mode(
         "app-scope", description="This is a test mode at the application scope"
     )

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -1182,6 +1182,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                 )
                 mod_inst = DisabledModifier(mod_inst)
 
+            mod_inst.check_conflicts(self._modifier_instances)
             self._modifier_instances.append(mod_inst)
 
             # Add this modifiers required variables for validation

--- a/var/ramble/repos/builtin/base_classes/disabled-modifier/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/disabled-modifier/base_class.py
@@ -23,6 +23,8 @@ class DisabledModifier(ModifierBase):
 
     name = "disabled"
 
+    modifier_conflict(None)
+
     def __init__(self, instance_to_disable):
         super().__init__(instance_to_disable._file_path)
 

--- a/var/ramble/repos/builtin/base_classes/modifier-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/modifier-base/base_class.py
@@ -15,9 +15,18 @@ import ramble.repository
 import ramble.util.class_attributes
 import ramble.util.directives
 import ramble.variants
-from ramble.error import InvalidModeError, ModifierError
-from ramble.language.modifier_language import ModifierMeta, mode
+from ramble.error import (
+    ConflictingModifiersError,
+    InvalidModeError,
+    ModifierError,
+)
+from ramble.language.modifier_language import (
+    ModifierMeta,
+    mode,
+    modifier_conflict,
+)
 from ramble.language.shared_language import SharedMeta
+from ramble.util.conflicts import MODIFIER_CONFLICT
 from ramble.util.logger import logger
 from ramble.util.naming import NS_SEPARATOR
 
@@ -51,6 +60,7 @@ class ModifierBase(ObjectMixin, metaclass=ModifierMeta):
 
     disabled = False
 
+    modifier_conflict(MODIFIER_CONFLICT["name_executables"])
     mode("disabled", description="Mode to disable all modifier functionality")
 
     def __init__(self, file_path):
@@ -162,6 +172,156 @@ class ModifierBase(ObjectMixin, metaclass=ModifierMeta):
         modded_vars = self.modded_variables(app)
         self.expander._variables.update(modded_vars)
         self.app_inst = app
+
+    @property
+    def conflict_value(self):
+        """
+        Evaluate when sets to determine the most restrictive conflict that is currently satisfied.
+        """
+        value = None
+        for when_set, conflict_value in self.modifier_conflicts.items():
+            if self.expander.satisfies(when_set, self.object_variants):
+                if value is None:
+                    value = conflict_value
+                else:
+                    if conflict_value.value < value.value:
+                        value = conflict_value
+        return value
+
+    def check_conflicts(self, existing_modifiers):
+        """Evaluate conflicts with other existing modifiers.
+
+
+        Iterate over (input) existing modifiers, and evaluate if they conflict based on
+        this modifier's conflict setting.
+
+        Args:
+            existing_modifiers: Existing modifiers in a list
+        """
+        conflict_value = self.conflict_value
+
+        if conflict_value is None:
+            return
+
+        self_idx = len(existing_modifiers)
+
+        for mod_idx, mod_inst in enumerate(existing_modifiers):
+            if mod_inst is self:
+                self_idx = mod_idx
+                continue
+
+            if conflict_value == MODIFIER_CONFLICT.name:
+                if mod_inst.name == self.name:
+                    comp_str = mod_inst.config_str(index=mod_idx, indent=4)
+                    self_str = self.config_str(index=self_idx, indent=4)
+                    raise ConflictingModifiersError(
+                        f"Two modifier definitions conflict by having the same name.\n"
+                        f"Modifier 1:\n"
+                        f"{comp_str}"
+                        f"Modifier 2:\n"
+                        f"{self_str}"
+                    )
+
+            elif conflict_value == MODIFIER_CONFLICT.name_mode:
+                if (
+                    mod_inst.name == self.name
+                    and mod_inst._usage_mode == self._usage_mode
+                ):
+                    comp_str = mod_inst.config_str(
+                        index=mod_idx, include_mode=True, indent=4
+                    )
+                    self_str = self.config_str(
+                        index=self_idx, include_mode=True, indent=4
+                    )
+                    raise ConflictingModifiersError(
+                        "Two modifier definitions conflict by having the same "
+                        "name and mode.\n"
+                        f"Modifier 1:\n"
+                        f"{comp_str}"
+                        f"Modifier 2:\n"
+                        f"{self_str}"
+                    )
+
+            elif conflict_value == MODIFIER_CONFLICT.name_executables:
+                if mod_inst.name == self.name:
+                    compare_set = set(mod_inst._on_executables)
+                    self_set = set(self._on_executables)
+                    intersect = self_set.intersection(compare_set)
+                    if intersect:
+                        comp_str = mod_inst.config_str(
+                            index=mod_idx, include_executables=True, indent=4
+                        )
+                        self_str = self.config_str(
+                            index=self_idx, include_executables=True, indent=4
+                        )
+                        raise ConflictingModifiersError(
+                            "Two modifier definitions conflict by having the same "
+                            "name and overlapping on_executable.\n"
+                            f"Modifier 1:\n"
+                            f"{comp_str}"
+                            f"Modifier 2:\n"
+                            f"{self_str}"
+                        )
+
+            elif conflict_value == MODIFIER_CONFLICT.name_mode_executables:
+                if (
+                    mod_inst.name == self.name
+                    and mod_inst._usage_mode == self._usage_mode
+                ):
+                    compare_set = set(mod_inst._on_executables)
+                    self_set = set(self._on_executables)
+                    intersect = self_set.intersection(compare_set)
+                    if intersect:
+                        comp_str = mod_inst.config_str(
+                            index=mod_idx,
+                            include_mode=True,
+                            include_executables=True,
+                            indent=4,
+                        )
+                        self_str = self.config_str(
+                            index=self_idx,
+                            include_mode=True,
+                            include_executables=True,
+                            indent=4,
+                        )
+                        raise ConflictingModifiersError(
+                            "Two modifier definitions conflict by having the same "
+                            "name, mode, and overlapping on_executable.\n"
+                            f"Modifier 1:\n"
+                            f"{comp_str}"
+                            f"Modifier 2:\n"
+                            f"{self_str}"
+                        )
+
+    def config_str(
+        self,
+        index=None,
+        include_mode=False,
+        include_executables=False,
+        indent=0,
+    ):
+        """Construct a string representation of this modifier's configuration
+
+        Args:
+            index (int): Index of this modifier to include if provided
+            include_mode (bool): Whether to include the mode of the modifier in the configuration or not
+            include_executables (bool): Whether to include the on_executables attribute or not
+            indent (int): Number of spaces to prefix the config with
+
+        Returns:
+            (str) String representation of the modifier's configuration
+        """
+        indentation = " " * indent
+        out_str = f"{indentation}Name: {self.name}\n"
+        if index is not None:
+            out_str += f"{indentation}Index: {index}\n"
+        if include_mode:
+            out_str += f"{indentation}Mode: {self._usage_mode}\n"
+        if include_executables and self._on_executables:
+            out_str += f"{indentation}On Executables\n"
+            for exec in self._on_executables:
+                out_str += f"{indentation}- {exec}\n"
+        return out_str
 
     def define_variable(self, var_name, var_value):
         """Define a variable within this modifier's expander instance"""


### PR DESCRIPTION
This merge adds a new language feature (`modifier_conflict`) which can be used within modifiers to control when a modifier should conflict with other modifier definitions. This aims to provide a better user experience when modifiers conflict with each other.

Tests and documentation are added as well.