### PR TITLE
Update yaml parsing to avoid swalloing trailing colons

### DIFF
--- a/lib/ramble/ramble/test/end_to_end/env_var_builtin.py
+++ b/lib/ramble/ramble/test/end_to_end/env_var_builtin.py
@@ -42,7 +42,7 @@ ramble:
                 n_nodes: 1
               env_vars:
                 set:
-                  MY_VAR: 'TEST'
+                  MY_VAR: 'TEST:'
         test_wl2:
           experiments:
             simple_test:
@@ -50,7 +50,7 @@ ramble:
                 n_nodes: 1
               env_vars:
                 set:
-                  MY_VAR: 'TEST'
+                  MY_VAR: 'TEST:'
         test_wl3:
           experiments:
             simple_test:
@@ -58,7 +58,7 @@ ramble:
                 n_nodes: 1
               env_vars:
                 set:
-                  MY_VAR: 'TEST'
+                  MY_VAR: 'TEST:'
   software:
     packages: {}
     environments: {}
@@ -82,7 +82,7 @@ ramble:
         exp3_dir = os.path.join(experiment_root, "interleved-env-vars", "test_wl3", "simple_test")
         exp3_script = os.path.join(exp3_dir, "execute_experiment")
 
-        export_regex = re.compile(r"export MY_VAR=TEST")
+        export_regex = re.compile(r"export MY_VAR=TEST:")
         cmd1_regex = re.compile("bar >>")
         cmd2_regex = re.compile("baz >>")
         cmd3_regex = re.compile("foo >>")

--- a/lib/ramble/spack/util/spack_yaml.py
+++ b/lib/ramble/spack/util/spack_yaml.py
@@ -127,7 +127,8 @@ class OrderedLineLoader(RoundTripLoader):
         # so this assumes we are talking about a Spack config override key if
         # it ends with a ':' and does not contain a '@' (which can appear
         # in config values that refer to Spack specs)
-        if value and value.endswith(':') and '@' not in value:
+        # and is not quoted (identified by a non-empty node.style)
+        if value and value.endswith(':') and '@' not in value and not node.style:
             value = syaml_str(value[:-1])
             value.override = True
         else:


### PR DESCRIPTION
This causes issues when for instance:

```
env_vars:
  set:
    PSM3_IDENTIFY: '1:'
```

becomes (with the colon stripped)

```
export PSM3_IDENTIFY=1;
```