### PR TITLE
Avoid nodelist output truncation

### DIFF
--- a/var/ramble/repos/builtin/workflow_managers/slurm/batch_query.tpl
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/batch_query.tpl
@@ -28,8 +28,9 @@ echo "  job_id: ${job_id}" | tee -a $saved
 echo "  job_name: {job_name}" | tee -a $saved
 echo "  job_status: $status" | tee -a $saved
 
+# To avoid nodelist truncation, use a big number. `xargs` handles the extra space correctly.
 paste -d ":" \
   <(echo "job_nodes job_start job_end job_elapsed_time job_exit_code" | xargs -n1) \
-  <(sacct -j "${job_id}" -o 'nodelist%80,start,end,elapsed,exitcode' -X -n | xargs -n1) \
+  <(sacct -j "${job_id}" -o 'nodelist%4096,start,end,elapsed,exitcode' -X -n | xargs -n1) \
   | sed "s/^/  /" \
   | tee -a $saved


### PR DESCRIPTION
Test output:

```
job-id = 31934
job-status = COMPLETE
job-nodes = hpcperf-h4dnodeset-[8,16,19-20,23,40,43,55,63,66,81-83,86,6,9-10,13,18,22,24,39,56,60-62,67,69,71,73,80,89,0,4,41-42,44,58,65,75-76,78,90-95,7,11,14-15,17,36-38,54,57,59,64,72,74,77,79]
job-start = 2025-10-24T00:49:49
job-end = 2025-10-24T00:53:52
job-elapsed_time = 00:04:03
```