### PR TITLE
Import pandas dynamically

### DIFF
--- a/lib/ramble/ramble/reports.py
+++ b/lib/ramble/ramble/reports.py
@@ -21,15 +21,15 @@ from ramble.keywords import keywords
 from ramble.util.file_util import create_symlink
 from ramble.util.foms import BetterDirection, FomType, SummaryFoms
 from ramble.util.logger import logger
+from ramble.util.module_utils import import_pandas
 
 import spack.util.spack_yaml as syaml
 
 try:
     import matplotlib.pyplot as plt
-    import pandas as pd
     from matplotlib.backends.backend_pdf import PdfPages
 except ModuleNotFoundError:
-    logger.die("matplotlib or pandas was not found. Ensure requirements.txt are installed.")
+    logger.die("matplotlib was not found. Ensure requirements.txt are installed.")
 
 
 class ReportVars(Enum):
@@ -82,6 +82,7 @@ for obj in ramble.repository.ObjectTypes:
 
 def to_numeric_if_possible(series):
     """Try to convert a Pandas series to numeric, or return the series unchanged."""
+    pd = import_pandas()
     try:
         return pd.to_numeric(series)
     except (ValueError, TypeError):
@@ -313,9 +314,7 @@ def get_all_vars(result_index):
     return all_vars
 
 
-def extract_data(
-    experiments: List[dict], foms: List[str], variables: List[str], where_query=None
-) -> pd.DataFrame:
+def extract_data(experiments: List[dict], foms: List[str], variables: List[str], where_query=None):
     """Extracts data from the experiments dicts and returns it as a Pandas DataFrame.
 
     Args:
@@ -370,6 +369,7 @@ def extract_data(
 
                     extracted_data.append(exp_data)
 
+    pd = import_pandas()
     extracted_df = pd.DataFrame.from_dict(extracted_data)
 
     # Apply where to down select
@@ -418,6 +418,7 @@ class PlotFactory:
 
 class PlotGenerator:
     def __init__(self, spec, normalize, report_dir_path, exp_results, logx, logy, split_by):
+        pd = import_pandas()
         self.normalize = normalize
         self.spec = spec
         self.report_dir_path = report_dir_path
@@ -618,6 +619,7 @@ class ScalingPlotGenerator(PlotGenerator):
     def generate_plot_data(self, pdf_report):
         """Creates a dataframe for plotting line charts with scaling var on x axis,
         and performance variable on y axis."""
+        pd = import_pandas()
         self.validate_spec(self.spec, self.result_index)
 
         perf_measure, scale_var, *additional_vars = self.spec
@@ -853,14 +855,13 @@ class FomPlot(PlotGenerator):
 
     # TODO: dry bar plot drawing
     def draw(self, perf_measure, scale_var, series, unit, pdf_report):
+        pd = import_pandas()
 
         self.output_df[ReportVars.FOM_VALUE.value] = to_numeric_if_possible(
             self.output_df[ReportVars.FOM_VALUE.value]
         )
 
-        from pandas.api.types import is_numeric_dtype
-
-        if not is_numeric_dtype(self.output_df[ReportVars.FOM_VALUE.value]):
+        if not pd.api.types.is_numeric_dtype(self.output_df[ReportVars.FOM_VALUE.value]):
             logger.warn(f"Skipping drawing of non numeric FOM: {perf_measure}")
             return
 

--- a/lib/ramble/ramble/results_table.py
+++ b/lib/ramble/ramble/results_table.py
@@ -9,10 +9,9 @@
 import copy
 import os
 
-import pandas
-
 from ramble.util.file_util import create_symlink
 from ramble.util.logger import logger
+from ramble.util.module_utils import import_pandas
 
 
 class ResultsColumn:
@@ -248,11 +247,12 @@ class ResultsTable:
 
     def _to_dataframe(self):
         """Construct a pandasdata frame from this table's data"""
-        self._df = pandas.DataFrame(self._data)
+        pd = import_pandas()
+        self._df = pd.DataFrame(self._data)
 
         for column in self._df.columns:
             try:
-                self._df[column] = pandas.to_numeric(self._df[column])
+                self._df[column] = pd.to_numeric(self._df[column])
             except ValueError:
                 pass
 

--- a/lib/ramble/ramble/test/test_results_tables.py
+++ b/lib/ramble/ramble/test/test_results_tables.py
@@ -134,18 +134,23 @@ class TestResultsTable(unittest.TestCase):
         self.assertEqual(self.table._data["col2"], ["val2"])
 
     @patch("ramble.results_table.create_symlink")
-    @patch("ramble.results_table.pandas.DataFrame")
-    def test_to_csv(self, mock_df, mock_symlink):
+    @patch("ramble.results_table.import_pandas")
+    def test_to_csv(self, mock_import_pandas, mock_symlink):
         self.table._data = {"col1": ["a", "b"], "col2": [1, 2]}
         self.table._num_rows = 2
 
-        mock_df_instance = mock_df.return_value
+        mock_pd_module = MagicMock()
+        mock_import_pandas.return_value = mock_pd_module
+        mock_df_constructor = MagicMock()
+        mock_pd_module.DataFrame = mock_df_constructor
+
+        mock_df_instance = mock_df_constructor.return_value
         mock_df_instance.groupby.return_value.max.return_value = mock_df_instance
         mock_df_instance.sort_values.return_value = mock_df_instance
 
         self.table.to_csv("/tmp", "timestamp")
 
-        mock_df.assert_called_with(self.table._data)
+        mock_df_constructor.assert_called_with(self.table._data)
         mock_df_instance.to_csv.assert_called_with("/tmp/test_table.timestamp.csv", index=False)
         mock_symlink.assert_called_with(
             "/tmp/test_table.timestamp.csv", "/tmp/test_table.latest.csv"

--- a/lib/ramble/ramble/test/util/module_utils.py
+++ b/lib/ramble/ramble/test/util/module_utils.py
@@ -1,0 +1,24 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import unittest
+from unittest.mock import patch
+
+from ramble.util.module_utils import import_module
+
+
+class TestModuleUtils(unittest.TestCase):
+    @patch("ramble.util.logger.logger.die")
+    def test_import_non_existent_module(self, mock_die):
+        mock_die.side_effect = SystemExit
+        with self.assertRaises(SystemExit):
+            import_module("non_existent_module")
+        mock_die.assert_called_once_with(
+            "`non_existent_module` was not found. Ensure all the packages in "
+            "`requirements.txt` are installed."
+        )

--- a/lib/ramble/ramble/util/module_utils.py
+++ b/lib/ramble/ramble/util/module_utils.py
@@ -1,0 +1,35 @@
+# Copyright 2022-2025 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+"""A utility for dynamically importing modules."""
+
+import importlib
+
+from ramble.util.logger import logger
+
+_modules = {}
+
+
+def import_module(module_name):
+    """A utility for dynamically importing a module."""
+    global _modules  # noqa: F824
+    if module_name not in _modules:
+        try:
+            module = importlib.import_module(module_name)
+            _modules[module_name] = module
+        except ModuleNotFoundError:
+            logger.die(
+                f"`{module_name}` was not found. Ensure all the packages in "
+                "`requirements.txt` are installed."
+            )
+    return _modules[module_name]
+
+
+def import_pandas():
+    """A utility for dynamically importing pandas."""
+    return import_module("pandas")


### PR DESCRIPTION
The motivation comes from using Python build that supports free-threading. Older versions of pandas don't declare support for free-threading, so importing it statically means all Ramble commands will run with GIL enabled, losing the benefit of free-threading. Changing it to import on-demand, such that commands that don't use this dependency can still run with GIL disabled, if the Python build supports it.

Validation:

```
(py314t) linsword-mac:ramble linsword$ ramble -V
<frozen importlib._bootstrap>:491: RuntimeWarning: The global interpreter lock (GIL) has been enabled to load module 'pandas._libs.pandas_parser', which has not declared that it can run safely without the GIL. To override this behavior and keep the GIL disabled (at your own risk), run with PYTHON_GIL=0 or -Xgil=0.
0.6.0 (7de39c98863f366b10e74242faa92084d26eeb03)
(py314t) linsword-mac:ramble linsword$ git stash pop
(py314t) linsword-mac:ramble linsword$ ramble -V
0.6.0 (7de39c98863f366b10e74242faa92084d26eeb03)
```