### PR TITLE
Add a separate bash-completion file to support command aliases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ __pycache__/
 *.x
 var/ramble/cache
 var/ramble/workspaces
+
+# bash autocomplete with user-defined aliases
+share/ramble/custom-ramble-completion.bash

--- a/lib/ramble/ramble/cmd/commands.py
+++ b/lib/ramble/ramble/cmd/commands.py
@@ -36,11 +36,21 @@ formatters = {}
 #: standard arguments for updating completion scripts
 #: we iterate through these when called with --update-completion
 update_completion_args = {
-    "bash": {
-        "aliases": True,
+    # Default one included in source control
+    # Disable aliases to avoid custom configs leaking into it
+    "bash_no_aliases": {
+        "aliases": False,
         "format": "bash",
         "header": os.path.join(ramble.paths.share_path, "bash", "ramble-completion.in"),
         "update": os.path.join(ramble.paths.share_path, "ramble-completion.bash"),
+    },
+    # Generate a version that supports aliases (including ones defined in `config:aliases`)
+    # This one is not included in source control as it is user-specific
+    "base_with_aliases": {
+        "aliases": True,
+        "format": "bash",
+        "header": os.path.join(ramble.paths.share_path, "bash", "ramble-completion.in"),
+        "update": os.path.join(ramble.paths.share_path, "custom-ramble-completion.bash"),
     },
 }
 

--- a/share/ramble/bash/ramble-completion.in
+++ b/share/ramble/bash/ramble-completion.in
@@ -10,6 +10,8 @@
 #
 #   $ ramble commands --update-completion
 #
+# Running the above command would also generate a version supporting custom aliases.
+#
 # Please do not manually modify this file.
 
 

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -10,6 +10,8 @@
 #
 #   $ ramble commands --update-completion
 #
+# Running the above command would also generate a version supporting custom aliases.
+#
 # Please do not manually modify this file.
 
 
@@ -297,7 +299,7 @@ _ramble_config() {
     then
         RAMBLE_COMPREPLY="-h --help --scope"
     else
-        RAMBLE_COMPREPLY="get blame edit list add remove rm update revert"
+        RAMBLE_COMPREPLY="get blame edit list add remove update revert"
     fi
 }
 
@@ -342,15 +344,6 @@ _ramble_config_add() {
 }
 
 _ramble_config_remove() {
-    if $list_options
-    then
-        RAMBLE_COMPREPLY="-h --help"
-    else
-        RAMBLE_COMREPLY=""
-    fi
-}
-
-_ramble_config_rm() {
     if $list_options
     then
         RAMBLE_COMPREPLY="-h --help"
@@ -473,7 +466,7 @@ _ramble_mirror() {
     then
         RAMBLE_COMPREPLY="-h --help -n --no-checksum"
     else
-        RAMBLE_COMPREPLY="destroy add remove rm set-url list"
+        RAMBLE_COMPREPLY="destroy add remove set-url list"
     fi
 }
 
@@ -491,15 +484,6 @@ _ramble_mirror_add() {
 }
 
 _ramble_mirror_remove() {
-    if $list_options
-    then
-        RAMBLE_COMPREPLY="-h --help --scope"
-    else
-        RAMBLE_COMREPLY=""
-    fi
-}
-
-_ramble_mirror_rm() {
     if $list_options
     then
         RAMBLE_COMPREPLY="-h --help --scope"
@@ -539,7 +523,7 @@ _ramble_repo() {
     then
         RAMBLE_COMPREPLY="-h --help"
     else
-        RAMBLE_COMPREPLY="create list add remove rm"
+        RAMBLE_COMPREPLY="create list add remove"
     fi
 }
 
@@ -566,15 +550,6 @@ _ramble_repo_add() {
 }
 
 _ramble_repo_remove() {
-    if $list_options
-    then
-        RAMBLE_COMPREPLY="-h --help --scope -t --type"
-    else
-        _repos
-    fi
-}
-
-_ramble_repo_rm() {
     if $list_options
     then
         RAMBLE_COMPREPLY="-h --help --scope -t --type"
@@ -632,7 +607,7 @@ _ramble_workspace() {
     then
         RAMBLE_COMPREPLY="-h --help"
     else
-        RAMBLE_COMPREPLY="activate archive deactivate create concretize config setup analyze push-to-cache info edit mirror experiment-logs list ls remove rm generate-config manage"
+        RAMBLE_COMPREPLY="activate archive deactivate create concretize config setup analyze push-to-cache info edit mirror experiment-logs list remove generate-config manage"
     fi
 }
 
@@ -707,20 +682,7 @@ _ramble_workspace_list() {
     RAMBLE_COMPREPLY="-h --help"
 }
 
-_ramble_workspace_ls() {
-    RAMBLE_COMPREPLY="-h --help"
-}
-
 _ramble_workspace_remove() {
-    if $list_options
-    then
-        RAMBLE_COMPREPLY="-h --help -y --yes-to-all"
-    else
-        _workspaces
-    fi
-}
-
-_ramble_workspace_rm() {
     if $list_options
     then
         RAMBLE_COMPREPLY="-h --help -y --yes-to-all"

--- a/share/ramble/setup-env.sh
+++ b/share/ramble/setup-env.sh
@@ -349,6 +349,11 @@ done
 #
 if [ "$_rmb_shell" = bash ]; then
     source $_rmb_share_dir/ramble-completion.bash
+    # The custom version includes support for command aliases, it is
+    # generated via `ramble commands --update-completion`.
+    if [ -f "$_rmb_share_dir/custom-ramble-completion.bash" ]; then
+        source $_rmb_share_dir/custom-ramble-completion.bash
+    fi
 fi
 
 # done: unset sentinel variable as we're no longer initializing


### PR DESCRIPTION
Prior to this change, if there's user-defined `config:aliases`, then running the autocomplete generation (`ramble commands --update-completion`) would update the existing file with these aliases. Such leaking is not desirable for the source-controlled autocomplete file. OTOH, users would likely prefer having autocomplete for their custom aliases. To address this conflict, now the autocomplete update will generate two files, one serves as the default one (without aliases) and is source-controlled, while the other is ignored by source control and includes aliases. The setup script will source in the custom one, if present.

This means that for a user:

* If they do nothing, then they will use the default autocomplete. They get the usual autocomplete support, but no support for aliases.
* If they want autocomplete support for aliases, then they need to invoke `ramble commands --update-completion`, and re-source the `setup-env.sh` script.