### PR TITLE
Allow `workspace analyze` to output tabular results

### DIFF
--- a/lib/ramble/docs/configuration_files.rst
+++ b/lib/ramble/docs/configuration_files.rst
@@ -40,6 +40,7 @@ Currently, Ramble supports the following configuration sections:
 * :ref:`repos <repos-config>`
 * :ref:`software <software-config>`
 * :ref:`success_criteria <success-criteria-config>`
+* :ref:`tables <tables-config>`
 * :ref:`variables <variables-config>`
 * :ref:`variants <variants-config>`
 
@@ -142,6 +143,7 @@ In the above ``[optional_definitions]`` can include any of:
 * :ref:`internals <internals-config>`
 * :ref:`modifiers <modifiers-config>`
 * :ref:`success_criteria <success-criteria-config>`
+* :ref:`tables <tables-config>`
 * :ref:`variables <variables-config>`
 * :ref:`variants <variants-config>`
 
@@ -675,6 +677,89 @@ use when determining if they were successful or not. Its format is as follows:
 For more information about using success criteria, see the
 :ref:`success criteria documentation<success-criteria>`.
 
+.. _tables-config:
+
+---------------
+Tables Section:
+---------------
+
+The tables section is used to define tables that should be generated when a
+workspace is analyzed. Its format is as follows:
+
+.. code-block:: yaml
+
+     tables:
+     - name: "table_name_template"
+       [optional table attributes]
+       columns:
+       - name: "column_name_template"
+         [column_attributes]
+
+
+In the tables section, a list of tables can be provided. Tables can also be
+included in the :ref:`applications<application-config>` section. In this case,
+tables are scoped to the section they are added in (i.e. a table added within a
+specific application name will only generate data for that application's
+experiments, and likewise for workloads and experiment blocks).
+
+In the above, ``[optional table attributes]`` includes any of the following:
+
+.. code-block:: yaml
+
+   group_by:
+   - "list of column names"
+   - "to group (collapse) data by"
+   group_method: "max" # Method of applying the grouping
+   sort_by:
+   - "list of column names"
+   - "to sort data by"
+   where:
+   - "list of expressions"
+   - "to filter experiments"
+   - "to build table from"
+
+The ``group_method`` can be selected from any `groupby method supported by
+Pandas dataframes
+<https://pandas.pydata.org/docs/reference/groupby.html#dataframegroupby-computations-descriptive-stats>`_.
+
+Additionally, ``[column_attributes]`` can include any of the following:
+
+.. code-block:: yaml
+
+   columns:
+   - name: "column name template"
+     where:
+     - "list of expressions"
+     - "to filter experiments"
+     - "when building this column"
+     expression: "Ramble-style expression for column value"
+     figure_of_merit: "Figure of merit name for column value"
+     figure_of_merit_context: "Context name to extract figure of merit from"
+     figure_of_merit_origin_type: "Origin type to extract figure of merit from"
+
+One of ``expression`` and ``figure_of_merit`` are required for each column. If
+a context is not provided, Ramble will attempt to auto-detect the context.
+Similarly, if the origin type is not provided, Ramble will auto detect the
+origin type.
+
+Columns are built in YAML order. The ``expression`` attribute can be used to
+refer to values from other columns that are defined before the current column.
+
+Both ``table_name_template`` and ``column_name_template`` can include Ramble
+variables, to automatically generate new tables and columns. As an example:
+
+.. code-block:: yaml
+
+   tables:
+   - name: '{workload_name} status'
+     columns:
+     - name: Experiment
+       expression: '{experiment_name}'
+     - name: Status
+       expression: '{experiment_status}'
+
+Will automatically create one table per workload, with the status summary of
+that workload's experiments.
 
 .. _variables-config:
 

--- a/lib/ramble/ramble/config.py
+++ b/lib/ramble/ramble/config.py
@@ -69,6 +69,7 @@ import ramble.schema.package_manager_repos
 import ramble.schema.repos
 import ramble.schema.software
 import ramble.schema.success_criteria
+import ramble.schema.tables
 import ramble.schema.variables
 import ramble.schema.variants
 import ramble.schema.workflow_manager_repos
@@ -94,6 +95,7 @@ section_schemas: Dict[str, Dict[str, Any]] = {
     "modifiers": ramble.schema.modifiers.schema,
     "software": ramble.schema.software.schema,
     "success_criteria": ramble.schema.success_criteria.schema,
+    "tables": ramble.schema.tables.schema,
     "applications": ramble.schema.applications.schema,
     "variables": ramble.schema.variables.schema,
     "variants": ramble.schema.variants.schema,

--- a/lib/ramble/ramble/context.py
+++ b/lib/ramble/ramble/context.py
@@ -38,6 +38,7 @@ class Context:
         self.zips = {}
         self.matrices = []
         self.tags = []
+        self.tables = []
         self.is_template = False
         self.n_repeats = 0
 
@@ -95,6 +96,8 @@ class Context:
             self.formatted_executables.update(in_context.formatted_executables)
         if in_context.success_criteria:
             self.success_criteria.extend(in_context.success_criteria)
+        if in_context.tables:
+            self.tables.extend(in_context.tables)
 
 
 def create_context_from_dict(context_name, in_dict):
@@ -158,6 +161,9 @@ def create_context_from_dict(context_name, in_dict):
 
     if namespace.zips in in_dict:
         new_context.zips = in_dict[namespace.zips]
+
+    if namespace.tables in in_dict:
+        new_context.tables = in_dict[namespace.tables].copy()
 
     if namespace.tags in in_dict:
         new_context.tags = in_dict[namespace.tags].copy()

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -67,6 +67,7 @@ class ExperimentSet:
         workspace_context.zips = workspace.get_workspace_zips()
         workspace_context.variants = workspace.get_workspace_variants()
         workspace_context.success_criteria = workspace.get_workspace_success_criteria()
+        workspace_context.tables = workspace.get_workspace_tables()
 
         try:
             self.keywords.check_reserved_keys(workspace_context.variables)
@@ -505,6 +506,8 @@ class ExperimentSet:
             used_variables = used_variables.union(exp_used_variables)
         render_group.used_variables = used_variables.copy()
 
+        workload_names = set()
+
         rendered_experiments = set()
         for experiment_vars, repeats in renderer.render_objects(
             render_group, exclude_where=exclude_where
@@ -573,10 +576,46 @@ class ExperimentSet:
                         )
                     pass
 
+                workload_names.add(app_inst.expander.workload_name)
+
                 app_inst.set_success_list(final_context.success_criteria)
                 rendered_experiments.add(final_exp_namespace)
                 self.experiments[final_exp_namespace] = app_inst
                 self.experiment_order.append(final_exp_namespace)
+
+            self.define_scoped_tables(workload_names, experiment_template_name)
+
+    def define_scoped_tables(self, workload_names, experiment_template_name):
+        # Generate focused tables for results
+        app_context = self._context[self._contexts["application"]]
+        for table in app_context.tables:
+            results_table = self._workspace.results_tables.add_table_template(table)
+            results_table.add_where(
+                f"'{{application_name}}' == '{app_context.context_name}'",
+            )
+
+        wl_context = self._context[self._contexts["workload"]]
+        for table in wl_context.tables:
+            for workload_name in workload_names:
+                results_table = self._workspace.results_tables.add_table_template(table)
+                results_table.add_where(
+                    [
+                        f"'{{application_name}}' == '{app_context.context_name}'",
+                        f"'{{workload_name}}' == '{workload_name}'",
+                    ]
+                )
+
+        exp_context = self._context[self._contexts["experiment"]]
+        for table in exp_context.tables:
+            for workload_name in workload_names:
+                results_table = self._workspace.results_tables.add_table_template(table)
+                results_table.add_where(
+                    [
+                        f"'{{application_name}}' == '{app_context.context_name}'",
+                        f"'{{workload_name}}' == '{workload_name}'",
+                        f"'{experiment_template_name}' in '{{experiment_name}}'",
+                    ]
+                )
 
     def build_experiment_chains(self):
         base_experiments = self.experiment_order.copy()

--- a/lib/ramble/ramble/namespace.py
+++ b/lib/ramble/ramble/namespace.py
@@ -26,6 +26,7 @@ class namespace:
     template = "template"
     chained_experiments = "chained_experiments"
     modifiers = "modifiers"
+    tables = "tables"
     tags = "tags"
     n_repeats = "n_repeats"
     formatted_executables = "formatted_executables"

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -24,6 +24,7 @@ import ramble.config
 import ramble.expander
 import ramble.experiment_result
 import ramble.fetch_strategy
+import ramble.results_table
 import ramble.software_environments
 import ramble.stage
 import ramble.uploader
@@ -69,6 +70,10 @@ class Pipeline:
         self._software_environments = ramble.software_environments.SoftwareEnvironments(workspace)
         self.workspace.software_environments = self._software_environments
         self._experiment_set = workspace.build_experiment_set()
+
+    @property
+    def experiment_set(self):
+        return self._experiment_set
 
     def _construct_experiment_hashes(self):
         """Hash all of the experiments.
@@ -296,6 +301,8 @@ class AnalyzePipeline(Pipeline):
             print_results=self.print_results,
             summary_only=self.summary_only,
         )
+
+        self.workspace.dump_tables(self.experiment_set, self.filters)
 
         if self.upload_results:
             ramble.uploader.upload_results(self.workspace.results)

--- a/lib/ramble/ramble/results_table.py
+++ b/lib/ramble/ramble/results_table.py
@@ -1,0 +1,373 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import copy
+import os
+
+import pandas
+
+from ramble.util.file_util import create_symlink
+from ramble.util.logger import logger
+
+
+class ResultsColumn:
+    """Class representing a single column in a results table"""
+
+    _where_name = "where"
+    _column_attrs = [
+        "name",
+        "expression",
+        "figure_of_merit",
+        "figure_of_merit_context",
+        "figure_of_merit_origin_type",
+    ]
+
+    def __init__(self, conf_dict):
+        """Construct a column from a configuration dict, assuming the structure matches the
+        column schema in lib/ramble/ramble/schema/tables.py
+
+        Args:
+            conf_dict (dict): dictionary structured like the column schema in tables.py
+
+        """
+        # Extract column attributes
+        for attr in self._column_attrs:
+            setattr(self, attr, str(conf_dict[attr]) if attr in conf_dict else None)
+
+        if self.expression and self.figure_of_merit:
+            logger.die(
+                "Results columns cannot have both 'expression' and 'figure_of_merit' attributes"
+            )
+
+        if not self.expression and not self.figure_of_merit:
+            logger.die(
+                "One of either 'expression' or 'figure_of_merit' are required for each "
+                "column definition"
+            )
+
+        self.where = []
+        if self._where_name in conf_dict:
+            self.where.extend(conf_dict[self._where_name])
+
+    def col_name(self, app_inst):
+        """Expand this columns name based on the current experiment
+
+        Args:
+            app_inst: Instance of an application class to expand name with
+
+        Returns:
+            (str): Expanded column name
+        """
+        return app_inst.expander.expand_var(self.name)
+
+    def extract_value(self, app_inst, extra_vars=None):
+        """Extract this column's value based on an application instance and other column values
+
+        Args:
+            app_inst: Instance of an application class
+            extra_vars: Dictionary containing additional variables to expand with
+
+            iteration (Union[None, str]): The iteration to search for.
+            instance (Union[None, str]): The instance to search for.
+        """
+        if extra_vars is None:
+            extra_vars = {}
+
+        value = None
+
+        action_experiment = True
+        for expression in self.where:
+            if not app_inst.expander.evaluate_predicate(expression):
+                action_experiment = False
+
+        if not action_experiment:
+            return value
+
+        if self.expression:
+            value = app_inst.expander.expand_var(self.expression, extra_vars=extra_vars)
+        elif self.figure_of_merit:
+            fom_name = self.figure_of_merit
+            context_name = None
+            if self.figure_of_merit_context:
+                context_name = app_inst.expander.expand_var(self.figure_of_merit_context)
+
+            origin_type = None
+            if self.figure_of_merit_origin_type:
+                origin_type = app_inst.expander.expand_var(self.figure_of_merit_origin_type)
+
+            results = app_inst.result
+            for context in results.contexts:
+                if context_name is None or context_name == context["name"]:
+                    for fom in context["foms"]:
+                        if fom["name"] == fom_name:
+                            keep = True
+                            if origin_type and origin_type != fom["origin_type"]:
+                                keep = False
+
+                            if keep:
+                                if value is not None:
+                                    logger.warn(
+                                        "Non-unique values found " f"for column {self.name}"
+                                    )
+                                value = fom["value"]
+        return value
+
+
+class ResultsTable:
+    """A single results table based on the tables.py schema"""
+
+    _default_group_method = "max"
+    _group_method_name = "group_method"
+    _group_by_name = "group_by"
+    _sort_by_name = "sort_by"
+    _columns_name = "columns"
+    _where_name = "where"
+
+    def __init__(self, conf_dict):
+        """Constructor for a single table
+
+        Args:
+            conf_dict (dict): Configuration dictionary based on the table schema in tables.py
+        """
+        self._num_rows = 0
+        self._data = {}
+
+        self.name = conf_dict["name"]
+
+        self.group_method = self._default_group_method
+        if self._group_method_name in conf_dict:
+            self.group_method = conf_dict[self._group_method_name]
+
+        # Build group_by and sort_by attrs
+        for set_name in ["group", "sort"]:
+            temp_list = []
+            set_name_attr = getattr(self, f"_{set_name}_by_name")
+            if set_name_attr in conf_dict:
+                if isinstance(conf_dict[set_name_attr], list):
+                    temp_list.extend(conf_dict[set_name_attr])
+                else:
+                    temp_list.append(conf_dict[set_name_attr])
+            setattr(self, f"{set_name}_by", temp_list)
+
+        # Build table where statements
+        self.where = []
+        if self._where_name in conf_dict:
+            self.where.extend(conf_dict[self._where_name])
+
+        # Build table columns
+        self.columns = []
+        if self._columns_name in conf_dict:
+            for column_config in conf_dict[self._columns_name]:
+                self.columns.append(ResultsColumn(column_config))
+
+    def render(self, app_inst):
+        new_table = copy.deepcopy(self)
+        new_table.name = app_inst.expander.expand_var(self.name)
+        return new_table
+
+    def table_name(self, app_inst):
+        """Determine the name for this table, based on a given experiment
+
+        Args:
+            app_inst: Instance of an application class
+
+        Returns:
+            (str): Name of table
+        """
+
+        return app_inst.expander.expand_var(self.name)
+
+    def add_where(self, expressions):
+        """Add a where expression to this table
+
+        Args:
+            expression (Union[List[str], str]): The regular expression to search for.
+        """
+
+        if not expressions:
+            return
+
+        if isinstance(expressions, list):
+            self.where.extend(expressions)
+        else:
+            self.where.append(expressions)
+
+    def includes_experiment(self, app_inst):
+        """Determine if an experiment is included in this table.
+
+        Args:
+            app_inst: Instance of an application class
+
+        Returns:
+            (bool): True if the app_inst is included in table, False otherwise
+        """
+
+        include_experiment = True
+
+        for expression in self.where:
+            if not app_inst.expander.evaluate_predicate(expression):
+                include_experiment = False
+
+        return include_experiment
+
+    def extract_row(self, app_inst):
+        """Extract a row of data from an experiment
+
+        Args:
+            app_inst: Instance of an application class to extract data from
+        """
+        column_values = {}
+        remaining_columns = set(self._data.keys())
+
+        for column in self.columns:
+            col_value = column.extract_value(app_inst, extra_vars=column_values)
+
+            if col_value is None:
+                continue
+
+            col_name = column.col_name(app_inst)
+
+            if col_name in remaining_columns:
+                remaining_columns.remove(col_name)
+                self._data[col_name].append(col_value)
+
+            elif col_name not in self._data.keys():
+                self._data[col_name] = [None] * self._num_rows + [col_value]
+
+            column_values[col_name] = col_value
+
+        for col_name in remaining_columns:
+            self._data[col_name].append(None)
+
+        self._num_rows += 1
+
+    def _to_dataframe(self):
+        """Construct a pandasdata frame from this table's data"""
+        self._df = pandas.DataFrame(self._data)
+
+        for column in self._df.columns:
+            try:
+                self._df[column] = pandas.to_numeric(self._df[column])
+            except ValueError:
+                pass
+
+    def _group_dataframe(self):
+        """Apply any grouping to this pandas dataframe"""
+        if self.group_by:
+            try:
+                grouped_df = self._df.groupby(*self.group_by, as_index=False)
+
+                group_func = getattr(grouped_df, self.group_method, grouped_df.max)
+                self._df = group_func()
+            except KeyError:
+                pass
+
+    def _sort_dataframe(self):
+        """Apply any sorting to this pandas dataframe"""
+        if self.sort_by:
+            try:
+                self._df = self._df.sort_values(by=self.sort_by)
+            except KeyError:
+                pass
+
+    def to_csv(self, directory, timestamp):
+        """CSV converter for results table
+
+        Args:
+            directory (str): Directory to write tabular data into
+            timestamp (str): Timestamp to apply to table output files
+        """
+        self._to_dataframe()
+        self._group_dataframe()
+        self._sort_dataframe()
+
+        extension = "csv"
+        inner_delim = "."
+        filename = self.name + inner_delim + timestamp + inner_delim + extension
+        latestname = self.name + inner_delim + "latest" + inner_delim + extension
+        file_path = os.path.join(directory, filename)
+        latest_path = os.path.join(directory, latestname)
+        self._df.to_csv(file_path, index=False)
+
+        create_symlink(file_path, latest_path)
+        return file_path, latest_path
+
+
+class ResultsTables:
+    """Class representing a set of results tables"""
+
+    def __init__(self):
+        self.table_templates = []
+        self.tables = {}
+
+    @property
+    def num_tables(self):
+        return len(self.table_templates)
+
+    def add_table_template(self, table_conf):
+        """Construct a new results table, and add to this set of tables
+
+        Args:
+            table_conf (dict): Dictionary configuration of table,
+                               assuming table schema from tables.py
+
+        Returns:
+            (ResultsTable): New table instance
+        """
+        new_table = ResultsTable(table_conf)
+        self.table_templates.append(new_table)
+        return new_table
+
+    def all_table_templates(self):
+        """Yield all table templates
+
+        Yields:
+            (ResultsTable): All of the results table templates
+        """
+
+        yield from self.table_templates
+
+    def build_tables(self, experiment_set, filters):
+        """Extract data for each table in this set
+
+        Args:
+            experiment_set: Set of experiments to extract data from
+            filters: Filter object to downselect experiments
+        """
+        for _, app_inst, _ in experiment_set.filtered_experiments(filters):
+            for table_template in self.table_templates:
+                if table_template.includes_experiment(app_inst):
+                    table_name = table_template.table_name(app_inst)
+
+                    if table_name not in self.tables:
+                        self.tables[table_name] = table_template.render(app_inst)
+
+                    self.tables[table_name].extract_row(app_inst)
+
+    def output_tables(self, directory, timestamp):
+        """Output tabular data for each of the tables in this set
+
+        Args:
+            directory (str): Directory to write tables into
+            timestamp (str): Timestamp to apply to table output files
+        """
+        table_files = []
+        table_symlinks = []
+        for table in self.tables.values():
+            table_file, table_symlink = table.to_csv(directory, timestamp)
+            table_files.append(table_file)
+            table_symlinks.append(table_symlink)
+
+        if table_files:
+            logger.all_msg("Tables written:")
+            for file in table_files:
+                logger.all_msg(f"  {file}")
+
+            logger.all_msg("Table symlinks updated:")
+            for symlink in table_symlinks:
+                logger.all_msg(f"  {symlink}")

--- a/lib/ramble/ramble/schema/applications.py
+++ b/lib/ramble/ramble/schema/applications.py
@@ -19,6 +19,7 @@ import ramble.schema.formatted_executables
 import ramble.schema.internals
 import ramble.schema.modifiers
 import ramble.schema.success_criteria
+import ramble.schema.tables
 import ramble.schema.types
 import ramble.schema.variables
 import ramble.schema.variants
@@ -96,14 +97,15 @@ tags_def = {"type": "array", "default": [], "items": {"type": "string"}}
 repeats_def = union_dicts(ramble.schema.types.string_or_num, {"default": 0})
 
 sub_props = union_dicts(
-    ramble.schema.variables.properties,
-    ramble.schema.variants.properties,
-    ramble.schema.success_criteria.properties,
     ramble.schema.env_vars.properties,
+    ramble.schema.formatted_executables.properties,
     ramble.schema.internals.properties,
     ramble.schema.modifiers.properties,
+    ramble.schema.success_criteria.properties,
+    ramble.schema.tables.properties,
+    ramble.schema.variables.properties,
+    ramble.schema.variants.properties,
     ramble.schema.zips.properties,
-    ramble.schema.formatted_executables.properties,
     {
         "chained_experiments": chained_experiment_def,
         "template": {"type": "boolean"},

--- a/lib/ramble/ramble/schema/merged.py
+++ b/lib/ramble/ramble/schema/merged.py
@@ -31,6 +31,7 @@ import ramble.schema.package_manager_repos
 import ramble.schema.repos
 import ramble.schema.software
 import ramble.schema.success_criteria
+import ramble.schema.tables
 import ramble.schema.variables
 import ramble.schema.variants
 import ramble.schema.workflow_manager_repos
@@ -53,6 +54,7 @@ properties = union_dicts(
     ramble.schema.repos.properties,
     ramble.schema.software.properties,
     ramble.schema.success_criteria.properties,
+    ramble.schema.tables.properties,
     ramble.schema.variables.properties,
     ramble.schema.variants.properties,
     ramble.schema.env_vars.properties,

--- a/lib/ramble/ramble/schema/tables.py
+++ b/lib/ramble/ramble/schema/tables.py
@@ -1,0 +1,61 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+"""Schema for the `tables` section of a ramble config."""
+
+where_clause = {"type": "array", "items": {"type": "string"}}
+
+column = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "expression": {"type": "string", "default": None},
+        "figure_of_merit": {"type": "string", "default": None},
+        "figure_of_merit_context": {"type": "string", "default": None},
+        "figure_of_merit_origin_type": {"type": "string", "default": None},
+        "where": where_clause,
+    },
+    "required": ["name"],
+    "additionalProperties": False,
+}
+
+# TODO: Make key a table attribute that has to be an expression
+properties = {
+    "tables": {
+        "type": "array",
+        "default": [],
+        "items": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "columns": {"type": "array", "items": column},
+                "group_method": {"type": "string", "default": "max"},
+                "group_by": {
+                    "type": ["string", "array"],
+                    "items": {"type": "string"},
+                    "default": None,
+                },
+                "sort_by": {
+                    "type": ["string", "array"],
+                    "items": {"type": "string"},
+                    "default": None,
+                },
+                "where": where_clause,
+            },
+            "required": ["name", "columns"],
+            "additionalProperties": False,
+        },
+    }
+}
+
+schema = {
+    "$schema": "http://json-schema.org/schema#",
+    "title": "Ramble tables configuration file schema",
+    "type": "object",
+    "properties": properties,
+}

--- a/lib/ramble/ramble/test/end_to_end/test_fast_tables.py
+++ b/lib/ramble/ramble/test/end_to_end/test_fast_tables.py
@@ -1,0 +1,72 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import csv
+import os
+
+import pytest
+
+import ramble.workspace
+from ramble.main import RambleCommand
+
+pytestmark = pytest.mark.usefixtures(
+    "mutable_config",
+    "mutable_mock_workspace_path",
+)
+
+workspace = RambleCommand("workspace")
+on_cmd = RambleCommand("on")
+
+
+def test_tables_output(workspace_name):
+    ws = ramble.workspace.create(workspace_name)
+    ws.write()
+    global_args = ["-w", workspace_name]
+
+    _CONFIG = """ramble:
+  applications:
+    hostname:
+      workloads:
+        local:
+          variables:
+            foo: bar
+          tables:
+          - name: test_table
+            columns:
+            - name: "hostname"
+              figure_of_merit: "possible hostname"
+            - name: "foo"
+              expression: "{foo}"
+          experiments:
+            generated:
+              variables:
+                n_ranks: 1
+                n_nodes: 1
+    """
+
+    with open(os.path.join(ws.config_dir, "ramble.yaml"), "w") as f:
+        f.write(_CONFIG)
+
+    ws._re_read()
+
+    workspace("setup", global_args=global_args)
+
+    on_cmd(global_args=global_args)
+
+    workspace("analyze", global_args=global_args)
+
+    table_path = os.path.join(ws.tables_dir, "test_table.latest.csv")
+    assert os.path.exists(table_path)
+
+    with open(table_path) as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+        assert len(rows) == 1
+        row = rows[0]
+        assert "hostname" in row
+        assert row["foo"] == "bar"

--- a/lib/ramble/ramble/test/test_results_tables.py
+++ b/lib/ramble/ramble/test/test_results_tables.py
@@ -1,0 +1,198 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ramble.results_table import ResultsColumn, ResultsTable, ResultsTables
+
+
+class TestResultsColumn(unittest.TestCase):
+    def test_init(self):
+        conf_dict = {
+            "name": "test_column",
+            "expression": "{var}",
+            "where": ["'{var}' == 'value'"],
+        }
+        column = ResultsColumn(conf_dict)
+        self.assertEqual(column.name, "test_column")
+        self.assertEqual(column.expression, "{var}")
+        self.assertEqual(column.where, ["'{var}' == 'value'"])
+        self.assertIsNone(column.figure_of_merit)
+
+    @patch("ramble.results_table.logger.die")
+    def test_init_both_expression_and_fom(self, mock_die):
+        conf_dict = {
+            "name": "test_column",
+            "expression": "{var}",
+            "figure_of_merit": "fom_name",
+        }
+        ResultsColumn(conf_dict)
+        mock_die.assert_called_once()
+
+    @patch("ramble.results_table.logger.die")
+    def test_init_missing_expression_and_fom(self, mock_die):
+        conf_dict = {"name": "test_column"}
+        ResultsColumn(conf_dict)
+        mock_die.assert_called_once()
+
+    def test_col_name(self):
+        conf_dict = {"name": "col_{var}", "expression": "{var}"}
+        column = ResultsColumn(conf_dict)
+        app_inst = MagicMock()
+        app_inst.expander.expand_var.return_value = "col_value"
+        self.assertEqual(column.col_name(app_inst), "col_value")
+        app_inst.expander.expand_var.assert_called_with("col_{var}")
+
+    def test_extract_value_expression(self):
+        conf_dict = {"name": "test", "expression": "{var}"}
+        column = ResultsColumn(conf_dict)
+        app_inst = MagicMock()
+        app_inst.expander.evaluate_predicate.return_value = True
+        app_inst.expander.expand_var.return_value = "expanded_value"
+        value = column.extract_value(app_inst)
+        self.assertEqual(value, "expanded_value")
+
+    def test_extract_value_fom(self):
+        conf_dict = {
+            "name": "test",
+            "figure_of_merit": "fom_name",
+            "figure_of_merit_context": "fom_context",
+            "figure_of_merit_origin_type": "fom_origin",
+        }
+        column = ResultsColumn(conf_dict)
+        app_inst = MagicMock()
+        app_inst.expander.evaluate_predicate.return_value = True
+        app_inst.expander.expand_var.side_effect = lambda x: x
+        app_inst.result.contexts = [
+            {
+                "name": "fom_context",
+                "foms": [
+                    {
+                        "name": "fom_name",
+                        "origin_type": "fom_origin",
+                        "value": "fom_value",
+                    }
+                ],
+            }
+        ]
+        value = column.extract_value(app_inst)
+        self.assertEqual(value, "fom_value")
+
+    def test_extract_value_where_fails(self):
+        conf_dict = {"name": "test", "expression": "{var}", "where": ["'a' == 'b'"]}
+        column = ResultsColumn(conf_dict)
+        app_inst = MagicMock()
+        app_inst.expander.evaluate_predicate.return_value = False
+        value = column.extract_value(app_inst)
+        self.assertIsNone(value)
+
+
+class TestResultsTable(unittest.TestCase):
+    def setUp(self):
+        self.conf_dict = {
+            "name": "test_table",
+            "columns": [
+                {"name": "col1", "expression": "{var1}"},
+                {"name": "col2", "figure_of_merit": "fom1"},
+            ],
+            "group_by": "col1",
+            "sort_by": ["col2"],
+            "where": ["'{var1}' != 'skip'"],
+        }
+        self.table = ResultsTable(self.conf_dict)
+
+    def test_init(self):
+        self.assertEqual(self.table.name, "test_table")
+        self.assertEqual(len(self.table.columns), 2)
+        self.assertEqual(self.table.group_by, ["col1"])
+        self.assertEqual(self.table.sort_by, ["col2"])
+        self.assertEqual(self.table.where, ["'{var1}' != 'skip'"])
+
+    def test_add_where(self):
+        self.table.add_where("'new_cond' == 'true'")
+        self.assertIn("'new_cond' == 'true'", self.table.where)
+        self.table.add_where(["'cond2'"])
+        self.assertIn("'cond2'", self.table.where)
+
+    def test_extract_row(self):
+        app_inst = MagicMock()
+        app_inst.expander.evaluate_predicate.return_value = True
+        app_inst.expander.expand_var.side_effect = lambda x, **kwargs: x.strip("{}")
+        app_inst.result.contexts = [{"name": "ctx", "foms": [{"name": "fom1", "value": "val2"}]}]
+
+        with patch.object(ResultsColumn, "extract_value", side_effect=["val1", "val2"]):
+            self.table.extract_row(app_inst)
+
+        self.assertEqual(self.table._num_rows, 1)
+        self.assertEqual(self.table._data["col1"], ["val1"])
+        self.assertEqual(self.table._data["col2"], ["val2"])
+
+    @patch("ramble.results_table.create_symlink")
+    @patch("ramble.results_table.pandas.DataFrame")
+    def test_to_csv(self, mock_df, mock_symlink):
+        self.table._data = {"col1": ["a", "b"], "col2": [1, 2]}
+        self.table._num_rows = 2
+
+        mock_df_instance = mock_df.return_value
+        mock_df_instance.groupby.return_value.max.return_value = mock_df_instance
+        mock_df_instance.sort_values.return_value = mock_df_instance
+
+        self.table.to_csv("/tmp", "timestamp")
+
+        mock_df.assert_called_with(self.table._data)
+        mock_df_instance.to_csv.assert_called_with("/tmp/test_table.timestamp.csv", index=False)
+        mock_symlink.assert_called_with(
+            "/tmp/test_table.timestamp.csv", "/tmp/test_table.latest.csv"
+        )
+
+
+class TestResultsTables(unittest.TestCase):
+    def setUp(self):
+        self.tables = ResultsTables()
+
+    def test_add_table_template(self):
+        conf = {"name": "new_table", "columns": []}
+        table = self.tables.add_table_template(conf)
+        self.assertIsInstance(table, ResultsTable)
+        self.assertIn(table, self.tables.table_templates)
+
+    def test_build_tables(self):
+        table1 = MagicMock()
+        table2 = MagicMock()
+        self.tables.table_templates = [table1, table2]
+
+        exp1 = (None, MagicMock(), None)
+        exp2 = (None, MagicMock(), None)
+        experiment_set = MagicMock()
+        experiment_set.all_experiments.return_value = [exp1, exp2]
+
+        filters = MagicMock()
+
+        self.tables.build_tables(experiment_set, filters)
+
+        for table in self.tables.tables.values():
+            self.assertEqual(table.extract_row.call_count, 2)
+
+    def test_output_tables(self):
+        table1 = MagicMock()
+        table1.to_csv.return_value = ("file1.csv", "file1.latest.csv")
+        table2 = MagicMock()
+        table2.to_csv.return_value = ("file2.csv", "file2.latest.csv")
+        self.tables.tables = {"table1": table1, "table2": table2}
+
+        with patch("ramble.util.logger.logger.all_msg") as mock_log:
+            self.tables.output_tables("/tmp", "timestamp")
+
+        table1.to_csv.assert_called_with("/tmp", "timestamp")
+        table2.to_csv.assert_called_with("/tmp", "timestamp")
+        self.assertGreater(mock_log.call_count, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -27,6 +27,7 @@ import ramble.error
 import ramble.experiment_set
 import ramble.keywords
 import ramble.repository
+import ramble.results_table
 import ramble.schema.applications
 import ramble.schema.merged
 import ramble.schema.workspace
@@ -56,6 +57,9 @@ _active_workspace = None
 
 #: Subdirectory where workspace configs are stored
 workspace_config_path = "configs"
+
+#: Name of subdirectory within workspace where tables are stored
+workspace_tables_path = "tables"
 
 #: Name of subdirectory within workspaces where logs are stored
 workspace_log_path = "logs"
@@ -463,6 +467,8 @@ class Workspace:
         )
 
         self.workspace_hash = None
+
+        self.results_tables = ramble.results_table.ResultsTables()
 
         self.specs = []
 
@@ -1631,6 +1637,19 @@ ramble:
                         f.write(f"      {text}\n")
                         pkg_info_set.add(text)
 
+    def dump_tables(self, experiment_set, filters):
+        tables_config = ramble.config.get("tables", [])
+
+        if tables_config:
+            for table_conf in tables_config:
+                self.results_tables.add_table_template(table_conf)
+
+        if self.results_tables.num_tables > 0:
+            self.results_tables.build_tables(experiment_set, filters)
+
+            fs.mkdirp(self.tables_dir)
+            self.results_tables.output_tables(self.tables_dir, self.date_string())
+
     def dump_results(self, output_formats=None, print_results=False, summary_only=False):
         """
         Write out result file in desired format
@@ -2082,6 +2101,11 @@ ramble:
         return os.path.join(self.root, workspace_software_path)
 
     @property
+    def tables_dir(self):
+        """Path to the tables directory"""
+        return os.path.join(self.root, workspace_tables_path)
+
+    @property
     def log_dir(self):
         """Path to the logs directory"""
         return os.path.join(self.root, workspace_log_path)
@@ -2152,6 +2176,7 @@ ramble:
             namespace.workspace: root,
             "workspace_configs": os.path.join(root, workspace_config_path),
             "workspace_software": os.path.join(root, workspace_software_path),
+            "workspace_tables": os.path.join(root, workspace_tables_path),
             "workspace_logs": os.path.join(root, workspace_log_path),
             "workspace_inputs": os.path.join(root, workspace_input_path),
             "workspace_experiments": os.path.join(root, workspace_experiment_path),
@@ -2612,6 +2637,10 @@ ramble:
         """Return the software dictionary for this workspace"""
         software_dict = ramble.config.config.get_config(namespace.software)
         return software_dict
+
+    def get_workspace_tables(self):
+        """Return a dict of workspace tables"""
+        return ramble.config.config.get_config(namespace.tables)
 
     def get_applications(self):
         """Get the dictionary of applications"""


### PR DESCRIPTION
This merge adds a new configuration section to control tabulating the results of experiments.

Tables are scoped to the block they are defined inside. Currently only csv output is supported, but the results table classes can be extended to support alternative output formats.

Tests and documentation are added for this feature.