### PR TITLE
Add support for validating multi-choice variable values

### DIFF
--- a/lib/ramble/ramble/language/application_language.py
+++ b/lib/ramble/ramble/language/application_language.py
@@ -226,7 +226,7 @@ def workload_variable(
     default=None,
     description="",
     values=None,
-    strict: bool = False,
+    strict: bool = True,
     workload=None,
     workloads=None,
     workload_group=None,
@@ -250,7 +250,7 @@ def workload_variable(
         default: Default value of variable definition
         description (str): Description of variable's purpose
         values (list): Optional list of suggested values for this variable
-        strict (bool): If True and values is not None, the variable's value
+        strict (bool): If True (the default) and values is not None, the variable's value
                        will be validated against the values list.
         workload (str): Single workload this variable is used in
         workloads (list): List of modes this variable is used in

--- a/lib/ramble/ramble/language/application_language.py
+++ b/lib/ramble/ramble/language/application_language.py
@@ -226,6 +226,7 @@ def workload_variable(
     default=None,
     description="",
     values=None,
+    strict: bool = False,
     workload=None,
     workloads=None,
     workload_group=None,
@@ -249,6 +250,8 @@ def workload_variable(
         default: Default value of variable definition
         description (str): Description of variable's purpose
         values (list): Optional list of suggested values for this variable
+        strict (bool): If True and values is not None, the variable's value
+                       will be validated against the values list.
         workload (str): Single workload this variable is used in
         workloads (list): List of modes this variable is used in
         workload_group (str): Name of workload group this variable is used in.
@@ -285,6 +288,8 @@ def workload_variable(
         else:
             env_var = None
 
+        validation = strict and values
+
         # If a workload map is passed, handle that.
         if workload_defaults:
             if any([workload, workloads, workload_group, default]):
@@ -306,6 +311,10 @@ def workload_variable(
                 for when_set, app_workloads in app.workloads.items():
                     if wl_name in app_workloads:
                         app.workloads[when_set][wl_name].add_variable(workload_var.copy())
+                        if validation:
+                            ramble.language.language_helpers.add_variable_validator(
+                                app, name, values, when_list, wl_name=wl_name
+                            )
                         if env_var is not None:
                             app.workloads[when_set][wl_name].add_environment_variable(
                                 env_var.copy()
@@ -328,6 +337,10 @@ def workload_variable(
             for wl_name in all_workloads:
                 if wl_name in app_workloads:
                     app.workloads[when_set][wl_name].add_variable(workload_var.copy())
+                    if validation:
+                        ramble.language.language_helpers.add_variable_validator(
+                            app, name, values, when_list, wl_name=wl_name
+                        )
                     if env_var:
                         app.workloads[when_set][wl_name].add_environment_variable(env_var.copy())
 
@@ -349,6 +362,10 @@ def workload_variable(
                     if wl_name in app_workloads:
                         # Apply the variable
                         app.workloads[when_set][wl_name].add_variable(workload_var.copy())
+                        if validation:
+                            ramble.language.language_helpers.add_variable_validator(
+                                app, name, values, when_list, wl_name=wl_name
+                            )
                         if env_var:
                             app.workloads[when_set][wl_name].add_environment_variable(
                                 env_var.copy()

--- a/lib/ramble/ramble/language/language_helpers.py
+++ b/lib/ramble/ramble/language/language_helpers.py
@@ -240,6 +240,30 @@ def expand_patterns(merged_types: list, multiple_pattern_match: Union[list, dict
     return list(expanded_patterns.keys())
 
 
+def add_variable_validator(obj, var_name, var_values, when_list, wl_name=None):
+    """Adds a validator to an object to ensure a variable's value is in a list of values."""
+    validator_name = f"validate_values_for_{var_name}_obj_{obj.name}"
+
+    predicate = f"'{{{var_name}}}' in {var_values!r}"
+    message = (
+        f"Value of variable '{var_name}' ('{{{var_name}}}') is not one of the allowed values: "
+        f"{var_values}"
+    )
+    new_when_list = when_list.copy()
+    if wl_name is not None:
+        new_when_list.extend([f"workload_name={wl_name}"])
+    when_set = frozenset(new_when_list)
+
+    if when_set not in obj.validators:
+        obj.validators[when_set] = {}
+
+    obj.validators[when_set][validator_name] = {
+        "predicate": predicate,
+        "message": message,
+        "fail_on_invalid": True,
+    }
+
+
 def build_when_list(
     when_arg: Union[str, List[str]], obj: Any, directive_id: str, directive_name: str
 ) -> List[str]:

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -803,7 +803,7 @@ def variable(
     default,
     description: str,
     values: Optional[list] = None,
-    strict: bool = False,
+    strict: bool = True,
     expandable: bool = True,
     track_used: bool = False,
     when=None,
@@ -818,7 +818,7 @@ def variable(
         default: Default value of variable definition
         description (str): Description of variable's purpose
         values (list): Optional list of suggested values for this variable
-        strict (bool): If True and values is not None, the variable's value
+        strict (bool): If True (the default) and values is not None, the variable's value
                        will be validated against the values list.
         expandable (bool): True if the variable should be expanded, False if not.
         track_used (bool): True if the variable should be tracked as used,

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -803,6 +803,7 @@ def variable(
     default,
     description: str,
     values: Optional[list] = None,
+    strict: bool = False,
     expandable: bool = True,
     track_used: bool = False,
     when=None,
@@ -817,6 +818,8 @@ def variable(
         default: Default value of variable definition
         description (str): Description of variable's purpose
         values (list): Optional list of suggested values for this variable
+        strict (bool): If True and values is not None, the variable's value
+                       will be validated against the values list.
         expandable (bool): True if the variable should be expanded, False if not.
         track_used (bool): True if the variable should be tracked as used,
                            False if not. Can help with allowing lists without vectorizing
@@ -848,6 +851,9 @@ def variable(
                 **kwargs,
             )
         )
+
+        if strict and values is not None:
+            ramble.language.language_helpers.add_variable_validator(obj, name, values, when_list)
 
         if environment_variable_name is not None:
             if when_set not in obj.object_environment_variables:

--- a/lib/ramble/ramble/test/end_to_end/object_validation.py
+++ b/lib/ramble/ramble/test/end_to_end/object_validation.py
@@ -33,6 +33,8 @@ def test_object_validation(workspace_name):
         "processes_per_node=1",
         "-v",
         "batch_submit={execute_experiment}",
+        "--wf",
+        "test_validation",
         global_args=global_args,
     )
     ws._re_read()
@@ -50,6 +52,8 @@ def test_object_validation(workspace_name):
         "n_nodes=2",
         "-v",
         "processes_per_node=1",
+        "--wf",
+        "test_validation",
         "--overwrite",
         global_args=global_args,
     )
@@ -69,6 +73,8 @@ def test_object_validation(workspace_name):
         "n_nodes=2",
         "-v",
         "processes_per_node=1",
+        "--wf",
+        "test_validation",
         "--overwrite",
         global_args=global_args,
     )
@@ -77,3 +83,139 @@ def test_object_validation(workspace_name):
     out = workspace("setup", global_args=global_args)
     assert "Warning: Validator 'validate_var_check'" in out
     assert "The validate_var is recommended to start with 'valid', but got 'invalid'" in out
+
+
+def test_variable_validation_workload(workspace_name):
+    global_args = ["-w", workspace_name]
+
+    ws = ramble.workspace.create(workspace_name)
+
+    workspace(
+        "manage",
+        "experiments",
+        "validation",
+        "-v",
+        "n_nodes=2",
+        "-v",
+        "processes_per_node=1",
+        "-v",
+        "batch_submit={execute_experiment}",
+        "-v",
+        "multi_choice_var=invalid",
+        "--wf",
+        "test_validation_workload_var",
+        global_args=global_args,
+    )
+    ws._re_read()
+    with pytest.raises(
+        ramble.error.ObjectValidationError,
+        match=r"variable 'multi_choice_var' \('invalid'\) is not one of the allowed values",
+    ):
+        workspace("setup", global_args=global_args)
+
+    workspace(
+        "manage",
+        "experiments",
+        "validation",
+        "-v",
+        "n_nodes=2",
+        "-v",
+        "processes_per_node=1",
+        "-v",
+        "batch_submit={execute_experiment}",
+        "-v",
+        "multi_choice_var=choice2",
+        "--wf",
+        "test_validation_workload_var",
+        "--overwrite",
+        global_args=global_args,
+    )
+    ws._re_read()
+    # No error when a valid value is given
+    workspace("setup", global_args=global_args)
+
+
+def test_variable_validation_workload_defaults(workspace_name):
+    global_args = ["-w", workspace_name]
+
+    ws = ramble.workspace.create(workspace_name)
+    workspace(
+        "manage",
+        "experiments",
+        "validation",
+        "-v",
+        "n_nodes=2",
+        "-v",
+        "processes_per_node=1",
+        "-v",
+        "batch_submit={execute_experiment}",
+        "-v",
+        "multi_choice_var2=choice0",
+        "--wf",
+        "test_validation_workload_var_with_workload_defaults",
+        global_args=global_args,
+    )
+    ws._re_read()
+    with pytest.raises(
+        ramble.error.ObjectValidationError,
+        match=r"variable 'multi_choice_var2' \('choice0'\) is not one of the allowed values",
+    ):
+        workspace("setup", global_args=global_args)
+
+
+def test_variable_validation_workload_group(workspace_name):
+    global_args = ["-w", workspace_name]
+
+    ws = ramble.workspace.create(workspace_name)
+    workspace(
+        "manage",
+        "experiments",
+        "validation",
+        "-v",
+        "n_nodes=2",
+        "-v",
+        "processes_per_node=1",
+        "-v",
+        "batch_submit={execute_experiment}",
+        "-v",
+        "multi_choice_var3=choice0",
+        "--wf",
+        "test_validation_workload_var_with_workload_group",
+        global_args=global_args,
+    )
+    ws._re_read()
+    with pytest.raises(
+        ramble.error.ObjectValidationError,
+        match=r"variable 'multi_choice_var3' \('choice0'\) is not one of the allowed values",
+    ):
+        workspace("setup", global_args=global_args)
+
+
+def test_object_variable_validation(workspace_name, mutable_mock_pkg_mans_repo):
+    global_args = ["-w", workspace_name]
+
+    ws = ramble.workspace.create(workspace_name)
+    workspace(
+        "manage",
+        "experiments",
+        "validation",
+        "-v",
+        "n_nodes=2",
+        "-v",
+        "processes_per_node=1",
+        "-v",
+        "batch_submit={execute_experiment}",
+        "-v",
+        "obj_multi_choice_var=a",
+        "--wf",
+        "test_validation",
+        "-p",
+        "info",
+        global_args=global_args,
+    )
+    ws._re_read()
+    with pytest.raises(
+        ramble.error.ObjectValidationError,
+        match=r"variable 'obj_multi_choice_var' \('a'\) is not one of the allowed values",
+    ):
+        workspace("setup", global_args=global_args)

--- a/var/ramble/repos/builtin.mock/applications/validation/application.py
+++ b/var/ramble/repos/builtin.mock/applications/validation/application.py
@@ -31,11 +31,19 @@ class Validation(ExecutableApplication):
     )
 
     workload_variable(
+        "loose_multi_choice_var",
+        default="choice-1",
+        description="A variable that can be set to a value outside the values list",
+        values=["choice1", "choice2", "choice3"],
+        strict=False,
+        workload="test_validation_workload_var",
+    )
+
+    workload_variable(
         "multi_choice_var",
         default="choice1",
         description="A variable that can only be set to values from a predefined list",
         values=["choice1", "choice2", "choice3"],
-        strict=True,
         workload="test_validation_workload_var",
     )
 
@@ -49,7 +57,6 @@ class Validation(ExecutableApplication):
         },
         description="A variable that can only be set to values from a predefined list",
         values=["choice1", "choice2", "choice3"],
-        strict=True,
     )
 
     workload_group(
@@ -62,7 +69,6 @@ class Validation(ExecutableApplication):
         default="choice1",
         description="A variable that can only be set to values from a predefined list",
         values=["choice1", "choice2", "choice3"],
-        strict=True,
         workload_group="target_workloads",
     )
 

--- a/var/ramble/repos/builtin.mock/applications/validation/application.py
+++ b/var/ramble/repos/builtin.mock/applications/validation/application.py
@@ -15,12 +15,55 @@ class Validation(ExecutableApplication):
     executable("foo", "bar")
 
     workload("test_validation", executable="foo")
+    workload("test_validation_workload_var", executable="foo")
+    workload(
+        "test_validation_workload_var_with_workload_defaults", executable="foo"
+    )
+    workload(
+        "test_validation_workload_var_with_workload_group", executable="foo"
+    )
 
     workload_variable(
         "validate_var",
         default="valid",
         description="A var",
         workload="test_validation",
+    )
+
+    workload_variable(
+        "multi_choice_var",
+        default="choice1",
+        description="A variable that can only be set to values from a predefined list",
+        values=["choice1", "choice2", "choice3"],
+        strict=True,
+        workload="test_validation_workload_var",
+    )
+
+    workload_variable(
+        "multi_choice_var2",
+        workload_defaults={
+            "test_validation": "choice1",
+            "test_validation_workload_var": "choice2",
+            "test_validation_workload_var_with_workload_defaults": "choice3",
+            "test_validation_workload_var_with_workload_group": "choice3",
+        },
+        description="A variable that can only be set to values from a predefined list",
+        values=["choice1", "choice2", "choice3"],
+        strict=True,
+    )
+
+    workload_group(
+        "target_workloads",
+        workloads=["test_validation_workload_var_with_workload_group"],
+    )
+
+    workload_variable(
+        "multi_choice_var3",
+        default="choice1",
+        description="A variable that can only be set to values from a predefined list",
+        values=["choice1", "choice2", "choice3"],
+        strict=True,
+        workload_group="target_workloads",
     )
 
     register_validator(

--- a/var/ramble/repos/builtin.mock/package_managers/info/package_manager.py
+++ b/var/ramble/repos/builtin.mock/package_managers/info/package_manager.py
@@ -41,11 +41,18 @@ class Info(PackageManagerBase):
     )
 
     variable(
+        "loose_obj_multi_choice_var",
+        default="-1",
+        description="A variable that does not validate its value",
+        values=["1", "2", "3"],
+        strict=False,
+    )
+
+    variable(
         "obj_multi_choice_var",
         default="1",
         description="A variable with a prescribed set of values",
         values=["1", "2", "3"],
-        strict=True,
     )
 
     environment_variable(

--- a/var/ramble/repos/builtin.mock/package_managers/info/package_manager.py
+++ b/var/ramble/repos/builtin.mock/package_managers/info/package_manager.py
@@ -40,6 +40,14 @@ class Info(PackageManagerBase):
         when=["variant_name=a_variant_val"],
     )
 
+    variable(
+        "obj_multi_choice_var",
+        default="1",
+        description="A variable with a prescribed set of values",
+        values=["1", "2", "3"],
+        strict=True,
+    )
+
     environment_variable(
         "ENV_VAR_NAME",
         value="ENVVARVAL",
@@ -93,7 +101,7 @@ class Info(PackageManagerBase):
 
     register_builtin("builtin_name", required=True)
 
-    def builtin_name():
+    def builtin_name(self):
         return 'echo "builtin"'
 
     register_phase(

--- a/var/ramble/repos/builtin/applications/intel-mlc/application.py
+++ b/var/ramble/repos/builtin/applications/intel-mlc/application.py
@@ -91,7 +91,6 @@ class IntelMlc(ExecutableApplication):
         "thread_distribution",
         default="spread",
         values=["spread", "compact"],
-        strict=True,
         description="Thread distribution method when generating cpu_list",
         workload_group="all_workloads",
     )

--- a/var/ramble/repos/builtin/applications/intel-mlc/application.py
+++ b/var/ramble/repos/builtin/applications/intel-mlc/application.py
@@ -91,6 +91,7 @@ class IntelMlc(ExecutableApplication):
         "thread_distribution",
         default="spread",
         values=["spread", "compact"],
+        strict=True,
         description="Thread distribution method when generating cpu_list",
         workload_group="all_workloads",
     )
@@ -132,15 +133,6 @@ class IntelMlc(ExecutableApplication):
             "node, but is configured with n_nodes = {n_nodes}"
         ),
         fail_on_invalid=False,
-    )
-
-    register_validator(
-        name="validate_thread_distribution",
-        predicate='"{thread_distribution}" in ["spread", "compact"]',
-        message=(
-            "Unsupported thread distribution method {thread_distribution} requested. "
-            "Options are 'spread' and 'compact'"
-        ),
     )
 
     figure_of_merit(

--- a/var/ramble/repos/builtin/modifiers/nccl-env/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/nccl-env/modifier.py
@@ -47,7 +47,7 @@ class NcclEnv(BasicModifier):
         "nccl_socket_family",
         default="",
         description="Allows users to force IPv4 or IPv6 interfaces",
-        values=["AF_INET", "AF_INET6"],
+        values=["", "AF_INET", "AF_INET6"],
         modes=["standard"],
     )
 
@@ -68,7 +68,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_cross_nic",
         default="",
-        values=[0, 1, 2],
+        values=["", 0, 1, 2],
         description="Controls whether NCCL should allow rings/trees to use different NICs.",
         modes=["standard"],
     )
@@ -104,7 +104,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_ib_addr_family",
         default="",
-        values=["AF_INET", "AF_INET6"],
+        values=["", "AF_INET", "AF_INET6"],
         description="Defines the IP address family associated to the InfiniBand GID.",
         modes=["standard"],
     )
@@ -140,7 +140,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_ib_return_async_events",
         default="",
-        values=["0", "1"],
+        values=["", "0", "1"],
         description="IB Events are reported to the user as warnings. If enabled NCCL will also stop IB communications upon fatal IB async events.",
         modes=["standard"],
     )
@@ -148,7 +148,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_oob_net_enable",
         default="",
-        values=["0", "1"],
+        values=["", "0", "1"],
         description="Enables the use of NCCL net for out-of-band communications.",
         modes=["standard"],
     )
@@ -212,7 +212,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_ignore_cpu_affinity",
         default="",
-        values=["0", "1"],
+        values=["", "0", "1"],
         description="Causes NCCL to ignore the job's CPU affinity, and use the GPU affinity only.",
         modes=["standard"],
     )
@@ -227,7 +227,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_debug",
         default="",
-        values=["VERSION", "WARN", "INFO", "TRACE"],
+        values=["", "VERSION", "WARN", "INFO", "TRACE"],
         description="Controls the debug information that is displayed from NCCL",
         modes=["standard"],
     )
@@ -249,7 +249,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_collnet_enable",
         default="",
-        values=["0", "1"],
+        values=["", "0", "1"],
         description="Enable the use of the CollNet plugin",
         modes=["standard"],
     )
@@ -278,7 +278,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_set_thread_name",
         default="",
-        values=["0", "1"],
+        values=["", "0", "1"],
         description="Give more meaningful names to NCCL CPU threads to ease debugging and analysis.",
         modes=["standard"],
     )
@@ -286,7 +286,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_p2p_disable",
         default="",
-        values=["0", "1"],
+        values=["", "0", "1"],
         description="Disables the peer to peer transport, which uses CUDA direct access between GPUs, using NVLink or PCI.",
         modes=["standard"],
     )
@@ -294,7 +294,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_p2p_level",
         default="",
-        values=["LOC", "NVL", "PIX", "PXB", "PHB", "SYS"],
+        values=["", "LOC", "NVL", "PIX", "PXB", "PHB", "SYS"],
         description="Allows fine control when using the peer to peer transport between GPUs.",
         modes=["standard"],
     )
@@ -302,7 +302,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_p2p_direct_disable",
         default="",
-        values=["0", "1"],
+        values=["", "0", "1"],
         description="Forbids NCCL to directly access user buffers through P2P between GPUs.",
         modes=["standard"],
     )
@@ -310,7 +310,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_shm_disable",
         default="",
-        values=["0", "1"],
+        values=["", "0", "1"],
         description="Disables the Shared Memory transports.",
         modes=["standard"],
     )
@@ -346,7 +346,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_checks_disable",
         default="",
-        values=["0", "1"],
+        values=["", "0", "1"],
         description="Used to disable argument checks on each collective call",
         modes=["standard"],
     )
@@ -354,7 +354,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_check_pointers",
         default="",
-        values=["0", "1"],
+        values=["", "0", "1"],
         description="Enables checking of the CUDA memory pointers on each collective call.",
         modes=["standard"],
     )
@@ -362,7 +362,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_launch_mode",
         default="",
-        values=["PARALLEL", "GROUP"],
+        values=["", "PARALLEL", "GROUP"],
         description="(Deprecated) Controls how NCCL launches CUDA kernels.",
         modes=["standard"],
     )
@@ -370,7 +370,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_ib_disable",
         default="",
-        values=["0", "1"],
+        values=["", "0", "1"],
         description="Prevents the IB/RoCE transport from being used by NCCL. Forces IP sockets.",
         modes=["standard"],
     )
@@ -392,7 +392,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_ib_split_data_on_qps",
         default="",
-        values=["0", "1"],
+        values=["", "0", "1"],
         description="Controls how queue pairs are used when more than one are created.",
         modes=["standard"],
     )
@@ -400,7 +400,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_ib_cuda_support",
         default="",
-        values=["0", "1"],
+        values=["", "0", "1"],
         description="Force or disable the use of GPU Direct RDMA. 0 disables GPU Direct RDMA, 1 forces GPU Direct RDMA.",
         modes=["standard"],
     )
@@ -408,7 +408,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_ib_pci_relaxed_ordering",
         default="",
-        values=["0", "1"],
+        values=["", "0", "1"],
         description="Enables the use of Relaxed Ordering for IB Verbs.",
         modes=["standard"],
     )
@@ -416,7 +416,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_ib_adaptive_routing",
         default="",
-        values=["0", "1"],
+        values=["", "0", "1"],
         description="Enables the use of Adaptive Routing for IB Verbs.",
         modes=["standard"],
     )
@@ -431,7 +431,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_cumem_enable",
         default="",
-        values=["0", "1"],
+        values=["", "0", "1"],
         description="NCCL uses CUDA cuMem* functions to allocate memory",
         modes=["standard"],
     )
@@ -439,7 +439,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_cumem_host_enable",
         default="",
-        values=["0", "1"],
+        values=["", "0", "1"],
         description="NCCL uses CUDA cuMem* functions to allocate host memory",
         modes=["standard"],
     )
@@ -447,7 +447,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_net_gdr_level",
         default="",
-        values=["LOC", "PIX", "PXB", "PHB", "SYS"],
+        values=["", "LOC", "PIX", "PXB", "PHB", "SYS"],
         description="Allows fine control over when to use GPU Direct RDMA between a NIC and a GPU.",
         modes=["standard"],
     )
@@ -455,7 +455,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_net_gdr_read",
         default="",
-        values=["0", "1"],
+        values=["", "0", "1"],
         description="Enables GPU Direct RDMA when sending data as long as the distance is wtihin the GDR Level distance.",
         modes=["standard"],
     )
@@ -463,7 +463,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_net_shared_buffers",
         default="",
-        values=["0", "1"],
+        values=["", "0", "1"],
         description="Allows the use of shared buffers for inter-node point-to-point communication.",
         modes=["standard"],
     )
@@ -471,7 +471,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_net_shared_comms",
         default="",
-        values=["0", "1"],
+        values=["", "0", "1"],
         description="Reuse the same connections in the context of PXN.",
         modes=["standard"],
     )
@@ -501,6 +501,7 @@ class NcclEnv(BasicModifier):
         "nccl_algo",
         default="",
         values=[
+            "",
             "Tree",
             "Ring",
             "Collnet",
@@ -515,7 +516,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_proto",
         default="",
-        values=["LL", "LL128", "Simple"],
+        values=["", "LL", "LL128", "Simple"],
         description="(Use is Discouraged) Defines which protocol NCCL will use.",
         modes=["standard"],
     )


### PR DESCRIPTION
When a variable has `values=` present, a validator is injected to ensure the variable value is from `values`. This default behavior can be turned off with `strict=False`.