### PR TITLE
Move `-noconfout` arg into `additional_args`

### DIFF
--- a/var/ramble/repos/builtin/applications/gromacs/application.py
+++ b/var/ramble/repos/builtin/applications/gromacs/application.py
@@ -59,7 +59,7 @@ class Gromacs(ExecutableApplication):
     executable(
         "execute-gen",
         "{mdrun} {notunepme} -dlb {dlb} "
-        + "{verbose} -resetstep {resetstep} -noconfout -nsteps {nsteps} "
+        + "{verbose} -resetstep {resetstep} -nsteps {nsteps} "
         + "-s exp_input.tpr {additional_args}",
         use_mpi=True,
         output_capture=OUTPUT_CAPTURE.ALL,
@@ -67,7 +67,7 @@ class Gromacs(ExecutableApplication):
     executable(
         "execute",
         "{mdrun} {notunepme} -dlb {dlb} "
-        + "{verbose} -resetstep {resetstep} -noconfout -nsteps {nsteps} "
+        + "{verbose} -resetstep {resetstep} -nsteps {nsteps} "
         + "-s {input_path} {additional_args}",
         use_mpi=True,
         output_capture=OUTPUT_CAPTURE.ALL,
@@ -213,7 +213,7 @@ class Gromacs(ExecutableApplication):
 
     workload_variable(
         "additional_args",
-        default="",
+        default="-noconfout",
         description="Additiaonl Exec Args",
         workload_group="all_workloads",
     )


### PR DESCRIPTION
Such that this can be optionally excluded.

This arg has been deprecated since gromacs 2019: https://manual.gromacs.org/documentation/2026-beta/release-notes/2025/major/deprecated-functionality.html#benchmarking-options-only-available-with-gmx-benchmark

And the default is already no-write: https://github.com/gromacs/gromacs/blob/main/src/gromacs/mdrun/legacymdrunoptions.h#L375

That said, still by default preserve this arg for consistency.