### PR TITLE
Remove unused imports

### DIFF
--- a/lib/ramble/ramble/mirror.py
+++ b/lib/ramble/ramble/mirror.py
@@ -17,7 +17,6 @@ to download inputs directly from a mirror (e.g., on an intranet).
 """
 import collections
 import operator
-import os
 import os.path
 
 import ruamel.yaml.error as yaml_error

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -24,7 +24,6 @@ import ramble.config
 import ramble.expander
 import ramble.experiment_result
 import ramble.fetch_strategy
-import ramble.results_table
 import ramble.software_environments
 import ramble.stage
 import ramble.uploader

--- a/lib/ramble/ramble/repository.py
+++ b/lib/ramble/ramble/repository.py
@@ -11,7 +11,6 @@ import collections
 import contextlib
 import errno
 import functools
-import importlib
 import importlib.machinery
 import importlib.util
 import inspect

--- a/lib/ramble/ramble/stage.py
+++ b/lib/ramble/ramble/stage.py
@@ -36,7 +36,6 @@ import ramble.util.lock
 from ramble.util.logger import logger
 
 import spack.config
-import spack.paths
 import spack.util.path as sup
 import spack.util.pattern as pattern
 import spack.util.url as url_util

--- a/lib/ramble/ramble/test/cmd/config.py
+++ b/lib/ramble/ramble/test/cmd/config.py
@@ -879,7 +879,6 @@ def section_args(section_name):
 
 def test_config_edit_file(mutable_config, config_section, mock_editor):
     import ramble.cmd.config
-    import ramble.util.editor
 
     args = section_args(config_section)
 

--- a/lib/ramble/ramble/util/web.py
+++ b/lib/ramble/ramble/util/web.py
@@ -27,7 +27,6 @@ import ramble
 import ramble.config
 from ramble.util.logger import logger
 
-import spack
 import spack.error
 import spack.util.gcs as gcs_util
 import spack.util.s3 as s3_util

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,9 +131,10 @@ extend-exclude = [
 ]
 
 [tool.ruff.lint]
+preview = true
 # B905 requires Python 3.9 or up.
 ignore = ["B905"]
-extend-select = ["B", "C4"]
+extend-select = ["B", "C4", "F401"]
 
 [tool.ruff.lint.per-file-ignores]
 "lib/ramble/ramble/*kit.py" = ["F403"]


### PR DESCRIPTION
These are findings from `ruff` linter, using its preview F401 rule.