### PR TITLE
Include in command output for failed RambleCommand call

### DIFF
--- a/lib/ramble/ramble/main.py
+++ b/lib/ramble/ramble/main.py
@@ -717,8 +717,13 @@ class RambleCommand:
         if fail_on_error and self.returncode not in (None, 0):
             self._log_command_output(out)
             raise RambleCommandError(
-                "Command exited with code %d: %s(%s)"
-                % (self.returncode, self.command_name, ", ".join("'%s'" % a for a in argv))
+                "Command exited with code %d: %s(%s).\nCommand output:\n\n%s"
+                % (
+                    self.returncode,
+                    self.command_name,
+                    ", ".join("'%s'" % a for a in argv),
+                    out.getvalue(),
+                )
             )
 
         return out.getvalue()

--- a/lib/ramble/ramble/test/when.py
+++ b/lib/ramble/ramble/test/when.py
@@ -234,10 +234,11 @@ test inheritance 12.0
 
         ws._re_read()
 
-        with pytest.raises(RambleCommandError):
-
-            captured = workspace("analyze", global_args=global_args)
-            assert "context 'test_context_when'" in captured
+        with pytest.raises(
+            RambleCommandError,
+            match=r"Command output:\n\n.*context 'test_context_when'.*is not found",
+        ):
+            workspace("analyze", global_args=global_args)
 
 
 def test_same_fom_name_different_context(workspace_name):


### PR DESCRIPTION
This helps with debugging test failures from the logs.