### PR TITLE
Allow rendering of chained experiments

### DIFF
--- a/lib/ramble/ramble/context.py
+++ b/lib/ramble/ramble/context.py
@@ -19,6 +19,24 @@ class Context:
     (such as application, workload, or experiment) and logic to merge in
     additional contexts by order of precedence."""
 
+    output_mapping = {
+        "variables": namespace.variables,
+        "variants": namespace.variants,
+        "env_variables": namespace.env_var,
+        "internals": namespace.internals,
+        "chained_experiments": namespace.chained_experiments,
+        "modifiers": namespace.modifiers,
+        "template": namespace.template,  # TODO: Make sure this is good
+        "exclude": namespace.exclude,
+        "zips": namespace.zips,
+        "tables": namespace.tables,
+        "tags": namespace.tags,
+        "matrices": namespace.matrices,
+        "n_repeats": namespace.n_repeats,
+        "formatted_executables": namespace.formatted_executables,
+        "success_criteria": namespace.success,
+    }
+
     def __init__(self):
         """Constructor for a Context
 
@@ -98,6 +116,28 @@ class Context:
             self.success_criteria.extend(in_context.success_criteria)
         if in_context.tables:
             self.tables.extend(in_context.tables)
+
+    def to_workspace_config(self, application_name, workload_name):
+        experiment_config = {}
+
+        for attr_name, namespace_name in self.output_mapping.items():
+            attr_val = getattr(self, attr_name, None)
+            if attr_val:
+                experiment_config[namespace_name] = attr_val
+
+        workspace_config = {
+            "ramble": {
+                "applications": {
+                    application_name: {
+                        "workloads": {
+                            workload_name: {"experiments": {self.context_name: experiment_config}}
+                        }
+                    }
+                }
+            }
+        }
+
+        return workspace_config
 
 
 def create_context_from_dict(context_name, in_dict):

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -12,6 +12,7 @@ import os
 import sys
 from enum import Enum
 from functools import partial
+from typing import Set
 
 import ramble.context
 import ramble.error
@@ -146,7 +147,9 @@ class ExperimentSet:
 
         self._set_context(self._contexts.workload, workload_context)
 
-    def set_experiment_context(self, experiment_context, die_on_validate_error=True):
+    def set_experiment_context(
+        self, experiment_context, die_on_validate_error=True, chained=False
+    ) -> list:
         """Set up current experiment context"""
 
         try:
@@ -156,7 +159,9 @@ class ExperimentSet:
             raise RambleVariableDefinitionError(f"In experiment {namespace}: {e}") from None
 
         self._set_context(self._contexts.experiment, experiment_context)
-        self._ingest_experiments(die_on_validate_error=die_on_validate_error)
+        return self._ingest_experiments(
+            die_on_validate_error=die_on_validate_error, chained=chained
+        )
 
     @property
     def application_namespace(self):
@@ -213,7 +218,6 @@ class ExperimentSet:
         # Setup the application instance
         app_inst = ramble.repository.get(final_app_name)
         app_inst.set_variables_and_variants(variables, context.variants, self)
-
         app_inst.set_active_workload()
         app_inst.set_modifiers(context.modifiers)
         app_inst.set_required_variables()
@@ -260,14 +264,6 @@ class ExperimentSet:
             (Application): Instance of an application class for this experiment
         """
 
-        experiment_suffix = ""
-        # After generating the base experiment, append the index to repeat experiments
-        if repeats.repeat_index:
-            experiment_suffix = f".{repeats.repeat_index}"
-            variables[self.keywords.repeat_index] = repeats.repeat_index
-        else:
-            variables[self.keywords.repeat_index] = 0
-
         app_inst = self._setup_experiment_minimal(workload_template_name, variables, context)
 
         final_wl_name = app_inst.expander.expand_var_name(
@@ -278,13 +274,9 @@ class ExperimentSet:
         app_inst.repeats = repeats
 
         # Setup experiment name after modifiers are defined
-        final_exp_name = app_inst.expander.expand_var(
-            exp_template_name + experiment_suffix, allow_passthrough=False
-        )
+        final_exp_name = app_inst.expander.expand_var(exp_template_name, allow_passthrough=False)
 
-        app_inst.define_variable(
-            self.keywords.experiment_template_name, exp_template_name + experiment_suffix
-        )
+        app_inst.define_variable(self.keywords.experiment_template_name, exp_template_name)
         app_inst.define_variable(self.keywords.experiment_name, final_exp_name)
 
         app_inst.define_variable(
@@ -315,7 +307,6 @@ class ExperimentSet:
             app_inst.define_variable(name, value)
 
         app_inst.define_variables_for_template_path(self._workspace)
-        app_inst.read_status()
 
         experiment_namespace = app_inst.expander.experiment_namespace
         app_inst.define_variable(self.keywords.experiment_namespace, experiment_namespace)
@@ -354,31 +345,53 @@ class ExperimentSet:
     ):
         """Helper to render a base and its repeated experiments, for parallel execution."""
         experiment_vars, repeats = render_item
+
+        base_app_inst = self._prepare_experiment(
+            workload_template_name,
+            experiment_template_name,
+            experiment_vars.copy(),
+            final_context,
+            repeats,
+        )
+
+        if repeats.n_repeats > 0:
+            base_app_inst.repeats.set_repeats(True, repeats.n_repeats)
+        else:
+            base_app_inst.repeats.set_repeats(False, 0)
+
         processed_experiments = []
         # Expand and prepare base and repeated experiments
-        # TODO: Exploit the relationship between base and repeated experiments,
-        # to save up redundant works.
-        # For instance, caching may be enabled for expanders across these experiments.
         for n in range(0, repeats.n_repeats + 1):
-            cur_repeats = ramble.repeats.Repeats()
+            app_inst = base_app_inst.clone()
+            app_inst.set_modifiers(final_context.modifiers)
+            app_inst.set_chained_experiments(final_context.chained_experiments)
+            app_inst.set_template(final_context.is_template)
+            app_inst.set_env_variable_sets(final_context.env_variables)
+            app_inst.set_tags(final_context.tags)
             if repeats.is_repeat_base:
                 if n == 0:
-                    cur_repeats.set_repeats(True, repeats.n_repeats)
+                    app_inst.repeats.set_repeats(True, repeats.n_repeats)
                 else:
-                    cur_repeats.set_repeat_index(n)
-
-            app_inst = self._prepare_experiment(
-                workload_template_name,
-                experiment_template_name,
-                experiment_vars.copy(),
-                final_context,
-                cur_repeats,
-            )
-
+                    app_inst.repeats.set_repeat_index(n)
+                    app_inst.define_variable(
+                        self.keywords.experiment_name,
+                        base_app_inst.variables[self.keywords.experiment_name] + f".{n}",
+                    )
+                    app_inst.define_variable(
+                        self.keywords.experiment_namespace,
+                        base_app_inst.variables[self.keywords.experiment_namespace] + f".{n}",
+                    )
             final_exp_name = app_inst.expander.expand_var_name(self.keywords.experiment_name)
             final_exp_namespace = app_inst.expander.expand_var_name(
                 self.keywords.experiment_namespace
             )
+
+            try:
+                app_inst.validate_experiment(warn_validation=True, die_on_validate_error=True)
+            except ramble.keywords.RambleKeywordError as e:
+                raise RambleVariableDefinitionError(
+                    f"In experiment {final_exp_namespace}: {e}"
+                ) from None
 
             # Skip explicitly excluded experiments
             if final_exp_name not in excluded_experiments:
@@ -390,20 +403,60 @@ class ExperimentSet:
                             break
 
                 if active:
+                    app_inst.read_status()
                     processed_experiments.append((app_inst, final_exp_namespace, n == 0))
         return processed_experiments
 
-    def _ingest_experiments(self, die_on_validate_error=True):
+    def render_chained_experiments(self, app_name, workload_name, experiment_context) -> list:
+        """Render a set of experiments into the chained experiment set.
+
+        This method will render a new set of experiments for a given app (input
+        with app_name) and workload (input with workload_name, but could be
+        an indirect variable reference). It takes a context object for the
+        experiment, and will process any vectors and matrices to create
+        multiple experiments.
+
+        These are added to this experiment set's chained_experiments list,
+        rather than the base experiments list. Upon completion, all rendered
+        experiment instances are returned in a list, to allow further
+        processing. For example, if one wants to render chained experiments
+        from the child experiment.
+
+        Args:
+            app_name (str): Name of application to render experiments for
+            workload_name (str): Name, or template, of workload(s) to render
+                                 experiments for
+            experiment_context (ramble.context.Context): Context object for the
+                                                         set of experiments to render
+
+        Returns:
+            (list): List of application instances from the rendered set of experiments
+        """
+        app_context = ramble.context.Context()
+        app_context.context_name = app_name
+
+        wl_context = ramble.context.Context()
+        wl_context.context_name = workload_name
+        self.set_application_context(app_context)
+        self.set_workload_context(wl_context)
+        return self.set_experiment_context(experiment_context, chained=True)
+
+    def _ingest_experiments(self, die_on_validate_error=True, chained=False) -> list:
         """Ingest experiments based on the current context.
 
         Merge all contexts, and render individual experiments. Track these
         experiments within this experiment set.
 
         Args:
-            None
+            die_on_validated_error (bool): Whether rendering should kill
+                                           execution when validation errors are
+                                           encountered or not
+            chained (bool): Whether the rendered experiments should be added to
+                            the chained experiments list, or the base
+                            experiments list.
 
         Returns:
-            None
+            (list): List of application instances that are rendered
         """
 
         no_var_contexts = [
@@ -496,7 +549,7 @@ class ExperimentSet:
         tracking_group.n_repeats = final_context.n_repeats
         tracking_group.used_variables = set()
 
-        used_variables = set()
+        used_variables: Set[str] = set()
         for tracking_vars, _ in renderer.render_objects(
             tracking_group, exclude_where=exclude_where, ignore_used=False, fatal=False
         ):
@@ -511,6 +564,7 @@ class ExperimentSet:
 
         workload_names = set()
         rendered_experiments = set()
+        rendered_instances = []
 
         render_list = renderer.render_objects(render_group, exclude_where=exclude_where)
 
@@ -593,13 +647,21 @@ class ExperimentSet:
 
             workload_names.add(app_inst.expander.workload_name)
 
-            app_inst.define_variable(self.keywords.experiment_index, len(self.experiments) + 1)
+            app_inst.define_variable(
+                self.keywords.experiment_index,
+                len(self.experiments) + len(self.chained_experiments) + 1,
+            )
             app_inst.set_success_list(final_context.success_criteria)
             rendered_experiments.add(final_exp_namespace)
-            self.experiments[final_exp_namespace] = app_inst
-            self.experiment_order.append(final_exp_namespace)
+            rendered_instances.append(app_inst)
+            if not chained:
+                self.experiments[final_exp_namespace] = app_inst
+                self.experiment_order.append(final_exp_namespace)
+            else:
+                self.add_chained_experiment(app_inst.expander.experiment_name, app_inst)
 
         self.define_scoped_tables(workload_names, experiment_template_name)
+        return rendered_instances
 
     def define_scoped_tables(self, workload_names, experiment_template_name):
         # Generate focused tables for results

--- a/lib/ramble/ramble/test/application.py
+++ b/lib/ramble/ramble/test/application.py
@@ -132,9 +132,12 @@ def test_application_copy_is_deep(app_name, wl_name, mutable_mock_apps_repo):
     src_inst = mutable_mock_apps_repo.get(app_name)
 
     defined_variables = {
-        "workload_name": wl_name,
+        "n_nodes": "1",
+        "n_ranks": "{processes_per_node}*{n_nodes}",
+        "processes_per_node": "1",
         "test_var1": "test_val1",
         "test_var2": "test_val2",
+        "workload_name": wl_name,
     }
 
     defined_env_vars = [
@@ -532,7 +535,12 @@ ramble:
 
 def test_class_attributes(mutable_mock_apps_repo):
     basic_inst = mutable_mock_apps_repo.get("basic")
-    basic_inst.variables = {"workload_name": "test_wl"}
+    basic_inst.variables = {
+        "n_nodes": "1",
+        "n_ranks": "{processes_per_node}*{n_nodes}",
+        "processes_per_node": "1",
+        "workload_name": "test_wl",
+    }
     basic_clone = basic_inst.clone()
 
     instances = [basic_inst, basic_clone]

--- a/lib/ramble/ramble/test/application_language.py
+++ b/lib/ramble/ramble/test/application_language.py
@@ -497,3 +497,39 @@ def test_stage_files_directive_invalid_method():
     app_inst = TestApp("/not/a/path")
     with pytest.raises(DirectiveError):
         app_inst.stage_files(src="src", dst="dst", method="invalid")
+
+
+@pytest.mark.parametrize("app_class", app_types)
+def test_non_reserved_variables(app_class):
+    app_inst = app_class("/not/a/path")
+    app_inst.variables = {
+        "user_var1": "value1",
+        "workspace_name": "reserved_value",
+        "user_var2": "value2",
+        "n_nodes": "reserved_value2",
+    }
+
+    # Mock the workspace object
+    class MockWorkspace:
+        def all_templates(self):
+            return [("template1", "path1")]
+
+    workspace = MockWorkspace()
+
+    # Mock _object_templates
+    app_inst._object_templates = lambda ws: [("template2", {"var_name": "tpl_var_name"})]
+
+    # Test without remove_keys
+    non_reserved = app_inst.non_reserved_variables(workspace)
+    assert "user_var1" in non_reserved
+    assert "user_var2" in non_reserved
+    assert "workspace_name" not in non_reserved
+    assert "template1" not in non_reserved
+    assert "tpl_var_name" not in non_reserved
+    assert len(non_reserved) == 3
+
+    # Test with remove_keys
+    non_reserved = app_inst.non_reserved_variables(workspace, remove_keys={"user_var1"})
+    assert "user_var1" not in non_reserved
+    assert "user_var2" in non_reserved
+    assert len(non_reserved) == 2

--- a/lib/ramble/ramble/test/context.py
+++ b/lib/ramble/ramble/test/context.py
@@ -1,0 +1,86 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import unittest
+
+from ramble.context import Context
+
+
+class TestContext(unittest.TestCase):
+    def test_to_workspace_config(self):
+        context = Context()
+        context.context_name = "test_experiment"
+        context.variables = {"foo": "bar"}
+        config = context.to_workspace_config("test_app", "test_workload")
+        self.assertIn("ramble", config)
+        self.assertIn("applications", config["ramble"])
+        self.assertIn("test_app", config["ramble"]["applications"])
+        self.assertIn("workloads", config["ramble"]["applications"]["test_app"])
+        self.assertIn("test_workload", config["ramble"]["applications"]["test_app"]["workloads"])
+        self.assertIn(
+            "experiments",
+            config["ramble"]["applications"]["test_app"]["workloads"]["test_workload"],
+        )
+        self.assertIn(
+            "test_experiment",
+            config["ramble"]["applications"]["test_app"]["workloads"]["test_workload"][
+                "experiments"
+            ],
+        )
+        self.assertIn(
+            "variables",
+            config["ramble"]["applications"]["test_app"]["workloads"]["test_workload"][
+                "experiments"
+            ]["test_experiment"],
+        )
+        self.assertEqual(
+            config["ramble"]["applications"]["test_app"]["workloads"]["test_workload"][
+                "experiments"
+            ]["test_experiment"]["variables"],
+            {"foo": "bar"},
+        )
+
+    def test_to_workspace_config_all_attributes(self):
+        context = Context()
+        context.context_name = "test_experiment"
+        context.variables = {"a": "b"}
+        context.variants = {"c": "d"}
+        context.env_variables = {"e": "f"}
+        context.internals = {"g": "h"}
+        context.chained_experiments = ["i"]
+        context.modifiers = ["j"]
+        context.template = "k"
+        context.exclude = ["l"]
+        context.zips = ["m"]
+        context.tables = ["n"]
+        context.tags = ["o"]
+        context.matrices = {"p": "q"}
+        context.n_repeats = 1
+        context.formatted_executables = {"r": "s"}
+        context.success_criteria = "t"
+
+        config = context.to_workspace_config("test_app", "test_workload")
+        experiment_config = config["ramble"]["applications"]["test_app"]["workloads"][
+            "test_workload"
+        ]["experiments"]["test_experiment"]
+
+        self.assertEqual(experiment_config["variables"], {"a": "b"})
+        self.assertEqual(experiment_config["variants"], {"c": "d"})
+        self.assertEqual(experiment_config["env_vars"], {"e": "f"})
+        self.assertEqual(experiment_config["internals"], {"g": "h"})
+        self.assertEqual(experiment_config["chained_experiments"], ["i"])
+        self.assertEqual(experiment_config["modifiers"], ["j"])
+        self.assertEqual(experiment_config["template"], "k")
+        self.assertEqual(experiment_config["exclude"], ["l"])
+        self.assertEqual(experiment_config["zips"], ["m"])
+        self.assertEqual(experiment_config["tables"], ["n"])
+        self.assertEqual(experiment_config["tags"], ["o"])
+        self.assertEqual(experiment_config["matrices"], {"p": "q"})
+        self.assertEqual(experiment_config["n_repeats"], 1)
+        self.assertEqual(experiment_config["formatted_executables"], {"r": "s"})
+        self.assertEqual(experiment_config["success_criteria"], "t")

--- a/lib/ramble/ramble/test/experiment_set.py
+++ b/lib/ramble/ramble/test/experiment_set.py
@@ -25,7 +25,7 @@ pytestmark = pytest.mark.usefixtures(
 workspace = RambleCommand("workspace")
 
 
-def test_single_experiment_in_set(mutable_mock_workspace_path):
+def test_single_experiment_in_set():
     workspace("create", "test")
 
     assert "test" in workspace("list")
@@ -62,7 +62,7 @@ def test_single_experiment_in_set(mutable_mock_workspace_path):
         assert "basic.test_wl.series1_4" in exp_set.experiments.keys()
 
 
-def test_vector_experiment_in_set(mutable_mock_workspace_path):
+def test_vector_experiment_in_set():
     workspace("create", "test")
 
     assert "test" in workspace("list")
@@ -96,13 +96,12 @@ def test_vector_experiment_in_set(mutable_mock_workspace_path):
         assert "basic.test_wl.series1_8" in exp_set.experiments.keys()
 
 
-def test_vector_length_mismatch_errors(request, mutable_mock_workspace_path, capsys):
-    ws_name = request.node.name
-    workspace("create", ws_name)
+def test_vector_length_mismatch_errors(workspace_name, capsys):
+    workspace("create", workspace_name)
 
-    assert ws_name in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read(ws_name) as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         application_context = ramble.context.Context()
@@ -132,12 +131,12 @@ def test_vector_length_mismatch_errors(request, mutable_mock_workspace_path, cap
         assert "Variable n_nodes has length 2" in captured
 
 
-def test_nonunique_vector_errors(mutable_mock_workspace_path, capsys):
-    workspace("create", "test")
+def test_nonunique_vector_errors(workspace_name, capsys):
+    workspace("create", workspace_name)
 
-    assert "test" in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read("test") as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         application_context = ramble.context.Context()
@@ -167,12 +166,12 @@ def test_nonunique_vector_errors(mutable_mock_workspace_path, capsys):
         assert "is not unique." in captured
 
 
-def test_zipped_vector_experiments(mutable_mock_workspace_path):
-    workspace("create", "test")
+def test_zipped_vector_experiments(workspace_name):
+    workspace("create", workspace_name)
 
-    assert "test" in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read("test") as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         application_context = ramble.context.Context()
@@ -205,12 +204,12 @@ def test_zipped_vector_experiments(mutable_mock_workspace_path):
         assert "basic.test_wl.series1_16_4" in exp_set.experiments.keys()
 
 
-def test_matrix_experiments(mutable_mock_workspace_path):
-    workspace("create", "test")
+def test_matrix_experiments(workspace_name):
+    workspace("create", workspace_name)
 
-    assert "test" in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read("test") as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         application_context = ramble.context.Context()
@@ -240,12 +239,12 @@ def test_matrix_experiments(mutable_mock_workspace_path):
         assert "basic.test_wl.series1_6" in exp_set.experiments.keys()
 
 
-def test_matrix_multiplication_experiments(mutable_mock_workspace_path):
-    workspace("create", "test")
+def test_matrix_multiplication_experiments(workspace_name):
+    workspace("create", workspace_name)
 
-    assert "test" in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read("test") as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         application_context = ramble.context.Context()
@@ -283,12 +282,12 @@ def test_matrix_multiplication_experiments(mutable_mock_workspace_path):
         assert "basic.test_wl.series1_24" in exp_set.experiments.keys()
 
 
-def test_matrix_vector_experiments(mutable_mock_workspace_path):
-    workspace("create", "test")
+def test_matrix_vector_experiments(workspace_name):
+    workspace("create", workspace_name)
 
-    assert "test" in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read("test") as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         application_context = ramble.context.Context()
@@ -324,12 +323,12 @@ def test_matrix_vector_experiments(mutable_mock_workspace_path):
         assert "basic.test_wl.series1_12" in exp_set.experiments.keys()
 
 
-def test_multi_matrix_experiments(mutable_mock_workspace_path):
-    workspace("create", "test")
+def test_multi_matrix_experiments(workspace_name):
+    workspace("create", workspace_name)
 
-    assert "test" in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read("test") as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         application_context = ramble.context.Context()
@@ -363,12 +362,12 @@ def test_multi_matrix_experiments(mutable_mock_workspace_path):
         assert "basic.test_wl.series1_12_4" in exp_set.experiments.keys()
 
 
-def test_full_experiments_from_dict(mutable_mock_workspace_path):
-    workspace("create", "test")
+def test_full_experiments_from_dict(workspace_name):
+    workspace("create", workspace_name)
 
-    assert "test" in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read("test") as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         app_dict = {
@@ -406,12 +405,12 @@ def test_full_experiments_from_dict(mutable_mock_workspace_path):
         assert exp_set._context[exp_set._contexts.workspace].context_name is not None
 
 
-def test_matrix_undefined_var_errors(mutable_mock_workspace_path, capsys):
-    workspace("create", "test")
+def test_matrix_undefined_var_errors(workspace_name, capsys):
+    workspace("create", workspace_name)
 
-    assert "test" in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read("test") as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         application_context = ramble.context.Context()
@@ -447,12 +446,12 @@ def test_matrix_undefined_var_errors(mutable_mock_workspace_path, capsys):
         assert "variable or zip foo has not been defined yet." in captured
 
 
-def test_experiment_names_match(mutable_mock_workspace_path):
-    workspace("create", "test")
+def test_experiment_names_match(workspace_name):
+    workspace("create", workspace_name)
 
-    assert "test" in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read("test") as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         application_context = ramble.context.Context()
@@ -489,13 +488,12 @@ def test_experiment_names_match(mutable_mock_workspace_path):
             assert exp == app.expander.expand_var("{experiment_namespace}")
 
 
-def test_cross_experiment_variable_references(request, mutable_mock_workspace_path):
-    ws_name = request.node.name
-    workspace("create", ws_name)
+def test_cross_experiment_variable_references(workspace_name):
+    workspace("create", workspace_name)
 
-    assert ws_name in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read(ws_name) as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         application_context = ramble.context.Context()
@@ -556,12 +554,12 @@ def test_cross_experiment_variable_references(request, mutable_mock_workspace_pa
         assert exp2_app.expander.expand_var("{test_var}") == "success"
 
 
-def test_cross_experiment_missing_experiment_errors(mutable_mock_workspace_path):
-    workspace("create", "test")
+def test_cross_experiment_missing_experiment_errors(workspace_name):
+    workspace("create", workspace_name)
 
-    assert "test" in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read("test") as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         application_context = ramble.context.Context()
@@ -605,12 +603,12 @@ def test_cross_experiment_missing_experiment_errors(mutable_mock_workspace_path)
             exp_set.set_experiment_context(experiment1_context)
 
 
-def test_n_ranks_correct_defaults(mutable_mock_workspace_path):
-    workspace("create", "test")
+def test_n_ranks_correct_defaults(workspace_name):
+    workspace("create", workspace_name)
 
-    assert "test" in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read("test") as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         application_context = ramble.context.Context()
@@ -639,12 +637,12 @@ def test_n_ranks_correct_defaults(mutable_mock_workspace_path):
         assert "basic.test_wl.series1_6" in exp_set.experiments.keys()
 
 
-def test_n_nodes_correct_defaults(mutable_mock_workspace_path):
-    workspace("create", "test")
+def test_n_nodes_correct_defaults(workspace_name):
+    workspace("create", workspace_name)
 
-    assert "test" in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read("test") as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         application_context = ramble.context.Context()
@@ -677,12 +675,12 @@ def test_n_nodes_correct_defaults(mutable_mock_workspace_path):
         assert "basic.test_wl.series1_6_3" in exp_set.experiments.keys()
 
 
-def test_processes_per_node_correct_defaults(mutable_mock_workspace_path):
-    workspace("create", "test")
+def test_processes_per_node_correct_defaults(workspace_name):
+    workspace("create", workspace_name)
 
-    assert "test" in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read("test") as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
         # Remove workspace vars, which default to a `processes_per_node = -1` definition.
         exp_set._context[exp_set._contexts.workspace].variables = {}
@@ -717,12 +715,12 @@ def test_processes_per_node_correct_defaults(mutable_mock_workspace_path):
 
 
 @pytest.mark.parametrize("var", ["env_path"])
-def test_reserved_keywords_error_in_application(mutable_mock_workspace_path, var):
-    workspace("create", "test")
+def test_reserved_keywords_error_in_application(workspace_name, var):
+    workspace("create", workspace_name)
 
-    assert "test" in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read("test") as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         application_context = ramble.context.Context()
@@ -745,12 +743,12 @@ def test_reserved_keywords_error_in_application(mutable_mock_workspace_path, var
 
 
 @pytest.mark.parametrize("var", ["env_path"])
-def test_reserved_keywords_error_in_workload(mutable_mock_workspace_path, var):
-    workspace("create", "test")
+def test_reserved_keywords_error_in_workload(workspace_name, var):
+    workspace("create", workspace_name)
 
-    assert "test" in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read("test") as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         application_context = ramble.context.Context()
@@ -777,12 +775,12 @@ def test_reserved_keywords_error_in_workload(mutable_mock_workspace_path, var):
 
 
 @pytest.mark.parametrize("var", ["env_path"])
-def test_reserved_keywords_error_in_experiment(mutable_mock_workspace_path, var):
-    workspace("create", "test")
+def test_reserved_keywords_error_in_experiment(workspace_name, var):
+    workspace("create", workspace_name)
 
-    assert "test" in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read("test") as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
         # Remove workspace vars, which default to a `processes_per_node = -1` definition.
         exp_set._context[exp_set._contexts.base].variables = {}
@@ -822,12 +820,12 @@ def test_reserved_keywords_error_in_experiment(mutable_mock_workspace_path, var)
         assert "is reserved by ramble" in captured
 
 
-def test_missing_required_keyword_errors(mutable_mock_workspace_path):
-    workspace("create", "test")
+def test_missing_required_keyword_errors(workspace_name):
+    workspace("create", workspace_name)
 
-    assert "test" in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read("test") as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         application_context = ramble.context.Context()
@@ -860,12 +858,12 @@ def test_missing_required_keyword_errors(mutable_mock_workspace_path):
             exp_set.set_experiment_context(experiment_context)
 
 
-def test_chained_experiments_populate_new_experiments(mutable_mock_workspace_path):
-    workspace("create", "test")
+def test_chained_experiments_populate_new_experiments(workspace_name):
+    workspace("create", workspace_name)
 
-    assert "test" in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read("test") as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         application_context = ramble.context.Context()
@@ -922,12 +920,12 @@ def test_chained_experiments_populate_new_experiments(mutable_mock_workspace_pat
         assert "basic.test_wl.test1" in exp_set.experiments
 
 
-def test_chained_experiment_has_correct_directory(mutable_mock_workspace_path):
-    workspace("create", "test")
+def test_chained_experiment_has_correct_directory(workspace_name):
+    workspace("create", workspace_name)
 
-    assert "test" in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read("test") as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         application_context = ramble.context.Context()
@@ -983,12 +981,12 @@ def test_chained_experiment_has_correct_directory(mutable_mock_workspace_path):
         assert chained_inst.variables["experiment_run_dir"] == expected_dir
 
 
-def test_chained_cycle_errors(mutable_mock_workspace_path):
-    workspace("create", "test")
+def test_chained_cycle_errors(workspace_name):
+    workspace("create", workspace_name)
 
-    assert "test" in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read("test") as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         application_context = ramble.context.Context()
@@ -1032,12 +1030,12 @@ def test_chained_cycle_errors(mutable_mock_workspace_path):
             exp_set.build_experiment_chains()
 
 
-def test_chained_invalid_order_errors(mutable_mock_workspace_path):
-    workspace("create", "test")
+def test_chained_invalid_order_errors(workspace_name):
+    workspace("create", workspace_name)
 
-    assert "test" in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read("test") as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         application_context = ramble.context.Context()
@@ -1081,12 +1079,12 @@ def test_chained_invalid_order_errors(mutable_mock_workspace_path):
             exp_set.build_experiment_chains()
 
 
-def test_modifiers_set_correctly(mutable_mock_workspace_path, mock_modifiers):
-    workspace("create", "test")
+def test_modifiers_set_correctly(workspace_name, mock_modifiers):
+    workspace("create", workspace_name)
 
-    assert "test" in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read("test") as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         application_context = ramble.context.Context()
@@ -1134,12 +1132,12 @@ def test_modifiers_set_correctly(mutable_mock_workspace_path, mock_modifiers):
         assert len(expected_modifier_modes) == 0
 
 
-def test_explicit_zips_work(mutable_mock_workspace_path):
-    workspace("create", "test")
+def test_explicit_zips_work(workspace_name):
+    workspace("create", workspace_name)
 
-    assert "test" in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read("test") as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         application_context = ramble.context.Context()
@@ -1170,12 +1168,12 @@ def test_explicit_zips_work(mutable_mock_workspace_path):
         assert "basic.test_wl.series1_8" in exp_set.experiments.keys()
 
 
-def test_explicit_zips_in_matrix(mutable_mock_workspace_path):
-    workspace("create", "test")
+def test_explicit_zips_in_matrix(workspace_name):
+    workspace("create", workspace_name)
 
-    assert "test" in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read("test") as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         application_context = ramble.context.Context()
@@ -1215,12 +1213,12 @@ def test_explicit_zips_in_matrix(mutable_mock_workspace_path):
         assert "basic.test_wl.series1_8_3" in exp_set.experiments.keys()
 
 
-def test_explicit_zips_unconsumed(mutable_mock_workspace_path):
-    workspace("create", "test")
+def test_explicit_zips_unconsumed(workspace_name):
+    workspace("create", workspace_name)
 
-    assert "test" in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read("test") as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         application_context = ramble.context.Context()
@@ -1260,12 +1258,12 @@ def test_explicit_zips_unconsumed(mutable_mock_workspace_path):
         assert "basic.test_wl.series1_8_3" in exp_set.experiments.keys()
 
 
-def test_single_var_explicit_zip(mutable_mock_workspace_path):
-    workspace("create", "test")
+def test_single_var_explicit_zip(workspace_name):
+    workspace("create", workspace_name)
 
-    assert "test" in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read("test") as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         application_context = ramble.context.Context()
@@ -1298,12 +1296,12 @@ def test_single_var_explicit_zip(mutable_mock_workspace_path):
         assert "basic.test_wl.series1_8" in exp_set.experiments.keys()
 
 
-def test_zip_multi_use_var_errors(mutable_mock_workspace_path, capsys):
-    workspace("create", "test")
+def test_zip_multi_use_var_errors(workspace_name, capsys):
+    workspace("create", workspace_name)
 
-    assert "test" in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read("test") as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         application_context = ramble.context.Context()
@@ -1336,12 +1334,12 @@ def test_zip_multi_use_var_errors(mutable_mock_workspace_path, capsys):
         assert "An undefined variable n_nodes is defined in zip test_zip2" in captured
 
 
-def test_zip_non_list_var_errors(mutable_mock_workspace_path, capsys):
-    workspace("create", "test")
+def test_zip_non_list_var_errors(workspace_name, capsys):
+    workspace("create", workspace_name)
 
-    assert "test" in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read("test") as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         application_context = ramble.context.Context()
@@ -1373,12 +1371,12 @@ def test_zip_non_list_var_errors(mutable_mock_workspace_path, capsys):
         assert "Variable processes_per_node in zip test_zip does not refer to a vector" in captured
 
 
-def test_zip_variable_lengths_errors(mutable_mock_workspace_path, capsys):
-    workspace("create", "test")
+def test_zip_variable_lengths_errors(workspace_name, capsys):
+    workspace("create", workspace_name)
 
-    assert "test" in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read("test") as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         application_context = ramble.context.Context()
@@ -1414,12 +1412,12 @@ def test_zip_variable_lengths_errors(mutable_mock_workspace_path, capsys):
         assert "differs from the current max of 2" in captured
 
 
-def test_vector_experiment_with_explicit_excludes(mutable_mock_workspace_path):
-    workspace("create", "test")
+def test_vector_experiment_with_explicit_excludes(workspace_name):
+    workspace("create", workspace_name)
 
-    assert "test" in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read("test") as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         application_context = ramble.context.Context()
@@ -1450,12 +1448,12 @@ def test_vector_experiment_with_explicit_excludes(mutable_mock_workspace_path):
         assert "basic.test_wl.series1_8" not in exp_set.experiments.keys()
 
 
-def test_matrix_experiments_explicit_excludes(mutable_mock_workspace_path):
-    workspace("create", "test")
+def test_matrix_experiments_explicit_excludes(workspace_name):
+    workspace("create", workspace_name)
 
-    assert "test" in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read("test") as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         application_context = ramble.context.Context()
@@ -1492,12 +1490,12 @@ def test_matrix_experiments_explicit_excludes(mutable_mock_workspace_path):
         assert "basic.test_wl.series1_6" not in exp_set.experiments.keys()
 
 
-def test_vector_experiment_with_where_excludes(mutable_mock_workspace_path):
-    workspace("create", "test")
+def test_vector_experiment_with_where_excludes(workspace_name):
+    workspace("create", workspace_name)
 
-    assert "test" in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read("test") as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         application_context = ramble.context.Context()
@@ -1579,12 +1577,12 @@ def test_vector_experiment_with_late_where_excludes(workspace_name):
         assert "basic.test_wl.series1_10" not in exp_set.experiments.keys()
 
 
-def test_vector_experiment_with_multi_where_excludes(mutable_mock_workspace_path):
-    workspace("create", "test")
+def test_vector_experiment_with_multi_where_excludes(workspace_name):
+    workspace("create", workspace_name)
 
-    assert "test" in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read("test") as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         application_context = ramble.context.Context()
@@ -1622,13 +1620,12 @@ def test_vector_experiment_with_multi_where_excludes(mutable_mock_workspace_path
         assert "basic.test_wl.series1_10" not in exp_set.experiments.keys()
 
 
-def test_unused_vector_no_error(request, mutable_mock_workspace_path):
-    ws_name = request.node.name
-    workspace("create", ws_name)
+def test_unused_vector_no_error(workspace_name):
+    workspace("create", workspace_name)
 
-    assert ws_name in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read(ws_name) as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         application_context = ramble.context.Context()
@@ -1667,13 +1664,12 @@ def test_unused_vector_no_error(request, mutable_mock_workspace_path):
         assert "basic.test_wl.series1_10" not in exp_set.experiments.keys()
 
 
-def test_unused_zip_no_error(request, mutable_mock_workspace_path):
-    ws_name = request.node.name
-    workspace("create", ws_name)
+def test_unused_zip_no_error(workspace_name):
+    workspace("create", workspace_name)
 
-    assert ws_name in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read(ws_name) as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         application_context = ramble.context.Context()
@@ -1716,13 +1712,12 @@ def test_unused_zip_no_error(request, mutable_mock_workspace_path):
         assert "basic.test_wl.series1_10" not in exp_set.experiments.keys()
 
 
-def test_unused_var_propagates_to_chain(request, mutable_mock_workspace_path):
-    ws_name = request.node.name
-    workspace("create", ws_name)
+def test_unused_var_propagates_to_chain(workspace_name):
+    workspace("create", workspace_name)
 
-    assert ws_name in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read(ws_name) as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         expanded_app_context = ramble.context.Context()
@@ -1790,13 +1785,12 @@ def test_unused_var_propagates_to_chain(request, mutable_mock_workspace_path):
         assert app_inst.variables["my_var"] == "5.0"
 
 
-def test_custom_executables_track_variables(request, mutable_mock_workspace_path):
-    ws_name = request.node.name
-    workspace("create", ws_name)
+def test_custom_executables_track_variables(workspace_name):
+    workspace("create", workspace_name)
 
-    assert ws_name in workspace("list")
+    assert workspace_name in workspace("list")
 
-    with ramble.workspace.read(ws_name) as ws:
+    with ramble.workspace.read(workspace_name) as ws:
         exp_set = ramble.experiment_set.ExperimentSet(ws)
 
         expanded_app_context = ramble.context.Context()
@@ -1862,3 +1856,84 @@ def test_custom_executables_track_variables(request, mutable_mock_workspace_path
         app_inst = exp_set.get_experiment("basic.test_wl.test1.chain.0.expanded_foms.test_wl.test")
 
         assert app_inst.variables["my_var"] == "5.0"
+
+
+def test_chained_experiments(workspace_name):
+    """Test that chained experiments are rendered correctly."""
+    ramble.workspace.create(workspace_name)
+    with ramble.workspace.read(workspace_name) as ws:
+        exp_set = ramble.experiment_set.ExperimentSet(ws)
+        app_context = ramble.context.Context()
+        app_context.context_name = "basic"
+        exp_set.set_application_context(app_context)
+
+        workload_context = ramble.context.Context()
+        workload_context.context_name = "test_wl"
+        exp_set.set_workload_context(workload_context)
+
+        experiment_context = ramble.context.Context()
+        experiment_context.context_name = "test"
+        experiment_context.variables = {"n_ranks": "1", "processes_per_node": "1"}
+        rendered_instances = exp_set.render_chained_experiments(
+            "basic", "test_wl", experiment_context
+        )
+
+        assert len(rendered_instances) == 1
+        assert "test" in exp_set.chained_experiments
+        assert "basic.test_wl.test" not in exp_set.experiments
+
+
+def test_repeated_experiments(workspace_name):
+    """Test that repeated experiments are rendered correctly."""
+    ramble.workspace.create(workspace_name)
+    with ramble.workspace.read(workspace_name) as ws:
+        exp_set = ramble.experiment_set.ExperimentSet(ws)
+        app_context = ramble.context.Context()
+        app_context.context_name = "basic"
+        exp_set.set_application_context(app_context)
+
+        workload_context = ramble.context.Context()
+        workload_context.context_name = "test_wl"
+        exp_set.set_workload_context(workload_context)
+
+        experiment_context = ramble.context.Context()
+        experiment_context.context_name = "test"
+        experiment_context.variables = {"n_ranks": "1", "processes_per_node": "1"}
+        experiment_context.n_repeats = 2
+        experiment_context.is_repeat_base = True
+        exp_set.set_experiment_context(experiment_context)
+
+        assert "basic.test_wl.test" in exp_set.experiments
+        assert "basic.test_wl.test.1" in exp_set.experiments
+        assert "basic.test_wl.test.2" in exp_set.experiments
+        assert "basic.test_wl.test.3" not in exp_set.experiments
+
+        base_exp = exp_set.experiments["basic.test_wl.test"]
+        repeat1_exp = exp_set.experiments["basic.test_wl.test.1"]
+
+        assert base_exp.repeats.is_repeat_base
+        assert base_exp.repeats.n_repeats == 2
+        assert repeat1_exp.repeats.repeat_index == 1
+
+
+def test_validation_in_render_repeat_experiments(workspace_name):
+    """Test that validation is called in _render_repeat_experiments."""
+    ramble.workspace.create(workspace_name)
+    with ramble.workspace.read(workspace_name) as ws:
+        exp_set = ramble.experiment_set.ExperimentSet(ws)
+        app_context = ramble.context.Context()
+        app_context.context_name = "basic"
+        exp_set.set_application_context(app_context)
+
+        workload_context = ramble.context.Context()
+        workload_context.context_name = "test_wl"
+        exp_set.set_workload_context(workload_context)
+
+        experiment_context = ramble.context.Context()
+        experiment_context.context_name = "test"
+        experiment_context.n_repeats = 1
+        experiment_context.is_repeat_base = True
+
+        match_str = r"Invalid number of required variables defined"
+        with pytest.raises(ramble.error.ObjectValidationError, match=match_str):
+            exp_set.set_experiment_context(experiment_context)

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -247,6 +247,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         new_clone.set_template(False)
         new_clone.repeats.set_repeats(False, 0)
         new_clone.set_chained_experiments(None)
+        new_clone.set_required_variables()
 
         return new_clone
 
@@ -3211,6 +3212,9 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
     def get_status(self):
         """Get the status of this experiment"""
+        if self.keywords.experiment_status not in self.variables:
+            self.read_status()
+
         return self.variables[self.keywords.experiment_status]
 
     def get_ramble_status(self):

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -17,7 +17,7 @@ import stat
 import string
 import time
 from html import escape
-from typing import List
+from typing import Dict, List
 
 import llnl.util.filesystem as fs
 import llnl.util.tty.color as color
@@ -617,6 +617,35 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             self.expander.replacement_paths = (
                 experiment_set._workspace.workspace_paths()
             )
+
+    def non_reserved_variables(
+        self, workspace, remove_keys: set = None
+    ) -> Dict[str, str]:
+        """Replicate this instances variables, and remove any reserved variables from the dict.
+        Additionally, remove any variables in the remove_keys set.
+
+        Args:
+            remove_keys (set): Set of keys to remove from variable definitions
+
+        Returns:
+            (dict): A dictionary of variable, value pairs from this experiment.
+        """
+        if remove_keys is None:
+            remove_keys = {"env_name", "workspace_tables"}
+        cleaned_variables = self.variables.copy()
+        for key in self.keywords.all_reserved_keys():
+            cleaned_variables.pop(key, None)
+
+        for key in remove_keys:
+            cleaned_variables.pop(key, None)
+
+        for template_name, _ in workspace.all_templates():
+            cleaned_variables.pop(key, None)
+
+        for _, tpl_config in self._object_templates(workspace):
+            cleaned_variables.pop(key, None)
+
+        return cleaned_variables
 
     def define_missing_variables(self):
         """Iterate over missing variable definitions, and add them until there


### PR DESCRIPTION
This merge enables the ability to render experiments into the chained experiment list within an experiment set. Previously, rendered experiments could only be added as base experiments.