### PR TITLE
Update hashing semantics

### DIFF
--- a/lib/ramble/docs/configuration_files.rst
+++ b/lib/ramble/docs/configuration_files.rst
@@ -244,6 +244,23 @@ through and not cause an error. This is useful for things like `${ENV_VAR}`
 that are recognized as a variable. When passthrough is disabled, any variables
 that fail to expand will raise a syntax error, which can aid in debugging.
 
+.. _overwrite-inventories-config-option:
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Overwrite Experiment Inventories
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+An optional flag can be set in ``config`` or with ``--overwrite-inventories``
+on the command line to force workspace pipelines to overwrite existing
+experiment inventories and hashes. This will disable the hash checking / error
+semantics, and replace them with reconstruction of the hash regardless of it's
+previous contents. Its format is as follows:
+
+.. code-block:: yaml
+
+    config:
+      overwrite_inventories: True
+
 .. _experiment-repeats-config-option:
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/lib/ramble/ramble/main.py
+++ b/lib/ramble/ramble/main.py
@@ -471,6 +471,11 @@ def make_argument_parser(**kwargs):
         action="store_true",
         help="use the builtin.mock repository instead of builtin",
     )
+    parser.add_argument(
+        "--overwrite-inventories",
+        action="store_true",
+        help="enables all workspace actions to overwrite experiment inventories",
+    )
 
     for obj in ramble.repository.ObjectTypes:
         objname = obj.name.replace("_", "-")
@@ -577,7 +582,6 @@ def setup_main_options(args):
         spack.util.debug.register_interrupt_handler()
         ramble.config.set("config:debug", True, scope="command_line")
         spack.util.environment.tracing_enabled = True
-
     if args.timestamp:
         tty.set_timestamp(True)
 
@@ -598,6 +602,9 @@ def setup_main_options(args):
 
     if args.disable_progress_bar:
         ramble.config.set("config:disable_progress_bar", True, scope="command_line")
+
+    if args.overwrite_inventories:
+        ramble.config.set("config:overwrite_inventories", True, scope="command_line")
 
     objects_to_mock = set()
     if args.mock:

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -54,7 +54,6 @@ class Pipeline:
         self.filters = filters
         self.workspace = workspace
         self.force_inventory = False
-        self.require_inventory = False
         self.action_string = "Operating on"
         self.suppress_per_experiment_prints = False
         self.suppress_run_header = False
@@ -69,22 +68,24 @@ class Pipeline:
         self._software_environments = ramble.software_environments.SoftwareEnvironments(workspace)
         self.workspace.software_environments = self._software_environments
         self._experiment_set = workspace.build_experiment_set()
+        self.updated_experiment_hashes = False
 
     @property
     def experiment_set(self):
         return self._experiment_set
 
-    def _construct_experiment_hashes(self):
+    def _construct_experiment_hashes(self) -> bool:
         """Hash all of the experiments.
 
         Populate the workspace inventory information with experiment hash data.
         """
+        changed = False
         for _, app_inst, _ in self._experiment_set.all_experiments():
-            app_inst.populate_inventory(
+            changed = app_inst.populate_inventory(
                 self.workspace,
                 force_compute=self.force_inventory,
-                require_exist=self.require_inventory,
             )
+        return changed
 
     def _construct_workspace_hash(self):
         """Construct workspace inventory
@@ -131,7 +132,7 @@ class Pipeline:
 
     def _prepare(self):
         """Perform preparation for pipeline execution"""
-        pass
+        self.updated_experiment_hashes = self._construct_experiment_hashes()
 
     def _execute(self):
         """Hook for executing the pipeline"""
@@ -205,7 +206,12 @@ class Pipeline:
 
     def _complete(self):
         """Hook for performing pipeline actions after execution is complete"""
-        pass
+        if self.updated_experiment_hashes:
+            try:
+                self._construct_workspace_hash()
+            except FileNotFoundError as e:
+                tty.warn("Unable to construct workspace hash due to missing file")
+                tty.warn(e)
 
     def run(self):
         """Run the full pipeline"""
@@ -249,7 +255,6 @@ class AnalyzePipeline(Pipeline):
         super().__init__(workspace, filters)
         self.action_string = "Analyzing"
         self.output_formats = ["text"] if output_formats is None else output_formats
-        self.require_inventory = True
         self.upload_results = upload
         self.print_results = print_results
         self.summary_only = summary_only
@@ -285,11 +290,11 @@ class AnalyzePipeline(Pipeline):
                 " Make sure your workspace is setup with\n"
                 "    ramble workspace setup"
             )
-        super()._construct_experiment_hashes()
-        super()._construct_workspace_hash()
+
         super()._prepare()
 
     def _complete(self):
+        super()._complete()
         # Calculate statistics for repeats and inject into base experiment results
         for _, app_inst, _ in self._experiment_set.filtered_experiments(self.filters):
 
@@ -337,10 +342,7 @@ class ArchivePipeline(Pipeline):
             self.create_tar = True
 
     def _prepare(self):
-        super()._construct_experiment_hashes()
-        super()._construct_workspace_hash()
         super()._prepare()
-
         date_str = self.workspace.date_string()
 
         # Use the basename from the path as the name of the workspace.
@@ -416,6 +418,7 @@ class ArchivePipeline(Pipeline):
         create_symlink(archive_path, archive_path_latest)
 
     def _complete(self):
+        super()._complete()
         if self.create_tar:
             tar_extension = ".tar.gz"
             tar = which("tar", required=True)
@@ -459,7 +462,6 @@ class MirrorPipeline(Pipeline):
         self.mirror_path = mirror_path
 
     def _prepare(self):
-        super()._prepare()
         self.workspace.create_mirror(self.mirror_path)
 
     def _complete(self):
@@ -497,14 +499,9 @@ class SetupPipeline(Pipeline):
     def __init__(self, workspace, filters):
         super().__init__(workspace, filters)
         self.force_inventory = True
-        self.require_inventory = False
         self.action_string = "Setting up"
 
     def _prepare(self):
-        # Check if the selected phases require the inventory is successful
-        if "write_inventory" in self.filters.phases or "*" in self.filters.phases:
-            self.require_inventory = True
-
         super()._prepare()
         experiment_file = open(self.workspace.all_experiments_path, "w+")
         shell = ramble.config.get("config:shell")
@@ -512,15 +509,8 @@ class SetupPipeline(Pipeline):
         experiment_file.write(f"#!{shell_path}\n")
         self.workspace.experiments_script = experiment_file
 
-        super()._construct_experiment_hashes()
-
     def _complete(self):
-        try:
-            super()._construct_workspace_hash()
-        except FileNotFoundError as e:
-            tty.warn("Unable to construct workspace hash due to missing file")
-            tty.warn(e)
-
+        super()._complete()
         self.workspace.experiments_script.close()
         experiment_file_path = os.path.join(
             self.workspace.root, self.workspace.all_experiments_path
@@ -543,6 +533,7 @@ class PushToCachePipeline(Pipeline):
         self.workspace.spack_cache_path = self.spack_cache_path
 
     def _complete(self):
+        super()._complete()
         logger.msg(f"Pushed envs to spack cache {self.spack_cache_path}")
 
 
@@ -561,7 +552,6 @@ class ExecutePipeline(Pipeline):
     ):
         super().__init__(workspace, filters)
         self.action_string = "Executing"
-        self.require_inventory = True
         self.executor = executor
         self.suppress_per_experiment_prints = suppress_per_experiment_prints
         self.suppress_run_header = suppress_run_header
@@ -621,7 +611,6 @@ class LogsPipeline(Pipeline):
     ):
         super().__init__(workspace, filters)
         self.action_string = "Getting log information for"
-        self.require_inventory = False
         self.first_only = first_only
         self.suppress_per_experiment_prints = suppress_per_experiment_prints
         self.suppress_run_header = suppress_run_header
@@ -693,7 +682,6 @@ class PushDeploymentPipeline(Pipeline):
         workspace_expander = ramble.expander.Expander(workspace.get_workspace_vars(), None)
 
         self.action_string = "Pushing deployment of"
-        self.require_inventory = True
         self.create_tar = create_tar
 
         if upload_url:
@@ -729,6 +717,7 @@ class PushDeploymentPipeline(Pipeline):
                 yield os.path.join(self.workspace.named_deployment, root, name)
 
     def _complete(self):
+        super()._complete()
         # Create an index.json of the deployment
         deployment_index = {self.index_namespace: []}
         for file in self._deployment_files():

--- a/lib/ramble/ramble/schema/config.py
+++ b/lib/ramble/ramble/schema/config.py
@@ -184,6 +184,8 @@ properties["config"]["repeat_success_strict"] = {"type": "boolean", "default": T
 
 properties["config"]["enable_workspace_prompt"] = {"type": "boolean", "default": False}
 
+properties["config"]["overwrite_inventories"] = {"type": "boolean", "default": False}
+
 properties["config"]["stage_method"] = {
     "type": "string",
     "enum": ["cp", "rsync", "symbolic_link", "hard_link"],

--- a/lib/ramble/ramble/test/data/config/config.yaml
+++ b/lib/ramble/ramble/test/data/config/config.yaml
@@ -1,5 +1,6 @@
 config:
     test_stage: ~/.ramble/test
+    overwrite_inventories: false
     spack:
       install:
         flags: --reuse

--- a/lib/ramble/ramble/test/end_to_end/experiment_hashes.py
+++ b/lib/ramble/ramble/test/end_to_end/experiment_hashes.py
@@ -61,9 +61,9 @@ def test_experiment_hashes(mutable_config, mutable_mock_workspace_path, workspac
     with open(experiment_inventory) as f:
         data = sjson.load(f)
 
-    assert "application_definition" in data
-    assert data["application_definition"] != ""
-    assert data["application_definition"] is not None
+    assert "object_configuration" in data
+    assert data["object_configuration"] != []
+    assert data["object_configuration"] is not None
 
     # Test Attributes
     expected_attrs = {"variables", "modifiers", "env_vars", "internals", "chained_experiments"}
@@ -98,18 +98,21 @@ def test_experiment_hashes(mutable_config, mutable_mock_workspace_path, workspac
 
     assert len(expected_envs) == 0
 
-    # Test package manager
-    expected_pkgmans = {"spack"}
-    assert "package_manager" in data
-    for pkgman in data["package_manager"]:
-        if pkgman["name"] in expected_pkgmans:
-            assert pkgman["digest"] != ""
-            assert pkgman["digest"] is not None
-            assert pkgman["version"] != ""
-            assert pkgman["version"] is not None
-            expected_pkgmans.remove(pkgman["name"])
+    # Test objects
+    expected_objects = {}
+    expected_objects["applications"] = {"gromacs"}
+    expected_objects["workflow_managers"] = {"user-managed"}
+    expected_objects["package_managers"] = {"spack"}
+    for object_def in data["object_configuration"]:
+        if "object_type" in object_def:
+            obj_type = object_def["object_type"]
+            if "name" in object_def and object_def["name"] in expected_objects[obj_type]:
+                expected_objects[obj_type].remove(object_def["name"])
+                assert object_def["digest"] != ""
+                assert object_def["digest"] is not None
 
-    assert len(expected_pkgmans) == 0
+    for obj_set in expected_objects.values():
+        assert len(obj_set) == 0
 
     # Test workspace inventory
     assert os.path.isfile(workspace_inventory)

--- a/lib/ramble/ramble/test/when.py
+++ b/lib/ramble/ramble/test/when.py
@@ -11,6 +11,7 @@ import os
 
 import pytest
 
+import ramble.config
 import ramble.workspace
 from ramble.error import ObjectValidationError, RambleCommandError
 from ramble.main import RambleCommand
@@ -96,6 +97,7 @@ test inheritance 12.0
 
         workspace("setup", global_args=global_args)
 
+        ws._re_read()
         with open(output_path, "w+") as f:
             f.write(test_output)
 
@@ -111,8 +113,8 @@ test inheritance 12.0
 
         config("add", "variants:register_fom_context_when:true", global_args=global_args)
 
-        ws._re_read()
-        workspace("analyze", global_args=global_args)
+        with ramble.config.override("config:overwrite_inventories", True):
+            workspace("analyze", global_args=global_args)
 
         with open(results_path) as f:
             results = f.read()
@@ -174,7 +176,8 @@ test inheritance 12.0
         config("add", "variants:register_fom_when:true", global_args=global_args)
 
         ws._re_read()
-        workspace("analyze", global_args=global_args)
+        with ramble.config.override("config:overwrite_inventories", True):
+            workspace("analyze", global_args=global_args)
 
         with open(results_path) as f:
             results = f.read()
@@ -293,7 +296,8 @@ test inheritance 12.0
         config("add", "variants:register_fom_context_when:true", global_args=global_args)
 
         ws._re_read()
-        workspace("analyze", global_args=global_args)
+        with ramble.config.override("config:overwrite_inventories", True):
+            workspace("analyze", global_args=global_args)
 
         with open(results_path) as f:
             results = f.read()
@@ -357,7 +361,8 @@ test inheritance 12.0
 
         ws._re_read()
 
-        output = workspace("analyze", global_args=global_args)
+        with ramble.config.override("config:overwrite_inventories", True):
+            output = workspace("analyze", global_args=global_args)
 
         assert "Overwriting with new definition from when-directives-inherited" in output
 
@@ -781,7 +786,8 @@ test inheritance 12.0
         config("add", "variants:success_criteria_when:true", global_args=global_args)
 
         ws._re_read()
-        workspace("analyze", global_args=global_args)
+        with ramble.config.override("config:overwrite_inventories", True):
+            workspace("analyze", global_args=global_args)
 
         with open(results_path) as f:
             results = f.read()

--- a/lib/ramble/ramble/variants.py
+++ b/lib/ramble/ramble/variants.py
@@ -296,6 +296,7 @@ class VariantSet:
                         f"When defining variant {name} the value {variant.default} is not valid.\n"
                         f"   Valid values include: {self.default_variants[name].values}"
                     )
+
                 out_set.add(variant.as_definition())
                 defined_variants.add(name)
 

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -266,7 +266,7 @@ complete -o bashdefault -o default -F _bash_completion_ramble ramble
 _ramble() {
     if $list_options
     then
-        RAMBLE_COMPREPLY="-h --help -H --all-help --color -c --config -C --config-scope -d --debug --disable-passthrough -N --disable-logger -P --disable-progress-bar --timestamp --pdb -w --workspace -D --workspace-dir -W --no-workspace --use-workspace-repo --resolve-variables-in-subprocesses -k --insecure -l --enable-locks -L --disable-locks -m --mock --mock-applications --mock-modifiers --mock-package-managers --mock-workflow-managers --mock-base-classes --mock-base-applications --mock-base-modifiers --mock-base-package-managers --mock-base-workflow-managers -p --profile --sorted-profile --lines --profile-restrictions -v --verbose --stacktrace -V --version --print-shell-vars"
+        RAMBLE_COMPREPLY="-h --help -H --all-help --color -c --config -C --config-scope -d --debug --disable-passthrough -N --disable-logger -P --disable-progress-bar --timestamp --pdb -w --workspace -D --workspace-dir -W --no-workspace --use-workspace-repo --resolve-variables-in-subprocesses -k --insecure -l --enable-locks -L --disable-locks -m --mock --overwrite-inventories --mock-applications --mock-modifiers --mock-package-managers --mock-workflow-managers --mock-base-classes --mock-base-applications --mock-base-modifiers --mock-base-package-managers --mock-base-workflow-managers -p --profile --sorted-profile --lines --profile-restrictions -v --verbose --stacktrace -V --version --print-shell-vars"
     else
         RAMBLE_COMPREPLY="attributes clean commands config debug deployment docs edit help info license list mirror on python repo results software-definitions style unit-test workspace"
     fi

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -199,18 +199,6 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
         self.license_names = self.license_names + [self.name]
 
-        self.hash_inventory = {
-            "application_definition": None,
-            "modifier_definitions": [],
-            "attributes": [],
-            "inputs": [],
-            "software": [],
-            "templates": [],
-            "package_manager": [],
-            "modifier_artifacts": [],
-        }
-        self.experiment_hash = None
-
         self.application_class = "ApplicationBase"
 
         self.license_path = ""
@@ -2075,9 +2063,18 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         before hashing, to help give useful hashes.
         """
 
-        # Purge workspace name, as this shouldn't affect the experiments
-        if "workspace_name" in variables:
-            del variables["workspace_name"]
+        remove_variables = [
+            "workspace_name",
+            "experiment_hash",
+            "experiment_status",
+            "RAMBLE_STATUS",
+        ]
+
+        # Remove some variables that don't affect the experiment, and change
+        # frequently (or are actually output variables)
+        for var in remove_variables:
+            if var in variables:
+                del variables[var]
 
         # Remove the workspace path from variable definitions before hashing
         for var in variables:
@@ -2086,9 +2083,38 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                     workspace.root, "$workspace_root"
                 )
 
+    def variant_inventory(self):
+        """Construct a list of all variants from any object in the experiment,
+        for the experiment's inventory.
+
+        Returns:
+            (list[str]): List of variant definitions from all objects
+        """
+
+        variant_definitions = set()
+
+        for _, obj in self._objects():
+            variant_definitions = variant_definitions.union(
+                obj.experiment_variants(app_inst=self).as_set()
+            )
+
+        return list(sorted(variant_definitions))
+
+    def _purge_inventory(self):
+        self.hash_inventory = {
+            "object_configuration": [],
+            "attributes": [],
+            "inputs": [],
+            "software": [],
+            "templates": [],
+        }
+        self.experiment_hash = None
+
     def populate_inventory(
-        self, workspace, force_compute=False, require_exist=False
-    ):
+        self,
+        workspace,
+        force_compute: bool = False,
+    ) -> bool:
         """Populate this experiment's hash inventory
 
         If an inventory file exists, read it first.
@@ -2102,127 +2128,141 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                            consuming it.
         """
 
+        changed = False
+        self._purge_inventory()
+
         experiment_run_dir = self.expander.experiment_run_dir
         inventory_file = os.path.join(
             experiment_run_dir, self._inventory_file_name
         )
 
-        if os.path.exists(inventory_file) and not force_compute:
+        force = force_compute or ramble.config.get(
+            "config:overwrite_inventories", default=False
+        )
+
+        existing_hash = None
+        if os.path.exists(inventory_file) and not force:
             with open(inventory_file) as f:
-                self.hash_inventory = spack.util.spack_json.load(f)
+                existing_inventory = spack.util.spack_json.load(f)
+            existing_hash = ramble.util.hashing.hash_json(existing_inventory)
 
-        else:
-            # Clean up variables before hashing
-            vars_to_hash = self.variables.copy()
-            self._clean_hash_variables(workspace, vars_to_hash)
+        # Clean up variables before hashing
+        vars_to_hash = self.variables.copy()
+        self._clean_hash_variables(workspace, vars_to_hash)
 
-            # Build inventory of attributes
-            attributes_to_hash = [
-                ("variables", vars_to_hash),
-                ("modifiers", self.modifiers),
-                ("chained_experiments", self.chained_experiments),
-                ("internals", self.internals),
-                ("env_vars", self._env_variable_sets),
-            ]
+        # Build inventory of attributes
+        attributes_to_hash = [
+            ("variables", vars_to_hash),
+            ("modifiers", self.modifiers),
+            ("variants", self.variant_inventory()),
+            ("chained_experiments", self.chained_experiments),
+            ("internals", self.internals),
+            ("env_vars", self._env_variable_sets),
+        ]
 
-            self.hash_inventory["application_definition"] = (
-                ramble.util.hashing.hash_file(self._file_path)
-            )
+        added_objects = {}
+        for obj_type, obj in self._objects():
+            if obj_type not in added_objects:
+                added_objects[obj_type] = set()
 
-            added_mods = set()
-            for mod_inst in self._modifier_instances:
-                if mod_inst.name not in added_mods:
-                    self.hash_inventory["modifier_definitions"].append(
-                        {
-                            "name": mod_inst.name,
-                            "digest": ramble.util.hashing.hash_file(
-                                mod_inst._file_path
-                            ),
-                        }
+            if obj.name not in added_objects[obj_type]:
+                added_objects[obj_type].add(obj.name)
+                object_inventory = {
+                    "name": obj.name,
+                    "object_type": obj_type.name,
+                    "digest": ramble.util.hashing.hash_file(obj._file_path),
+                }
+
+                version_func = getattr(obj, "get_version", None)
+                if version_func is not None and callable(version_func):
+                    object_inventory["version"] = obj.get_version(
+                        workspace=workspace
                     )
-                    added_mods.add(mod_inst.name)
 
-            for attr, attr_dict in attributes_to_hash:
-                self.hash_inventory["attributes"].append(
-                    {
-                        "name": attr,
-                        "digest": ramble.util.hashing.hash_json(attr_dict),
-                    }
+                if obj is not self:
+                    populate_func = getattr(obj, "populate_inventory", None)
+                    if populate_func is not None and callable(populate_func):
+                        obj.populate_inventory(workspace, force)
+
+                artifact_func = getattr(obj, "artifact_inventory", None)
+                if artifact_func is not None and callable(artifact_func):
+                    inventory = obj.artifact_inventory(workspace, self)
+                    if inventory:
+                        if hasattr(obj, "_usage_mode"):
+                            object_inventory["mode"] = obj._usage_mode
+                        object_inventory["artifacts"] = inventory
+
+                self.hash_inventory["object_configuration"].append(
+                    object_inventory
                 )
 
-            # Build inventory of workspace templates
-            for template_name, template_conf in workspace.all_templates():
-                self.hash_inventory["templates"].append(
+        for attr, attr_dict in attributes_to_hash:
+            self.hash_inventory["attributes"].append(
+                {
+                    "name": attr,
+                    "digest": ramble.util.hashing.hash_json(attr_dict),
+                }
+            )
+
+        # Build inventory of workspace templates
+        for template_name, template_conf in workspace.all_templates():
+            self.hash_inventory["templates"].append(
+                {
+                    "name": template_name,
+                    "digest": template_conf["digest"],
+                }
+            )
+
+        # Build inventory of inputs
+        self._inputs_and_fetchers(self.expander.workload_name)
+
+        for input_conf in self._input_fetchers.values():
+            if input_conf["fetcher"].digest:
+                self.hash_inventory["inputs"].append(
                     {
-                        "name": template_name,
-                        "digest": template_conf["digest"],
+                        "name": input_conf["input_name"],
+                        "digest": input_conf["fetcher"].digest,
                     }
                 )
-
-            # Build inventory of inputs
-            self._inputs_and_fetchers(self.expander.workload_name)
-
-            for input_conf in self._input_fetchers.values():
-                if input_conf["fetcher"].digest:
-                    self.hash_inventory["inputs"].append(
-                        {
-                            "name": input_conf["input_name"],
-                            "digest": input_conf["fetcher"].digest,
-                        }
-                    )
-                else:
-                    self.hash_inventory["inputs"].append(
-                        {
-                            "name": input_conf["input_name"],
-                            "digest": ramble.util.hashing.hash_string(
-                                input_conf["fetcher"].url
-                            ),
-                        }
-                    )
-
-        if self.package_manager is not None:
-            self.package_manager.populate_inventory(
-                workspace, force_compute, require_exist
-            )
+            else:
+                self.hash_inventory["inputs"].append(
+                    {
+                        "name": input_conf["input_name"],
+                        "digest": ramble.util.hashing.hash_string(
+                            input_conf["fetcher"].url
+                        ),
+                    }
+                )
 
         self.experiment_hash = ramble.util.hashing.hash_json(
             self.hash_inventory
         )
+
+        # Compare inventory hashes, to validate experiment hasn't changed
+        if existing_hash is not None and self.experiment_hash != existing_hash:
+            logger.die(
+                f"Mismatch on experiment hash for experiment {self.expander.experiment_namespace}.\n"
+                f"  Hash from experiment directory: {existing_hash}\n"
+                f"  Hash computed current config: {self.experiment_hash}\n"
+                "To overwrite the experiment hash, use the global --overwrite-inventories option"
+            )
+
         self.variables[self.keywords.experiment_hash] = self.experiment_hash
 
-    register_phase(
-        "write_inventory", pipeline="setup", run_after=["make_experiments"]
-    )
+        # Write out experiment inventory, if hash is different
+        if existing_hash != self.experiment_hash:
+            changed = True
 
-    def _write_inventory(self, workspace, app_inst=None):
-        """Build and write an inventory of an experiment
+        writable = True
+        if self.repeats.is_repeat_base:
+            writable = False
 
-        Write an inventory file describing all of the contents of this
-        experiment.
-        """
+        if changed and writable:
+            with lk.WriteTransaction(self.experiment_lock):
+                with open(inventory_file, "w+") as f:
+                    spack.util.spack_json.dump(self.hash_inventory, f)
 
-        experiment_run_dir = self.expander.experiment_run_dir
-        inventory_file = os.path.join(
-            experiment_run_dir, self._inventory_file_name
-        )
-
-        # Populate modifier artifacts portion of inventory
-        # This happens here to allow modifiers to hash files
-        # that are downloaded within phases earlier than this.
-        for mod_inst in self._modifier_instances:
-            inventory = mod_inst.artifact_inventory(workspace, app_inst)
-            if inventory:
-                self.hash_inventory["modifier_artifacts"].append(
-                    {
-                        "name": mod_inst.name,
-                        "mode": mod_inst._usage_mode,
-                        "artifacts": inventory,
-                    }
-                )
-
-        with lk.WriteTransaction(self.experiment_lock):
-            with open(inventory_file, "w+") as f:
-                spack.util.spack_json.dump(self.hash_inventory, f)
+        return changed
 
     register_phase("archive_experiments", pipeline="archive")
 

--- a/var/ramble/repos/builtin/base_classes/object-mixin/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/object-mixin/base_class.py
@@ -88,7 +88,9 @@ class ObjectMixin:
         experiment_variants = self.experiment_variants()
         return app_inst.expander.satisfies(when_key, experiment_variants)
 
-    def experiment_variants(self, include_modifier=None, allow_caching=True):
+    def experiment_variants(
+        self, include_modifier=None, allow_caching=True, app_inst=None
+    ):
         """Construct a VariantSet for this experiment.
 
         Apply some merging logic to VariantSet combination, in order to
@@ -112,7 +114,8 @@ class ObjectMixin:
             if cache_key in self._variant_cache:
                 return self._variant_cache[cache_key]
 
-        app_inst = self._get_app_inst()
+        if app_inst is None:
+            app_inst = self._get_app_inst()
 
         self_type = self._get_object_type()
         new_set = self.object_variants.copy()

--- a/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
@@ -199,9 +199,7 @@ class PackageManagerBase(ObjectMixin, metaclass=PackageManagerMeta):
 
         return self.app_inst.expander._used_variables
 
-    def populate_inventory(
-        self, workspace, force_compute=False, require_exist=False
-    ):
+    def populate_inventory(self, workspace, force_compute=False) -> bool:
         """Stub class method for populating an experiment inventory.
         Specific package managers should implement this to convey inventory
         information to the workspace / experiment.

--- a/var/ramble/repos/builtin/package_managers/environment-modules/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/environment-modules/package_manager.py
@@ -78,15 +78,7 @@ class EnvironmentModules(PackageManagerBase):
 
         return self._load_string
 
-    def populate_inventory(
-        self, workspace, force_compute=False, require_exist=False
-    ):
-        self.app_inst.hash_inventory["package_manager"].append(
-            {
-                "name": self.name,
-            }
-        )
-
+    def populate_inventory(self, workspace, force_compute=False) -> bool:
         env_path = self.app_inst.expander.env_path
         env_hash = ramble.util.hashing.hash_string(
             self._generate_loads_content(workspace)

--- a/var/ramble/repos/builtin/package_managers/pip/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/pip/package_manager.py
@@ -237,15 +237,6 @@ class Pip(PackageManagerBase):
         self.runner.set_dry_run(workspace.dry_run)
         self.runner.configure_env(env_path)
 
-        pkgman_version = self.get_version(workspace=workspace)
-
-        self.app_inst.hash_inventory["package_manager"].append(
-            {
-                "name": self.name,
-                "version": pkgman_version,
-                "digest": hash_string(pkgman_version),
-            }
-        )
         self.app_inst.hash_inventory["software"].append(
             {
                 "name": self.runner.env_path.replace(

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
@@ -424,18 +424,6 @@ class SpackLightweight(PackageManagerBase):
         self.runner.set_env(env_path, require_exists=False)
         self.runner.activate()
 
-        try:
-            pkgman_version = self.get_version(workspace=workspace)
-        except RunnerError:
-            pkgman_version = "unknown"
-
-        self.app_inst.hash_inventory["package_manager"].append(
-            {
-                "name": self.name,
-                "version": pkgman_version,
-                "digest": ramble.util.hashing.hash_string(pkgman_version),
-            }
-        )
         self.app_inst.hash_inventory["software"].append(
             {
                 "name": self.runner.env_path.replace(


### PR DESCRIPTION
This merge updates the general hashing semantics of workspaces. Pipelines are updated so they all validate the hash of the contained experiments. If the hash differs from what they expect, an error is raised.

A runtime flag can be used to bypass the error, and rewrite the inventory / hash for the experiment.

Docs, tests, and bash completion are updated for this change.