### PR TITLE
Add usage filters to executable_modifiers

### DIFF
--- a/lib/ramble/ramble/language/modifier_language.py
+++ b/lib/ramble/ramble/language/modifier_language.py
@@ -131,7 +131,7 @@ def variable_modification(
 
 
 @modifier_directive("executable_modifiers")
-def executable_modifier(name, when=None, **kwargs):
+def executable_modifier(name, usage_filter=None, when=None, **kwargs):
     """Register an executable modifier
 
     Executable modifiers can modify various aspects of non-builtin application
@@ -166,6 +166,9 @@ def executable_modifier(name, when=None, **kwargs):
     Args:
         name (str): Name of executable modifier to use. Should be the name of a
                     class method.
+        usage_filter (str): Filters the application of this executable modifier.
+                            Modifiers can register filters to select how to apply this.
+                            Valid default options include: None, "once", "first_mpi", "all_mpi"
         when (list | None): List of when conditions this executable modifier should apply in
 
     Each executable modifier needs to return:
@@ -185,6 +188,7 @@ def executable_modifier(name, when=None, **kwargs):
             mod.executable_modifiers[when_set] = {}
 
         mod.executable_modifiers[when_set][name] = {
+            "usage_filter": usage_filter,
             "when": when_list,
         }
 

--- a/lib/ramble/ramble/test/modifier_functionality/executable_modifier_usage_filters.py
+++ b/lib/ramble/ramble/test/modifier_functionality/executable_modifier_usage_filters.py
@@ -1,0 +1,164 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+import re
+
+import pytest
+
+import ramble.workspace
+from ramble.error import RambleCommandError
+from ramble.main import RambleCommand
+
+workspace = RambleCommand("workspace")
+
+
+@pytest.mark.parametrize(
+    "filter_type,expected_count",
+    [
+        ("none", -1),
+        ("once", 1),
+        ("all_mpi", 6),
+        ("first_mpi", 1),
+    ],
+)
+def test_executable_modifier_usage_filters(
+    mutable_mock_workspace_path,
+    mutable_applications,
+    mock_modifiers,
+    workspace_name,
+    filter_type,
+    expected_count,
+):
+
+    global_args = ["-w", workspace_name]
+
+    pre_str = f"exec_mod_{filter_type}_pre_applied"
+    post_str = f"exec_mod_{filter_type}_post_applied"
+
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+
+        workspace(
+            "manage",
+            "experiments",
+            "openfoam",
+            "--wf",
+            "motorbike_20m",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "openfoam_path=/not/needed",
+            global_args=global_args,
+        )
+
+        workspace(
+            "manage",
+            "modifiers",
+            "--add",
+            "--scope",
+            "workspace",
+            "--name",
+            "exec-mod-usage-filters",
+            global_args=global_args,
+        )
+
+        with open(os.path.join(ws.config_dir, "variants.yaml"), "w+") as f:
+            f.write(
+                f"""variants:
+  usage_filter_type: {filter_type}"""
+            )
+
+        ws._re_read()
+
+        workspace("setup", "--dry-run", global_args=global_args)
+
+        exec_path = os.path.join(
+            ws.experiment_dir, "openfoam", "motorbike_20m", "generated", "execute_experiment"
+        )
+
+        assert os.path.isfile(exec_path)
+
+        pre_regex = re.compile(pre_str)
+        post_regex = re.compile(post_str)
+
+        with open(exec_path) as f:
+            pre_count = 0
+            post_count = 0
+
+            for line in f.readlines():
+                pre_m = pre_regex.search(line)
+                if pre_m:
+                    pre_count += 1
+
+                post_m = post_regex.search(line)
+                if post_m:
+                    post_count += 1
+
+        if expected_count >= 0:
+            assert pre_count == expected_count
+            assert post_count == expected_count
+        else:
+            assert pre_count > 0
+            assert post_count > 0
+
+
+def test_executable_modifier_usage_filters_broken_errors(
+    mutable_mock_workspace_path,
+    mutable_applications,
+    mock_modifiers,
+    workspace_name,
+):
+
+    expected_err = (
+        "When extracting a usage_filter for an executable_modifier "
+        "on modifier exec-mod-usage-filters the filter __broken__ does not exist"
+    )
+    global_args = ["-w", workspace_name]
+
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+
+        workspace(
+            "manage",
+            "experiments",
+            "openfoam",
+            "--wf",
+            "motorbike_20m",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "openfoam_path=/not/needed",
+            global_args=global_args,
+        )
+
+        workspace(
+            "manage",
+            "modifiers",
+            "--add",
+            "--scope",
+            "workspace",
+            "--name",
+            "exec-mod-usage-filters",
+            global_args=global_args,
+        )
+
+        with open(os.path.join(ws.config_dir, "variants.yaml"), "w+") as f:
+            f.write(
+                """variants:
+  usage_filter_type: broken"""
+            )
+
+        ws._re_read()
+
+        with pytest.raises(RambleCommandError, match=expected_err):
+            workspace("setup", "--dry-run", global_args=global_args)

--- a/var/ramble/repos/builtin.mock/modifiers/exec-mod-usage-filters/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/exec-mod-usage-filters/modifier.py
@@ -1,0 +1,146 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.modkit import *
+
+
+class ExecModUsageFilters(BasicModifier):
+    """Define a modifier to test usage filters on executable modifiers"""
+
+    name = "exec-mod-usage-filters"
+
+    tags("test")
+
+    mode("test", description="This is a test mode")
+    default_mode("test")
+
+    modifier_conflict(MODIFIER_CONFLICT.name_mode_executables)
+
+    variant(
+        "usage_filter_type",
+        default="none",
+        values=["none", "once", "all_mpi", "first_mpi", "broken"],
+        description="Control which usage filter to use on exec mods",
+    )
+
+    executable_modifier(
+        "exec_mod_none", usage_filter=None, when=["usage_filter_type=none"]
+    )
+
+    def exec_mod_none(self, executable_name, executable, app_inst=None):
+        from ramble.util.executable import CommandExecutable
+
+        pre_cmds = [
+            CommandExecutable(
+                "exec-mod-none-pre", template=["exec_mod_none_pre_applied"]
+            )
+        ]
+
+        post_cmds = [
+            CommandExecutable(
+                "exec-mod-once-post", template=["exec_mod_none_post_applied"]
+            )
+        ]
+
+        return pre_cmds, post_cmds
+
+    executable_modifier(
+        "exec_mod_once", usage_filter="once", when=["usage_filter_type=once"]
+    )
+
+    def exec_mod_once(self, executable_name, executable, app_inst=None):
+        from ramble.util.executable import CommandExecutable
+
+        pre_cmds = [
+            CommandExecutable(
+                "exec-mod-once-pre", template=["exec_mod_once_pre_applied"]
+            )
+        ]
+
+        post_cmds = [
+            CommandExecutable(
+                "exec-mod-once-post", template=["exec_mod_once_post_applied"]
+            )
+        ]
+
+        return pre_cmds, post_cmds
+
+    executable_modifier(
+        "exec_mod_first_mpi",
+        usage_filter="first_mpi",
+        when=["usage_filter_type=first_mpi"],
+    )
+
+    def exec_mod_first_mpi(self, executable_name, executable, app_inst=None):
+        from ramble.util.executable import CommandExecutable
+
+        pre_cmds = [
+            CommandExecutable(
+                "exec-mod-first-mpi-pre",
+                template=["exec_mod_first_mpi_pre_applied"],
+            )
+        ]
+
+        post_cmds = [
+            CommandExecutable(
+                "exec-mod-first-mpi-post",
+                template=["exec_mod_first_mpi_post_applied"],
+            )
+        ]
+
+        return pre_cmds, post_cmds
+
+    executable_modifier(
+        "exec_mod_all_mpi",
+        usage_filter="all_mpi",
+        when=["usage_filter_type=all_mpi"],
+    )
+
+    def exec_mod_all_mpi(self, executable_name, executable, app_inst=None):
+        from ramble.util.executable import CommandExecutable
+
+        pre_cmds = [
+            CommandExecutable(
+                "exec-mod-all-mpi-pre",
+                template=["exec_mod_all_mpi_pre_applied"],
+            )
+        ]
+
+        post_cmds = [
+            CommandExecutable(
+                "exec-mod-all-mpi-post",
+                template=["exec_mod_all_mpi_post_applied"],
+            )
+        ]
+
+        return pre_cmds, post_cmds
+
+    executable_modifier(
+        "exec_mod_broken",
+        usage_filter="__broken__",
+        when=["usage_filter_type=broken"],
+    )
+
+    def exec_mod_broken(self, executable_name, executable, app_inst=None):
+        from ramble.util.executable import CommandExecutable
+
+        pre_cmds = [
+            CommandExecutable(
+                "exec-mod-all-mpi-pre",
+                template=["exec_mod_all_mpi_pre_applied"],
+            )
+        ]
+
+        post_cmds = [
+            CommandExecutable(
+                "exec-mod-all-mpi-post",
+                template=["exec_mod_all_mpi_post_applied"],
+            )
+        ]
+
+        return pre_cmds, post_cmds

--- a/var/ramble/repos/builtin/base_classes/modifier-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/modifier-base/base_class.py
@@ -70,6 +70,7 @@ class ModifierBase(ObjectMixin, metaclass=ModifierMeta):
         self.expander = None
         self._usage_mode = None
         self.app_inst = None
+        self._executable_modification_applied = set()
 
         self._mod_regex = re.compile(
             self._mod_prefix_builtin + f"{self.name}{NS_SEPARATOR}"
@@ -375,22 +376,130 @@ class ModifierBase(ObjectMixin, metaclass=ModifierMeta):
 
         return bool(self._mod_regex.match(executable))
 
+    def executable_modifier_applied(self, exec_mod):
+        """Check if an executable modifier has been applies alerady
+
+
+        Returns:
+            (bool): True if the executable modifier has been applied. False otherwise
+        """
+        if exec_mod in self._executable_modification_applied:
+            return True
+        return False
+
+    def executable_modifier_usage_filter(filter_name: str):
+        """Decorator for registering a usage filter for executable modifiers"""
+
+        def _decorator(decorated_function):
+            if not hasattr(decorated_function, "_ramble_attributes"):
+                decorated_function._ramble_attributes = {}
+            decorated_function._ramble_attributes["filter_name"] = filter_name
+            return decorated_function
+
+        return _decorator
+
+    @executable_modifier_usage_filter("once")
+    def filter_once(self, exec_mod, executable) -> bool:
+        """Usage filter for only allowing an executable modifier to be applied
+        once in an experiment"""
+        return not self.executable_modifier_applied(exec_mod)
+
+    @executable_modifier_usage_filter("first_mpi")
+    def filter_first_mpi(self, exec_mod, executable) -> bool:
+        """Usage filter for only applying executable modifier to the first MPI
+        executable in an experiment"""
+        return executable.mpi and not self.executable_modifier_applied(
+            exec_mod
+        )
+
+    @executable_modifier_usage_filter("all_mpi")
+    def filter_all_mpi(self, exec_mod, executable) -> bool:
+        """Usage filter for applying an executalbe modifier to only MPI
+        executables in an experiment"""
+        return executable.mpi
+
+    def get_executable_modifier_filter(self, filter_name):
+        """Get the filter function for a usage filter (by name)
+
+        Args:
+            filter_name (str): Name of usage filter to extract for filtering executable modifier
+
+        Returns:
+            Reference to function, if found. None otherwise"""
+
+        filter_names = set()
+        for attr in dir(self):
+            method = getattr(self, attr)
+
+            if callable(method):
+                method_attributes = getattr(method, "_ramble_attributes", {})
+                test_filter_name = None
+                if "filter_name" in method_attributes:
+                    test_filter_name = method_attributes["filter_name"]
+                filter_names.add(test_filter_name)
+                if filter_name == test_filter_name:
+                    return method
+
+        if filter_name is not None and filter_name != "None":
+            logger.die(
+                f"When extracting a usage_filter for an executable_modifier "
+                f"on modifier {self.name} "
+                f"the filter {filter_name} does not exist. Registered filters are: \n"
+                f"{filter_names}"
+            )
+        return None
+
+    def executable_modification_applies(
+        self, exec_mod, filter_name, executable
+    ):
+        """Determine if an executable modifier applies to an executable or not
+
+        Args:
+            exec_mod (str): Name of executable modifier
+            filter_name (str): Name of usage filter to apply
+            executable: CommandExecutable object to check if exec_mod applies to
+
+        """
+        apply = True
+
+        filter_func = self.get_executable_modifier_filter(filter_name)
+
+        if filter_func is not None:
+            apply = filter_func(exec_mod, executable)
+
+        return apply
+
     def apply_executable_modifiers(
         self, executable_name, executable, app_inst=None
     ):
+        """Apply all executable modifiers to an executable
+
+        Args:
+            executable_name (str): Name of executable
+            executable: CommandExecutable object
+            app_inst: Instance of application object
+
+        Returns
+            (list, list): List of CommandExecutable objects that occur before
+                          and after (respectively) to the input executable.
+        """
         pre_execs = []
         post_execs = []
         for when_set, exec_mods in self.executable_modifiers.items():
             if self.expander.satisfies(when_set, self.experiment_variants()):
-                for exec_mod in exec_mods:
-                    mod_func = getattr(self, exec_mod)
+                for exec_mod, mod_conf in exec_mods.items():
+                    if self.executable_modification_applies(
+                        exec_mod, mod_conf["usage_filter"], executable
+                    ):
+                        self._executable_modification_applied.add(exec_mod)
+                        mod_func = getattr(self, exec_mod)
 
-                    pre_exec, post_exec = mod_func(
-                        executable_name, executable, app_inst=app_inst
-                    )
+                        pre_exec, post_exec = mod_func(
+                            executable_name, executable, app_inst=app_inst
+                        )
 
-                    pre_execs.extend(pre_exec)
-                    post_execs.extend(post_exec)
+                        pre_execs.extend(pre_exec)
+                        post_execs.extend(post_exec)
 
         return pre_execs, post_execs
 

--- a/var/ramble/repos/builtin/base_classes/modifier-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/modifier-base/base_class.py
@@ -427,6 +427,9 @@ class ModifierBase(ObjectMixin, metaclass=ModifierMeta):
         Returns:
             Reference to function, if found. None otherwise"""
 
+        if filter_name is None or filter_name == "None":
+            return None
+
         filter_names = set()
         for attr in dir(self):
             method = getattr(self, attr)
@@ -438,16 +441,17 @@ class ModifierBase(ObjectMixin, metaclass=ModifierMeta):
                     test_filter_name = method_attributes["filter_name"]
                 filter_names.add(test_filter_name)
                 if filter_name == test_filter_name:
+                    logger.all_msg(
+                        f" Found matching filter? {filter_name} == {test_filter_name}"
+                    )
                     return method
 
-        if filter_name is not None and filter_name != "None":
-            logger.die(
-                f"When extracting a usage_filter for an executable_modifier "
-                f"on modifier {self.name} "
-                f"the filter {filter_name} does not exist. Registered filters are: \n"
-                f"{filter_names}"
-            )
-        return None
+        logger.die(
+            f"When extracting a usage_filter for an executable_modifier "
+            f"on modifier {self.name} "
+            f"the filter {filter_name} does not exist. Registered filters are: \n"
+            f"{filter_names}"
+        )
 
     def executable_modification_applies(
         self, exec_mod, filter_name, executable
@@ -465,6 +469,7 @@ class ModifierBase(ObjectMixin, metaclass=ModifierMeta):
         filter_func = self.get_executable_modifier_filter(filter_name)
 
         if filter_func is not None:
+            logger.all_msg(f" Filter func = {filter_func}")
             apply = filter_func(exec_mod, executable)
 
         return apply

--- a/var/ramble/repos/builtin/modifiers/env-var-aggregator/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/env-var-aggregator/modifier.py
@@ -78,10 +78,6 @@ class EnvVarAggregator(BasicModifier):
         modes=["explicit"],
     )
 
-    def __init__(self, file_path):
-        super().__init__(file_path)
-        self._applied_aggregation = False
-
     def _aggregate_all_env_vars(self, shell):
         script_lines = []
 
@@ -133,16 +129,13 @@ class EnvVarAggregator(BasicModifier):
 
         return script_lines
 
-    executable_modifier("inject_env_aggregation_script")
+    executable_modifier("inject_env_aggregation_script", usage_filter="once")
 
     def inject_env_aggregation_script(
         self, executable_name, executable, app_inst=None
     ):
         pre_cmds = []
         post_cmds = []
-
-        if self._applied_aggregation or not app_inst:
-            return pre_cmds, post_cmds
 
         item_prefix = app_inst.expander.expand_var_name(
             "aggregated_env_var_item_prefix"
@@ -174,7 +167,5 @@ class EnvVarAggregator(BasicModifier):
             output_capture=None,
         )
         pre_cmds.append(cmd_exec)
-
-        self._applied_aggregation = True
 
         return pre_cmds, post_cmds

--- a/var/ramble/repos/builtin/modifiers/execution-date/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/execution-date/modifier.py
@@ -18,8 +18,6 @@ class ExecutionDate(BasicModifier):
 
     mode("standard", description="Standard execution mode")
 
-    executable_modifier("get_startend_date")
-
     modifier_variable(
         "date_format",
         default="",
@@ -27,13 +25,10 @@ class ExecutionDate(BasicModifier):
         mode="standard",
     )
 
+    executable_modifier("get_startend_date", usage_filter="once")
+
     def get_startend_date(self, executable_name, executable, app_inst=None):
         from ramble.util.executable import CommandExecutable
-
-        if hasattr(self, "_already_applied"):
-            return [], []
-
-        self._already_applied = True
 
         pre_cmds = []
         post_cmds = []

--- a/var/ramble/repos/builtin/modifiers/gcp-metadata/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/gcp-metadata/modifier.py
@@ -65,15 +65,10 @@ class GcpMetadata(BasicModifier):
         description="Optional suffix for {metadata_parallel_prefix}",
     )
 
-    executable_modifier("gcp_metadata_exec")
+    executable_modifier("gcp_metadata_exec", usage_filter="once")
 
     def gcp_metadata_exec(self, executable_name, executable, app_inst=None):
         from ramble.util.executable import CommandExecutable
-
-        if hasattr(self, "_already_applied"):
-            return [], []
-
-        self._already_applied = True
 
         post_cmds = []
         pre_cmds = []

--- a/var/ramble/repos/builtin/modifiers/install-ramble/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/install-ramble/modifier.py
@@ -111,7 +111,7 @@ fi
         modes=["standard", "quiet"],
     )
 
-    executable_modifier("source_installed_ramble")
+    executable_modifier("source_installed_ramble", usage_filter="once")
 
     def source_installed_ramble(
         self, executable_name, executable, app_inst=None
@@ -124,15 +124,13 @@ fi
         if self._usage_mode == "quiet":
             return pre_exec, post_exec
 
-        if not hasattr(self, "_already_applied"):
-            pre_exec.append(
-                CommandExecutable(
-                    "source-installed-ramble",
-                    template=[
-                        "{source_ramble}",
-                    ],
-                )
+        pre_exec.append(
+            CommandExecutable(
+                "source-installed-ramble",
+                template=[
+                    "{source_ramble}",
+                ],
             )
+        )
 
-            self._already_applied = True
         return pre_exec, post_exec

--- a/var/ramble/repos/builtin/modifiers/install-spack/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/install-spack/modifier.py
@@ -87,7 +87,7 @@ fi
         modes=["standard", "quiet"],
     )
 
-    executable_modifier("source_installed_spack")
+    executable_modifier("source_installed_spack", usage_filter="once")
 
     def source_installed_spack(
         self, executable_name, executable, app_inst=None
@@ -100,15 +100,13 @@ fi
         if self._usage_mode == "quiet":
             return pre_exec, post_exec
 
-        if not hasattr(self, "_already_applied"):
-            pre_exec.append(
-                CommandExecutable(
-                    "source-installed-spack",
-                    template=[
-                        "{source_spack}",
-                    ],
-                )
+        pre_exec.append(
+            CommandExecutable(
+                "source-installed-spack",
+                template=[
+                    "{source_spack}",
+                ],
             )
+        )
 
-            self._already_applied = True
         return pre_exec, post_exec

--- a/var/ramble/repos/builtin/modifiers/intel-aps/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/intel-aps/modifier.py
@@ -80,7 +80,7 @@ class IntelAps(BasicModifier):
 
     modifier_variable(
         "apply_aps_exe_regex",
-        default="",
+        default=".*",
         description="apply aps to executables that match with the regex",
         mode="mpi",
     )
@@ -115,7 +115,7 @@ class IntelAps(BasicModifier):
 
         required_package("intel-oneapi-vtune")
 
-    executable_modifier("aps_summary")
+    executable_modifier("aps_summary", usage_filter="all_mpi")
 
     def aps_summary(self, executable_name, executable, app_inst=None):
         from ramble.util.executable import CommandExecutable
@@ -125,7 +125,7 @@ class IntelAps(BasicModifier):
 
         exe_regex = self.expander.expand_var_name("apply_aps_exe_regex")
         applicable = exe_regex and re.match(exe_regex, executable_name)
-        if applicable or executable.mpi:
+        if applicable:
             env_var_name = self.expander.expand_var_name(
                 "external_aps_env_var"
             )

--- a/var/ramble/repos/builtin/modifiers/nccl-env/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/nccl-env/modifier.py
@@ -666,10 +666,6 @@ class NcclEnv(BasicModifier):
         modes=["standard"],
     )
 
-    def __init__(self, file_path):
-        super().__init__(file_path)
-        self._applied = False
-
     def generate_env_var_dict(self, app_inst):
         env_var_set = {}
         set_env_vars = {}
@@ -684,39 +680,42 @@ class NcclEnv(BasicModifier):
 
         return env_var_set
 
-    executable_modifier("define_nccl_env_vars")
+    @ModifierBase.executable_modifier_usage_filter("first_workload_exec")
+    def filter_first_workload_executable(self, exec_mod, executable):
+        # Apply before the first executable from the workload
+        app_inst = self._get_app_inst()
+        workload = app_inst.get_workload()
+        return executable.name == workload.executables[
+            0
+        ] and not self.executable_modifier_applied(exec_mod)
+
+    executable_modifier(
+        "define_nccl_env_vars", usage_filter="first_workload_exec"
+    )
 
     def define_nccl_env_vars(self, executable_name, executable, app_inst=None):
         pre_cmds = []
         post_cmds = []
-        if self._applied:
-            return pre_cmds, post_cmds
 
-        workload = app_inst.get_workload()
+        action_funcs = ramble.util.env.action_funcs
+        shell = ramble.config.get("config:shell")
+        env_var_dict = self.generate_env_var_dict(app_inst)
+        env_var_cmds = []
+        for action, conf in env_var_dict.items():
+            (env_cmds, _) = action_funcs[action](conf, set(), shell=shell)
 
-        # Apply before the first executable from the workload
-        if executable_name == workload.executables[0]:
-            self._applied = True
+            for cmd in env_cmds:
+                if cmd:
+                    env_var_cmds.append(cmd)
 
-            action_funcs = ramble.util.env.action_funcs
-            shell = ramble.config.get("config:shell")
-            env_var_dict = self.generate_env_var_dict(app_inst)
-            env_var_cmds = []
-            for action, conf in env_var_dict.items():
-                (env_cmds, _) = action_funcs[action](conf, set(), shell=shell)
-
-                for cmd in env_cmds:
-                    if cmd:
-                        env_var_cmds.append(cmd)
-
-            pre_cmds.append(
-                ramble.util.executable.CommandExecutable(
-                    "nccl_env_vars",
-                    template=env_var_cmds,
-                    mpi=False,
-                    redirect="",
-                    output_capture="",
-                )
+        pre_cmds.append(
+            ramble.util.executable.CommandExecutable(
+                "nccl_env_vars",
+                template=env_var_cmds,
+                mpi=False,
+                redirect="",
+                output_capture="",
             )
+        )
 
         return pre_cmds, post_cmds

--- a/var/ramble/repos/builtin/modifiers/pre-exec-print/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/pre-exec-print/modifier.py
@@ -28,9 +28,7 @@ class PreExecPrint(BasicModifier):
     mode("standard", description="Standard execution mode for pre-print")
     default_mode("standard")
 
-    executable_modifier("pre_exec_print")
-
-    _attr_name = "_applied_pre_exec_print"
+    executable_modifier("pre_exec_print", usage_filter="once")
 
     def pre_exec_print(self, executable_name, executable, app_inst=None):
         from ramble.util.executable import CommandExecutable
@@ -38,18 +36,19 @@ class PreExecPrint(BasicModifier):
         pre_cmds = []
         post_cmds = []
 
-        if not hasattr(self, self._attr_name):
-            echo_string = "Index: {experiment_index} -- Namespace: {experiment_namespace}"
-            if "pre_exec_print_template" in app_inst.variables:
-                echo_string = "{pre_exec_print_template}"
-            pre_cmds.append(
-                CommandExecutable(
-                    "perform-pre-exec-print",
-                    template=[f'echo "Running: {echo_string}"'],
-                    mpi=False,
-                    redirect="",
-                    output_capture="",
-                )
+        echo_string = (
+            "Index: {experiment_index} -- Namespace: {experiment_namespace}"
+        )
+        if "pre_exec_print_template" in app_inst.variables:
+            echo_string = "{pre_exec_print_template}"
+        pre_cmds.append(
+            CommandExecutable(
+                "perform-pre-exec-print",
+                template=[f'echo "Running: {echo_string}"'],
+                mpi=False,
+                redirect="",
+                output_capture="",
             )
-            setattr(self, self._attr_name, True)
+        )
+
         return pre_cmds, post_cmds

--- a/var/ramble/repos/builtin/modifiers/run-directory/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/run-directory/modifier.py
@@ -73,7 +73,7 @@ class RunDirectory(BasicModifier):
         dest_path="postrun_copy.sh",
     )
 
-    executable_modifier("apply_run_directory_change")
+    executable_modifier("apply_run_directory_change", usage_filter="once")
 
     def apply_run_directory_change(
         self, executable_name, executable, app_inst
@@ -89,8 +89,8 @@ class RunDirectory(BasicModifier):
             return pre_cmds, post_cmds
         from ramble.util import executable
 
-        if not getattr(self, "_applied", False):
-            self._applied = True
+        if not getattr(self, "_target_cleaned", False):
+            self._target_cleaned = True
             should_cleanup = self.expander.expand_var_name(
                 "cleanup_target_directory_before_run",
                 typed=True,


### PR DESCRIPTION
This merge allows executable_modifiers defined within modifiers to apply usage filters. Usage filters can change what the rules are for applying an executable_modifier to a given executable. Pre-defined filters include "None" (i.e. no restrictions), "once" (only apply once), "first_mpi" (apply to the first MPI executable), or "all_mpi" (apply to all MPI executables).

Modifiers can define their own additional usage_filters as well, to change the logic.