### PR TITLE
Add type-checking via `mypy`

### DIFF
--- a/lib/ramble/ramble/cmd/style.py
+++ b/lib/ramble/ramble/cmd/style.py
@@ -121,8 +121,8 @@ pattern_exemptions = {
     for file_pattern, error_dict in pattern_exemptions.items()
 }
 
-# Tools run in the given order, with flake8 as the last check.
-tool_names = ["isort", "black", "flake8"]
+# Tools run in the given order
+tool_names = ["isort", "black", "flake8", "mypy"]
 
 tools = {}
 
@@ -255,10 +255,11 @@ def setup_parser(subparser):
 def print_tool_header(tool, file_list):
     print("=======================================================")
     print(f"{tool}: running {tool} checks on ramble.")
-    print()
-    print("Modified files:")
-    for filename in file_list:
-        print(f"  {filename.strip()}")
+    if file_list:
+        print()
+        print("Modified files:")
+        for filename in file_list:
+            print(f"  {filename.strip()}")
     print("=======================================================")
 
 
@@ -499,6 +500,22 @@ def run_isort(isort_cmd, file_list, args):
         returncode |= isort_cmd.returncode
     print_output(output, args)
     print_tool_result("isort", returncode)
+    return returncode
+
+
+@tool("mypy")
+def run_mypy(mypy_cmd, file_list, args):
+    del file_list
+    print_tool_header("mypy", [])
+
+    config_file = os.path.join(ramble.paths.prefix, "pyproject.toml")
+    mypy_args = ("--config-file", config_file)
+
+    output = mypy_cmd(*mypy_args, fail_on_error=False, output=str, error=str)
+    returncode = mypy_cmd.returncode
+
+    print_output(output, args)
+    print_tool_result("mypy", returncode)
     return returncode
 
 

--- a/lib/ramble/ramble/config.py
+++ b/lib/ramble/ramble/config.py
@@ -39,6 +39,7 @@ import os
 import re
 import sys
 from contextlib import contextmanager
+from typing import Any, Dict, List
 
 import ruamel.yaml as yaml
 from ruamel.yaml.error import MarkedYAMLError
@@ -83,7 +84,7 @@ import spack.util.spack_yaml as syaml
 from spack.util.cpus import cpus_available
 
 #: Dict from section names -> schema for that section
-section_schemas = {
+section_schemas: Dict[str, Dict[str, Any]] = {
     "formatted_executables": ramble.schema.formatted_executables.schema,
     "config": ramble.schema.config.schema,
     "env_vars": ramble.schema.env_vars.schema,
@@ -794,7 +795,7 @@ def override(path_or_scope, value=None):
 
 #: configuration scopes added on the command line
 #: set by ``ramble.main.main()``.
-command_line_scopes = []
+command_line_scopes: List[str] = []
 
 
 def _add_platform_scope(cfg, scope_type, name, path):

--- a/lib/ramble/ramble/repository.py
+++ b/lib/ramble/ramble/repository.py
@@ -22,8 +22,8 @@ import stat
 import sys
 import traceback
 import types
-from collections.abc import Mapping
 from enum import Enum
+from typing import Mapping
 
 import ruamel.yaml as yaml
 
@@ -390,7 +390,7 @@ class FastObjectChecker(Mapping):
     """
 
     #: Global cache, reused by every instance
-    _paths_cache = {}
+    _paths_cache: Mapping[str, str] = {}
 
     def __init__(self, objects_path, object_file_name, object_type):
         # The path of the repository managed by this instance

--- a/lib/ramble/ramble/schema/config.py
+++ b/lib/ramble/ramble/schema/config.py
@@ -11,11 +11,12 @@
 .. literalinclude:: _ramble_root/lib/ramble/ramble/schema/config.py
    :lines: 15-
 """
+from typing import Any, Dict
 
 import spack.schema.config
 
 #: Properties for inclusion in other schemas
-properties = {
+properties: Dict[str, Any] = {
     "config": {**spack.schema.config.properties["config"]},
 }
 
@@ -194,7 +195,7 @@ schema = {
 }
 
 
-def update(data):
+def update(data: Dict[str, Any]) -> bool:
     """Update the data in place to remove deprecated properties.
 
     Args:

--- a/lib/ramble/ramble/spec.py
+++ b/lib/ramble/ramble/spec.py
@@ -7,6 +7,7 @@
 # except according to those terms.
 
 import io
+from typing import Mapping
 
 import llnl.util.tty.color as clr
 
@@ -21,7 +22,7 @@ HASH, DEP, AT, COLON, COMMA, ON, OFF, PCT, EQ, ID, VAL, FILE = range(12)
 #: Regex for fully qualified spec names. (e.g., builtin.hdf5)
 spec_id_re = r"\w[\w.-]*"
 
-color_formats = {}
+color_formats: Mapping[str, str] = {}
 
 default_format = "{name}"
 

--- a/lib/ramble/ramble/util/lock.py
+++ b/lib/ramble/ramble/util/lock.py
@@ -11,7 +11,13 @@ import os
 import stat
 
 import llnl.util.lock
-from llnl.util.lock import *  # noqa
+from llnl.util.lock import (
+    LockError,
+    LockTimeoutError,
+    LockUpgradeError,
+    ReadTransaction,
+    WriteTransaction,
+)
 
 import ramble.config
 import ramble.error
@@ -79,3 +85,14 @@ def check_lock_safety(path):
                 "restrict permissions on {} or enable locks."
             ).format(path)
             raise ramble.error.RambleError(msg, long_msg)
+
+
+__all__ = [
+    "LockError",
+    "LockTimeoutError",
+    "LockUpgradeError",
+    "ReadTransaction",
+    "WriteTransaction",
+    "Lock",
+    "check_lock_safety",
+]

--- a/lib/ramble/ramble/util/spec_utils.py
+++ b/lib/ramble/ramble/util/spec_utils.py
@@ -7,7 +7,7 @@
 # except according to those terms.
 
 import copy
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import ramble.util.colors
 
@@ -41,16 +41,16 @@ class SoftwareSpec:
         name: str,
         pkg_spec: str,
         prefix: str = "",
-        compiler: str = None,
-        compiler_spec: str = None,
-        when: List[str] = None,
+        compiler: Optional[str] = None,
+        compiler_spec: Optional[str] = None,
+        when: Optional[List[str]] = None,
     ):
         self.name = name
         self.pkg_spec = pkg_spec
         self.prefix = prefix
         self.compiler = compiler
         self.compiler_spec = compiler_spec
-        self.when = when.copy()
+        self.when = when.copy() if when else []
 
     def to_dict(self, apply_prefix: bool = False):
         prefix_base = self.prefix if apply_prefix else ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,3 +104,16 @@ omit = [
 
 [tool.coverage.html]
 directory = "htmlcov"
+
+[tool.mypy]
+# TODO: Add in more files for type-checking
+# For now, only type-check the util directory
+files = ["lib/ramble/ramble/util/**/*.py"]
+ignore_errors = true
+ignore_missing_imports = true
+allow_redefinition = true
+
+[[tool.mypy.overrides]]
+# Only enable ramble modules
+module = "ramble.*"
+ignore_errors = false

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,4 @@ pytest-clarity
 line_profiler
 isort
 codecov-cli
+mypy


### PR DESCRIPTION
As a start, only the `lib/ramble/ramble/util` files are checked.

Use `mypy` mostly for its maturity (and Spack also uses it.) `pytype` has been deprecated, and there is `pytype2` planned for Google-owned projects, but that's not available yet. There are other popular choices like `pyright`, `pyrefly` and `ty`. Happy to discuss if there's another preferred choice.