### PR TITLE
Remove limitation on codecov-cli for py314

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,8 +9,5 @@ pytest-xdist
 pytest-clarity
 line_profiler
 isort
-# codecov-cli relies on test-results-parser, which currently has a dep pin on
-# a pyo3 version that is not compatible with 3.14: https://github.com/codecov/test-results-parser/blob/main/Cargo.toml#L14.
-# Also see https://github.com/codecov/test-results-parser/issues/86.
-codecov-cli;python_version<"3.14"
+codecov-cli
 mypy


### PR DESCRIPTION
The underlying bug on the codecov side has been resolved: https://github.com/codecov/test-results-parser/pull/92.