### PR TITLE
Ensure spack pkgman has the `environment_(un)load_commands` methods

### DIFF
--- a/lib/ramble/ramble/language/language_base.py
+++ b/lib/ramble/ramble/language/language_base.py
@@ -10,6 +10,7 @@
 directives, which are to allow functions to be invoked at class level
 """
 
+import abc
 import copy
 import functools
 import inspect
@@ -55,7 +56,7 @@ def _pop_default_args() -> dict:
     return DirectiveMeta._default_args.pop()
 
 
-class DirectiveMeta(type):
+class DirectiveMeta(abc.ABCMeta):
     """Flushes the directives that were temporarily stored in the staging
     area into the package.
     """

--- a/lib/ramble/ramble/test/package_manager_language.py
+++ b/lib/ramble/ramble/test/package_manager_language.py
@@ -9,11 +9,13 @@
 
 import pytest
 
-from ramble.pkgmankit import *  # noqa
+import ramble.repository
 
-pm_types = [
-    PackageManagerBase,  # noqa: F405
-]
+UserManagedPackageManager = ramble.repository.get_obj_class(
+    "user-managed", ramble.repository.ObjectTypes.package_managers
+)
+
+pm_types = [UserManagedPackageManager]
 
 
 @pytest.mark.parametrize("pm_class", pm_types)

--- a/var/ramble/repos/builtin.mock/package_managers/info/package_manager.py
+++ b/var/ramble/repos/builtin.mock/package_managers/info/package_manager.py
@@ -136,3 +136,9 @@ class Info(PackageManagerBase):
     )
 
     package_manager_family("info-package-manager")
+
+    def environment_load_commands(self) -> List[str]:
+        return []
+
+    def environment_unload_commands(self) -> List[str]:
+        return []

--- a/var/ramble/repos/builtin.mock/package_managers/when-package-manager/package_manager.py
+++ b/var/ramble/repos/builtin.mock/package_managers/when-package-manager/package_manager.py
@@ -64,3 +64,9 @@ class WhenPackageManager(PackageManagerBase):
         description="Test required key",
         when=["+pkg_man_required_key"],
     )
+
+    def environment_load_commands(self) -> List[str]:
+        return []
+
+    def environment_unload_commands(self) -> List[str]:
+        return []

--- a/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
@@ -7,6 +7,7 @@
 # except according to those terms.
 """Define base classes for package manager definitions"""
 
+import abc
 import os
 from typing import List
 
@@ -244,15 +245,15 @@ class PackageManagerBase(ObjectMixin, metaclass=PackageManagerMeta):
         del workspace
         return []
 
+    @abc.abstractmethod
     def environment_load_commands(self) -> List[str]:
         """Stub method for acquiring the commands to load
         an experiment's execution environment"""
-        return []
 
+    @abc.abstractmethod
     def environment_unload_commands(self) -> List[str]:
         """Stub method for acquiring the commands to unload an
         experiment's execution environment"""
-        return []
 
     def _extract_specs(
         self, attr_name="software_specs", app_inst=None, prefixed=False

--- a/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
@@ -249,7 +249,6 @@ class PackageManagerBase(ObjectMixin, metaclass=PackageManagerMeta):
         an experiment's execution environment"""
         return []
 
-    @property
     def environment_unload_commands(self) -> List[str]:
         """Stub method for acquiring the commands to unload an
         experiment's execution environment"""

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
@@ -526,6 +526,12 @@ class SpackLightweight(PackageManagerBase):
     def spack_deactivate(self):
         return self.runner.generate_deactivate_command()
 
+    def environment_load_commands(self):
+        return self.spack_activate()
+
+    def environment_unload_commands(self):
+        return self.spack_deactivate()
+
     def get_spec_str(self, pkg, all_pkgs, compiler):
         """Return a spec string for the given pkg
 

--- a/var/ramble/repos/builtin/package_managers/user-managed/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/user-managed/package_manager.py
@@ -6,6 +6,8 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+from typing import List
+
 from ramble.pkgmankit import *
 
 
@@ -95,3 +97,9 @@ class UserManaged(PackageManagerBase):
                 pkg_list.append(software_info)
 
         return pkg_list
+
+    def environment_load_commands(self) -> List[str]:
+        return []
+
+    def environment_unload_commands(self) -> List[str]:
+        return []


### PR DESCRIPTION
Also remove the (wrong) decoration of setting `environment_unload_commands` as a property in the base class.

One general change is to use `abc.ABCMeta` to enforce abstract methods on the package-manager-base, such that derived pkgmans are now required to implement these methods.