### PR TITLE
Fix Rambld doc breakage

### DIFF
--- a/lib/ramble/docs/conf.py
+++ b/lib/ramble/docs/conf.py
@@ -219,6 +219,7 @@ nitpick_ignore = [
     ("py:class", "llnl.util.argparsewriter.ArgparseRstWriter"),
     ("py:class", "llnl.util.argparsewriter.ArgparseWriter"),
     ("py:class", "llnl.util.lock.Lock"),
+    ("py:class", "llnl.util.lock.LockTransaction"),
     ("py:class", "pandas.core.frame.DataFrame"),
     ("py:class", "spack.environment.Environment"),
     ("py:class", "spack.error.SpackError"),


### PR DESCRIPTION
The breakage at https://app.readthedocs.org/projects/ramble/builds/29983507/ was caused by the change introduced to util/lock.py in https://github.com/GoogleCloudPlatform/ramble/pull/1282/files#diff-c0aee000a0ab7b557ded0f29eeeb712549d868d0ee4ab20a784705863692bc34, where the wildcard import was replaced.