### PR TITLE
Add caching to experiment results to speed repeated analysis

### DIFF
--- a/lib/ramble/ramble/experiment_result.py
+++ b/lib/ramble/ramble/experiment_result.py
@@ -6,9 +6,15 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+import os
 from enum import Enum
 
 from ramble.namespace import namespace
+from ramble.software_info import SoftwareInfo
+from ramble.util.file_util import get_newest_experiment_file
+from ramble.util.logger import logger
+
+import spack.util.spack_json as sjson
 
 
 # Can use auto() once we're at >= python 3.11
@@ -28,6 +34,7 @@ class ExperimentStatus(str, Enum):
 
 _OUTPUT_MAPPING = {
     "name": "name",
+    "status": "EXPERIMENT_STATUS",
     namespace.n_repeats: "N_REPEATS",
     "keys": "keys",
     "contexts": "CONTEXTS",
@@ -38,12 +45,15 @@ _OUTPUT_MAPPING = {
     namespace.variants: "VARIANTS",
     "experiment_chain": "EXPERIMENT_CHAIN",
     "success_criteria": "SUCCESS_CRITERIA",
+    "object_definitions": "OBJECT_DEFINITIONS",
 }
 
 
 # TODO: would be better to use dataclass after 3.6 support is dropped
 class ExperimentResult:
     """Class containing results and related metadata of an experiment"""
+
+    cache_file_name = "ramble_results_cache.json"
 
     def __init__(self, app_inst):
         """Build up the result from the given app instance"""
@@ -60,8 +70,59 @@ class ExperimentResult:
         self.raw_variables = {}
         self.variables = {}
         self.variants = []
+        self.object_definitions = []
 
-    def finalize(self):
+    def read_cache(self, workspace, app_inst) -> bool:
+        experiment_dir = app_inst.expander.experiment_run_dir
+        cache_file = os.path.join(experiment_dir, self.cache_file_name)
+
+        logger.debug(f"Experiment results cache file is: {cache_file}")
+
+        if not os.path.isfile(cache_file):
+            logger.debug("No valid experiment results cache found. Will create one.")
+            return False
+        cache_timestamp = os.path.getmtime(cache_file)
+
+        newest_file, file_timestamp = get_newest_experiment_file(experiment_dir)
+
+        if file_timestamp is not None and cache_timestamp < file_timestamp:
+            logger.all_msg("Invalidating experiment results cache: timestamp difference")
+            return False
+
+        with open(cache_file) as f:
+            cache_dict = sjson.load(f)
+
+        if (
+            "experiment_hash" not in cache_dict
+            or app_inst.experiment_hash != cache_dict["experiment_hash"]
+        ):
+            logger.all_msg("Invalidating experiment results cache: experiment hash difference")
+            return False
+
+        self.from_dict(cache_dict)
+        logger.all_msg("Reading experiment results from cache file")
+        return True
+
+    def write_cache(self, app_inst):
+        experiment_dir = app_inst.expander.experiment_run_dir
+        cache_file = os.path.join(experiment_dir, self.cache_file_name)
+
+        out_dict = self.to_dict()
+        out_dict["experiment_hash"] = app_inst.experiment_hash
+
+        software_key = _OUTPUT_MAPPING["software"]
+        software_packages = {}
+        if software_key in out_dict:
+            software_packages = out_dict[software_key].copy()
+
+        out_dict[software_key] = {}
+        for key, pkg_list in software_packages.items():
+            out_dict[software_key][key] = [pkg.to_dict() for pkg in pkg_list]
+
+        with open(cache_file, "w+") as f:
+            sjson.dump(out_dict, f)
+
+    def finalize(self, workspace):
         app_inst = self._app_inst
         self.name = app_inst.expander.experiment_namespace
 
@@ -85,6 +146,25 @@ class ExperimentResult:
                 self.variables[var] = app_inst.expander.expand_var(val)
 
         self.variants = sorted(app_inst.experiment_variants().as_set())
+
+        self.object_definitions = app_inst.object_inventory(workspace)
+
+    def from_dict(self, in_dict: dict):
+        """Convert a dict back into a results object
+
+        Args:
+            in_dict (dict): Input dictionary of results from a cache
+        """
+
+        for lookup_key, output_key in _OUTPUT_MAPPING.items():
+            if output_key in in_dict:
+                setattr(self, lookup_key, in_dict[output_key])
+
+        software_key = _OUTPUT_MAPPING["software"]
+        if software_key in in_dict:
+            self.software = {}
+            for key, pkg_list in in_dict[software_key].items():
+                self.software[key] = [SoftwareInfo(**pkg_conf) for pkg_conf in pkg_list]
 
     def to_dict(self):
         """Generate a dict for encoders (json, yaml) and uploaders.

--- a/lib/ramble/ramble/test/experiment_result.py
+++ b/lib/ramble/ramble/test/experiment_result.py
@@ -8,10 +8,32 @@
 
 """Tests on the ExperimentResult class"""
 
+import os
+import time
+
+import pytest
+
 from ramble.experiment_result import ExperimentResult
+from ramble.util.file_util import get_newest_experiment_file
 
 
-def test_to_dict(mutable_mock_apps_repo):
+@pytest.fixture
+def experiment_result():
+    """Returns a basic experiment result"""
+
+    class AppInst:
+        def __init__(self):
+            class Expander:
+                def __init__(self):
+                    self.experiment_run_dir = ""
+
+            self.expander = Expander()
+            self.experiment_hash = "test_hash"
+
+    return ExperimentResult(AppInst())
+
+
+def test_experiment_result_to_dict(mutable_mock_apps_repo):
     basic_app_inst = mutable_mock_apps_repo.get("basic")
     basic_app_inst.set_variables_and_variants(
         {"workload_name": "test_wl", "experiment_status": "placeholder", "test_var": "my_var"},
@@ -20,7 +42,7 @@ def test_to_dict(mutable_mock_apps_repo):
     )
     basic_app_inst.set_status("UNKNOWN")
     exp_res = ExperimentResult(basic_app_inst)
-    exp_res.finalize()
+    exp_res.finalize(None)
     res_dict = exp_res.to_dict()
 
     assert "name" in res_dict
@@ -34,3 +56,81 @@ def test_to_dict(mutable_mock_apps_repo):
     assert res_dict["RAMBLE_VARIABLES"]["test_var"] == "my_var"
     assert res_dict["RAMBLE_RAW_VARIABLES"]["test_var"] == "my_var"
     assert "RAMBLE_RAW_VARIABLES" in res_dict
+
+
+def test_experiment_result_read_write_cache(tmpdir, experiment_result):
+    """Test that the cache is written and read correctly"""
+    experiment_dir = tmpdir.mkdir("experiment")
+    experiment_result._app_inst.expander.experiment_run_dir = str(experiment_dir)
+
+    # Test that the cache is written
+    experiment_result.write_cache(experiment_result._app_inst)
+    cache_file = os.path.join(str(experiment_dir), experiment_result.cache_file_name)
+    assert os.path.exists(cache_file)
+
+    # Test that the cache is read correctly
+    assert experiment_result.read_cache(None, experiment_result._app_inst)
+
+
+def test_experiment_result_cache_invalidation_new_file(tmpdir, experiment_result):
+    """Test that the cache is invalidated if a file is newer than the cache"""
+    experiment_dir = tmpdir.mkdir("experiment")
+    experiment_result._app_inst.expander.experiment_run_dir = str(experiment_dir)
+
+    # Write the cache
+    experiment_result.write_cache(experiment_result._app_inst)
+    time.sleep(0.1)
+
+    # Create a new file
+    new_file = os.path.join(str(experiment_dir), "new_file")
+    with open(new_file, "w") as f:
+        f.write("test")
+
+    # Test that the cache is invalidated
+    assert not experiment_result.read_cache(None, experiment_result._app_inst)
+
+
+def test_experiment_result_cache_invalidation_hash_change(tmpdir, experiment_result):
+    """Test that the cache is invalidated if the experiment hash changes"""
+    experiment_dir = tmpdir.mkdir("experiment")
+    experiment_result._app_inst.expander.experiment_run_dir = str(experiment_dir)
+
+    # Write the cache
+    experiment_result.write_cache(experiment_result._app_inst)
+
+    # Change the experiment hash
+    experiment_result._app_inst.experiment_hash = "new_hash"
+
+    # Test that the cache is invalidated
+    assert not experiment_result.read_cache(None, experiment_result._app_inst)
+
+
+def test_experiment_result_get_newest_experiment_file(tmpdir):
+    """Test that the newest experiment file is found correctly"""
+    experiment_dir = tmpdir.mkdir("experiment")
+    sub_dir = os.path.join(str(experiment_dir), "sub")
+    os.mkdir(sub_dir)
+
+    # Create some files
+    file1 = os.path.join(str(experiment_dir), "file1")
+    file2 = os.path.join(sub_dir, "file2")
+    ramble_file = os.path.join(str(experiment_dir), "ramble_file")
+
+    with open(file1, "w") as f:
+        f.write("test")
+    time.sleep(0.1)
+
+    with open(file2, "w") as f:
+        f.write("test")
+    time.sleep(0.1)
+
+    with open(ramble_file, "w") as f:
+        f.write("test")
+
+    # Test that the newest file is found correctly
+    newest_file, _ = get_newest_experiment_file(str(experiment_dir))
+    assert newest_file == file2
+
+    # Test that ramble_file is ignored
+    newest_file, _ = get_newest_experiment_file(str(experiment_dir))
+    assert "ramble_file" not in newest_file

--- a/lib/ramble/ramble/util/file_util.py
+++ b/lib/ramble/ramble/util/file_util.py
@@ -7,6 +7,7 @@
 # except according to those terms.
 
 import os
+from pathlib import Path
 
 _DRY_RUN_PATH_PREFIX = os.path.join("dry-run", "path", "to")
 
@@ -39,3 +40,27 @@ def create_symlink(base, link):
         os.unlink(link)
 
     os.symlink(base, link)
+
+
+def get_newest_experiment_file(base_directory):
+    """Given a base directory, determine the newest file in the directory (and
+    it's subdirectories)and return the file path and it's timestamp in seconds.
+
+    Args:
+        base_directory (str): Directory to search newest file for
+
+    Returns:
+        (str): Path to newest file (or None if not found)
+        (int): Timestamp of file in seconds (or None if no file is found)
+    """
+    files = Path(base_directory).rglob("*")
+    files = [f for f in files if f.is_file() and not os.path.basename(f).startswith("ramble_")]
+
+    if not files:
+        return None, None
+
+    newest_file_path = max(files, key=os.path.getmtime)
+
+    timestamp_seconds = os.path.getmtime(newest_file_path)
+
+    return str(newest_file_path), timestamp_seconds

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -54,6 +54,7 @@ from ramble.experiment_result import ExperimentResult, ExperimentStatus
 from ramble.language.application_language import ApplicationMeta
 from ramble.language.shared_language import (
     SharedMeta,
+    archive_pattern,
     register_builtin,
     register_phase,
 )
@@ -146,6 +147,8 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
     license_names: List[str] = []
 
+    archive_pattern("{experiment_run_dir}/" + ExperimentResult.cache_file_name)
+
     def __init__(self, file_path):
         super().__init__()
 
@@ -198,6 +201,16 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         self._file_path = file_path
 
         self.license_names = self.license_names + [self.name]
+
+        self.hash_inventory = {
+            "attributes": [],
+            "inputs": [],
+            "software": [],
+            "templates": [],
+            "package_manager": [],
+            "modifier_artifacts": [],
+        }
+        self.experiment_hash = None
 
         self.application_class = "ApplicationBase"
 
@@ -1176,6 +1189,38 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
             # Define any missing modifier variables
             self.define_missing_variables()
+
+    @property
+    def inventory_file(self):
+        experiment_run_dir = self.expander.experiment_run_dir
+        return os.path.join(experiment_run_dir, self._inventory_file_name)
+
+    def object_hashes(self):
+        for obj_type, obj in self._objects():
+            yield obj_type, obj, ramble.util.hashing.hash_file(obj._file_path)
+
+    def object_inventory(self, workspace):
+        object_definitions = []
+        added_objects = {}
+        for obj_type, obj, obj_hash in self.object_hashes():
+            if obj_type not in added_objects:
+                added_objects[obj_type] = set()
+
+            if obj.name not in added_objects[obj_type]:
+                obj_inventory = {
+                    "name": obj.name,
+                    "type": obj_type.name,
+                    "digest": obj_hash,
+                }
+
+                if hasattr(obj, "get_version"):
+                    obj_inventory["external_version"] = obj.get_version(
+                        workspace=workspace
+                    )
+
+                object_definitions.append(obj_inventory)
+                added_objects[obj_type].add(obj.name)
+        return object_definitions
 
     def validate_experiment(
         self, warn_validation=True, die_on_validate_error=True
@@ -2431,7 +2476,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             logger.warn(
                 f"Experiment has status {self.get_status()}. Skipping analysis..\n"
             )
-            self.result.finalize()
+            self.result.finalize(workspace)
             return
 
         def format_context(context_match, context_format):
@@ -2445,213 +2490,236 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             context_string = context_format.format(**context_val)
             return context_string
 
-        criteria_list = self.success_list
-        if not criteria_list:
-            criteria_list = ramble.success_criteria.ScopedCriteriaList()
-        criteria_list.reset()
+        if not self.result.read_cache(workspace, self):
+            criteria_list = self.success_list
+            if not criteria_list:
+                criteria_list = ramble.success_criteria.ScopedCriteriaList()
+            criteria_list.reset()
 
-        files, f_defs, inmem_defs = self._analysis_dicts(criteria_list)
+            files, f_defs, inmem_defs = self._analysis_dicts(criteria_list)
 
-        exp_lock = self.experiment_lock
+            exp_lock = self.experiment_lock
 
-        fom_values = {}
-        # Iterate over files. We already know they exist
-        with lk.ReadTransaction(exp_lock):
-            for file, file_conf in files.items():
+            fom_values = {}
+            # Iterate over files. We already know they exist
+            with lk.ReadTransaction(exp_lock):
+                for file, file_conf in files.items():
 
-                # Start with no active contexts in a file.
-                active_contexts = {}
-                logger.debug(f"Reading log file: {file}")
+                    # Start with no active contexts in a file.
+                    active_contexts = {}
+                    logger.debug(f"Reading log file: {file}")
 
-                if not os.path.exists(file):
-                    logger.debug(
-                        f"Skipping analysis of non-existent file: {file}"
-                    )
-                    continue
+                    if not os.path.exists(file):
+                        logger.debug(
+                            f"Skipping analysis of non-existent file: {file}"
+                        )
+                        continue
 
-                per_file_crit_objs = [
-                    criteria_list.find_criteria(c)
-                    for c in file_conf["success_criteria"]
-                ]
+                    per_file_crit_objs = [
+                        criteria_list.find_criteria(c)
+                        for c in file_conf["success_criteria"]
+                    ]
 
-                with open(file) as f:
-                    for line in f.readlines():
-                        new_per_file_crit_objs = []
-                        for crit_obj in per_file_crit_objs:
-                            if crit_obj.passed(line, self):
-                                crit_obj.mark_found()
-                            elif crit_obj.anti_matched(line):
-                                crit_obj.mark_anti_found()
-                            else:
-                                new_per_file_crit_objs.append(crit_obj)
-                        per_file_crit_objs = new_per_file_crit_objs
+                    with open(file) as f:
+                        for line in f.readlines():
+                            new_per_file_crit_objs = []
+                            for crit_obj in per_file_crit_objs:
+                                if crit_obj.passed(line, self):
+                                    crit_obj.mark_found()
+                                elif crit_obj.anti_matched(line):
+                                    crit_obj.mark_anti_found()
+                                else:
+                                    new_per_file_crit_objs.append(crit_obj)
+                            per_file_crit_objs = new_per_file_crit_objs
 
-                        # Iterate over contexts and add matched contexts to active_contexts
-                        for context, foms in file_conf["contexts"].items():
-                            if not context == _NULL_CONTEXT:
-                                context_conf = f_defs[context]["definition"]
-                                context_match = context_conf["regex"].match(
-                                    line
-                                )
+                            # Iterate over contexts and add matched contexts to active_contexts
+                            for context, foms in file_conf["contexts"].items():
+                                if not context == _NULL_CONTEXT:
+                                    context_conf = f_defs[context][
+                                        "definition"
+                                    ]
+                                    context_match = context_conf[
+                                        "regex"
+                                    ].match(line)
 
-                                if context_match:
-                                    context_name = format_context(
-                                        context_match, context_conf["format"]
-                                    )
-                                    logger.debug("Line was: %s" % line)
-                                    logger.debug(
-                                        f" Context match {context} -- {context_name}"
-                                    )
-
-                                    active_contexts[context] = context_name
-
-                                    if context_name not in fom_values:
-                                        fom_values[context_name] = {}
-
-                            for fom in foms:
-                                fom_conf = f_defs[context]["foms"][fom]
-                                fom_match = fom_conf["regex"].match(line)
-
-                                if fom_match:
-                                    fom_vars = {}
-                                    for k, v in fom_match.groupdict().items():
-                                        fom_vars[k] = v
-                                    if (
-                                        fom_conf["fom_name_expanded"]
-                                        is not None
-                                    ):
-                                        fom_name = fom_conf[
-                                            "fom_name_expanded"
-                                        ]
-                                    else:
-                                        fom_name = self.expander.expand_var(
-                                            fom, extra_vars=fom_vars
+                                    if context_match:
+                                        context_name = format_context(
+                                            context_match,
+                                            context_conf["format"],
                                         )
-
-                                    if (
-                                        fom_conf["group"]
-                                        in fom_conf["regex"].groupindex
-                                    ):
+                                        logger.debug("Line was: %s" % line)
                                         logger.debug(
-                                            " --- Matched fom %s" % fom_name
+                                            f" Context match {context} -- {context_name}"
                                         )
-                                        fom_contexts = []
-                                        # if a FOM has contexts, check if each is active
-                                        if fom_conf["contexts"]:
-                                            for _ in fom_conf["contexts"]:
-                                                context_name = (
-                                                    active_contexts[context]
-                                                    if context
-                                                    in active_contexts
-                                                    else _NULL_CONTEXT
-                                                )
-                                                fom_contexts.append(
-                                                    context_name
-                                                )
-                                        else:
-                                            fom_contexts.append(_NULL_CONTEXT)
 
-                                        for fom_context in fom_contexts:
-                                            if fom_context not in fom_values:
-                                                fom_values[fom_context] = {}
-                                            fom_val = fom_match.group(
-                                                fom_conf["group"]
+                                        active_contexts[context] = context_name
+
+                                        if context_name not in fom_values:
+                                            fom_values[context_name] = {}
+
+                                for fom in foms:
+                                    fom_conf = f_defs[context]["foms"][fom]
+                                    fom_match = fom_conf["regex"].match(line)
+
+                                    if fom_match:
+                                        fom_vars = {}
+                                        for (
+                                            k,
+                                            v,
+                                        ) in fom_match.groupdict().items():
+                                            fom_vars[k] = v
+                                        if (
+                                            fom_conf["fom_name_expanded"]
+                                            is not None
+                                        ):
+                                            fom_name = fom_conf[
+                                                "fom_name_expanded"
+                                            ]
+                                        else:
+                                            fom_name = (
+                                                self.expander.expand_var(
+                                                    fom, extra_vars=fom_vars
+                                                )
                                             )
-                                            if (
-                                                fom_conf["units_expanded"]
-                                                is not None
-                                            ):
-                                                fom_unit = fom_conf["units"]
+
+                                        if (
+                                            fom_conf["group"]
+                                            in fom_conf["regex"].groupindex
+                                        ):
+                                            logger.debug(
+                                                " --- Matched fom %s"
+                                                % fom_name
+                                            )
+                                            fom_contexts = []
+                                            # if a FOM has contexts, check if each is active
+                                            if fom_conf["contexts"]:
+                                                for _ in fom_conf["contexts"]:
+                                                    context_name = (
+                                                        active_contexts[
+                                                            context
+                                                        ]
+                                                        if context
+                                                        in active_contexts
+                                                        else _NULL_CONTEXT
+                                                    )
+                                                    fom_contexts.append(
+                                                        context_name
+                                                    )
                                             else:
-                                                fom_unit = (
-                                                    self.expander.expand_var(
+                                                fom_contexts.append(
+                                                    _NULL_CONTEXT
+                                                )
+
+                                            for fom_context in fom_contexts:
+                                                if (
+                                                    fom_context
+                                                    not in fom_values
+                                                ):
+                                                    fom_values[fom_context] = (
+                                                        {}
+                                                    )
+                                                fom_val = fom_match.group(
+                                                    fom_conf["group"]
+                                                )
+                                                if (
+                                                    fom_conf["units_expanded"]
+                                                    is not None
+                                                ):
+                                                    fom_unit = fom_conf[
+                                                        "units"
+                                                    ]
+                                                else:
+                                                    fom_unit = self.expander.expand_var(
                                                         fom_conf["units"],
                                                         extra_vars=fom_vars,
                                                     )
-                                                )
-                                            fom_values[fom_context][
-                                                fom_name
-                                            ] = {
-                                                "value": fom_val,
-                                                "units": fom_unit,
-                                                "origin": fom_conf["origin"],
-                                                "origin_type": fom_conf[
-                                                    "origin_type"
-                                                ],
-                                                "fom_type": fom_conf[
-                                                    "fom_type"
-                                                ],
-                                            }
-        self._extract_inmem_foms(inmem_defs, fom_values)
+                                                fom_values[fom_context][
+                                                    fom_name
+                                                ] = {
+                                                    "value": fom_val,
+                                                    "units": fom_unit,
+                                                    "origin": fom_conf[
+                                                        "origin"
+                                                    ],
+                                                    "origin_type": fom_conf[
+                                                        "origin_type"
+                                                    ],
+                                                    "fom_type": fom_conf[
+                                                        "fom_type"
+                                                    ],
+                                                }
+            self._extract_inmem_foms(inmem_defs, fom_values)
 
-        # Test all non-file based success criteria
-        for criteria_obj, _ in criteria_list.all_criteria():
-            if criteria_obj.file is None:
-                if criteria_obj.passed(app_inst=self, fom_values=fom_values):
-                    criteria_obj.mark_found()
+            # Test all non-file based success criteria
+            for criteria_obj, _ in criteria_list.all_criteria():
+                if criteria_obj.file is None:
+                    if criteria_obj.passed(
+                        app_inst=self, fom_values=fom_values
+                    ):
+                        criteria_obj.mark_found()
 
-        # If an app has no FOMs defined, don't fail it for that
-        success = (not f_defs and not inmem_defs) or False
-        for fom in fom_values.values():
-            for value in fom.values():
-                if (
-                    "origin_type" in value
-                    and value["origin_type"] == "application"
+            # If an app has no FOMs defined, don't fail it for that
+            success = (not f_defs and not inmem_defs) or False
+            for fom in fom_values.values():
+                for value in fom.values():
+                    if (
+                        "origin_type" in value
+                        and value["origin_type"] == "application"
+                    ):
+                        success = True
+            success = success and criteria_list.passed()
+
+            status = self.get_status()
+            if status == ExperimentStatus.SUCCESS and not success:
+                status = ExperimentStatus.FAILED
+            elif success:
+                status = ExperimentStatus.SUCCESS
+
+            # When workflow_manager is present, only use app_status when workflow is completed or
+            # unresolved.
+            if self.workflow_manager is not None:
+                wm_status = self.workflow_manager.get_status(workspace)
+                if not (
+                    wm_status is None
+                    or wm_status
+                    in [ExperimentStatus.COMPLETE, ExperimentStatus.UNRESOLVED]
                 ):
-                    success = True
-        success = success and criteria_list.passed()
+                    status = wm_status
 
-        status = self.get_status()
-        if status == ExperimentStatus.SUCCESS and not success:
-            status = ExperimentStatus.FAILED
-        elif success:
-            status = ExperimentStatus.SUCCESS
+            self.set_status(status)
 
-        # When workflow_manager is present, only use app_status when workflow is completed or
-        # unresolved.
-        if self.workflow_manager is not None:
-            wm_status = self.workflow_manager.get_status(workspace)
-            if not (
-                wm_status is None
-                or wm_status
-                in [ExperimentStatus.COMPLETE, ExperimentStatus.UNRESOLVED]
-            ):
-                status = wm_status
+            self.result.finalize(workspace)
 
-        self.set_status(status)
+            for criteria_obj, criteria_scope in criteria_list.all_criteria():
+                if criteria_obj.owner is not None:
+                    criteria_name = f"{criteria_obj.owner.scoped_name}::{criteria_obj.name}"
+                else:
+                    criteria_name = (
+                        f"config::{criteria_scope}::{criteria_obj.name}"
+                    )
+                if criteria_obj.ok():
+                    self.result.success_criteria[criteria_name] = "PASSED"
+                else:
+                    self.result.success_criteria[criteria_name] = "FAILED"
 
-        self.result.finalize()
+            for context, fom_map in fom_values.items():
+                context_map = {
+                    "name": context,
+                    "foms": [],
+                    "display_name": _get_context_display_name(context),
+                }
 
-        for criteria_obj, criteria_scope in criteria_list.all_criteria():
-            if criteria_obj.owner is not None:
-                criteria_name = (
-                    f"{criteria_obj.owner.scoped_name}::{criteria_obj.name}"
-                )
-            else:
-                criteria_name = (
-                    f"config::{criteria_scope}::{criteria_obj.name}"
-                )
-            if criteria_obj.ok():
-                self.result.success_criteria[criteria_name] = "PASSED"
-            else:
-                self.result.success_criteria[criteria_name] = "FAILED"
+                for fom_name, fom in fom_map.items():
+                    fom_copy = fom.copy()
+                    fom_copy["name"] = fom_name
+                    context_map["foms"].append(fom_copy)
 
-        for context, fom_map in fom_values.items():
-            context_map = {
-                "name": context,
-                "foms": [],
-                "display_name": _get_context_display_name(context),
-            }
-
-            for fom_name, fom in fom_map.items():
-                fom_copy = fom.copy()
-                fom_copy["name"] = fom_name
-                context_map["foms"].append(fom_copy)
-
-            if context == _NULL_CONTEXT:
-                self.result.contexts.insert(0, context_map)
-            else:
-                self.result.contexts.append(context_map)
+                if context == _NULL_CONTEXT:
+                    self.result.contexts.insert(0, context_map)
+                else:
+                    self.result.contexts.append(context_map)
+        else:
+            self.result.finalize(workspace)
 
     register_phase(
         "append_results_to_workspace",
@@ -2762,7 +2830,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         else:
             self.set_status(status=ExperimentStatus.FAILED)
 
-        self.result.finalize()
+        self.result.finalize(workspace)
 
         logger.debug(
             f"Calculating statistics for {self.repeats.n_repeats} repeats of {base_exp_name}"
@@ -3256,6 +3324,17 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             with lk.ReadTransaction(exp_lock):
                 with open(status_path, "w+") as f:
                     spack.util.spack_json.dump(status_data, f)
+
+    register_phase(
+        "write_results_cache",
+        pipeline="analyze",
+        run_after=["write_status", "append_results_to_workspace"],
+    )
+
+    def _write_results_cache(self, workspace, app_inst=None):
+        if hasattr(self, "result") and self.result is not None:
+            with lk.WriteTransaction(self.experiment_lock):
+                self.result.write_cache(self)
 
     register_phase("deploy_artifacts", pipeline="pushdeployment")
 

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -2490,236 +2490,222 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             context_string = context_format.format(**context_val)
             return context_string
 
-        if not self.result.read_cache(workspace, self):
-            criteria_list = self.success_list
-            if not criteria_list:
-                criteria_list = ramble.success_criteria.ScopedCriteriaList()
-            criteria_list.reset()
+        # Exit early if read from cache works.
+        if self.result.read_cache(workspace, self):
+            self.result.finalize(workspace)
+            return
 
-            files, f_defs, inmem_defs = self._analysis_dicts(criteria_list)
+        criteria_list = self.success_list
+        if not criteria_list:
+            criteria_list = ramble.success_criteria.ScopedCriteriaList()
+        criteria_list.reset()
 
-            exp_lock = self.experiment_lock
+        files, f_defs, inmem_defs = self._analysis_dicts(criteria_list)
 
-            fom_values = {}
-            # Iterate over files. We already know they exist
-            with lk.ReadTransaction(exp_lock):
-                for file, file_conf in files.items():
+        exp_lock = self.experiment_lock
 
-                    # Start with no active contexts in a file.
-                    active_contexts = {}
-                    logger.debug(f"Reading log file: {file}")
+        fom_values = {}
+        # Iterate over files. We already know they exist
+        with lk.ReadTransaction(exp_lock):
+            for file, file_conf in files.items():
 
-                    if not os.path.exists(file):
-                        logger.debug(
-                            f"Skipping analysis of non-existent file: {file}"
-                        )
-                        continue
+                # Start with no active contexts in a file.
+                active_contexts = {}
+                logger.debug(f"Reading log file: {file}")
 
-                    per_file_crit_objs = [
-                        criteria_list.find_criteria(c)
-                        for c in file_conf["success_criteria"]
-                    ]
+                if not os.path.exists(file):
+                    logger.debug(
+                        f"Skipping analysis of non-existent file: {file}"
+                    )
+                    continue
 
-                    with open(file) as f:
-                        for line in f.readlines():
-                            new_per_file_crit_objs = []
-                            for crit_obj in per_file_crit_objs:
-                                if crit_obj.passed(line, self):
-                                    crit_obj.mark_found()
-                                elif crit_obj.anti_matched(line):
-                                    crit_obj.mark_anti_found()
-                                else:
-                                    new_per_file_crit_objs.append(crit_obj)
-                            per_file_crit_objs = new_per_file_crit_objs
+                per_file_crit_objs = [
+                    criteria_list.find_criteria(c)
+                    for c in file_conf["success_criteria"]
+                ]
 
-                            # Iterate over contexts and add matched contexts to active_contexts
-                            for context, foms in file_conf["contexts"].items():
-                                if not context == _NULL_CONTEXT:
-                                    context_conf = f_defs[context][
-                                        "definition"
-                                    ]
-                                    context_match = context_conf[
-                                        "regex"
-                                    ].match(line)
+                with open(file) as f:
+                    for line in f.readlines():
+                        new_per_file_crit_objs = []
+                        for crit_obj in per_file_crit_objs:
+                            if crit_obj.passed(line, self):
+                                crit_obj.mark_found()
+                            elif crit_obj.anti_matched(line):
+                                crit_obj.mark_anti_found()
+                            else:
+                                new_per_file_crit_objs.append(crit_obj)
+                        per_file_crit_objs = new_per_file_crit_objs
 
-                                    if context_match:
-                                        context_name = format_context(
-                                            context_match,
-                                            context_conf["format"],
+                        # Iterate over contexts and add matched contexts to active_contexts
+                        for context, foms in file_conf["contexts"].items():
+                            if not context == _NULL_CONTEXT:
+                                context_conf = f_defs[context]["definition"]
+                                context_match = context_conf["regex"].match(
+                                    line
+                                )
+
+                                if context_match:
+                                    context_name = format_context(
+                                        context_match,
+                                        context_conf["format"],
+                                    )
+                                    logger.debug("Line was: %s" % line)
+                                    logger.debug(
+                                        f" Context match {context} -- {context_name}"
+                                    )
+
+                                    active_contexts[context] = context_name
+
+                                    if context_name not in fom_values:
+                                        fom_values[context_name] = {}
+
+                            for fom in foms:
+                                fom_conf = f_defs[context]["foms"][fom]
+                                fom_match = fom_conf["regex"].match(line)
+
+                                if fom_match:
+                                    fom_vars = {}
+                                    for (
+                                        k,
+                                        v,
+                                    ) in fom_match.groupdict().items():
+                                        fom_vars[k] = v
+                                    if (
+                                        fom_conf["fom_name_expanded"]
+                                        is not None
+                                    ):
+                                        fom_name = fom_conf[
+                                            "fom_name_expanded"
+                                        ]
+                                    else:
+                                        fom_name = self.expander.expand_var(
+                                            fom, extra_vars=fom_vars
                                         )
-                                        logger.debug("Line was: %s" % line)
+
+                                    if (
+                                        fom_conf["group"]
+                                        in fom_conf["regex"].groupindex
+                                    ):
                                         logger.debug(
-                                            f" Context match {context} -- {context_name}"
+                                            " --- Matched fom %s" % fom_name
                                         )
-
-                                        active_contexts[context] = context_name
-
-                                        if context_name not in fom_values:
-                                            fom_values[context_name] = {}
-
-                                for fom in foms:
-                                    fom_conf = f_defs[context]["foms"][fom]
-                                    fom_match = fom_conf["regex"].match(line)
-
-                                    if fom_match:
-                                        fom_vars = {}
-                                        for (
-                                            k,
-                                            v,
-                                        ) in fom_match.groupdict().items():
-                                            fom_vars[k] = v
-                                        if (
-                                            fom_conf["fom_name_expanded"]
-                                            is not None
-                                        ):
-                                            fom_name = fom_conf[
-                                                "fom_name_expanded"
-                                            ]
-                                        else:
-                                            fom_name = (
-                                                self.expander.expand_var(
-                                                    fom, extra_vars=fom_vars
+                                        fom_contexts = []
+                                        # if a FOM has contexts, check if each is active
+                                        if fom_conf["contexts"]:
+                                            for _ in fom_conf["contexts"]:
+                                                context_name = (
+                                                    active_contexts[context]
+                                                    if context
+                                                    in active_contexts
+                                                    else _NULL_CONTEXT
                                                 )
-                                            )
-
-                                        if (
-                                            fom_conf["group"]
-                                            in fom_conf["regex"].groupindex
-                                        ):
-                                            logger.debug(
-                                                " --- Matched fom %s"
-                                                % fom_name
-                                            )
-                                            fom_contexts = []
-                                            # if a FOM has contexts, check if each is active
-                                            if fom_conf["contexts"]:
-                                                for _ in fom_conf["contexts"]:
-                                                    context_name = (
-                                                        active_contexts[
-                                                            context
-                                                        ]
-                                                        if context
-                                                        in active_contexts
-                                                        else _NULL_CONTEXT
-                                                    )
-                                                    fom_contexts.append(
-                                                        context_name
-                                                    )
-                                            else:
                                                 fom_contexts.append(
-                                                    _NULL_CONTEXT
+                                                    context_name
                                                 )
+                                        else:
+                                            fom_contexts.append(_NULL_CONTEXT)
 
-                                            for fom_context in fom_contexts:
-                                                if (
-                                                    fom_context
-                                                    not in fom_values
-                                                ):
-                                                    fom_values[fom_context] = (
-                                                        {}
-                                                    )
-                                                fom_val = fom_match.group(
-                                                    fom_conf["group"]
-                                                )
-                                                if (
-                                                    fom_conf["units_expanded"]
-                                                    is not None
-                                                ):
-                                                    fom_unit = fom_conf[
-                                                        "units"
-                                                    ]
-                                                else:
-                                                    fom_unit = self.expander.expand_var(
+                                        for fom_context in fom_contexts:
+                                            if fom_context not in fom_values:
+                                                fom_values[fom_context] = {}
+                                            fom_val = fom_match.group(
+                                                fom_conf["group"]
+                                            )
+                                            if (
+                                                fom_conf["units_expanded"]
+                                                is not None
+                                            ):
+                                                fom_unit = fom_conf["units"]
+                                            else:
+                                                fom_unit = (
+                                                    self.expander.expand_var(
                                                         fom_conf["units"],
                                                         extra_vars=fom_vars,
                                                     )
-                                                fom_values[fom_context][
-                                                    fom_name
-                                                ] = {
-                                                    "value": fom_val,
-                                                    "units": fom_unit,
-                                                    "origin": fom_conf[
-                                                        "origin"
-                                                    ],
-                                                    "origin_type": fom_conf[
-                                                        "origin_type"
-                                                    ],
-                                                    "fom_type": fom_conf[
-                                                        "fom_type"
-                                                    ],
-                                                }
-            self._extract_inmem_foms(inmem_defs, fom_values)
+                                                )
+                                            fom_values[fom_context][
+                                                fom_name
+                                            ] = {
+                                                "value": fom_val,
+                                                "units": fom_unit,
+                                                "origin": fom_conf["origin"],
+                                                "origin_type": fom_conf[
+                                                    "origin_type"
+                                                ],
+                                                "fom_type": fom_conf[
+                                                    "fom_type"
+                                                ],
+                                            }
+        self._extract_inmem_foms(inmem_defs, fom_values)
 
-            # Test all non-file based success criteria
-            for criteria_obj, _ in criteria_list.all_criteria():
-                if criteria_obj.file is None:
-                    if criteria_obj.passed(
-                        app_inst=self, fom_values=fom_values
-                    ):
-                        criteria_obj.mark_found()
+        # Test all non-file based success criteria
+        for criteria_obj, _ in criteria_list.all_criteria():
+            if criteria_obj.file is None:
+                if criteria_obj.passed(app_inst=self, fom_values=fom_values):
+                    criteria_obj.mark_found()
 
-            # If an app has no FOMs defined, don't fail it for that
-            success = (not f_defs and not inmem_defs) or False
-            for fom in fom_values.values():
-                for value in fom.values():
-                    if (
-                        "origin_type" in value
-                        and value["origin_type"] == "application"
-                    ):
-                        success = True
-            success = success and criteria_list.passed()
-
-            status = self.get_status()
-            if status == ExperimentStatus.SUCCESS and not success:
-                status = ExperimentStatus.FAILED
-            elif success:
-                status = ExperimentStatus.SUCCESS
-
-            # When workflow_manager is present, only use app_status when workflow is completed or
-            # unresolved.
-            if self.workflow_manager is not None:
-                wm_status = self.workflow_manager.get_status(workspace)
-                if not (
-                    wm_status is None
-                    or wm_status
-                    in [ExperimentStatus.COMPLETE, ExperimentStatus.UNRESOLVED]
+        # If an app has no FOMs defined, don't fail it for that
+        success = (not f_defs and not inmem_defs) or False
+        for fom in fom_values.values():
+            for value in fom.values():
+                if (
+                    "origin_type" in value
+                    and value["origin_type"] == "application"
                 ):
-                    status = wm_status
+                    success = True
+        success = success and criteria_list.passed()
 
-            self.set_status(status)
+        status = self.get_status()
+        if status == ExperimentStatus.SUCCESS and not success:
+            status = ExperimentStatus.FAILED
+        elif success:
+            status = ExperimentStatus.SUCCESS
 
-            self.result.finalize(workspace)
+        # When workflow_manager is present, only use app_status when workflow is completed or
+        # unresolved.
+        if self.workflow_manager is not None:
+            wm_status = self.workflow_manager.get_status(workspace)
+            if not (
+                wm_status is None
+                or wm_status
+                in [ExperimentStatus.COMPLETE, ExperimentStatus.UNRESOLVED]
+            ):
+                status = wm_status
 
-            for criteria_obj, criteria_scope in criteria_list.all_criteria():
-                if criteria_obj.owner is not None:
-                    criteria_name = f"{criteria_obj.owner.scoped_name}::{criteria_obj.name}"
-                else:
-                    criteria_name = (
-                        f"config::{criteria_scope}::{criteria_obj.name}"
-                    )
-                if criteria_obj.ok():
-                    self.result.success_criteria[criteria_name] = "PASSED"
-                else:
-                    self.result.success_criteria[criteria_name] = "FAILED"
+        self.set_status(status)
 
-            for context, fom_map in fom_values.items():
-                context_map = {
-                    "name": context,
-                    "foms": [],
-                    "display_name": _get_context_display_name(context),
-                }
+        self.result.finalize(workspace)
 
-                for fom_name, fom in fom_map.items():
-                    fom_copy = fom.copy()
-                    fom_copy["name"] = fom_name
-                    context_map["foms"].append(fom_copy)
+        for criteria_obj, criteria_scope in criteria_list.all_criteria():
+            if criteria_obj.owner is not None:
+                criteria_name = (
+                    f"{criteria_obj.owner.scoped_name}::{criteria_obj.name}"
+                )
+            else:
+                criteria_name = (
+                    f"config::{criteria_scope}::{criteria_obj.name}"
+                )
+            if criteria_obj.ok():
+                self.result.success_criteria[criteria_name] = "PASSED"
+            else:
+                self.result.success_criteria[criteria_name] = "FAILED"
 
-                if context == _NULL_CONTEXT:
-                    self.result.contexts.insert(0, context_map)
-                else:
-                    self.result.contexts.append(context_map)
-        else:
-            self.result.finalize(workspace)
+        for context, fom_map in fom_values.items():
+            context_map = {
+                "name": context,
+                "foms": [],
+                "display_name": _get_context_display_name(context),
+            }
+
+            for fom_name, fom in fom_map.items():
+                fom_copy = fom.copy()
+                fom_copy["name"] = fom_name
+                context_map["foms"].append(fom_copy)
+
+            if context == _NULL_CONTEXT:
+                self.result.contexts.insert(0, context_map)
+            else:
+                self.result.contexts.append(context_map)
 
     register_phase(
         "append_results_to_workspace",


### PR DESCRIPTION
This merge introduces file based caching / serialization of experiment results within each experiment's run directory. These are then read in (if they are not invalid) instead of re-processing the output files for the experiment.

These caches are invalidated if the timestamp on the cache is older than any other file in the experiment directory, or if the hashes on the objects (i.e. application / modifier / etc) changed relative to the last time the cache was written.

Tests are also added for this.