### PR TITLE
Allows software_spec's to be injected if not present in environments

### DIFF
--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -328,6 +328,7 @@ class ExperimentSet:
         app_inst.set_formatted_executables(context.formatted_executables)
 
         if app_inst.package_manager is not None:
+            app_inst.package_manager.define_missing_packages(self._workspace)
             app_inst.define_variable(
                 self.keywords.env_path,
                 os.path.join(

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -161,7 +161,14 @@ def figure_of_merit(
 
 @shared_directive("compilers")
 def define_compiler(
-    name, pkg_spec, compiler_spec=None, compiler=None, package_manager=None, when=None, **kwargs
+    name,
+    pkg_spec,
+    compiler_spec=None,
+    compiler=None,
+    package_manager=None,
+    inject_if_missing=False,
+    when=None,
+    **kwargs,
 ):
     """Defines the compiler that will be used with this object
 
@@ -175,6 +182,8 @@ def define_compiler(
         compiler (str): Package name to use for compilation
         package_manager (str): Glob supported pattern to match package managers
                                this compiler applies to
+        inject_if_missing (bool): Whether the package should be defined if a
+                                  matching package is not already defined
         when (list | None): List of when conditions to apply to directive
     """
 
@@ -195,7 +204,12 @@ def define_compiler(
 
         obj.compilers[name].append(
             SoftwareSpec(
-                name, pkg_spec, compiler=compiler, compiler_spec=compiler_spec, when=when_list
+                name,
+                pkg_spec,
+                compiler=compiler,
+                compiler_spec=compiler_spec,
+                inject_if_missing=inject_if_missing,
+                when=when_list,
             )
         )
 
@@ -204,7 +218,14 @@ def define_compiler(
 
 @shared_directive("software_specs")
 def software_spec(
-    name, pkg_spec, compiler_spec=None, compiler=None, package_manager=None, when=None, **kwargs
+    name,
+    pkg_spec,
+    compiler_spec=None,
+    compiler=None,
+    package_manager=None,
+    inject_if_missing=False,
+    when=None,
+    **kwargs,
 ):
     """Defines a new software spec needed for this object.
 
@@ -223,6 +244,8 @@ def software_spec(
         compiler (str): Package name to use as compiler for compiling this package
         package_manager (str): Glob supported pattern to match package managers
                                this package applies to
+        inject_if_missing (bool): Whether the package should be added to experiment
+                                  environments automatically or not.
         when (list | None): List of when conditions to apply to directive
     """
 
@@ -244,7 +267,12 @@ def software_spec(
         # Define the spec
         obj.software_specs[name].append(
             SoftwareSpec(
-                name, pkg_spec, compiler=compiler, compiler_spec=compiler_spec, when=when_list
+                name,
+                pkg_spec,
+                compiler=compiler,
+                compiler_spec=compiler_spec,
+                inject_if_missing=inject_if_missing,
+                when=when_list,
             )
         )
 

--- a/lib/ramble/ramble/software_environments.py
+++ b/lib/ramble/ramble/software_environments.py
@@ -14,6 +14,7 @@ import ramble.util.colors as rucolor
 from ramble.expander import Expander
 from ramble.namespace import namespace
 from ramble.util.logger import logger
+from ramble.util.spec_utils import SoftwareSpec
 
 SUB_INDENT = 2
 
@@ -55,6 +56,7 @@ class SoftwarePackage:
         self.pkg_info = pkg_info
         self._package_type = "Base"
         self._used = False
+        self.injected = False
 
     def mark_used(self):
         """Mark this package a used"""
@@ -107,7 +109,9 @@ class SoftwarePackage:
         indentation = " " * indent
         color = rucolor.level_func(color_level)
 
-        out_str = color(f"{indentation}{self._package_type} package: {self.name}\n")
+        injected_str = "" if not self.injected else " (injected by ramble)"
+
+        out_str = color(f"{indentation}{self._package_type} package: {self.name} {injected_str}\n")
         return out_str
 
     def __str__(self):
@@ -466,14 +470,24 @@ class SoftwareEnvironment:
         Returns:
             (bool): True if environments are equivalent, False otherwise
         """
-        equal = self.name == other.name and len(self._packages) == len(other._packages)
+        equal = self.name == other.name
 
         if not equal:
             return False
 
-        for self_pkg, other_pkg in zip(self._packages, other._packages):
-            if self_pkg != other_pkg:
-                return False
+        self_pkgs = {}
+        other_pkgs = {}
+
+        for self_pkg in self._packages:
+            if not self_pkg.injected:
+                self_pkgs[self_pkg.name] = self_pkg
+
+        for other_pkg in other._packages:
+            if not other_pkg.injected:
+                other_pkgs[other_pkg.name] = other_pkg
+
+        if self_pkgs != other_pkgs:
+            return False
 
         return True
 
@@ -853,6 +867,7 @@ class SoftwareEnvironments:
 
                             if rendered_pkg.compiler:
                                 cur_compiler = rendered_pkg.compiler
+
                     if not added:
                         raise RambleSoftwareEnvironmentError(
                             f"Compiler {pkg.compiler} used, but not "
@@ -920,6 +935,45 @@ class SoftwareEnvironments:
 
         for pkg in environment._packages:
             yield pkg.spec_str(all_packages=self._rendered_packages, compiler=False)
+
+    def add_spec_to_environment(
+        self,
+        environment: SoftwareEnvironment,
+        spec: SoftwareSpec,
+        expander: Expander,
+        package_manager,
+    ):
+        """Add a spec to a given environment
+
+        Creates a new template / rendered package (if needed) from the input spec,
+        and adds to the template and rendered environment as a package in the environment.
+
+        Args:
+            environment (SoftwareEnvironment): Rendered environment to add package to
+            spec (ramble.util.spec_utils.SoftwareSpec): Software spec to add to environment
+            expander (ramble.expander.Expander): Experiment's expander object,
+                                                 to render package / environment with
+            package_manager: Package manager from the experiment
+        """
+
+        pm_name = package_manager.spec_prefix
+
+        if spec.name not in self._package_templates:
+            template_package = TemplatePackage(spec.name, spec.to_dict())
+
+            self._package_templates[spec.name] = template_package
+
+        template_package = self._package_templates[spec.name]
+
+        rendered_package = template_package.render_package(expander, package_manager)
+        rendered_package.injected = True
+
+        if rendered_package.name not in self._rendered_packages:
+            template_package.add_rendered_package(
+                rendered_package, self._rendered_packages, pm_name
+            )
+
+        environment.add_package(rendered_package)
 
     def _check_environment(self, environment):
         """Check an environment for common issues

--- a/lib/ramble/ramble/software_environments.py
+++ b/lib/ramble/ramble/software_environments.py
@@ -470,9 +470,7 @@ class SoftwareEnvironment:
         Returns:
             (bool): True if environments are equivalent, False otherwise
         """
-        equal = self.name == other.name
-
-        if not equal:
+        if not self.name == other.name:
             return False
 
         self_pkgs = {}

--- a/lib/ramble/ramble/test/end_to_end/software_spec_injection.py
+++ b/lib/ramble/ramble/test/end_to_end/software_spec_injection.py
@@ -1,0 +1,261 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.workspace
+from ramble.error import RambleCommandError
+from ramble.main import RambleCommand
+from ramble.pkg_man.builtin.spack_lightweight import SpackRunner
+from ramble.software_environments import RambleSoftwareEnvironmentError
+from ramble.util.command_runner import RunnerError
+
+pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_path")
+
+workspace = RambleCommand("workspace")
+
+
+def test_software_spec_injection_works(mock_modifiers, workspace_name):
+
+    try:
+        SpackRunner()
+    except RunnerError as e:
+        pytest.skip(e)
+
+    global_args = ["-w", workspace_name]
+
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+
+        with open(os.path.join(ws.config_dir, "variants.yaml"), "w+") as f:
+            f.write(
+                """variants:
+  implicit_compiler: True"""
+            )
+
+        workspace(
+            "manage",
+            "experiments",
+            "gromacs",
+            "--wf",
+            "water_bare",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "n_ranks=1",
+            "-p",
+            "spack",
+            global_args=global_args,
+        )
+
+        workspace("concretize", global_args=global_args)
+
+        ws.write()
+
+        info_output = workspace("info", "--software", global_args=global_args)
+
+        assert "missing_mod_package" not in info_output
+        assert "missing_package@1.1" not in info_output
+        assert "mod_compiler" not in info_output
+
+        workspace(
+            "manage",
+            "modifiers",
+            "--add",
+            "--name",
+            "spack-mod",
+            "--scope",
+            "workspace",
+            global_args=global_args,
+        )
+
+        info_output = workspace("info", "--software", global_args=global_args)
+
+        assert "missing_mod_package" in info_output
+        assert "missing_package@1.1" in info_output
+        assert "mod_compiler" in info_output
+        assert "injected by ramble" in info_output
+
+
+def test_existing_software_spec_does_not_inject(mock_modifiers, workspace_name):
+
+    try:
+        SpackRunner()
+    except RunnerError as e:
+        pytest.skip(e)
+
+    global_args = ["-w", workspace_name]
+
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+
+        with open(os.path.join(ws.config_dir, "variants.yaml"), "w+") as f:
+            f.write(
+                """variants:
+  implicit_compiler: True"""
+            )
+
+        workspace(
+            "manage",
+            "experiments",
+            "gromacs",
+            "--wf",
+            "water_bare",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "n_ranks=1",
+            "-p",
+            "spack",
+            global_args=global_args,
+        )
+
+        workspace("concretize", global_args=global_args)
+
+        ws.write()
+
+        info_output = workspace("info", "--software", global_args=global_args)
+
+        assert "missing_mod_package" not in info_output
+        assert "missing_package@1.1" not in info_output
+        assert "mod_compiler" not in info_output
+
+        workspace(
+            "manage",
+            "modifiers",
+            "--add",
+            "--name",
+            "spack-mod",
+            "--scope",
+            "workspace",
+            global_args=global_args,
+        )
+
+        workspace("concretize", "-f", global_args=global_args)
+        info_output = workspace("info", "--software", global_args=global_args)
+
+        assert "missing_mod_package" in info_output
+        assert "missing_package@1.1" in info_output
+        assert "mod_compiler" in info_output
+        assert "injected by ramble" not in info_output
+
+
+def test_software_spec_injection_missing_compiler_errors(mock_modifiers, workspace_name):
+
+    try:
+        SpackRunner()
+    except RunnerError as e:
+        pytest.skip(e)
+
+    global_args = ["-w", workspace_name]
+
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+
+        with open(os.path.join(ws.config_dir, "variants.yaml"), "w+") as f:
+            f.write(
+                """variants:
+  missing_compiler: True"""
+            )
+
+        workspace(
+            "manage",
+            "experiments",
+            "gromacs",
+            "--wf",
+            "water_bare",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "n_ranks=1",
+            "-p",
+            "spack",
+            global_args=global_args,
+        )
+
+        workspace("concretize", global_args=global_args)
+
+        ws.write()
+
+        workspace(
+            "manage",
+            "modifiers",
+            "--add",
+            "--name",
+            "spack-mod",
+            "--scope",
+            "workspace",
+            global_args=global_args,
+        )
+
+        with pytest.raises(
+            RambleCommandError,
+            match=r"When injecting packages from modifier spack-mod"
+            + r".*non_existent_compiler.*is not defined",
+        ):
+            workspace("info", "--software", global_args=global_args)
+
+
+def test_software_spec_compiler_injection_works(mock_applications, mock_modifiers, workspace_name):
+
+    try:
+        SpackRunner()
+    except RunnerError as e:
+        pytest.skip(e)
+
+    global_args = ["-w", workspace_name]
+
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+
+        with open(os.path.join(ws.config_dir, "variants.yaml"), "w+") as f:
+            f.write(
+                """variants:
+  injected_compiler: True"""
+            )
+
+        workspace(
+            "manage",
+            "experiments",
+            "zlib",
+            "--wf",
+            "ensure_installed",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "n_ranks=1",
+            "-p",
+            "spack",
+            global_args=global_args,
+        )
+
+        workspace("concretize", global_args=global_args)
+
+        with pytest.raises(
+            RambleSoftwareEnvironmentError,
+            match=r"Compiler injected_compiler used, but "
+            + r"not defined in environment zlib by package zlib",
+        ):
+            workspace("info", "--software", global_args=global_args)
+
+        workspace(
+            "manage",
+            "modifiers",
+            "--add",
+            "--name",
+            "spack-mod",
+            "--scope",
+            "workspace",
+            global_args=global_args,
+        )
+
+        info_out = workspace("info", "--software", global_args=global_args)
+
+        assert "injected_compiler" in info_out

--- a/lib/ramble/ramble/util/spec_utils.py
+++ b/lib/ramble/ramble/util/spec_utils.py
@@ -43,6 +43,7 @@ class SoftwareSpec:
         prefix: str = "",
         compiler: Optional[str] = None,
         compiler_spec: Optional[str] = None,
+        inject_if_missing: bool = False,
         when: Optional[List[str]] = None,
     ):
         self.name = name
@@ -50,6 +51,7 @@ class SoftwareSpec:
         self.prefix = prefix
         self.compiler = compiler
         self.compiler_spec = compiler_spec
+        self.inject_if_missing = inject_if_missing
         self.when = when.copy() if when else []
 
     def to_dict(self, apply_prefix: bool = False):

--- a/var/ramble/repos/builtin.mock/applications/zlib/application.py
+++ b/var/ramble/repos/builtin.mock/applications/zlib/application.py
@@ -12,9 +12,21 @@ from ramble.appkit import *
 class Zlib(ExecutableApplication):
     name = "zlib"
 
-    software_spec(
-        "zlib", pkg_spec="zlib", when=["package_manager_family=spack"]
+    variant(
+        "injected_compiler",
+        description="This variant enables a compiler spec that needs to be injected",
+        default=False,
+        values=[True, False],
     )
+
+    with when("package_manager_family=spack"):
+        with when("~injected_compiler"):
+            software_spec("zlib", pkg_spec="zlib")
+
+        with when("+injected_compiler"):
+            software_spec(
+                "zlib", pkg_spec="zlib", compiler="injected_compiler"
+            )
 
     executable("list_lib", "ls {zlib_path}/lib", use_mpi=False)
 

--- a/var/ramble/repos/builtin.mock/modifiers/spack-mod/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/spack-mod/modifier.py
@@ -18,6 +18,27 @@ class SpackMod(BasicModifier):
 
     mode("default", description="This is the default mode for the spack-mod")
 
+    variant(
+        "missing_compiler",
+        description="This variant enables software specs that refer to undefined compilers",
+        default=False,
+        values=[True, False],
+    )
+
+    variant(
+        "implicit_compiler",
+        description="This variant enables a software spec that uses an implicit compiler",
+        default=False,
+        values=[True, False],
+    )
+
+    variant(
+        "injected_compiler",
+        description="This variant enables a compiler spec that needs to be injected",
+        default=False,
+        values=[True, False],
+    )
+
     with when("package_manager_family=spack"):
         package_manager_config("enable_debug", "config:debug:true")
 
@@ -38,6 +59,37 @@ class SpackMod(BasicModifier):
             pkg_spec="mod_package2@1.1",
             compiler="mod_compiler",
         )
+
+        with when("+injected_compiler"):
+            define_compiler(
+                "injected_compiler",
+                pkg_spec="injected_compiler@1.1",
+                compiler_spec="injected_compiler@1.1",
+                inject_if_missing=True,
+            )
+
+        with when("~missing_compiler"):
+            with when("+implicit_compiler"):
+                software_spec(
+                    "missing_mod_package",
+                    pkg_spec="missing_package@1.1",
+                    compiler="mod_compiler",
+                    inject_if_missing=True,
+                )
+
+            # with when("~implicit_compiler"):
+            #    software_spec(
+            #        "missing_mod_package",
+            #        pkg_spec="missing_package@1.1",
+            #    )
+
+        with when("+missing_compiler"):
+            software_spec(
+                "missing_mod_package",
+                pkg_spec="missing_package@1.1",
+                compiler="non_existent_compiler",
+                inject_if_missing=True,
+            )
 
     package_manager_requirement(
         "list not-a-package", validation_type="empty", modes=["default"]

--- a/var/ramble/repos/builtin.mock/package_managers/info/package_manager.py
+++ b/var/ramble/repos/builtin.mock/package_managers/info/package_manager.py
@@ -141,6 +141,9 @@ class Info(PackageManagerBase):
         del workspace
         return []
 
+    def package_name_from_spec(self, spec: str) -> str:
+        return spec
+
     def environment_load_commands(self) -> List[str]:
         return []
 

--- a/var/ramble/repos/builtin.mock/package_managers/when-package-manager/package_manager.py
+++ b/var/ramble/repos/builtin.mock/package_managers/when-package-manager/package_manager.py
@@ -69,6 +69,9 @@ class WhenPackageManager(PackageManagerBase):
         del workspace
         return []
 
+    def package_name_from_spec(self, spec: str) -> str:
+        return spec
+
     def environment_load_commands(self) -> List[str]:
         return []
 

--- a/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
@@ -18,6 +18,11 @@ import ramble.util.directives
 import ramble.variants
 from ramble.language.package_manager_language import PackageManagerMeta
 from ramble.language.shared_language import SharedMeta, register_phase
+from ramble.software_environments import (
+    RambleSoftwareEnvironmentError,
+    TemplatePackage,
+)
+from ramble.util.logger import logger
 from ramble.util.naming import NS_SEPARATOR
 
 import spack.util.naming
@@ -210,6 +215,137 @@ class PackageManagerBase(ObjectMixin, metaclass=PackageManagerMeta):
 
         pass
 
+    def define_missing_packages(self, workspace):
+        """Injection of missing packages that are auto-injected by objects
+
+        This method will iterate over the objects in an experiment, and
+        inject any missing packages that are defined as `inject_if_missing`
+        from their software_spec directives.
+
+        Args:
+            workspace (Workspace): The workspace that contains the software environments
+        """
+
+        require_env = self.environment_required
+        software_envs = workspace.software_environments
+
+        # Inject any missing, but injected compilers
+        for _, obj in self.app_inst._objects():
+            for comps in obj.compilers.values():
+                for comp in comps:
+                    if (
+                        comp.inject_if_missing
+                        and comp.name not in software_envs._package_templates
+                        and self.satisfy_when(
+                            comp.when,
+                            variant_set=obj.experiment_variants(),
+                        )
+                    ):
+                        comp_template = TemplatePackage(
+                            comp.name, comp.to_dict()
+                        )
+                        software_envs._package_templates[comp.name] = (
+                            comp_template
+                        )
+
+        app_context = self.app_inst.expander.expand_var_name(
+            self.keywords.env_name
+        )
+        try:
+            software_env = software_envs.render_environment(
+                app_context, self.app_inst.expander, self, require=require_env
+            )
+
+            # If there is no environment required or defined, skip defining
+            # packages.
+            if not require_env and software_env is None:
+                return
+
+            env_packages = set()
+            for pkg_spec in software_envs.package_specs_for_environment(
+                software_env
+            ):
+                env_packages.add(self.package_name_from_spec(pkg_spec))
+
+            for _, obj in self.app_inst._objects():
+                required_compilers = set()
+                # Inject any specs that need to be injected.
+                for specs in obj.software_specs.values():
+                    for spec in specs:
+                        pkg_name = self.package_name_from_spec(spec.pkg_spec)
+
+                        if (
+                            spec.inject_if_missing
+                            and pkg_name not in env_packages
+                            and self.app_inst.expander.satisfies(
+                                spec.when,
+                                variant_set=obj.experiment_variants(),
+                            )
+                        ):
+                            env_packages.add(pkg_name)
+                            new_spec = spec.copy()
+                            software_envs.add_spec_to_environment(
+                                software_env,
+                                new_spec,
+                                self.app_inst.expander,
+                                self,
+                            )
+
+                            if new_spec.compiler is not None:
+                                required_compilers.add(new_spec.compiler)
+
+                # Inject any dependent compilers
+                pm_name = self.spec_prefix
+                compilers_to_define = required_compilers.copy()
+                for compiler in required_compilers:
+                    rendered_compiler = self.app_inst.expander.expand_var(
+                        compiler
+                    )
+                    if (
+                        compiler in software_envs._package_templates
+                        or rendered_compiler
+                        in software_envs._rendered_packages[pm_name]
+                    ):
+                        compilers_to_define.remove(compiler)
+
+                for compiler in compilers_to_define:
+                    rendered_compiler = self.app_inst.expander.expand_var(
+                        compiler
+                    )
+
+                    compiler_name = None
+                    if compiler in obj.compilers:
+                        compiler_name = compiler
+                    elif rendered_compiler in obj.compilers:
+                        compiler_name = rendered_compiler
+
+                    if compiler_name is None:
+                        logger.die(
+                            f"When injecting packages from {obj.origin_type} "
+                            f"{obj.name}, compiler {compiler} (rendered to "
+                            f"{rendered_compiler}) is not defined."
+                        )
+
+                    for compiler_spec in obj.compilers[compiler_name]:
+                        if self.app_inst.expander.satisfies(
+                            compiler_spec.when,
+                            variant_set=obj.experiment_variants(),
+                        ):
+                            compiler_template = TemplatePackage(
+                                compiler_name, compiler_spec.to_dict()
+                            )
+
+                            software_envs._package_templates[compiler_name] = (
+                                compiler_template
+                            )
+                            rendered_compiler = (
+                                compiler_template.render_package(
+                                    self.app_inst.expander, self
+                                )
+                            )
+        except RambleSoftwareEnvironmentError:
+            pass
+
     register_phase(
         "add_software_to_results",
         pipeline="analyze",
@@ -244,6 +380,11 @@ class PackageManagerBase(ObjectMixin, metaclass=PackageManagerMeta):
     @abc.abstractmethod
     def get_package_list(self, workspace):
         """Method used by add_software_to_results phase to get software provenance info"""
+
+    @abc.abstractmethod
+    def package_name_from_spec(self, spec: str) -> str:
+        """Stub method for extracting a package name
+        from a spec object"""
 
     @abc.abstractmethod
     def environment_load_commands(self) -> List[str]:

--- a/var/ramble/repos/builtin/package_managers/environment-modules/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/environment-modules/package_manager.py
@@ -43,6 +43,16 @@ class EnvironmentModules(PackageManagerBase):
         run_before=["make_experiments"],
     )
 
+    name_regex = re.compile(r"\s*(?P<name>[\w-]+).*")
+
+    def package_name_from_spec(self, spec):
+        m = self.name_regex.match(spec)
+        pkg_name = None
+        if m:
+            pkg_name = m.group("name")
+
+        return pkg_name
+
     def _generate_loads_content(self, workspace):
         if not hasattr(self, "_load_string"):
             app_context = self.app_inst.expander.expand_var_name(

--- a/var/ramble/repos/builtin/package_managers/pip/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/pip/package_manager.py
@@ -60,6 +60,16 @@ class Pip(PackageManagerBase):
             self._runner = PipRunner()
         return self._runner
 
+    name_regex = re.compile(r"\s*(?P<name>[\w-]+).*")
+
+    def package_name_from_spec(self, spec):
+        m = self.name_regex.match(spec)
+        pkg_name = None
+        if m:
+            pkg_name = m.group("name")
+
+        return pkg_name
+
     register_builtin(
         "pip_activate", required=True, depends_on=["builtin::env_vars"]
     )

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
@@ -44,6 +44,16 @@ class SpackLightweight(PackageManagerBase):
 
         self._runner = None
 
+    name_regex = re.compile(r"\s*(?P<name>[\w-]+).*")
+
+    def package_name_from_spec(self, spec):
+        m = self.name_regex.match(spec)
+        pkg_name = None
+        if m:
+            pkg_name = m.group("name")
+
+        return pkg_name
+
     @property
     def runner(self):
         if self._runner is None:

--- a/var/ramble/repos/builtin/package_managers/spack-pip/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-pip/package_manager.py
@@ -49,6 +49,16 @@ class SpackPip(PackageManagerBase):
         self.spack_mgr.build_used_variables(workspace)
         self.pip_mgr.build_used_variables(workspace)
 
+    def define_missing_packages(self, workspace):
+        self.spack_mgr.define_missing_packages(workspace)
+        self.pip_mgr.define_missing_packages(workspace)
+
+    def package_name_from_spec(self, spec: str) -> str:
+        pkg_name = self.spack_mgr.package_name_from_spec(spec)
+        if not pkg_name:
+            pkg_name = self.pip_mgr.package_name_from_spec(spec)
+        return pkg_name
+
     def populate_inventory(
         self, workspace, force_compute=False, require_exist=False
     ):

--- a/var/ramble/repos/builtin/package_managers/user-managed/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/user-managed/package_manager.py
@@ -39,6 +39,9 @@ class UserManaged(PackageManagerBase):
     def __init__(self, file_path):
         super().__init__(file_path)
 
+    def package_name_from_spec(self, spec):
+        return spec
+
     register_phase(
         "define_requirements",
         pipeline="setup",


### PR DESCRIPTION
This merge adds a new keyword attribute (inject_if_missing) to all software_spec directive calls. This allows objects to quietly inject packages into experiment environments without having to edit the workspace configuration file.

Required compilers are also automatically injected into the environment to be used for the new packages.