### PR TITLE
Add iozone benchmark app definition

### DIFF
--- a/var/ramble/repos/builtin/applications/iozone/application.py
+++ b/var/ramble/repos/builtin/applications/iozone/application.py
@@ -1,0 +1,149 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.appkit import *
+
+
+class Iozone(ExecutableApplication):
+    """Define the Iozone file system benchmark."""
+
+    name = "iozone"
+
+    maintainers("linsword")
+
+    tags("storage-benchmark", "io-benchmark", "filesystem")
+
+    with when("package_manager_family=spack"):
+        # Use gcc < 10, as otherwise spack install fails due to gcc10's default nocommon flag
+        define_compiler("gcc9", pkg_spec="gcc@9.3.0")
+        software_spec("iozone", pkg_spec="iozone@3_506", compiler="gcc9")
+        required_package("iozone")
+
+    register_template(
+        "generate_clientlist",
+        src_path="generate_clientlist.sh.tpl",
+        dest_path="generate_clientlist.sh",
+    )
+
+    # The purpose of this step is to generate client entries expected by iozone.
+    # For instance, if running on two nodes, with PPN=3, then the clientlist
+    # file should look like the following:
+    #   client1 /path/to/working_directory/ /path/to/iozone
+    #   client1 /path/to/working_directory/ /path/to/iozone
+    #   client1 /path/to/working_directory/ /path/to/iozone
+    #   client2 /path/to/working_directory/ /path/to/iozone
+    #   client2 /path/to/working_directory/ /path/to/iozone
+    #   client2 /path/to/working_directory/ /path/to/iozone
+    # The number of clientlist entries needs to match with the `-t` option.
+    executable(
+        "gen_clientlist",
+        template="bash generate_clientlist.sh",
+        use_mpi=False,
+    )
+
+    executable(
+        "execute",
+        template="{iozone_bin_path} {test_args} -r {record_size} -s {file_size} -t {n_ranks} -+m {clientlist_path} {additional_args}",
+        use_mpi=False,
+    )
+
+    workload("cluster", executables=["gen_clientlist", "execute"])
+
+    workload_variable(
+        "test_args",
+        default="-i 0 -i 1",
+        description="Specify the tests to run",
+        workload="cluster",
+    )
+
+    workload_variable(
+        "file_size",
+        default="16g",
+        description="Size of the test file",
+        workload="cluster",
+    )
+
+    workload_variable(
+        "record_size",
+        default="1m",
+        description="Record size",
+        workload="cluster",
+    )
+
+    workload_variable(
+        "working_directory",
+        default="{experiment_run_dir}",
+        description="Working directory for the test",
+        workload="cluster",
+    )
+
+    workload_variable(
+        "additional_args", default="-c -e -+n -I", workload="cluster"
+    )
+
+    workload_variable(
+        "rsh_alternative",
+        default="ssh",
+        description="Alternative for rsh",
+        workload="cluster",
+    )
+
+    workload_variable(
+        "hostfile_path",
+        default="{experiment_run_dir}/hostfile",
+        workload="cluster",
+    )
+
+    workload_variable(
+        "clientlist_path",
+        default="{experiment_run_dir}/clientlist",
+        workload="cluster",
+    )
+
+    workload_variable(
+        "iozone_bin_path",
+        default="{iozone_path}/bin/iozone",
+        workload="cluster",
+    )
+
+    # iozone.c uses `getenv("RSH")` to decide on its remote access mechanism
+    environment_variable(
+        "RSH",
+        value="{rsh_alternative}",
+        description="Alternative remote access",
+        workload="cluster",
+    )
+
+    throughput_regex = r"\s*Children see throughput for\s+\d+\s+(?P<test>.*?)\s*=\s*(?P<throughput>[\d.]+)"
+
+    figure_of_merit_context(
+        "test", regex=throughput_regex, output_format="Test {test}"
+    )
+
+    figure_of_merit(
+        "Total throughput",
+        fom_regex=throughput_regex,
+        group_name="throughput",
+        units="kB/sec",
+        contexts=["test"],
+    )
+
+    for fom in ("Min", "Max", "Avg"):
+        figure_of_merit(
+            f"{fom} throughput",
+            fom_regex=rf"\s*{fom} throughput per process\s*=\s*(?P<throughput>[\d.]+)",
+            group_name="throughput",
+            units="kB/sec",
+            contexts=["test"],
+        )
+
+    success_criteria(
+        "test_complete",
+        mode="string",
+        match=r".*?iozone test complete",
+    )

--- a/var/ramble/repos/builtin/applications/iozone/generate_clientlist.sh.tpl
+++ b/var/ramble/repos/builtin/applications/iozone/generate_clientlist.sh.tpl
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+awk -v total="{n_ranks}" -v wd="{working_directory}" -v path="{iozone_bin_path}" '
+    {
+        hosts[NR-1] = $1
+    }
+    END {
+        num_hosts = NR
+        ppn = int("{processes_per_node}")
+        for (h = 0; h < num_hosts; h++) {
+            for (p = 0; p < ppn; p++) {
+                print hosts[h], wd, path
+            }
+        }
+    }
+' "{hostfile_path}" > "{clientlist_path}"


### PR DESCRIPTION
Compare with ior, iozone seems to provide more flexibility around testing different access patterns.

Test run:

```
Experiment iozone.cluster.test figures of merit:
  Status = SUCCESS
  Tags = ['filesystem', 'io-benchmark', 'storage-benchmark']
  default (null) context figures of merit:
    job-id = 31758
    job-status = COMPLETE
    job-nodes = hpcperf-c2dnodeset-[25,94]
    job-start = 2025-10-23T07:22:29
    job-end = 2025-10-23T07:24:36
    job-elapsed_time = 00:02:07
    job-exit_code = 0:0
    slurm-config-TopologyParam = SwitchAsNodeRank
    slurm-config-TopologyPlugin = topology/tree
    job-termination-overhead = 0 s
  Test initial writers context figures of merit:
    Total throughput = 1333031.88 kB/sec
    Min throughput = 328657.47 kB/sec
    Max throughput = 336364.38 kB/sec
    Avg throughput = 333257.97 kB/sec
  Test readers context figures of merit:
    Total throughput = 1429704.62 kB/sec
    Min throughput = 354526.41 kB/sec
    Max throughput = 359583.72 kB/sec
    Avg throughput = 357426.16 kB/sec
```