### PR TITLE
Fallback to string instead of bailout in binary op eval

### DIFF
--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -449,6 +449,8 @@ class Expander:
         self._experiment_set = experiment_set
         self.replacement_paths = {}
 
+        self._math_str_stack = []
+
         self._application_name = None
         self._workload_name = None
         self._experiment_name = None
@@ -862,25 +864,29 @@ class Expander:
             unmodified (if unsuccessful)
 
         """
-        with warnings.catch_warnings(record=True) as wal:
-            try:
-                math_ast = _ast_parse(in_str)
-                out_str = self.eval_math(math_ast.body)
-                return out_str
-            except MathEvaluationError as e:
-                logger.debug(f'   Math input is: "{in_str}"')
-                logger.debug(e)
-            except RambleSyntaxError as e:
-                raise RambleSyntaxError(f'{str(e)} in "{in_str}"') from None
-            except SyntaxError as e:
-                logger.debug(f"ast.parse hit the following syntax error on input: {in_str}")
-                logger.debug(e)
+        self._math_str_stack.append(in_str)
+        try:
+            with warnings.catch_warnings(record=True) as wal:
+                try:
+                    math_ast = _ast_parse(in_str)
+                    out_str = self.eval_math(math_ast.body)
+                    return out_str
+                except MathEvaluationError as e:
+                    logger.debug(f'   Math input is: "{in_str}"')
+                    logger.debug(e)
+                except RambleSyntaxError as e:
+                    raise RambleSyntaxError(f'{str(e)} in "{in_str}"') from None
+                except SyntaxError as e:
+                    logger.debug(f"ast.parse hit the following syntax error on input: {in_str}")
+                    logger.debug(e)
 
-            for warn in wal:
-                if r"invalid escape sequence '\{'" not in str(warn.message):
-                    logger.warn(str(warn.message))
+                for warn in wal:
+                    if r"invalid escape sequence '\{'" not in str(warn.message):
+                        logger.warn(str(warn.message))
 
-        return in_str
+            return in_str
+        finally:
+            self._math_str_stack.pop()
 
     def eval_math(self, node):
         """Evaluate math from parsing the AST
@@ -1106,6 +1112,34 @@ class Expander:
             right_eval = self.eval_math(node.right)
             op = supported_math_operators[type(node.op)]
             if isinstance(left_eval, str) or isinstance(right_eval, str):
+                # Determine the end of the left node and the start of the right node,
+                # to preserve strings in between.
+                # This is to avoid expanding "gromacs +debug" into "gromacs+debug".
+                op_str = None
+                if self._math_str_stack:
+                    source = self._math_str_stack[-1]
+                    l_node, r_node = node.left, node.right
+
+                    l_end_lineno = getattr(l_node, "end_lineno", None)
+                    l_end_col_offset = getattr(l_node, "end_col_offset", None)
+
+                    # The `end_lineno` and `end_col_offset` may not be available in older (<3.8)
+                    # versions of Python.
+                    if l_end_lineno is None and hasattr(l_node, "lineno"):
+                        if isinstance(l_node, ast.Name):
+                            l_end_lineno = l_node.lineno
+                            l_end_col_offset = l_node.col_offset + len(l_node.id)
+                        elif _is_num_node(l_node):
+                            l_end_lineno = l_node.lineno
+                            l_end_col_offset = l_node.col_offset + len(str(l_node.n))
+
+                    if l_end_lineno is not None and hasattr(r_node, "lineno"):
+                        if l_end_lineno == r_node.lineno:
+                            lines = source.splitlines(keepends=True)
+                            line = lines[l_end_lineno - 1]
+                            op_str = line[l_end_col_offset : r_node.col_offset]
+                    if op_str is not None:
+                        return f"{left_eval}{op_str}{right_eval}"
                 self.__dbg_syntax_error("Unsupported operand type in binary operator", node)
             return op(left_eval, right_eval)
         except TypeError:

--- a/lib/ramble/ramble/test/expander.py
+++ b/lib/ramble/ramble/test/expander.py
@@ -37,6 +37,7 @@ def exp_dict():
         "max_len": 9,
         "test_dict": {"test_key1": "test_val1", "test_key2": "test_val2"},
         "experiment_index": 5,
+        "var4": "a-b",
     }
 
 
@@ -156,6 +157,7 @@ def build_variant_set():
         ("str_no_such_method('a')", "str_no_such_method('a')", set(), 1),
         ("replace('abc', 'a', 'd')", "dbc", set(), 1),
         ("replace('{application_name}', 'f', 'F')", "Foo", set(), 1),
+        ("str_upper({var4})", "A-B", set(), 1),
     ],
 )
 def test_expansions(input, output, no_expand_vars, passes):


### PR DESCRIPTION
This is potentially more friendly to "bin-op-alike" expressions, such as "tcp-ip".