### PR TITLE
Apply linting suggestions from `ruff`

### DIFF
--- a/lib/ramble/ramble/appkit.py
+++ b/lib/ramble/ramble/appkit.py
@@ -16,13 +16,9 @@ import llnl.util.filesystem
 from llnl.util.filesystem import *
 
 import ramble.language.application_language
-from ramble.repository import get_base_class
-
-ExecutableApplication = get_base_class("executable-application")
-ApplicationBase = get_base_class("application-base")
-
 from ramble.language.application_language import *
 from ramble.language.shared_language import *
+from ramble.repository import get_base_class
 from ramble.spec import Spec
 from ramble.util.command_runner import (
     CommandRunner,
@@ -34,3 +30,6 @@ from ramble.util.file_util import get_file_path
 from ramble.util.foms import FomType
 from ramble.util.logger import logger
 from ramble.util.output_capture import OUTPUT_CAPTURE
+
+ExecutableApplication = get_base_class("executable-application")
+ApplicationBase = get_base_class("application-base")

--- a/lib/ramble/ramble/cmd/__init__.py
+++ b/lib/ramble/ramble/cmd/__init__.py
@@ -113,7 +113,7 @@ def get_module(cmd_name):
         try:
             module = spack.extensions.get_module(cmd_name)
         except AttributeError:
-            raise RambleCommandError("Command %s does not exist." % cmd_name)
+            raise RambleCommandError("Command %s does not exist." % cmd_name) from None
 
     attr_setdefault(module, SETUP_PARSER, lambda *args: None)  # null-op
     attr_setdefault(module, DESCRIPTION, "")

--- a/lib/ramble/ramble/cmd/mirror.py
+++ b/lib/ramble/ramble/cmd/mirror.py
@@ -8,7 +8,6 @@
 import ramble.cmd.common.arguments as arguments
 import ramble.config
 import ramble.mirror
-from ramble.error import RambleError
 from ramble.util.logger import logger
 
 import spack.util.url as url_util
@@ -169,22 +168,6 @@ def mirror_list(args):
         return
 
     mirrors.display()
-
-
-def _read_specs_from_file(filename):
-    specs = []
-    with open(filename) as stream:
-        for i, string in enumerate(stream):
-            try:
-                s = ramble.Spec(string)
-                s.application
-                specs.append(s)
-            except RambleError as e:
-                logger.debug(e)
-                logger.die(
-                    "Parse error in %s, line %d:" % (filename, i + 1), ">>> " + string, str(e)
-                )
-    return specs
 
 
 def mirror_destroy(args):

--- a/lib/ramble/ramble/config.py
+++ b/lib/ramble/ramble/config.py
@@ -217,7 +217,7 @@ class ConfigScope:
             with open(filename, "w") as f:
                 syaml.dump_config(data, stream=f, default_flow_style=False)
         except (yaml.YAMLError, OSError) as e:
-            raise ConfigFileError("Error writing to config file: '%s'" % str(e))
+            raise ConfigFileError("Error writing to config file") from e
 
     def clear(self):
         """Empty cached config information."""
@@ -347,7 +347,7 @@ class SingleFileScope(ConfigScope):
             rename(tmp, self.path)
 
         except (yaml.YAMLError, OSError) as e:
-            raise ConfigFileError("Error writing to config file: '%s'" % str(e))
+            raise ConfigFileError("Error writing to config file") from e
 
     def __repr__(self):
         return f"<SingleFileScope: {self.name}: {self.path}>"
@@ -753,7 +753,7 @@ class Configuration:
             data[section] = self.get_config(section)
             syaml.dump_config(data, stream=sys.stdout, default_flow_style=False, blame=blame)
         except (yaml.YAMLError, OSError):
-            raise ConfigError("Error reading configuration: %s" % section)
+            raise ConfigError("Error reading configuration: %s" % section) from None
 
 
 @contextmanager
@@ -1033,13 +1033,15 @@ def read_config_file(filename, schema=None):
         return data
 
     except StopIteration:
-        raise ConfigFileError("Config file is empty or is not a valid YAML dict: %s" % filename)
+        raise ConfigFileError(
+            "Config file is empty or is not a valid YAML dict: %s" % filename
+        ) from None
 
     except MarkedYAMLError as e:
-        raise ConfigFileError(f"Error parsing yaml{str(e.context_mark)}: {e.problem}")
+        raise ConfigFileError(f"Error parsing yaml{str(e.context_mark)}: {e.problem}") from e
 
     except OSError as e:
-        raise ConfigFileError(f"Error reading configuration file {filename}: {str(e)}")
+        raise ConfigFileError(f"Error reading configuration file {filename}") from e
 
 
 def _override(string):

--- a/lib/ramble/ramble/definitions/families.py
+++ b/lib/ramble/ramble/definitions/families.py
@@ -6,7 +6,7 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-from typing import List
+from typing import List, Optional
 
 
 class Families:
@@ -15,7 +15,7 @@ class Families:
     def __init__(
         self,
         origin_type: str,
-        families: List[str] = [],
+        families: Optional[List[str]] = None,
     ):
         """Constructor for families object
 
@@ -24,7 +24,7 @@ class Families:
             families: List of families
         """
         self.family_type = f"{origin_type}_family"
-        self.families = families
+        self.families = families if families is not None else []
 
     def __iter__(self):
         """Iterate over families"""

--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -684,7 +684,7 @@ class Expander:
             if not passthrough_setting:
                 raise RambleSyntaxError(
                     f"Encountered a passthrough error while expanding {var}\n" f"{e}"
-                )
+                ) from None
 
         logger.debug(f"END OF EXPAND_VAR STACK {value}")
         if typed:
@@ -849,7 +849,7 @@ class Expander:
                 logger.debug(f'   Math input is: "{in_str}"')
                 logger.debug(e)
             except RambleSyntaxError as e:
-                raise RambleSyntaxError(f'{str(e)} in "{in_str}"')
+                raise RambleSyntaxError(f'{str(e)} in "{in_str}"') from None
             except SyntaxError as e:
                 logger.debug(f"ast.parse hit the following syntax error on input: {in_str}")
                 logger.debug(e)

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -72,7 +72,7 @@ class ExperimentSet:
         try:
             self.keywords.check_reserved_keys(workspace_context.variables)
         except ramble.keywords.RambleKeywordError as e:
-            raise RambleVariableDefinitionError(f"Workspace variable error: {e}")
+            raise RambleVariableDefinitionError(f"Workspace variable error: {e}") from None
 
         self._set_context(self._contexts.workspace, workspace_context)
 
@@ -125,7 +125,9 @@ class ExperimentSet:
         try:
             self.keywords.check_reserved_keys(app_context.variables)
         except ramble.keywords.RambleKeywordError as e:
-            raise RambleVariableDefinitionError(f"In application {app_context.context_name}: {e}")
+            raise RambleVariableDefinitionError(
+                f"In application {app_context.context_name}: {e}"
+            ) from None
 
         self._set_context(self._contexts.application, app_context)
 
@@ -136,7 +138,7 @@ class ExperimentSet:
             self.keywords.check_reserved_keys(workload_context.variables)
         except ramble.keywords.RambleKeywordError as e:
             namespace = f"{self.application_namespace}.{workload_context.context_name}"
-            raise RambleVariableDefinitionError(f"In workload {namespace}: {e}")
+            raise RambleVariableDefinitionError(f"In workload {namespace}: {e}") from None
 
         self._set_context(self._contexts.workload, workload_context)
 
@@ -147,7 +149,7 @@ class ExperimentSet:
             self.keywords.check_reserved_keys(experiment_context.variables)
         except ramble.keywords.RambleKeywordError as e:
             namespace = f"{self.workload_namespace}.{experiment_context.templates}"
-            raise RambleVariableDefinitionError(f"In experiment {namespace}: {e}")
+            raise RambleVariableDefinitionError(f"In experiment {namespace}: {e}") from None
 
         self._set_context(self._contexts.experiment, experiment_context)
         self._ingest_experiments(die_on_validate_error=die_on_validate_error)
@@ -573,7 +575,7 @@ class ExperimentSet:
                     if die_on_validate_error:
                         raise RambleVariableDefinitionError(
                             f"In experiment {final_exp_namespace}: {e}"
-                        )
+                        ) from None
                     pass
 
                 workload_names.add(app_inst.expander.workload_name)

--- a/lib/ramble/ramble/fetch_strategy.py
+++ b/lib/ramble/ramble/fetch_strategy.py
@@ -363,7 +363,7 @@ class URLFetchStrategy(FetchStrategy):
                       {}\n with error {}".format(
                     url, werr
                 )
-                raise FailedDownloadError(url, msg)
+                raise FailedDownloadError(url, msg) from None
             return response.getcode() is None or response.getcode() == 200
 
     def _fetch_from_url(self, url):
@@ -403,7 +403,7 @@ class URLFetchStrategy(FetchStrategy):
             if save_file and os.path.exists(save_file):
                 os.remove(save_file)
             msg = f"urllib failed to fetch with error {e}"
-            raise FailedDownloadError(url, msg)
+            raise FailedDownloadError(url, msg) from None
 
         with open(save_file, "wb") as _open_file:
             shutil.copyfileobj(response, _open_file)
@@ -1402,7 +1402,7 @@ class S3FetchStrategy(URLFetchStrategy):
             super().__init__(*args, **kwargs)
         except ValueError:
             if not kwargs.get("url"):
-                raise ValueError("S3FetchStrategy requires a url for fetching.")
+                raise ValueError("S3FetchStrategy requires a url for fetching.") from None
 
     @_needs_stage
     def fetch(self):
@@ -1447,7 +1447,7 @@ class GCSFetchStrategy(URLFetchStrategy):
             super().__init__(*args, **kwargs)
         except ValueError:
             if not kwargs.get("url"):
-                raise ValueError("GCSFetchStrategy requires a url for fetching.")
+                raise ValueError("GCSFetchStrategy requires a url for fetching.") from None
 
     @_needs_stage
     def fetch(self):

--- a/lib/ramble/ramble/graphs.py
+++ b/lib/ramble/ramble/graphs.py
@@ -132,8 +132,8 @@ class AttributeGraph:
                     exp_name = self._obj_inst.name
                 raise GraphCycleError(
                     f"In experiment {exp_name} a cycle was detected "
-                    f"when processing the {self.node_type} graph.\n" + str(e)
-                )
+                    f"when processing the {self.node_type} graph."
+                ) from e
             self._prepared = True
 
         yield from self._sorted

--- a/lib/ramble/ramble/renderer.py
+++ b/lib/ramble/ramble/renderer.py
@@ -184,7 +184,7 @@ class Renderer:
                     var = expander.expand_var(unexpanded_var)
                     matrix[i] = var
         if zips:
-            for zip_group, group_def in zips.items():
+            for group_def in zips.values():
                 for i, unexpanded_var in enumerate(group_def):
                     group_def[i] = expander.expand_var(unexpanded_var)
 
@@ -415,7 +415,7 @@ class Renderer:
         if vector_vars:
             # Check that sizes are the same
             length_mismatch = False
-            for var, val in vector_vars.items():
+            for val in vector_vars.values():
                 if len(val) != max_vector_size:
                     length_mismatch = True
 

--- a/lib/ramble/ramble/repository.py
+++ b/lib/ramble/ramble/repository.py
@@ -1176,7 +1176,7 @@ class Repo:
             # handler by wrapping them
             if ramble.config.get("config:debug"):
                 sys.excepthook(*sys.exc_info())
-            raise FailedConstructorError(spec.fullname, *sys.exc_info())
+            raise FailedConstructorError(spec.fullname, *sys.exc_info()) from e
 
     @autospec
     def dump_provenance(self, spec, path):
@@ -1324,7 +1324,7 @@ class Repo:
                 # manually construct the error message in order to give the
                 # user the correct .py where the syntax error is
                 # located
-                raise SyntaxError(f"invalid syntax in {file_path}, line {e.lineno}")
+                raise SyntaxError(f"invalid syntax in {file_path}, line {e.lineno}") from None
 
             module.__object__ = self.full_namespace
             module.__loader__ = self
@@ -1442,9 +1442,7 @@ def create_repo(
         else:
             shutil.rmtree(root, ignore_errors=True)
 
-        raise BadRepoError(
-            "Failed to create new repository in %s." % root, f"Caused by {type(e)}: {e}"
-        )
+        raise BadRepoError("Failed to create new repository in %s." % root) from e
 
     return full_path, namespace
 
@@ -1490,7 +1488,7 @@ class RepositoryNamespace(types.ModuleType):
             setattr(self, name, __import__(submodule))
         except ImportError:
             msg = "'{0}' object has no attribute {1}"
-            raise AttributeError(msg.format(type(self), name))
+            raise AttributeError(msg.format(type(self), name)) from None
         return getattr(self, name)
 
 

--- a/lib/ramble/ramble/software_environments.py
+++ b/lib/ramble/ramble/software_environments.py
@@ -817,7 +817,7 @@ class SoftwareEnvironments:
                 cur_compiler = pkg.compiler
                 # Re-render compiler package to ensure variables are marked as used.
                 if cur_compiler in self._rendered_packages[pm_name]:
-                    for template_name, template_def in self._package_templates.items():
+                    for template_def in self._package_templates.values():
                         if cur_compiler in template_def._rendered_packages[pm_name]:
                             expander.flush_used_variable_stage()
                             rendered_pkg = template_def.render_package(

--- a/lib/ramble/ramble/spec.py
+++ b/lib/ramble/ramble/spec.py
@@ -94,7 +94,7 @@ class SpecParser(spack.parse.Parser):
             else:
                 self.next_token_error("Invalid token found")
         except spack.parse.ParseError as e:
-            raise SpecParseError(e)
+            raise SpecParseError(e) from None
 
         return [app_spec]
 
@@ -214,7 +214,7 @@ class Spec:
                         parent = ".".join(parts[:idx])
                         m = "Attempted to format attribute %s." % attribute
                         m += f"Spec {parent} has no attribute {part}"
-                        raise SpecFormatStringError(m)
+                        raise SpecFormatStringError(m) from None
 
                     if callable(current):
                         raise SpecFormatStringError("Attempted to format callable object")

--- a/lib/ramble/ramble/success_criteria.py
+++ b/lib/ramble/ramble/success_criteria.py
@@ -74,13 +74,13 @@ class ScopedCriteriaList:
         """
         self.validate_scope(scope)
 
-        for scope in self._flush_scopes[scope]:
-            logger.debug(f" Flushing scope: {scope}")
+        for s in self._flush_scopes[scope]:
+            logger.debug(f" Flushing scope: {s}")
             logger.debug("    It contained:")
-            for crit in self.criteria[scope]:
+            for crit in self.criteria[s]:
                 logger.debug(f"      {crit.name}")
-            del self.criteria[scope]
-            self.criteria[scope] = []
+            del self.criteria[s]
+            self.criteria[s] = []
 
     def passed(self):
         succeed = True

--- a/lib/ramble/ramble/test/end_to_end/package_manager_provenance.py
+++ b/lib/ramble/ramble/test/end_to_end/package_manager_provenance.py
@@ -88,11 +88,11 @@ def test_spack_package_manager_provenance_zlib(mock_applications, workspace_name
         import json
 
         data = json.load(f)
-        for data in data["experiments"]:
-            pkg_list = data["SOFTWARE"]["spack"]
+        for d in data["experiments"]:
+            pkg_list = d["SOFTWARE"]["spack"]
             names = [pkg["name"] for pkg in pkg_list]
-            assert "SOFTWARE" in data
-            assert "spack" in data["SOFTWARE"]
+            assert "SOFTWARE" in d
+            assert "spack" in d["SOFTWARE"]
             assert "zlib" in names
 
 

--- a/lib/ramble/ramble/test/modifier_language.py
+++ b/lib/ramble/ramble/test/modifier_language.py
@@ -105,10 +105,10 @@ def test_variable_modification_directive(mod_class):
 
     when_conditions = 0
     mod_count = 0
-    for when_set, var_mod_dict in mod_inst.variable_modifications.items():
+    for when_set in mod_inst.variable_modifications:
         when_conditions += len(when_set)
         for var_name in mod_inst.variable_modifications[when_set]:
-            for modification in mod_inst.variable_modifications[when_set][var_name]:
+            for _ in mod_inst.variable_modifications[when_set][var_name]:
                 mod_count += 1
     assert mod_count == 3  # Each call to add_variable_modification adds 1 variable modification
     assert when_conditions == 3  # Each modification applies in 3 modes, stored as when conditions
@@ -118,7 +118,7 @@ def test_variable_modification_directive(mod_class):
         mode_name = test_def["mode"]
         mode_when = f"{mod_inst.name}_mode={mode_name}"
 
-        for when_set, var_mod_dict in mod_inst.variable_modifications.items():
+        for when_set in mod_inst.variable_modifications:
             assert mode_when in when_set
             assert var_name in mod_inst.variable_modifications[when_set]
             found_match = (
@@ -137,7 +137,7 @@ def test_variable_modification_directive(mod_class):
         for mode_name in test_def["modes"]:
             mode_when = f"{mod_inst.name}_mode={mode_name}"
 
-            for when_set, var_mod_dict in mod_inst.variable_modifications.items():
+            for when_set in mod_inst.variable_modifications:
                 found_match = (
                     False if len(mod_inst.variable_modifications[when_set][var_name]) > 0 else True
                 )
@@ -337,7 +337,7 @@ def add_figure_of_merit(mod_inst, context_num=1):
         "contexts": contexts.copy(),
     }
 
-    for context in contexts:
+    for _ in contexts:
         mod_inst.figure_of_merit(
             name,
             fom_regex=fom_regex,

--- a/lib/ramble/ramble/test/stage.py
+++ b/lib/ramble/ramble/test/stage.py
@@ -121,11 +121,11 @@ def check_expand_archive(stage, stage_name, expected_file_list):
             contents = _extra_contents
 
         else:
-            assert False
+            raise AssertionError
 
         assert os.path.isfile(fn)
         with open(fn) as _file:
-            _file.read() == contents
+            assert _file.read() == contents
 
 
 def check_fetch(stage, stage_name):

--- a/lib/ramble/ramble/test/success_criteria_functionality/success_summary.py
+++ b/lib/ramble/ramble/test/success_criteria_functionality/success_summary.py
@@ -64,7 +64,7 @@ ramble:
         ramble_on(global_args=["-w", workspace_name])
         workspace("analyze", "-f", "text", "json", "yaml", global_args=["-w", workspace_name])
 
-        for extension in ["txt", "json", "yaml"]:
+        for _ in ["txt", "json", "yaml"]:
             with open(os.path.join(ws.root, "results.latest.txt")) as f:
                 data = f.read()
                 assert "Success criteria summary:" in data

--- a/lib/ramble/ramble/test/when.py
+++ b/lib/ramble/ramble/test/when.py
@@ -1215,8 +1215,8 @@ def test_obj_env_var_when(workspace_name, obj, mutable_mock_wms_repo, mutable_mo
         with open(exec_file) as f:
             data = f.read()
 
-            for obj_under_test, exec_test_str in exec_test_str.items():
-                assert (exec_test_str in data) == (obj_under_test == obj)
+            for obj_under_test, test_str in exec_test_str.items():
+                assert (test_str in data) == (obj_under_test == obj)
 
 
 @pytest.mark.parametrize(

--- a/lib/ramble/ramble/util/command_runner.py
+++ b/lib/ramble/ramble/util/command_runner.py
@@ -38,7 +38,7 @@ class CommandRunner:
             else:
                 self.command = which(command, required=required, path=path)
         except CommandNotFoundError:
-            raise RunnerError(f"Command {name} is not found in path")
+            raise RunnerError(f"Command {name} is not found in path") from None
 
     def get_version(self):
         """Hook to get the version of the executable

--- a/lib/ramble/ramble/util/matrices.py
+++ b/lib/ramble/ramble/util/matrices.py
@@ -37,8 +37,7 @@ def extract_matrices(action, name, in_dict):
                         "1 matrix in a matrices definition."
                     )
 
-                for name, val in matrix.items():
-                    matrices.append(val)
+                matrices.extend(matrix.values())
             elif isinstance(matrix, list):
                 matrices.append(matrix)
     return matrices

--- a/lib/ramble/ramble/util/web.py
+++ b/lib/ramble/ramble/util/web.py
@@ -121,7 +121,7 @@ def read_from_url(url, accept_content_type=None):
     try:
         response = _urlopen(req, timeout=timeout, context=context)
     except URLError as err:
-        raise SpackWebError(f"Download failed: {str(err)}")
+        raise SpackWebError("Download failed") from err
 
     if accept_content_type and not is_web_url:
         content_type = get_header(response.headers, "Content-type")

--- a/lib/ramble/ramble/variants.py
+++ b/lib/ramble/ramble/variants.py
@@ -283,7 +283,7 @@ class VariantSet:
                 out_set.add(variant.as_definition())
                 defined_variants.add(name)
 
-        for name, variant_list in self.multi_value_variants.items():
+        for variant_list in self.multi_value_variants.values():
             for variant in variant_list:
                 out_set.add(variant.as_definition())
 

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -320,7 +320,7 @@ def config_dict(yaml_data):
         raise RambleActiveWorkspaceError(
             "ramble.yaml needs to contain at least one of the "
             f"required keys {ramble.schema.workspace.keys}"
-        )
+        ) from None
 
 
 def get_workspace(args, cmd_name, required=False):
@@ -1816,8 +1816,8 @@ ramble:
                     fs.mkdirp(subdir)
                 except OSError as e:
                     raise ramble.mirror.MirrorError(
-                        "Cannot create directory '%s':" % subdir, str(e)
-                    )
+                        "Cannot create directory '%s':" % subdir
+                    ) from e
 
         self.software_mirror_stats = MirrorStats()
         self.input_mirror_stats = MirrorStats()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,3 +119,18 @@ allow_redefinition = true
 # Only enable ramble modules
 module = "ramble.*"
 ignore_errors = false
+
+# TODO: Add ruff into `ramble style` once it reaches v1.
+# For now, the ruff check can be invoked manually with `ruff check`.
+[tool.ruff]
+extend-include = ["bin/ramble"]
+extend-exclude = [
+  "lib/ramble/external",
+  "lib/ramble/spack",
+  "lib/ramble/llnl",
+]
+
+[tool.ruff.lint]
+# The F and E ignores here are already checked by flake8, and B905 requires Python 3.9 or up.
+ignore = ["B905", "F405", "F403", "E402"]
+extend-select = ["B"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,10 @@ extend-exclude = [
 ]
 
 [tool.ruff.lint]
-# The F and E ignores here are already checked by flake8, and B905 requires Python 3.9 or up.
-ignore = ["B905", "F405", "F403", "E402"]
+# B905 requires Python 3.9 or up.
+ignore = ["B905"]
 extend-select = ["B"]
+
+[tool.ruff.lint.per-file-ignores]
+"lib/ramble/ramble/*kit.py" = ["F403"]
+"var/ramble/repos/**/*.py" = ["F403", "F405"]

--- a/share/ramble/qa/flake8_formatter.py
+++ b/share/ramble/qa/flake8_formatter.py
@@ -4,7 +4,6 @@ from collections import defaultdict
 
 import pycodestyle
 from flake8.formatting.default import Pylint
-from flake8.style_guide import Violation
 
 #: This is a dict that maps:
 #:  filename pattern ->

--- a/var/ramble/repos/builtin/applications/intel-mlc/application.py
+++ b/var/ramble/repos/builtin/applications/intel-mlc/application.py
@@ -206,7 +206,7 @@ class IntelMlc(ExecutableApplication):
         threads = []
         cur_indices = []
         numa_index = 0
-        for i in range(0, spread_divisions):
+        for _ in range(0, spread_divisions):
             cur_indices.append(numa_index)
             numa_index += max_thread // spread_divisions
 

--- a/var/ramble/repos/builtin/applications/ior/application.py
+++ b/var/ramble/repos/builtin/applications/ior/application.py
@@ -197,7 +197,7 @@ class Ior(ExecutableApplication):
     ]
 
     summary_regex = "(?P<Operation>(read|write))"
-    for metric_name, unit, variant in metrics:
+    for metric_name, _, variant in metrics:
         if "str" in variant:
             summary_regex += r"\s+(?P<" + metric_name + r">\w+)"
         elif "int" in variant:

--- a/var/ramble/repos/builtin/applications/spack-stack/application.py
+++ b/var/ramble/repos/builtin/applications/spack-stack/application.py
@@ -139,7 +139,7 @@ class SpackStack(ExecutableApplication):
         "Stage",
         "Total",
     ]
-    for i, fom_part in enumerate(fom_parts):
+    for fom_part in fom_parts:
         full_regex = r".*?\s*" + fom_part + r":\s+(?P<fom>[0-9\.]+)s"
         figure_of_merit(
             fom_part,

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -105,7 +105,7 @@ def _check_shell_support(app_inst):
 
 def _run_phase_hook(obj, workspace, pipeline, hook):
     """Helper to enable an object run phase hooks defined in application"""
-    phase_defs = getattr(obj, "phase_definitions")
+    phase_defs = obj.phase_definitions
     if pipeline in phase_defs and hook in phase_defs[pipeline]:
         return
 
@@ -342,7 +342,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             workload_name = self.expander.workload_name
 
         found_workload = False
-        for when_set, workloads in self.workloads.items():
+        for workloads in self.workloads.values():
             if workload_name in workloads:
                 found_workload = True
                 yield workloads[workload_name]
@@ -596,7 +596,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
         base_chain = self.__class__.__mro__
         for cls in base_chain:
-            if hasattr(cls, "name") and getattr(cls, "name") is not None:
+            if hasattr(cls, "name") and cls.name is not None:
                 self.object_variants.multi_value_variant(
                     "application_name", value=cls.name
                 )
@@ -2494,9 +2494,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                                         fom_contexts = []
                                         # if a FOM has contexts, check if each is active
                                         if fom_conf["contexts"]:
-                                            for fom_context in fom_conf[
-                                                "contexts"
-                                            ]:
+                                            for _ in fom_conf["contexts"]:
                                                 context_name = (
                                                     active_contexts[context]
                                                     if context
@@ -3068,7 +3066,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                             else:
                                 dest_def_dict[context]["foms"][fom] = {}
 
-                            def _expand_var(var):
+                            def _expand_var(var, extra_vars=extra_vars):
                                 return self.expander.expand_var(
                                     var, extra_vars=extra_vars
                                 )

--- a/var/ramble/repos/builtin/base_classes/object-mixin/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/object-mixin/base_class.py
@@ -102,7 +102,7 @@ class ObjectMixin:
 
         if allow_caching:
             if not hasattr(self, "_variant_cache"):
-                setattr(self, "_variant_cache", {})
+                self._variant_cache = {}
 
             cache_key = f"{self.origin_type}::{self.name}"
             if include_modifier is not None:

--- a/var/ramble/repos/builtin/base_modifiers/container-base/base_modifier.py
+++ b/var/ramble/repos/builtin/base_modifiers/container-base/base_modifier.py
@@ -112,7 +112,7 @@ class ContainerBase(BasicModifier):
         container_env_vars variable.
         """
 
-        def extract_names(itr, name_set=set()):
+        def extract_names(itr, name_set=None):
             """Extract names of environment variables from the environment variable action sets
 
             Given an iterator over environment variable action sets, extract
@@ -120,6 +120,8 @@ class ContainerBase(BasicModifier):
 
             Modifies the name_set argument inplace.
             """
+            if name_set is None:
+                name_set = set()
             for action, conf in itr:
                 if action in ["set", "unset"]:
                     for name in conf:

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
@@ -1120,7 +1120,7 @@ class SpackRunner(CommandRunner):
             except ProcessError:
                 raise InvalidExternalEnvironment(
                     f"{path} is not a spack environment."
-                )
+                ) from None
 
         found_lock = False
 


### PR DESCRIPTION
Add in ruff check configuration.

The command used is `ruff check --config pyproject.toml` (or simply `ruff check`).
    
It mainly contains:

* Use of exception chaining, for better stack trace
* Clean up unused loop variables
* Fix up confusing names in loop
* Fix up function variable binding in loop (https://docs.astral.sh/ruff/rules/function-uses-loop-variable/)
* Misc. issues such as better assertion and attribute usage