### PR TITLE
Add iterative variable definition based on variant values

### DIFF
--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -759,9 +759,8 @@ class Expander:
         variant_definitions = set()
 
         if hasattr(variant_set, "as_set"):
-            for variant in variant_set.as_set():
-                exp_variant = self.expand_var(variant)
-                variant_definitions.add(exp_variant)
+            for variant in variant_set.as_set(self):
+                variant_definitions.add(variant)
 
         satisfied = True
         if reqs is not None:

--- a/lib/ramble/ramble/test/variant.py
+++ b/lib/ramble/ramble/test/variant.py
@@ -20,6 +20,7 @@ pytestmark = pytest.mark.usefixtures(
 
 config = RambleCommand("config")
 workspace = RambleCommand("workspace")
+on = RambleCommand("on")
 
 
 def test_default_arg_works(request):
@@ -319,3 +320,39 @@ def test_variant_info_works(request):
 
         assert "application_name=when-variants" in info_out
         assert "indirect_variant=test-value" in info_out
+
+
+@pytest.mark.parametrize("test_value", ["value1", "value2", "value3"])
+def test_variant_nesting_works(workspace_name, test_value):
+    global_args = ["-w", workspace_name]
+
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+
+        with open(os.path.join(ws.config_dir, "variants.yaml"), "w+") as f:
+            f.write(
+                f"""variants:
+  iterative_variant: {test_value}
+  iterative_variant2: {test_value}"""
+            )
+        workspace(
+            "manage",
+            "experiments",
+            "when-variants",
+            "--wf",
+            "test_wl",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "processes_per_node=1",
+            "-p",
+            "spack",
+            global_args=global_args,
+        )
+
+        ws._re_read()
+        exec_out = on("--executor='echo {leaf_value}'", global_args=global_args)
+
+        assert test_value in exec_out

--- a/var/ramble/repos/builtin.mock/applications/when-variants/application.py
+++ b/var/ramble/repos/builtin.mock/applications/when-variants/application.py
@@ -166,3 +166,52 @@ class WhenVariants(ExecutableApplication):
             default="unincluded",
             description="Test usage of the `variable` directive",
         )
+
+    variant(
+        "iterative_variant",
+        default="{iterative_variant}",
+        values=["value1", "value2", "value3"],
+        description="Variant that controls variable definitions",
+    )
+
+    variant(
+        "iterative_variant2",
+        default="{iterative_variant2}",
+        values=["value1", "value2", "value3"],
+        description="Variant that controls variable definitions",
+    )
+
+    with when("iterative_variant=value1"):
+        with when("iterative_variant2=value1"):
+            variable(
+                "leaf_variable", default="value1", description="Test variable"
+            )
+        variable(
+            "iterative_variant2",
+            default="sub_value1",
+            description="Test variable",
+        )
+
+    with when("iterative_variant=value2"):
+        with when("iterative_variant2=value2"):
+            variable(
+                "leaf_variable", default="value2", description="Test variable"
+            )
+
+        variable(
+            "iterative_variant2",
+            default="sub_value2",
+            description="Test variable",
+        )
+
+    with when("iterative_variant=value3"):
+        with when("iterative_variant2=value3"):
+            variable(
+                "leaf_variable", default="value3", description="Test variable"
+            )
+
+        variable(
+            "iterative_variant2",
+            default="sub_value3",
+            description="Test variable",
+        )

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -621,17 +621,31 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                         if not var.expandable:
                             self.no_expand_vars.add(var.name)
 
-        # Define missing variables
-        for _, obj in self._objects():
-            for var, val in obj.selected_variables.items():
-                if var not in self.variables:
-                    self.define_variable(var, val.default)
+        self.define_missing_variables()
 
         self.expander.set_no_expand_vars(self.no_expand_vars)
         if experiment_set and experiment_set._workspace:
             self.expander.replacement_paths = (
                 experiment_set._workspace.workspace_paths()
             )
+
+    def define_missing_variables(self):
+        """Iterate over missing variable definitions, and add them until there
+        are no more to add."""
+
+        while True:
+            missing_vars = {}
+            for _, obj in self._objects():
+                for var, val in obj.selected_variables.items():
+                    # Check for its presence in missing_vars, for the "first-defined-wins" semantic
+                    if var not in self.variables and var not in missing_vars:
+                        missing_vars[var] = val.default
+
+            if not missing_vars:
+                break
+
+            for var, default_val in missing_vars.items():
+                self.define_variable(var, default_val)
 
     def set_internals(self, internals):
         """Set internal reference to application internals"""
@@ -774,22 +788,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         ########################
         # Define extra variables
         ########################
-
-        var_objs = []
-
-        for mod_inst in self._modifier_instances:
-            var_objs.append(mod_inst)
-
-        if self.package_manager is not None:
-            var_objs.append(self.package_manager)
-
-        if self.workflow_manager is not None:
-            var_objs.append(self.workflow_manager)
-
-        for var_obj in var_objs:
-            for var in var_obj.selected_variables.values():
-                if var.name not in self.variables:
-                    self.variables[var.name] = var.default
+        self.define_missing_variables()
 
         ##########################################
         # Expand used variables to track all usage
@@ -1188,9 +1187,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                 mod_inst.expander.add_no_expand_var(var)
 
             # Define any missing modifier variables
-            for var, val in mod_inst.selected_variables.items():
-                if var not in self.variables:
-                    self.define_variable(var, val.default)
+            self.define_missing_variables()
 
     def validate_experiment(
         self, warn_validation=True, die_on_validate_error=True


### PR DESCRIPTION
This merge updates the logic for defining undefined variables based on the values of variants to be iterative.

This allows variables to recursively update the definition of variants, before allowing them to define additional variables.

Tests are added to cover this (arguably complex) case as well.