### PR TITLE
Rename modifier_conflict enum member name

### DIFF
--- a/lib/ramble/ramble/util/conflicts.py
+++ b/lib/ramble/ramble/util/conflicts.py
@@ -11,7 +11,7 @@ from enum import Enum
 
 class MODIFIER_CONFLICT(Enum):
     # Conflict on identical name only
-    name = 0
+    name_only = 0
 
     # Conflict on name, and mode
     name_mode = 1

--- a/var/ramble/repos/builtin.mock/modifiers/conflict-name-modifier/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/conflict-name-modifier/modifier.py
@@ -17,4 +17,4 @@ class ConflictNameModifier(BasicModifier):
 
     default_mode("standard")
 
-    modifier_conflict("name")
+    modifier_conflict("name_only")

--- a/var/ramble/repos/builtin/base_classes/modifier-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/modifier-base/base_class.py
@@ -208,7 +208,7 @@ class ModifierBase(ObjectMixin, metaclass=ModifierMeta):
                 self_idx = mod_idx
                 continue
 
-            if conflict_value == MODIFIER_CONFLICT.name:
+            if conflict_value == MODIFIER_CONFLICT.name_only:
                 if mod_inst.name == self.name:
                     comp_str = mod_inst.config_str(index=mod_idx, indent=4)
                     self_str = self.config_str(index=self_idx, indent=4)


### PR DESCRIPTION
This is complained by `mypy`, as the previous `name` member shadows the base enum class's `name`: https://docs.python.org/3/library/enum.html#enum.Enum.name.