### PR TITLE
Update requirements-dev.txt to support py3.14

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,5 +9,8 @@ pytest-xdist
 pytest-clarity
 line_profiler
 isort
-codecov-cli
+# codecov-cli relies on test-results-parser, which currently has a dep pin on
+# a pyo3 version that is not compatible with 3.14: https://github.com/codecov/test-results-parser/blob/main/Cargo.toml#L14.
+# Also see https://github.com/codecov/test-results-parser/issues/86.
+codecov-cli;python_version<"3.14"
 mypy


### PR DESCRIPTION
Right now the codecov-cli doesn't work with py3.14 yet, so skip requiring it for 314.