### PR TITLE
Add generalized copy / link directive

### DIFF
--- a/etc/ramble/defaults/config.yaml
+++ b/etc/ramble/defaults/config.yaml
@@ -25,6 +25,7 @@ config:
   report_dirs: ~/.ramble/reports
   include_phase_dependencies: false
   resolve_variables_in_subprocesses: false
+  stage_method: cp
   spack:
     install:
       flags: --reuse

--- a/lib/ramble/ramble/language/application_language.py
+++ b/lib/ramble/ramble/language/application_language.py
@@ -443,7 +443,10 @@ def stage_files(
         if when_set not in app.executables:
             app.executables[when_set] = {}
 
-        if exec_name in app.executables[when_set]:
+        if (
+            exec_name in app.executables[when_set]
+            and not app.executables[when_set][exec_name].allow_extension
+        ):
             raise DirectiveError(
                 f"stage_files directive on application {app.name} is creating "
                 f"has name attribute of '{exec_name}' which already exists "
@@ -460,15 +463,18 @@ def stage_files(
         else:  # stage_method == "cp"
             stage_cmd = f"cp -r {src} {dst}"
 
+        template = [stage_cmd]
+
         # Prepend mkdir if dst has a parent directory
         parent_dir = os.path.dirname(dst)
         if parent_dir and parent_dir != ".":
-            template = f"mkdir -p {parent_dir} && {stage_cmd}"
-        else:
-            template = stage_cmd
+            template.insert(0, f"mkdir -p {parent_dir}")
 
-        app.executables[when_set][exec_name] = CommandExecutable(
-            name=exec_name, template=template, **kwargs
-        )
+        if exec_name in app.executables[when_set]:
+            app.executables[when_set][exec_name].add_template(template)
+        else:
+            app.executables[when_set][exec_name] = CommandExecutable(
+                name=exec_name, template=template, allow_extension=True, **kwargs
+            )
 
     return _execute_stage_files

--- a/lib/ramble/ramble/language/application_language.py
+++ b/lib/ramble/ramble/language/application_language.py
@@ -399,3 +399,76 @@ def cleanup(
         }
 
     return _define_cleanup
+
+
+@application_directive("executables")
+def stage_files(
+    src,
+    dst,
+    name=None,
+    when=None,
+    **kwargs,
+):
+    """Adds an executable that stages an input file or directory.
+
+    Defines a new executable that copies or links a file or directory
+    from a source to a destination. This is useful for staging input
+    files that are not managed by the `input_file` directive.
+
+    The staging method is controlled by the `stage_method` configuration
+    option, which can be set to 'cp', 'rsync', 'symbolic_link', or 'hard_link'.
+
+    Args:
+        src (str): The source path of the file or directory.
+        dst (str): The destination path.
+        name (str, optional): The name of the executable. Defaults to 'stage-files'.
+        when (list | None): List of when conditions to apply to this directive.
+    """
+
+    def _execute_stage_files(app):
+        import os
+
+        import ramble.config
+        from ramble.util.executable import CommandExecutable
+
+        cfg = ramble.config.config
+        stage_method = cfg.get("config", {}).get("stage_method", "cp")
+
+        exec_name = name if name else "stage-files"
+
+        when_list = ramble.language.language_helpers.build_when_list(
+            when, app, exec_name, "stage_files"
+        )
+        when_set = frozenset(when_list)
+        if when_set not in app.executables:
+            app.executables[when_set] = {}
+
+        if exec_name in app.executables[when_set]:
+            raise DirectiveError(
+                f"stage_files directive on application {app.name} is creating "
+                f"has name attribute of '{exec_name}' which already exists "
+                "as an executable. Please provide a unique name attribute."
+            )
+
+        # Prepare the core staging command
+        if stage_method == "rsync":
+            stage_cmd = f"rsync -r {src} {dst}"
+        elif stage_method == "hard_link":
+            stage_cmd = f"ln {src} {dst}"
+        elif stage_method == "symbolic_link":
+            stage_cmd = f"ln -s {src} {dst}"
+        else:  # stage_method == "cp"
+            stage_cmd = f"cp -r {src} {dst}"
+
+        # Prepend mkdir if dst has a parent directory
+        parent_dir = os.path.dirname(dst)
+        if parent_dir and parent_dir != ".":
+            template = f"mkdir -p {parent_dir} && {stage_cmd}"
+        else:
+            template = stage_cmd
+
+        app.executables[when_set][exec_name] = CommandExecutable(
+            name=exec_name, template=template, **kwargs
+        )
+
+    return _execute_stage_files

--- a/lib/ramble/ramble/schema/config.py
+++ b/lib/ramble/ramble/schema/config.py
@@ -184,6 +184,12 @@ properties["config"]["repeat_success_strict"] = {"type": "boolean", "default": T
 
 properties["config"]["enable_workspace_prompt"] = {"type": "boolean", "default": False}
 
+properties["config"]["stage_method"] = {
+    "type": "string",
+    "enum": ["cp", "rsync", "symbolic_link", "hard_link"],
+    "default": "cp",
+}
+
 
 #: Full schema with metadata
 schema = {

--- a/lib/ramble/ramble/test/application_language.py
+++ b/lib/ramble/ramble/test/application_language.py
@@ -392,3 +392,33 @@ def test_workload_variable_workload_defaults_error():
             workloads=["test"],
         )
         assert "workload_defaults cannot be used with workload, workloads" in err
+
+
+@pytest.mark.parametrize(
+    "stage_method,template_contents",
+    [
+        ("cp", "cp -r src"),
+        ("rsync", "rsync -r src"),
+        ("symbolic_link", "ln -s src"),
+        ("hard_link", "ln src"),
+    ],
+)
+def test_stage_files_directive(stage_method, template_contents):
+    import ramble.config
+
+    with ramble.config.override("config:stage_method", stage_method):
+
+        class TestApp(ExecutableApplication):  # noqa: F405
+            name = "test-app"
+
+        app_inst = TestApp("/not/a/path")
+        app_inst.stage_files(src="src", dst="dst")
+
+        assert "stage-files" in app_inst.executables[frozenset()]
+        exec = app_inst.executables[frozenset()]["stage-files"]
+
+        found = False
+        for line in exec.template:
+            if template_contents in line:
+                found = True
+        assert found

--- a/lib/ramble/ramble/test/data/config/config.yaml
+++ b/lib/ramble/ramble/test/data/config/config.yaml
@@ -9,3 +9,4 @@ config:
         link_type: symlink
     include:
       - test_include: include.yaml
+    stage_method: 'cp'

--- a/lib/ramble/ramble/util/executable.py
+++ b/lib/ramble/ramble/util/executable.py
@@ -73,6 +73,7 @@ class CommandExecutable:
         redirect="{log_file}",
         output_capture=OUTPUT_CAPTURE.DEFAULT,
         run_in_background=False,
+        allow_extension=False,
         **kwargs,
     ):
         """Create a CommandExecutable instance
@@ -107,6 +108,7 @@ class CommandExecutable:
         self.output_capture = output_capture
         self.run_in_background = run_in_background
         self.variables = variables.copy()
+        self.allow_extension = allow_extension
 
     def copy(self):
         """Replicate a CommandExecutable instance"""
@@ -135,6 +137,12 @@ class CommandExecutable:
             self_str += f"    {color_attr}: {getattr(self, attr)}\n"
 
         return self_str
+
+    def add_template(self, commands):
+        if isinstance(commands, list):
+            self.template.extend(commands)
+        else:
+            self.template.append(commands)
 
 
 class CommandExecutableError(ramble.error.RambleError):

--- a/var/ramble/repos/builtin/applications/babelstream/application.py
+++ b/var/ramble/repos/builtin/applications/babelstream/application.py
@@ -31,22 +31,16 @@ class Babelstream(ExecutableApplication):
             pkg_spec="babelstream@5.0 +omp",
             compiler="gcc12",
         )
-    executable(
-        "get_bin",
-        template=[
-            "cp {env_path}/.spack-env/view/bin/{exec_name} {experiment_run_dir}/{exec_name}"
-        ],
-        use_mpi=False,
-        output_capture=OUTPUT_CAPTURE.STDERR,
+    stage_files(
+        name="stage-bin",
+        src="{env_path}/.spack-env/view/bin/{exec_name}",
+        dst="{experiment_run_dir}/{exec_name}",
     )
 
-    executable(
-        "get_bin_fortran",
-        template=[
-            "export F_COMPILER_NAME={compiler_list}; cp {env_path}/.spack-env/view/bin/BabelStream.${F_COMPILER_NAME//[0-9]/}.{f_model} {experiment_run_dir}/{exec_name}"
-        ],
-        use_mpi=False,
-        output_capture=OUTPUT_CAPTURE.STDERR,
+    stage_files(
+        name="stage-bin-fortran",
+        src="{env_path}/.spack-env/view/bin/BabelStream.${F_COMPILER_NAME//[0-9]/}.{f_model}",
+        dst="{experiment_run_dir}/{exec_name}",
     )
 
     executable(
@@ -63,10 +57,10 @@ class Babelstream(ExecutableApplication):
         output_capture=OUTPUT_CAPTURE.ALL,
     )
 
-    workload("cpp-models", executables=["get_bin", "execute_template"])
+    workload("cpp-models", executables=["stage-bin", "execute_template"])
 
     workload(
-        "fortran-models", executables=["get_bin_fortran", "execute_fortran"]
+        "fortran-models", executables=["stage-bin-fortran", "execute_fortran"]
     )
 
     workload_group("all_workloads", workloads=["cpp-models", "fortran-models"])

--- a/var/ramble/repos/builtin/applications/cloverleaf/application.py
+++ b/var/ramble/repos/builtin/applications/cloverleaf/application.py
@@ -40,45 +40,42 @@ class Cloverleaf(ExecutableApplication):
 
     executable("execute", "clover_leaf", use_mpi=True)
 
-    executable(
-        "get_input",
-        template=[
-            "cp {cloverleaf_path}/doc/tests/clover_{workload_name}.in {experiment_run_dir}/clover.in"
-        ],
-        use_mpi=False,
+    stage_files(
+        name="stage-input",
+        src="{cloverleaf_path}/doc/tests/clover_{workload_name}.in",
+        dst="{experiment_run_dir}/clover.in",
     )
 
-    executable(
-        "get_default_input",
-        template=[
-            "cp {cloverleaf_path}/doc/tests/clover.in {experiment_run_dir}/clover.in"
-        ],
-        use_mpi=False,
+    stage_files(
+        name="stage-default-input",
+        src="{cloverleaf_path}/doc/tests/clover.in",
+        dst="{experiment_run_dir}/clover.in",
     )
 
-    workload("bm_short_c", executables=["get_input", "execute"])
-    workload("bm_short", executables=["get_input", "execute"])
-    workload("qa", executables=["get_input", "execute"])
-    workload("sodbig", executables=["get_input", "execute"])
-    workload("sodx", executables=["get_input", "execute"])
-    workload("sodxy", executables=["get_input", "execute"])
-    workload("sody", executables=["get_input", "execute"])
-    workload("clover", executables=["get_default_input", "execute"])
+    workload("bm_short_c", executables=["stage-input", "execute"])
+    workload("bm_short", executables=["stage-input", "execute"])
+    workload("qa", executables=["stage-input", "execute"])
+    workload("sodbig", executables=["stage-input", "execute"])
+    workload("sodx", executables=["stage-input", "execute"])
+    workload("sodxy", executables=["stage-input", "execute"])
+    workload("sody", executables=["stage-input", "execute"])
+    workload("clover", executables=["stage-default-input", "execute"])
 
     # 2 through 8K
     for k in range(1, 14):
-        workload("bm" + str(2**k), executables=["get_input", "execute"])
+        workload("bm" + str(2**k), executables=["stage-input", "execute"])
 
     # 2 through 8K
     for k in range(1, 14):
         workload(
-            "bm" + str(2**k) + "_short", executables=["get_input", "execute"]
+            "bm" + str(2**k) + "_short", executables=["stage-input", "execute"]
         )
 
     # 1 through 16K
     for k in range(15):
         workload(
-            "bm" + str(2**k) + "s_short", executables=["get_input", "execute"]
+            "bm" + str(2**k) + "s_short",
+            executables=["stage-input", "execute"],
         )
 
     log_str = os.path.join(

--- a/var/ramble/repos/builtin/applications/elk/application.py
+++ b/var/ramble/repos/builtin/applications/elk/application.py
@@ -39,8 +39,10 @@ class Elk(ExecutableApplication):
     )
 
     executable("execute", "{install_prefix}/elk_openmpi", use_mpi=True)
-    executable(
-        "copy", "cp {input_path}/elk.in {experiment_run_dir}/.", use_mpi=False
+    stage_files(
+        name="stage-input",
+        src="{input_path}/elk.in",
+        dst="{experiment_run_dir}/.",
     )
     executable(
         "update_input",
@@ -49,7 +51,9 @@ class Elk(ExecutableApplication):
     )
 
     workload(
-        "Cu", executables=["copy", "update_input", "execute"], input="examples"
+        "Cu",
+        executables=["stage-input", "update_input", "execute"],
+        input="examples",
     )
 
     workload_variable(

--- a/var/ramble/repos/builtin/applications/hpcc/application.py
+++ b/var/ramble/repos/builtin/applications/hpcc/application.py
@@ -50,16 +50,16 @@ class Hpcc(ExecutableApplication):
         description="Input/Config file for HPCC benchmark",
     )
 
-    executable(
-        "copy-config",
-        template="cp -R {workload_input_dir}/* {experiment_run_dir}/.",
-        use_mpi=False,
+    stage_files(
+        name="stage-config",
+        src="{workload_input_dir}/*",
+        dst="{experiment_run_dir}/.",
     )
 
     executable("execute", "hpcc", use_mpi=True)
 
     workload(
-        "standard", executables=["copy-config", "execute"], input="hpccinf"
+        "standard", executables=["stage-config", "execute"], input="hpccinf"
     )
 
     workload_variable(

--- a/var/ramble/repos/builtin/applications/intel-hpl/application.py
+++ b/var/ramble/repos/builtin/applications/intel-hpl/application.py
@@ -40,6 +40,12 @@ class IntelHpl(HplBase):
     # - Link in the xhpl_intel64_dynamic binary to the running dir
     #   (This is needed due to runme_intel64_prv invoking it using "./")
     # - Account for newer directory layout from mkl 2024
+    stage_files(
+        name="stage-binary",
+        src="${hpl_bench_dir}/xhpl_intel64_dynamic",
+        dst="{experiment_run_dir}/.",
+        method="link",
+    )
     executable(
         "prepare",
         template=[
@@ -48,7 +54,6 @@ hpl_bench_dir="{intel-oneapi-mkl_path}/mkl/latest/benchmarks/mp_linpack"
 if [ ! -d ${hpl_bench_dir} ]; then
     hpl_bench_dir="{intel-oneapi-mkl_path}/mkl/latest/share/mkl/benchmarks/mp_linpack"
 fi
-ln -sf ${hpl_bench_dir}/xhpl_intel64_dynamic {experiment_run_dir}/.
 hpl_run="${hpl_bench_dir}/runme_intel64_prv"
     """.strip()
         ],
@@ -63,8 +68,8 @@ hpl_run="${hpl_bench_dir}/runme_intel64_prv"
         use_mpi=True,
     )
 
-    workload("standard", executables=["prepare", "execute"])
-    workload("calculator", executables=["prepare", "execute"])
+    workload("standard", executables=["prepare", "stage-binary", "execute"])
+    workload("calculator", executables=["prepare", "stage-binary", "execute"])
 
     workload_group("standard", workloads=["standard"], mode="append")
     workload_group("calculator", workloads=["calculator"], mode="append")

--- a/var/ramble/repos/builtin/applications/intel-hpl/application.py
+++ b/var/ramble/repos/builtin/applications/intel-hpl/application.py
@@ -37,14 +37,13 @@ class IntelHpl(HplBase):
     # - Prepare calling for the script runme_intel64_prv
     #   (We call this runner script instead of the underlying xhpl_intel64_dynamic
     #    since it sets up derived env var HPL_HOST_NODE for numa placement control.)
-    # - Link in the xhpl_intel64_dynamic binary to the running dir
+    # - Copy in the xhpl_intel64_dynamic binary to the running dir
     #   (This is needed due to runme_intel64_prv invoking it using "./")
     # - Account for newer directory layout from mkl 2024
     stage_files(
         name="stage-binary",
         src="${hpl_bench_dir}/xhpl_intel64_dynamic",
         dst="{experiment_run_dir}/.",
-        method="link",
     )
     executable(
         "prepare",

--- a/var/ramble/repos/builtin/applications/lammps/application.py
+++ b/var/ramble/repos/builtin/applications/lammps/application.py
@@ -129,10 +129,10 @@ class Lammps(ExecutableApplication):
         target_dir="{application_input_dir}/lammps-input-stage",
         description="Stage of lammps source from release",
     )
-    executable(
-        "copy",
-        template=["cp {input_path} {experiment_run_dir}/input.txt"],
-        use_mpi=False,
+    stage_files(
+        name="stage-input",
+        src="{input_path}",
+        dst="{experiment_run_dir}/input.txt",
     )
     executable(
         "configure-reaxff",
@@ -198,36 +198,32 @@ class Lammps(ExecutableApplication):
         use_mpi=False,
     )
 
-    executable(
-        "copy-cube",
-        template=[
-            "cp "
-            + os.path.join("{intel_test_path}", "mW*.data")
-            + " {experiment_run_dir}"
-            + os.path.sep
-            + "."
-            "cp "
-            + os.path.join("{intel_test_path}", "mW.sw")
-            + " {experiment_run_dir}"
-            + os.path.sep
-            + "."
-        ],
-        use_mpi=False,
+    stage_files(
+        name="stage-cube",
+        src=os.path.join("{intel_test_path}", "mW*.data"),
+        dst="{experiment_run_dir}/.",
+    )
+    stage_files(
+        name="stage-cube-sw",
+        src=os.path.join("{intel_test_path}", "mW.sw"),
+        dst="{experiment_run_dir}/.",
     )
 
-    executable(
-        "copy-contents",
-        template=[
-            "cp {input_path}/* {experiment_run_dir}/.",
-            "cp {input_file} input.txt",
-        ],
-        use_mpi=False,
+    stage_files(
+        name="stage-contents",
+        src="{input_path}/*",
+        dst="{experiment_run_dir}/.",
+    )
+    stage_files(
+        name="stage-input-file",
+        src="{input_file}",
+        dst="input.txt",
     )
 
     workload(
         "lj",
         executables=[
-            "copy",
+            "stage-input",
             "configure-size-scale",
             "configure-run-timesteps",
             "execute",
@@ -261,7 +257,7 @@ class Lammps(ExecutableApplication):
     workload(
         "eam",
         executables=[
-            "copy",
+            "stage-input",
             "configure-size-scale",
             "configure-run-timesteps",
             "execute",
@@ -295,7 +291,7 @@ class Lammps(ExecutableApplication):
     workload(
         "chain",
         executables=[
-            "copy",
+            "stage-input",
             "set-data-path",
             "configure-run-timesteps",
             "execute",
@@ -313,7 +309,7 @@ class Lammps(ExecutableApplication):
 
     workload(
         "chute",
-        executables=["copy", "configure-run-timesteps", "execute"],
+        executables=["stage-input", "configure-run-timesteps", "execute"],
         input="chute",
     )
     with default_args(workloads=["chute"]):
@@ -327,7 +323,7 @@ class Lammps(ExecutableApplication):
 
     workload(
         "rhodo",
-        executables=["copy", "set-data-path", "execute"],
+        executables=["stage-input", "set-data-path", "execute"],
         inputs=["rhodo", "lammps-stage"],
     )
     with default_args(workloads=["rhodo"]):
@@ -342,7 +338,7 @@ class Lammps(ExecutableApplication):
     workload(
         "intel.airebo",
         executables=[
-            "copy",
+            "stage-input",
             "change-root",
             "configure-size-scale",
             "configure-timestep-variables",
@@ -387,7 +383,7 @@ class Lammps(ExecutableApplication):
     workload(
         "intel.dpd",
         executables=[
-            "copy",
+            "stage-input",
             "change-root",
             "configure-size-scale",
             "configure-timestep-variables",
@@ -432,7 +428,7 @@ class Lammps(ExecutableApplication):
     workload(
         "intel.eam",
         executables=[
-            "copy",
+            "stage-input",
             "change-root",
             "configure-size-scale",
             "configure-timestep-variables",
@@ -477,7 +473,7 @@ class Lammps(ExecutableApplication):
     workload(
         "intel.lc",
         executables=[
-            "copy",
+            "stage-input",
             "change-root",
             "configure-timestep-variables",
             "execute",
@@ -506,7 +502,7 @@ class Lammps(ExecutableApplication):
     workload(
         "intel.lj",
         executables=[
-            "copy",
+            "stage-input",
             "change-root",
             "configure-size-scale",
             "configure-timestep-variables",
@@ -551,7 +547,7 @@ class Lammps(ExecutableApplication):
     workload(
         "intel.rhodo",
         executables=[
-            "copy",
+            "stage-input",
             "change-root",
             "configure-timestep-variables",
             "execute",
@@ -580,7 +576,7 @@ class Lammps(ExecutableApplication):
     workload(
         "intel.sw",
         executables=[
-            "copy",
+            "stage-input",
             "change-root",
             "configure-size-scale",
             "configure-timestep-variables",
@@ -625,7 +621,7 @@ class Lammps(ExecutableApplication):
     workload(
         "intel.tersoff",
         executables=[
-            "copy",
+            "stage-input",
             "change-root",
             "configure-size-scale",
             "configure-timestep-variables",
@@ -670,7 +666,7 @@ class Lammps(ExecutableApplication):
     workload(
         "intel.water",
         executables=[
-            "copy",
+            "stage-input",
             "change-root",
             "configure-timestep-variables",
             "execute",
@@ -698,7 +694,12 @@ class Lammps(ExecutableApplication):
 
     workload(
         "hns-reaxff",
-        executables=["copy-contents", "configure-reaxff", "execute"],
+        executables=[
+            "stage-contents",
+            "stage-input-file",
+            "configure-reaxff",
+            "execute",
+        ],
         inputs=["lammps-stage"],
     )
     with default_args(workloads=["hns-reaxff"]):

--- a/var/ramble/repos/builtin/applications/minixyce/application.py
+++ b/var/ramble/repos/builtin/applications/minixyce/application.py
@@ -44,12 +44,10 @@ class Minixyce(ExecutableApplication):
         use_mpi=True,
     )
 
-    executable(
-        "get_simple_network",
-        template=[
-            "cp {minixyce_path}/doc/tests/{workload_name}.net {experiment_run_dir}/{workload_name}.net"
-        ],
-        use_mpi=False,
+    stage_files(
+        name="stage-network-file",
+        src="{minixyce_path}/doc/tests/{workload_name}.net",
+        dst="{experiment_run_dir}/{workload_name}.net",
     )
 
     executable(
@@ -86,7 +84,7 @@ class Minixyce(ExecutableApplication):
 
     cir_workloads = ["cir1", "cir2", "cir3", "cir4", "cir5"]
     for cir_workload in cir_workloads:
-        workload(cir_workload, executables=["get_simple_network", "execute"])
+        workload(cir_workload, executables=["stage-network-file", "execute"])
 
     rc_workloads = ["RC_ladder", "RLC_ladder", "RC_ladder2", "RLC_ladder2"]
     for workload_name in rc_workloads:

--- a/var/ramble/repos/builtin/applications/namd/application.py
+++ b/var/ramble/repos/builtin/applications/namd/application.py
@@ -108,10 +108,10 @@ class Namd(ExecutableApplication):
         description="Tcl forces (decalanin)",
     )
 
-    executable(
-        "copy_inputs",
-        "cp {input_path}/* {experiment_run_dir}/.",
-        use_mpi=False,
+    stage_files(
+        name="stage-input",
+        src="{input_path}/*",
+        dst="{experiment_run_dir}/.",
     )
     executable("execute", "namd2 {namd_flags} {input_file}", use_mpi=True)
 
@@ -136,7 +136,7 @@ class Namd(ExecutableApplication):
     for wl_def in benchmark_workloads:
         workload(
             wl_def[0],
-            executables=["copy_inputs", "execute"],
+            executables=["stage-input", "execute"],
             inputs=[wl_def[0]],
         )
 

--- a/var/ramble/repos/builtin/applications/orca/application.py
+++ b/var/ramble/repos/builtin/applications/orca/application.py
@@ -39,10 +39,10 @@ class Orca(ExecutableApplication):
         pre=True,
     )
 
-    executable(
-        "copy_input",
-        f"cp -R {os.path.join('{input_path}', '*')} {{scratch_dir}}",
-        use_mpi=False,
+    stage_files(
+        name="stage-input",
+        src=os.path.join("{input_path}", "*"),
+        dst="{scratch_dir}",
     )
 
     # The only way to configure total ranks launched is by changing the PAL nprocs keyword
@@ -65,7 +65,7 @@ class Orca(ExecutableApplication):
     workload(
         "standard",
         executables=[
-            "copy_input",
+            "stage-input",
             "configure_nprocs",
             "run_orca",
         ],

--- a/var/ramble/repos/builtin/applications/quantum-espresso/application.py
+++ b/var/ramble/repos/builtin/applications/quantum-espresso/application.py
@@ -101,29 +101,20 @@ class QuantumEspresso(ExecutableApplication):
         description="O Pseudopotential for WATER_EXX benchmark",
     )
 
-    executable(
-        "copy_inputs",
-        "cp "
-        + os.path.join(Expander.expansion_str("input_path"), "*")
-        + " "
-        + os.path.join(Expander.expansion_str("experiment_run_dir"), "."),
-        use_mpi=False,
+    stage_files(
+        name="copy_inputs",
+        src=os.path.join(Expander.expansion_str("input_path"), "*"),
+        dst=os.path.join(Expander.expansion_str("experiment_run_dir"), "."),
     )
-    executable(
-        "copy_potential1",
-        template=[
-            "mkdir -p {experiment_run_dir}/pseudo",
-            "cp {potential1} {experiment_run_dir}/pseudo/.",
-        ],
-        use_mpi=False,
+    stage_files(
+        name="copy_potential1",
+        src="{potential1}",
+        dst="{experiment_run_dir}/pseudo/.",
     )
-    executable(
-        "copy_potential2",
-        template=[
-            "mkdir -p {experiment_run_dir}/pseudo",
-            "cp {potential2} {experiment_run_dir}/pseudo/.",
-        ],
-        use_mpi=False,
+    stage_files(
+        name="copy_potential2",
+        src="{potential2}",
+        dst="{experiment_run_dir}/pseudo/.",
     )
 
     executable("execute", "pw.x {flags} < {input_file}", use_mpi=True)

--- a/var/ramble/repos/builtin/applications/roms/application.py
+++ b/var/ramble/repos/builtin/applications/roms/application.py
@@ -44,22 +44,21 @@ class Roms(ExecutableApplication):
 
     executable("execute", "romsM {input_deck}", use_mpi=True)
 
-    executable(
-        "copy_input", "cp {input_path} {experiment_run_dir}/.", use_mpi=False
+    stage_files(
+        name="stage-input",
+        src="{input_path}",
+        dst="{experiment_run_dir}/.",
     )
 
-    executable(
-        "copy_varinfo",
-        template=[
-            "mkdir -p {experiment_run_dir}/ROMS/External/",
-            "cp {varinfo} {experiment_run_dir}/ROMS/External/",
-        ],
-        use_mpi=False,
+    stage_files(
+        name="stage-varinfo",
+        src="{varinfo}",
+        dst="{experiment_run_dir}/ROMS/External/",
     )
 
     workload(
         "benchmark_1",
-        executables=["copy_input", "copy_varinfo", "execute"],
+        executables=["stage-input", "stage-varinfo", "execute"],
         inputs=["bm1", "varinfo"],
     )
 

--- a/var/ramble/repos/builtin/applications/su2/application.py
+++ b/var/ramble/repos/builtin/applications/su2/application.py
@@ -47,7 +47,7 @@ class Su2(ExecutableApplication):
         expand=False,
     )
 
-    executable("link-inputs", template=["ln -s {input_path}/* ."])
+    stage_files(src="{input_path}/*", dst=".")
 
     executable(
         "execute",
@@ -57,7 +57,7 @@ class Su2(ExecutableApplication):
 
     workload(
         "inv_channel",
-        executables=["link-inputs", "execute"],
+        executables=["stage-files", "execute"],
         inputs=["inv_channel_in", "inv_mesh_in"],
     )
 

--- a/var/ramble/repos/builtin/applications/ufs-weather-model/application.py
+++ b/var/ramble/repos/builtin/applications/ufs-weather-model/application.py
@@ -58,15 +58,15 @@ class UfsWeatherModel(ExecutableApplication):
 
     executable("execute", "ufs_weather_model", use_mpi=True)
 
-    executable(
-        "copy_input",
-        template=["cp -pR {input_path}/* {experiment_run_dir}"],
-        use_mpi=False,
+    stage_files(
+        name="stage-input",
+        src="{input_path}/*",
+        dst="{experiment_run_dir}",
     )
 
     workload(
         "simple_test_case",
-        executables=["copy_input", "execute"],
+        executables=["stage-input", "execute"],
         input="simple_test_case",
     )
 
@@ -237,7 +237,7 @@ class UfsWeatherModel(ExecutableApplication):
 
     workload(
         "control_c48_intel",
-        executables=["copy_input", "execute"],
+        executables=["stage-input", "execute"],
         inputs=restart_file_names,
     )
 

--- a/var/ramble/repos/builtin/applications/wrfv3/application.py
+++ b/var/ramble/repos/builtin/applications/wrfv3/application.py
@@ -54,26 +54,28 @@ class Wrfv3(ExecutableApplication):
         use_mpi=False,
         output_capture=OUTPUT_CAPTURE.ALL,
     )
-    executable(
-        "copy",
-        template=[
-            "cp -R {input_path}/* {experiment_run_dir}/.",
-            "ln -s {wrf_path}/run/* {experiment_run_dir}/.",
-        ],
-        use_mpi=False,
-        output_capture=OUTPUT_CAPTURE.ALL,
+    stage_files(
+        name="stage-input",
+        src="{input_path}/*",
+        dst="{experiment_run_dir}/.",
+    )
+    stage_files(
+        name="link-run-files",
+        src="{wrf_path}/run/*",
+        dst="{experiment_run_dir}/.",
+        method="link",
     )
     executable("execute", "wrf.exe", use_mpi=True)
 
     workload(
         "CONUS_2p5km",
-        executables=["cleanup", "copy", "execute"],
+        executables=["cleanup", "stage-input", "link-run-files", "execute"],
         input="CONUS_2p5km",
     )
 
     workload(
         "CONUS_12km",
-        executables=["cleanup", "copy", "execute"],
+        executables=["cleanup", "stage-input", "link-run-files", "execute"],
         input="CONUS_12km",
     )
 

--- a/var/ramble/repos/builtin/applications/wrfv3/application.py
+++ b/var/ramble/repos/builtin/applications/wrfv3/application.py
@@ -60,22 +60,21 @@ class Wrfv3(ExecutableApplication):
         dst="{experiment_run_dir}/.",
     )
     stage_files(
-        name="link-run-files",
+        name="stage-run-files",
         src="{wrf_path}/run/*",
         dst="{experiment_run_dir}/.",
-        method="link",
     )
     executable("execute", "wrf.exe", use_mpi=True)
 
     workload(
         "CONUS_2p5km",
-        executables=["cleanup", "stage-input", "link-run-files", "execute"],
+        executables=["cleanup", "stage-input", "stage-run-files", "execute"],
         input="CONUS_2p5km",
     )
 
     workload(
         "CONUS_12km",
-        executables=["cleanup", "stage-input", "link-run-files", "execute"],
+        executables=["cleanup", "stage-input", "stage-run-files", "execute"],
         input="CONUS_12km",
     )
 

--- a/var/ramble/repos/builtin/applications/wrfv4/application.py
+++ b/var/ramble/repos/builtin/applications/wrfv4/application.py
@@ -93,14 +93,16 @@ class Wrfv4(ExecutableApplication):
         use_mpi=False,
         output_capture=OUTPUT_CAPTURE.ALL,
     )
-    executable(
-        "copy",
-        template=[
-            "cp -R {input_path}/* {experiment_run_dir}/.",
-            "ln -s {wrf_path}/run/* {experiment_run_dir}/.",
-        ],
-        use_mpi=False,
-        output_capture=OUTPUT_CAPTURE.ALL,
+    stage_files(
+        name="stage-input",
+        src="{input_path}/*",
+        dst="{experiment_run_dir}/.",
+    )
+    stage_files(
+        name="link-run-files",
+        src="{wrf_path}/run/*",
+        dst="{experiment_run_dir}/.",
+        method="link",
     )
     executable(
         "fix_12km",
@@ -150,7 +152,8 @@ class Wrfv4(ExecutableApplication):
     workload(
         "CONUS_2p5km",
         executables=[
-            "copy",
+            "stage-input",
+            "link-run-files",
             "cleanup",
             "define_nproc_y",
             "define_nproc_x",
@@ -163,7 +166,8 @@ class Wrfv4(ExecutableApplication):
     workload(
         "CONUS_12km",
         executables=[
-            "copy",
+            "stage-input",
+            "link-run-files",
             "cleanup",
             "define_nproc_y",
             "define_nproc_x",
@@ -177,7 +181,8 @@ class Wrfv4(ExecutableApplication):
     workload(
         "Maria_1km",
         executables=[
-            "copy",
+            "stage-input",
+            "link-run-files",
             "cleanup",
             "define_nproc_y",
             "define_nproc_x",

--- a/var/ramble/repos/builtin/applications/wrfv4/application.py
+++ b/var/ramble/repos/builtin/applications/wrfv4/application.py
@@ -94,15 +94,12 @@ class Wrfv4(ExecutableApplication):
         output_capture=OUTPUT_CAPTURE.ALL,
     )
     stage_files(
-        name="stage-input",
         src="{input_path}/*",
         dst="{experiment_run_dir}/.",
     )
     stage_files(
-        name="link-run-files",
         src="{wrf_path}/run/*",
         dst="{experiment_run_dir}/.",
-        method="link",
     )
     executable(
         "fix_12km",
@@ -152,8 +149,7 @@ class Wrfv4(ExecutableApplication):
     workload(
         "CONUS_2p5km",
         executables=[
-            "stage-input",
-            "link-run-files",
+            "stage-files",
             "cleanup",
             "define_nproc_y",
             "define_nproc_x",
@@ -166,8 +162,7 @@ class Wrfv4(ExecutableApplication):
     workload(
         "CONUS_12km",
         executables=[
-            "stage-input",
-            "link-run-files",
+            "stage-files",
             "cleanup",
             "define_nproc_y",
             "define_nproc_x",
@@ -181,8 +176,7 @@ class Wrfv4(ExecutableApplication):
     workload(
         "Maria_1km",
         executables=[
-            "stage-input",
-            "link-run-files",
+            "stage-files",
             "cleanup",
             "define_nproc_y",
             "define_nproc_x",

--- a/var/ramble/repos/builtin/base_applications/openfoam/base_application.py
+++ b/var/ramble/repos/builtin/base_applications/openfoam/base_application.py
@@ -36,7 +36,10 @@ class Openfoam(ExecutableApplication):
             wl,
             executables=[
                 "clean",
-                "get_inputs",
+                "stage_input",
+                "stage_trisurface",
+                "stage_geometry",
+                "stage_U",
                 "configure_mesh",
                 "surfaceFeatures",
                 "blockMesh",
@@ -204,18 +207,18 @@ class Openfoam(ExecutableApplication):
 
     executable("clean", template=["rm -rf processor* constant system log.*"])
 
-    executable(
-        "get_inputs",
-        template=[
-            "cp -Lr {input_path}/* {experiment_run_dir}/.",
-            "mkdir -p constant/triSurface",
-            "mkdir -p constant/geometry",
-            "cp {geometry_path} constant/triSurface/.",
-            "cp {geometry_path} constant/geometry/.",
-            "ln -sf {experiment_run_dir}/0/U.orig {experiment_run_dir}/0/U",
-        ],
-        use_mpi=False,
+    stage_files(
+        name="stage_input", src="{input_path}/*", dst="{experiment_run_dir}/."
     )
+    stage_files(
+        name="stage_trisurface",
+        src="{geometry_path}",
+        dst="constant/triSurface/.",
+    )
+    stage_files(
+        name="stage_geometry", src="{geometry_path}", dst="constant/geometry/."
+    )
+    stage_files(name="stage_U", src="0/U", dst="0/U.orig")
 
     executable(
         "configure_mesh",


### PR DESCRIPTION
This merge adds a new directive named stage_files which creates an executable to stage some files into a target directory, as part of an experiment.

This currently supports staging with: cp, rsync, and ln (symbolic / hard links).

Existing application definitions are updated to use this instead of hardcoded copy / link commands.