### PR TITLE
Allow workload map in workload_variable directive

### DIFF
--- a/lib/ramble/ramble/language/application_language.py
+++ b/lib/ramble/ramble/language/application_language.py
@@ -223,12 +223,13 @@ def input_file(
 @application_directive("workload_group_vars")
 def workload_variable(
     name,
-    default,
-    description,
+    default=None,
+    description="",
     values=None,
     workload=None,
     workloads=None,
     workload_group=None,
+    workload_defaults=None,
     expandable: bool = True,
     track_used: bool = True,
     when=None,
@@ -249,7 +250,10 @@ def workload_variable(
         values (list): Optional list of suggested values for this variable
         workload (str): Single workload this variable is used in
         workloads (list): List of modes this variable is used in
-        workload_group (str): Name of workload group this variable is used in
+        workload_group (str): Name of workload group this variable is used in.
+        workload_defaults (dict): Dictionary mapping workload names to default values.
+                                  Mututally exclusive with workload, workloads, workload_group,
+                                  and default.
         expandable (bool): True if the variable should be expanded, False if not.
         track_used (bool): True if the variable should be tracked as used,
                            False if not. Can help with allowing lists without vectorizing
@@ -267,6 +271,31 @@ def workload_variable(
             when, app, name, "workload_variable"
         )
 
+        # If a workload map is passed, handle that.
+        if workload_defaults:
+            if any([workload, workloads, workload_group, default]):
+                raise DirectiveError(
+                    "workload_defaults cannot be used with workload, workloads, "
+                    "workload_group, or default"
+                )
+
+            for wl_name, wl_default in workload_defaults.items():
+                workload_var = ramble.definitions.variables.Variable(
+                    name,
+                    default=wl_default,
+                    description=description or f"Default for {name} for {wl_name}",
+                    values=values,
+                    expandable=expandable,
+                    when=when_list,
+                    **kwargs,
+                )
+                for when_set, app_workloads in app.workloads.items():
+                    if wl_name in app_workloads:
+                        app.workloads[when_set][wl_name].add_variable(workload_var.copy())
+            return
+
+        # Handle the remainder of the workload_variable directive, if
+        # workload_defaults was not passed
         workload_var = ramble.definitions.variables.Variable(
             name,
             default=default,

--- a/lib/ramble/ramble/test/application_language.py
+++ b/lib/ramble/ramble/test/application_language.py
@@ -12,6 +12,7 @@ import pytest
 
 from ramble import language
 from ramble.appkit import *  # noqa
+from ramble.language.language_base import DirectiveError
 
 app_types = [
     ApplicationBase,  # noqa: F405
@@ -355,3 +356,37 @@ def test_license_name_directive(app_class):
     app_inst.license_name(new_license_name)
 
     assert new_license_name in app_inst.license_names
+
+
+def test_workload_variable_workload_defaults_works():
+    class BrokenWorkloadDefaults(ExecutableApplication):  # noqa: F405
+        name = "broken-workload-defaults"
+
+    broken_app = BrokenWorkloadDefaults("/not/a/path")
+    broken_app.executable("test", "echo '{test_var}'")
+    broken_app.workload("test", executables=["test"])
+    broken_app.workload_variable(
+        "test_var", description="Test var", workload_defaults={"test": "test_value"}
+    )
+
+    workload = broken_app.workloads[frozenset()]["test"]
+    workload_var = workload.find_variable("test_var")
+
+    assert workload_var
+
+
+def test_workload_variable_workload_defaults_error():
+    class BrokenWorkloadDefaults(ExecutableApplication):  # noqa: F405
+        name = "broken-workload-defaults"
+
+    broken_app = BrokenWorkloadDefaults("/not/a/path")
+    broken_app.executable("test", "echo '{test_var}'")
+    broken_app.workload("test", executables=["test"])
+    with pytest.raises(DirectiveError) as err:
+        broken_app.workload_variable(
+            "test_var",
+            description="Test var",
+            workload_defaults={"test": "test_value"},
+            workloads=["test"],
+        )
+        assert "workload_defaults cannot be used with workload, workloads" in err

--- a/var/ramble/repos/builtin/applications/gromacs/application.py
+++ b/var/ramble/repos/builtin/applications/gromacs/application.py
@@ -291,27 +291,23 @@ class Gromacs(ExecutableApplication):
     )
     workload_variable(
         "input_path",
-        default="{water_gmx50_bare}/{size}",
-        description="Input path for water GMX50",
-        workload="water_gmx50",
-    )
-    workload_variable(
-        "input_path",
-        default="{water_bare_hbonds}/{size}",
-        description="Input path for water bare hbonds",
-        workload="water_bare",
-    )
-    workload_variable(
-        "input_path",
-        default="{lignocellulose}/lignocellulose-rf.tpr",
-        description="Input path for lignocellulose",
-        workload="lignocellulose",
-    )
-    workload_variable(
-        "input_path",
-        default="{water_33m}/box_with_33M_waters_default.tpr",
-        description="Input path for water_33m",
-        workload="water_33m",
+        description="Input path for workload",
+        workload_defaults={
+            "water_gmx50": "{water_gmx50_bare}/{size}",
+            "water_bare": "{water_bare_hbonds}/{size}",
+            "lignocellulose": "{lignocellulose}/lignocellulose-rf.tpr",
+            "water_33m": "{water_33m}/box_with_33M_waters_default.tpr",
+            "hecbiosim": "{HECBioSim}/HECBioSim/{type}/benchmark.tpr",
+            "benchpep": "{BenchPEP}/benchPEP.tpr",
+            "benchmem": "{BenchMEM}/benchMEM.tpr",
+            "benchrib": "{BenchRIB}/benchRIB.tpr",
+            "benchpep_h": "{BenchPEP_h}/benchPEP-h.tpr",
+            "stmv_rf": "{JCP_benchmarks}/stmv",
+            "stmv_pme": "{JCP_benchmarks}/stmv",
+            "ion_channel": "{JCP_benchmarks}/{workload_name}",
+            "rnase_cubic": "{JCP_benchmarks}/{workload_name}",
+            "adh_dodec": "{JCP_benchmarks}/{workload_name}",
+        },
     )
     workload_variable(
         "type",
@@ -330,36 +326,6 @@ class Gromacs(ExecutableApplication):
         "hEGFRtetramerPair"
         "",
         workload="hecbiosim",
-    )
-    workload_variable(
-        "input_path",
-        default="{HECBioSim}/HECBioSim/{type}/benchmark.tpr",
-        description="Input path for hecbiosim",
-        workload="hecbiosim",
-    )
-    workload_variable(
-        "input_path",
-        default="{BenchPEP}/benchPEP.tpr",
-        description="Input path for Bench PEP workload",
-        workload="benchpep",
-    )
-    workload_variable(
-        "input_path",
-        default="{BenchMEM}/benchMEM.tpr",
-        description="Input path for Bench MEM workload",
-        workload="benchmem",
-    )
-    workload_variable(
-        "input_path",
-        default="{BenchRIB}/benchRIB.tpr",
-        description="Input path for Bench RIB workload",
-        workload="benchrib",
-    )
-    workload_variable(
-        "input_path",
-        default="{BenchPEP_h}/benchPEP-h.tpr",
-        description="Input path for Bench PEP-h workload",
-        workload="benchpep_h",
     )
     workload_variable(
         "type",

--- a/var/ramble/repos/builtin/applications/namd/application.py
+++ b/var/ramble/repos/builtin/applications/namd/application.py
@@ -131,25 +131,13 @@ class Namd(ExecutableApplication):
         ("decalanin", ["alanin.namd"]),
         ("tcl-forces", ["tclforces.namd"]),
     ]
+    all_benchmark_workloads = [wl[0] for wl in benchmark_workloads]
+
     for wl_def in benchmark_workloads:
         workload(
             wl_def[0],
             executables=["copy_inputs", "execute"],
             inputs=[wl_def[0]],
-        )
-
-        workload_variable(
-            "namd_flags",
-            default="+ppn {processes_per_node} +setcpuaffinity",
-            description="Flags for running NAMD",
-            workloads=[wl_def[0]],
-        )
-
-        workload_variable(
-            "input_path",
-            default=Expander.expansion_str(wl_def[0]),
-            description=f"Path to the {wl_def[0]} inputs",
-            workloads=[wl_def[0]],
         )
 
         workload_variable(
@@ -159,6 +147,31 @@ class Namd(ExecutableApplication):
             description="Input file for namd",
             workloads=[wl_def[0]],
         )
+
+    workload_group("all_benchmarks", workloads=all_benchmark_workloads)
+
+    workload_variable(
+        "namd_flags",
+        default="+ppn {processes_per_node} +setcpuaffinity",
+        description="Flags for running NAMD",
+        workload_group="all_benchmarks",
+    )
+
+    workload_variable(
+        "input_path",
+        description="Path to the workload inputs",
+        workload_defaults={
+            "stmv": "{stmv}",
+            "ApoA1": "{ApoA1}",
+            "ATPase": "{ATPase}",
+            "20STMV": "{20STMV}",
+            "tiny": "{tiny}",
+            "interactive_BPTI": "{interactive_BPTI}",
+            "ER-GRE": "{ER-GRE}",
+            "decalanin": "{decalanin}",
+            "tcl-forces": "{tcl-forces}",
+        },
+    )
 
     log_file_str = Expander.expansion_str(keywords.log_file)
 

--- a/var/ramble/repos/builtin/applications/quantum-espresso/application.py
+++ b/var/ramble/repos/builtin/applications/quantum-espresso/application.py
@@ -129,34 +129,9 @@ class QuantumEspresso(ExecutableApplication):
     executable("execute", "pw.x {flags} < {input_file}", use_mpi=True)
 
     workload_names = ["AUSURF112", "CNT10POR8", "GRIR443", "GRIR686", "PSIWAT"]
-    input_files = [
-        "ausurf.in",
-        "pw.in",
-        "grir443.in",
-        "grir686.in",
-        "psiwat.in",
-    ]
-    for wl_name, input_file in zip(workload_names, input_files):
+    for wl_name in workload_names:
         workload(
             wl_name, executables=["copy_inputs", "execute"], inputs=[wl_name]
-        )
-        workload_variable(
-            "input_path",
-            default=Expander.expansion_str(wl_name),
-            description="Path to inputs for " + wl_name + " workload",
-            workloads=[wl_name],
-        )
-        workload_variable(
-            "input_file",
-            default=input_file,
-            description="Name of input file for " + wl_name + " workload",
-            workloads=[wl_name],
-        )
-        workload_variable(
-            "flags",
-            default="",
-            description="Flags for Quantum Espresso",
-            workloads=[wl_name],
         )
 
     workload(
@@ -164,12 +139,41 @@ class QuantumEspresso(ExecutableApplication):
         executables=["copy_potential1", "copy_potential2", "execute"],
         inputs=["WATER_EXX", "WATER_EXX_H", "WATER_EXX_O"],
     )
+
+    workload_group("all_benchmarks", workloads=workload_names + ["WATER_EXX"])
+
+    workload_variable(
+        "flags",
+        default="",
+        description="Flags for Quantum Espresso",
+        workload_group="all_benchmarks",
+    )
+
+    workload_variable(
+        "input_path",
+        description="Path to inputs for workload",
+        workload_defaults={
+            "AUSURF112": "{AUSURF112}",
+            "CNT10POR8": "{CNT10POR8}",
+            "GRIR443": "{GRIR443}",
+            "GRIR686": "{GRIR686}",
+            "PSIWAT": "{PSIWAT}",
+        },
+    )
+
     workload_variable(
         "input_file",
-        default=Expander.expansion_str("WATER_EXX"),
-        description="Path to WATER_EXX input",
-        workloads=["WATER_EXX"],
+        description="Name of input file for workload",
+        workload_defaults={
+            "AUSURF112": "ausurf.in",
+            "CNT10POR8": "pw.in",
+            "GRIR443": "grir443.in",
+            "GRIR686": "grir686.in",
+            "PSIWAT": "psiwat.in",
+            "WATER_EXX": "{WATER_EXX}",
+        },
     )
+
     workload_variable(
         "potential1",
         default=Expander.expansion_str("WATER_EXX_H"),
@@ -180,13 +184,6 @@ class QuantumEspresso(ExecutableApplication):
         "potential2",
         default=Expander.expansion_str("WATER_EXX_O"),
         description="Path to WATER_EXX O potential file",
-        workloads=["WATER_EXX"],
-    )
-
-    workload_variable(
-        "flags",
-        default="",
-        description="Flags for Quantum Espresso",
         workloads=["WATER_EXX"],
     )
 

--- a/var/ramble/repos/builtin/applications/wrfv3/application.py
+++ b/var/ramble/repos/builtin/applications/wrfv3/application.py
@@ -79,16 +79,11 @@ class Wrfv3(ExecutableApplication):
 
     workload_variable(
         "input_path",
-        default="{CONUS_12km}",
-        description="Path for CONUS 12km inputs.",
-        workloads=["CONUS_12km"],
-    )
-
-    workload_variable(
-        "input_path",
-        default="{CONUS_2p5km}",
-        description="Path for CONUS 2.5km inputs.",
-        workloads=["CONUS_2p5km"],
+        description="Path for workload inputs.",
+        workload_defaults={
+            "CONUS_12km": "{CONUS_12km}",
+            "CONUS_2p5km": "{CONUS_2p5km}",
+        },
     )
 
     log_str = os.path.join(

--- a/var/ramble/repos/builtin/applications/wrfv4/application.py
+++ b/var/ramble/repos/builtin/applications/wrfv4/application.py
@@ -232,23 +232,12 @@ class Wrfv4(ExecutableApplication):
 
     workload_variable(
         "input_path",
-        default="{CONUS_12km}",
-        description="Path for CONUS 12km inputs.",
-        workloads=["CONUS_12km"],
-    )
-
-    workload_variable(
-        "input_path",
-        default="{CONUS_2p5km}",
-        description="Path for CONUS 2.5km inputs.",
-        workloads=["CONUS_2p5km"],
-    )
-
-    workload_variable(
-        "input_path",
-        default="{{workload_name}}",
         description="Path for workload inputs.",
-        workloads=["Maria_1km"],
+        workload_defaults={
+            "CONUS_12km": "{CONUS_12km}",
+            "CONUS_2p5km": "{CONUS_2p5km}",
+            "Maria_1km": "{Maria_1km}",
+        },
     )
 
     log_str = os.path.join(


### PR DESCRIPTION
This merge adds the ability for a workload_defaults map to be passed in to the workload_variable directive. This allows the workload_variable directive to be repeated less when many workloads have the same variable definition.