### PR TITLE
Update stage methods to dereference links

### DIFF
--- a/lib/ramble/ramble/language/application_language.py
+++ b/lib/ramble/ramble/language/application_language.py
@@ -455,13 +455,13 @@ def stage_files(
 
         # Prepare the core staging command
         if stage_method == "rsync":
-            stage_cmd = f"rsync -r {src} {dst}"
+            stage_cmd = f"rsync -Lr {src} {dst}"
         elif stage_method == "hard_link":
             stage_cmd = f"ln {src} {dst}"
         elif stage_method == "symbolic_link":
             stage_cmd = f"ln -s {src} {dst}"
         else:  # stage_method == "cp"
-            stage_cmd = f"cp -r {src} {dst}"
+            stage_cmd = f"cp -Lr {src} {dst}"
 
         template = [stage_cmd]
 

--- a/lib/ramble/ramble/test/application_language.py
+++ b/lib/ramble/ramble/test/application_language.py
@@ -397,8 +397,8 @@ def test_workload_variable_workload_defaults_error():
 @pytest.mark.parametrize(
     "stage_method,template_contents",
     [
-        ("cp", "cp -r src"),
-        ("rsync", "rsync -r src"),
+        ("cp", "cp -Lr src"),
+        ("rsync", "rsync -Lr src"),
         ("symbolic_link", "ln -s src"),
         ("hard_link", "ln src"),
     ],


### PR DESCRIPTION
This merge updates the stage methods to dereference symlinks when copying or rsync-ing files.