### PR TITLE
Move definition of required mpi variables to application

### DIFF
--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -8,7 +8,6 @@
 
 import concurrent.futures
 import fnmatch
-import math
 import os
 import sys
 from enum import Enum
@@ -193,81 +192,6 @@ class ExperimentSet:
             return f"{wl_ns}.{exp_ns}"
         return None
 
-    def _compute_mpi_vars(self, expander, variables):
-        """Compute required MPI variables
-
-        Perform computation of required MPI variables, including:
-        - n_ranks
-        - n_nodes
-        - processes_per_node
-        - n_threads
-        """
-        n_ranks = (
-            variables[self.keywords.n_ranks] if self.keywords.n_ranks in variables.keys() else None
-        )
-        ppn = (
-            variables[self.keywords.processes_per_node]
-            if self.keywords.processes_per_node in variables.keys()
-            else None
-        )
-        n_nodes = (
-            variables[self.keywords.n_nodes] if self.keywords.n_nodes in variables.keys() else None
-        )
-        n_threads = (
-            variables[self.keywords.n_threads]
-            if self.keywords.n_threads in variables.keys()
-            else None
-        )
-
-        def _expand(var):
-            try:
-                return int(var)
-            except ValueError:
-                return int(expander.expand_var(var))
-
-        if n_ranks:
-            n_ranks = _expand(n_ranks)
-            if n_ranks <= 0:
-                logger.error("n_ranks must be positive")
-
-        if ppn:
-            ppn = _expand(ppn)
-            if ppn <= 0:
-                logger.error("processes_per_node must be positive")
-
-        if n_nodes:
-            n_nodes = _expand(n_nodes)
-            if n_nodes <= 0:
-                logger.error("n_nodes must be positive")
-
-        if n_threads:
-            n_threads = _expand(n_threads)
-
-        if n_ranks and ppn:
-            test_n_nodes = math.ceil(n_ranks / ppn)
-
-            if n_nodes and n_nodes < test_n_nodes:
-                logger.error(
-                    f"n_nodes in {self.experiment_namespace} is {n_nodes} "
-                    f"and should be {test_n_nodes}"
-                )
-            elif not n_nodes:
-                logger.debug(f"Defining n_nodes in {self.experiment_namespace}")
-                variables[self.keywords.n_nodes] = test_n_nodes
-        elif n_ranks and n_nodes:
-            ppn = math.ceil(int(n_ranks) / int(n_nodes))
-            logger.debug(f"Defining processes_per_node in {self.experiment_namespace}")
-            variables[self.keywords.processes_per_node] = ppn
-        elif ppn and n_nodes:
-            n_ranks = ppn * n_nodes
-            logger.debug(f"Defining n_ranks in {self.experiment_namespace}")
-            variables[self.keywords.n_ranks] = n_ranks
-        elif not n_nodes:
-            variables[self.keywords.n_nodes] = 1
-
-        if not n_threads:
-            variables[self.keywords.n_threads] = 1
-
     def _setup_experiment_minimal(
         self,
         workload_template_name,
@@ -276,7 +200,6 @@ class ExperimentSet:
     ):
         """Perform minimal setup for an experiment instance."""
         expander = ramble.expander.Expander(variables, self)
-        self._compute_mpi_vars(expander, variables)
 
         final_app_name = expander.expand_var_name(
             self.keywords.application_name, allow_passthrough=False
@@ -291,9 +214,9 @@ class ExperimentSet:
         app_inst = ramble.repository.get(final_app_name)
         app_inst.set_variables_and_variants(variables, context.variants, self)
 
-        app_inst.set_required_variables()
         app_inst.set_active_workload()
         app_inst.set_modifiers(context.modifiers)
+        app_inst.set_required_variables()
         app_inst.set_internals(context.internals)
         app_inst.set_chained_experiments(context.chained_experiments)
         app_inst.set_env_variable_sets(context.env_variables)
@@ -548,7 +471,6 @@ class ExperimentSet:
                     exclude_group, ignore_used=False
                 ):
                     expander = ramble.expander.Expander(exclude_exp_vars, self)
-                    self._compute_mpi_vars(expander, exclude_exp_vars)
                     exclude_exp_name = expander.expand_var(
                         experiment_template_name, allow_passthrough=False
                     )

--- a/lib/ramble/ramble/test/experiment_set.py
+++ b/lib/ramble/ramble/test/experiment_set.py
@@ -822,7 +822,7 @@ def test_reserved_keywords_error_in_experiment(mutable_mock_workspace_path, var)
         assert "is reserved by ramble" in captured
 
 
-def test_missing_required_keyword_errors(mutable_mock_workspace_path, capsys):
+def test_missing_required_keyword_errors(mutable_mock_workspace_path):
     workspace("create", "test")
 
     assert "test" in workspace("list")
@@ -854,10 +854,10 @@ def test_missing_required_keyword_errors(mutable_mock_workspace_path, capsys):
 
         exp_set.set_application_context(application_context)
         exp_set.set_workload_context(workload_context)
-        with pytest.raises(ramble.experiment_set.RambleVariableDefinitionError):
+
+        match_str = r"Invalid number of required variables defined"
+        with pytest.raises(ramble.error.ObjectValidationError, match=match_str):
             exp_set.set_experiment_context(experiment_context)
-        captured = capsys.readouterr()
-        assert 'Required key "n_ranks" is not defined' in captured.err
 
 
 def test_chained_experiments_populate_new_experiments(mutable_mock_workspace_path):

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -1585,15 +1585,11 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                                 "{mpi_command}",
                                 exec_vars,
                             ).strip()
-                            if (
-                                not raw_mpi_cmd
-                                and int(
-                                    self.expander.expand_var_name(
-                                        self.keywords.n_nodes
-                                    )
-                                )
-                                > 1
-                            ):
+                            n_nodes = self.expander.expand_var_name(
+                                self.keywords.n_nodes
+                            )
+                            n_nodes = 1 if not n_nodes else int(n_nodes)
+                            if not raw_mpi_cmd and n_nodes > 1:
                                 logger.warn(
                                     f"Command {cmd_conf.name} requires a non-empty `mpi_command` "
                                     "variable in a multi-node experiment"
@@ -3526,6 +3522,48 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
     def set_required_variables(self):
         """Set required variables from all objects"""
+
+        def define_mpi_vars():
+            required_vars_defined = set()
+
+            required_vars = {
+                self.keywords.n_ranks: "int({processes_per_node}*{n_nodes})",
+                self.keywords.processes_per_node: "int({n_ranks}/{n_nodes})",
+                self.keywords.n_nodes: "int({n_ranks}/{processes_per_node})",
+            }
+
+            for required_var in required_vars:
+                if required_var in self.variables:
+                    required_vars_defined.add(required_var)
+
+            if len(required_vars_defined) < 2:
+                required_keys = "Two or more of the following are required to be defined.\n"
+                for var in required_vars.keys():
+                    required_keys += f"  - {var}\n"
+
+                defined_keys = f"Experiment {self.expander.experiment_namespace} only has:\n"
+                for var in required_vars_defined:
+                    defined_keys += f"  - {var}\n"
+                raise ramble.error.ObjectValidationError(
+                    "Invalid number of required variables defined.\n"
+                    + required_keys
+                    + defined_keys
+                )
+
+            for required_var in required_vars_defined:
+                del required_vars[required_var]
+
+            for var_name, formula in required_vars.items():
+                value = self.expander.expand_var(
+                    formula, allow_passthrough=False
+                )
+                self.define_variable(var_name, value)
+
+        define_mpi_vars()
+
+        if self.keywords.n_threads not in self.variables:
+            self.define_variable(self.keywords.n_threads, 1)
+
         for _, obj in self._objects():
             logger.debug(f"Setting required variables for {obj.name}")
             self.keywords.update_keys(obj.required_variables)


### PR DESCRIPTION
This merge moves the definition of undefined, but required MPI variables to the application base class instead of having it defined when creating an experiment set.

This allows the variables to be defined based on workload / object variables rather than erroring before workload / object variables are defined.