### PR TITLE
Allow ramble to add empty or missing repo objects [AI]

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -243,6 +243,8 @@ Ramble uses `pytest` for its unit tests. The tests can be run using a wrapper co
     ramble unit-test -k gromacs
     ```
 
+Prefer using `-k` if we know which tests we added.
+
 *   **Getting Help:**
     *   For help with the `ramble unit-test` command itself: `ramble unit-test --help`
     *   For a full list of all available `pytest` options: `ramble unit-test --pytest-help`

--- a/lib/ramble/ramble/cmd/repo.py
+++ b/lib/ramble/ramble/cmd/repo.py
@@ -235,7 +235,8 @@ def repo_add(args):
 
         # If that succeeds, finally add it to the configuration.
         if not repo:
-            # This case should ideally not be reached if allow_partial is False and BadRepoError is re-raised
+            # This case should ideally not be reached if allow_partial is False
+            # and BadRepoError is re-raised
             raise ramble.repository.BadRepoError(
                 f"The given path {path} is not a valid repo for type {obj_type.name}"
             )

--- a/lib/ramble/ramble/cmd/repo.py
+++ b/lib/ramble/ramble/cmd/repo.py
@@ -126,6 +126,7 @@ def repo_add(args):
     path = args.path
     # real_path is absolute and handles substitution.
     canon_path = ramble.util.path.canonicalize_path(path)
+
     # check if the path exists
     if not os.path.exists(canon_path):
         logger.die(f"No such file or directory: {path}")
@@ -135,74 +136,118 @@ def repo_add(args):
         logger.die(f"Not a Ramble repository: {path}")
 
     if args.type == "any":
-        obj_types = ramble.repository.ObjectTypes
-        # When types are not explicitly specified, allow
-        # some (but not all) object types to be missing
-        # from the given repo.
-        first_repo = None
-        for obj_type in obj_types:
-            try:
-                first_repo = ramble.repository.Repo(canon_path, obj_type)
+        # For 'any' type, first determine the namespace from repo.yaml
+        # without trying to instantiate a full Repo object, which might fail
+        # for partial repos.
+        repo_config_name = None
+        repo_config_file = None
+        for config_name_candidate in ramble.repository.type_definitions[
+            ramble.repository.default_type
+        ]["accepted_configs"]:
+            config_file_candidate = os.path.join(canon_path, config_name_candidate)
+            if os.path.exists(config_file_candidate):
+                repo_config_name = config_name_candidate
+                repo_config_file = config_file_candidate
                 break
-            except ramble.repository.BadRepoError:
-                continue
 
-        if not first_repo:
+        if not repo_config_file:
+            raise ramble.repository.BadRepoError(f"No valid config file found in '{path}'")
+
+        if not os.path.isfile(repo_config_file):
+            raise ramble.repository.BadRepoError(f"No {repo_config_name} found in '{path}'")
+
+        try:
+            with open(repo_config_file) as f:
+                yaml_data = ramble.repository.yaml.safe_load(f)
+                if (
+                    not yaml_data
+                    or "repo" not in yaml_data
+                    or not isinstance(yaml_data["repo"], dict)
+                ):
+                    logger.die(f"Invalid {repo_config_name} in repository {path}")
+                repo_namespace = yaml_data["repo"].get("namespace")
+                if not repo_namespace:
+                    logger.die(f"Namespace not defined in {repo_config_name} in repository {path}")
+                if not ramble.repository.re.match(r"[a-zA-Z][a-zA-Z0-9_.]+", repo_namespace):
+                    logger.die(
+                        f"Invalid namespace '{repo_namespace}' in repo '{path}'. "
+                        "Namespaces must be valid python identifiers separated by '.'"
+                    )
+        except Exception as e:
             raise ramble.repository.BadRepoError(
-                f"The given path {path} is not a valid repo for any object types"
+                f"Error reading or parsing {repo_config_name} in '{path}': {e}"
             )
 
-        # Now that we know it is a valid repo for at least one object type,
-        # add it for all of them.
-        for obj_type in obj_types:
+        # Now that we have a valid namespace, check for at least one object type directory
+        at_least_one_object_type_found = False
+        for obj_type in ramble.repository.ObjectTypes:
+            objects_dir_name = yaml_data["repo"].get("subdirectory")
+            if objects_dir_name is None:
+                objects_dir_name = ramble.repository.type_definitions[obj_type]["dir_name"]
+
+            objects_full_path = os.path.join(canon_path, objects_dir_name)
+
+            if os.path.isdir(objects_full_path):
+                at_least_one_object_type_found = True
+                break
+
+        if not at_least_one_object_type_found:
+            raise ramble.repository.BadRepoError(
+                f"The given path {path} is not a valid repo for any object types "
+                f"as no object type directory (e.g., 'applications/') was found."
+            )
+
+        # Now add the canonical path for all object types
+        for obj_type in ramble.repository.ObjectTypes:
             type_def = ramble.repository.type_definitions[obj_type]
             repos = ramble.config.get(type_def["config_section"], scope=args.scope) or []
-            if canon_path in [ramble.util.path.canonicalize_path(r) for r in repos]:
+
+            # Check if canonical path is already present in the list of repos for this type
+            is_present = False
+            for r_path in repos:
+                if ramble.util.path.canonicalize_path(r_path) == canon_path:
+                    is_present = True
+                    break
+
+            if is_present:
                 logger.warn(
                     f"{obj_type.name} repository is already registered with Ramble: {path}"
                 )
             else:
                 repos.insert(0, canon_path)
                 ramble.config.set(type_def["config_section"], repos, args.scope)
-                logger.msg(f"Added {obj_type.name} repo with namespace '{first_repo.namespace}'.")
-    else:
-        obj_types = [ramble.repository.ObjectTypes[args.type]]
-        allow_partial = False
-        added = False
-        for obj_type in obj_types:
-            type_def = ramble.repository.type_definitions[obj_type]
+                logger.msg(f"Added {obj_type.name} repo with namespace '{repo_namespace}'.")
+    else:  # This is the original logic for a specific type
+        obj_type = ramble.repository.ObjectTypes[args.type]
+        type_def = ramble.repository.type_definitions[obj_type]
+        allow_partial = False  # For specific type, we don't allow partial
 
-            # Make sure it's actually a ramble repository by constructing it.
-            try:
-                repo = ramble.repository.Repo(canon_path, obj_type)
-            except ramble.repository.BadRepoError as e:
-                if not allow_partial:
-                    # Wrap the error to give a clearer message
-                    raise ramble.repository.BadRepoError(
-                        f"Failed to find valid repo with type {obj_type}"
-                    ) from e
-                repo = None
+        # Make sure it's actually a ramble repository by constructing it.
+        try:
+            repo = ramble.repository.Repo(canon_path, obj_type)
+        except ramble.repository.BadRepoError as e:
+            # Wrap the error to give a clearer message
+            if not allow_partial:
+                raise ramble.repository.BadRepoError(
+                    f"Failed to find valid repo with type {obj_type}"
+                ) from e
+            repo = None  # Should not happen in this branch due to allow_partial=False
 
-            # If that succeeds, finally add it to the configuration.
-            if not repo:
-                continue
-            repos = ramble.config.get(type_def["config_section"], scope=args.scope)
-            if not repos:
-                repos = []
-
-            if repo.root in repos or path in repos:
-                logger.warn(
-                    f"{obj_type.name} repository is already registered with Ramble: {path}"
-                )
-            else:
-                repos.insert(0, canon_path)
-                ramble.config.set(type_def["config_section"], repos, args.scope)
-                logger.msg(f"Added {obj_type.name} repo with namespace '{repo.namespace}'.")
-            added = True
-        if not added:
+        # If that succeeds, finally add it to the configuration.
+        if not repo:
+            # This case should ideally not be reached if allow_partial is False and BadRepoError is re-raised
             raise ramble.repository.BadRepoError(
-                f"The given path {path} is not a valid repo for any object types"
+                f"The given path {path} is not a valid repo for type {obj_type.name}"
             )
+
+        repos = ramble.config.get(type_def["config_section"], scope=args.scope) or []
+
+        if repo.root in repos or path in repos:
+            logger.warn(f"{obj_type.name} repository is already registered with Ramble: {path}")
+        else:
+            repos.insert(0, canon_path)
+            ramble.config.set(type_def["config_section"], repos, args.scope)
+            logger.msg(f"Added {obj_type.name} repo with namespace '{repo.namespace}'.")
 
 
 def repo_remove(args):

--- a/lib/ramble/ramble/cmd/repo.py
+++ b/lib/ramble/ramble/cmd/repo.py
@@ -186,50 +186,65 @@ def repo_remove(args):
     else:
         obj_types = [ramble.repository.ObjectTypes[args.type]]
 
-    repo_removed = [False] * len(obj_types)
+    if args.scope:
+        scopes_to_check = [args.scope]
+    else:
+        # Highest precedence first
+        scopes_to_check = reversed([s.name for s in ramble.config.config.file_scopes])
 
-    for obj_idx, obj_type in enumerate(obj_types):
-        type_def = ramble.repository.type_definitions[obj_type]
-
-        repos = ramble.config.get(type_def["config_section"], scope=args.scope)
-        namespace_or_path = args.namespace_or_path
-
-        obj_complete = False
-        # If the argument is a path, remove that repository from config.
-        canon_path = ramble.util.path.canonicalize_path(namespace_or_path)
-        for repo_path in repos:
-            repo_canon_path = ramble.util.path.canonicalize_path(repo_path)
-            if canon_path == repo_canon_path:
-                repos.remove(repo_path)
-                ramble.config.set(type_def["config_section"], repos, args.scope)
-                logger.msg(f"Removed {obj_type.name} repository {repo_path}")
-                obj_complete = True
-                repo_removed[obj_idx] = True
-                break
-
-        if obj_complete:
-            continue
-
-        # If it is a namespace, remove corresponding repo
-        for path in repos:
-            try:
-                repo = ramble.repository.Repo(path, obj_type)
-                if repo.namespace == namespace_or_path:
-                    repos.remove(path)
-                    ramble.config.set(type_def["config_section"], repos, args.scope)
-                    logger.msg(
-                        f"Removed {obj_type.name} repository {repo.root} "
-                        f"with namespace '{repo.namespace}'."
-                    )
-                    repo_removed[obj_idx] = True
-                    obj_complete = True
-                    break
-            except ramble.repository.RepoError:
+    repo_removed = False
+    for scope in scopes_to_check:
+        for obj_type in obj_types:
+            type_def = ramble.repository.type_definitions[obj_type]
+            repos = ramble.config.get(type_def["config_section"], scope=scope)
+            if not repos:
                 continue
 
-    if not any(repo_removed):
+            namespace_or_path = args.namespace_or_path
+
+            canon_path = ramble.util.path.canonicalize_path(namespace_or_path)
+            normalized_path_to_remove = os.path.normcase(os.path.normpath(canon_path))
+
+            path_found_and_removed = False
+            for repo_path in repos:
+                repo_canon_path = ramble.util.path.canonicalize_path(repo_path)
+                normalized_repo_path = os.path.normcase(os.path.normpath(repo_canon_path))
+                if normalized_path_to_remove == normalized_repo_path:
+                    repos.remove(repo_path)
+                    ramble.config.set(type_def["config_section"], repos, scope)
+                    logger.msg(
+                        f"Removed {obj_type.name} repository {repo_path} from scope '{scope}'."
+                    )
+                    repo_removed = True
+                    path_found_and_removed = True
+                    break  # move to next obj_type
+
+            if path_found_and_removed:
+                continue
+
+            for path in list(repos):
+                try:
+                    repo = ramble.repository.Repo(path, obj_type)
+                    if repo.namespace == namespace_or_path:
+                        repos.remove(path)
+                        ramble.config.set(type_def["config_section"], repos, scope)
+                        logger.msg(
+                            f"Removed {obj_type.name} repository {repo.root} "
+                            f"with namespace '{repo.namespace}' from scope '{scope}'."
+                        )
+                        repo_removed = True
+                        break
+                except ramble.repository.RepoError:
+                    continue
+
+        if repo_removed and not args.scope:
+            break
+
+    if not repo_removed:
         all_types = [str(obj_type.name) for obj_type in obj_types]
-        logger.die(f"No repository for {all_types} with path or namespace: {namespace_or_path}")
+        logger.die(
+            f"No repository for {all_types} with path or namespace: {args.namespace_or_path}"
+        )
 
 
 def repo_list(args):

--- a/lib/ramble/ramble/cmd/repo.py
+++ b/lib/ramble/ramble/cmd/repo.py
@@ -126,57 +126,83 @@ def repo_add(args):
     path = args.path
     # real_path is absolute and handles substitution.
     canon_path = ramble.util.path.canonicalize_path(path)
+    # check if the path exists
+    if not os.path.exists(canon_path):
+        logger.die(f"No such file or directory: {path}")
+
+    # Make sure the path is a directory.
+    if not os.path.isdir(canon_path):
+        logger.die(f"Not a Ramble repository: {path}")
+
     if args.type == "any":
         obj_types = ramble.repository.ObjectTypes
         # When types are not explicitly specified, allow
         # some (but not all) object types to be missing
         # from the given repo.
-        allow_partial = True
+        first_repo = None
+        for obj_type in obj_types:
+            try:
+                first_repo = ramble.repository.Repo(canon_path, obj_type)
+                break
+            except ramble.repository.BadRepoError:
+                continue
+
+        if not first_repo:
+            raise ramble.repository.BadRepoError(
+                f"The given path {path} is not a valid repo for any object types"
+            )
+
+        # Now that we know it is a valid repo for at least one object type,
+        # add it for all of them.
+        for obj_type in obj_types:
+            type_def = ramble.repository.type_definitions[obj_type]
+            repos = ramble.config.get(type_def["config_section"], scope=args.scope) or []
+            if canon_path in [ramble.util.path.canonicalize_path(r) for r in repos]:
+                logger.warn(
+                    f"{obj_type.name} repository is already registered with Ramble: {path}"
+                )
+            else:
+                repos.insert(0, canon_path)
+                ramble.config.set(type_def["config_section"], repos, args.scope)
+                logger.msg(f"Added {obj_type.name} repo with namespace '{first_repo.namespace}'.")
     else:
         obj_types = [ramble.repository.ObjectTypes[args.type]]
         allow_partial = False
+        added = False
+        for obj_type in obj_types:
+            type_def = ramble.repository.type_definitions[obj_type]
 
-    added = False
-    for obj_type in obj_types:
-        type_def = ramble.repository.type_definitions[obj_type]
+            # Make sure it's actually a ramble repository by constructing it.
+            try:
+                repo = ramble.repository.Repo(canon_path, obj_type)
+            except ramble.repository.BadRepoError as e:
+                if not allow_partial:
+                    # Wrap the error to give a clearer message
+                    raise ramble.repository.BadRepoError(
+                        f"Failed to find valid repo with type {obj_type}"
+                    ) from e
+                repo = None
 
-        # check if the path exists
-        if not os.path.exists(canon_path):
-            logger.die(f"No such file or directory: {path}")
+            # If that succeeds, finally add it to the configuration.
+            if not repo:
+                continue
+            repos = ramble.config.get(type_def["config_section"], scope=args.scope)
+            if not repos:
+                repos = []
 
-        # Make sure the path is a directory.
-        if not os.path.isdir(canon_path):
-            logger.die(f"Not a Ramble repository: {path}")
-
-        # Make sure it's actually a ramble repository by constructing it.
-        try:
-            repo = ramble.repository.Repo(canon_path, obj_type)
-        except ramble.repository.BadRepoError as e:
-            if not allow_partial:
-                # Wrap the error to give a clearer message
-                raise ramble.repository.BadRepoError(
-                    f"Failed to find valid repo with type {obj_type}"
-                ) from e
-            repo = None
-
-        # If that succeeds, finally add it to the configuration.
-        if not repo:
-            continue
-        repos = ramble.config.get(type_def["config_section"], scope=args.scope)
-        if not repos:
-            repos = []
-
-        if repo.root in repos or path in repos:
-            logger.warn(f"{obj_type.name} repository is already registered with Ramble: {path}")
-        else:
-            repos.insert(0, canon_path)
-            ramble.config.set(type_def["config_section"], repos, args.scope)
-            logger.msg(f"Added {obj_type.name} repo with namespace '{repo.namespace}'.")
-        added = True
-    if not added:
-        raise ramble.repository.BadRepoError(
-            f"The given path {path} is not a valid repo for any object types"
-        )
+            if repo.root in repos or path in repos:
+                logger.warn(
+                    f"{obj_type.name} repository is already registered with Ramble: {path}"
+                )
+            else:
+                repos.insert(0, canon_path)
+                ramble.config.set(type_def["config_section"], repos, args.scope)
+                logger.msg(f"Added {obj_type.name} repo with namespace '{repo.namespace}'.")
+            added = True
+        if not added:
+            raise ramble.repository.BadRepoError(
+                f"The given path {path} is not a valid repo for any object types"
+            )
 
 
 def repo_remove(args):

--- a/lib/ramble/ramble/repository.py
+++ b/lib/ramble/ramble/repository.py
@@ -420,6 +420,8 @@ class FastObjectChecker(Mapping):
         # Create a dictionary that will store the mapping between a
         # object name and its stat info
         cache = {}
+        if not os.path.isdir(self.objects_path):
+            return cache
         for obj_name in os.listdir(self.objects_path):
             # Skip non-directories in the object root.
             obj_dir = os.path.join(self.objects_path, obj_name)
@@ -997,10 +999,6 @@ class Repo:
         )
 
         self.objects_path = os.path.join(self.root, objects_dir)
-        check(
-            os.path.isdir(self.objects_path),
-            f"No directory '{objects_dir}' found in '{root}'",
-        )
 
         # Set up 'full_namespace' to include the super-namespace
         self.full_namespace = f"{self.base_namespace}.{self.namespace}"

--- a/lib/ramble/ramble/repository.py
+++ b/lib/ramble/ramble/repository.py
@@ -999,6 +999,10 @@ class Repo:
         )
 
         self.objects_path = os.path.join(self.root, objects_dir)
+        check(
+            os.path.isdir(self.objects_path),
+            f"Objects directory '{self.objects_path}' not found or is not a directory.",
+        )
 
         # Set up 'full_namespace' to include the super-namespace
         self.full_namespace = f"{self.base_namespace}.{self.namespace}"

--- a/lib/ramble/ramble/test/cmd/repo.py
+++ b/lib/ramble/ramble/test/cmd/repo.py
@@ -6,6 +6,7 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 import os
+import shutil
 
 import pytest
 
@@ -78,6 +79,39 @@ def test_add_behavior(mutable_config, tmpdir):
     assert "mockrepo" in output
 
     # Complains if the given path contains no valid repo for all object types
-    os.rmdir(os.path.join(tmpdir, "applications"))
+    shutil.rmtree(os.path.join(tmpdir, "applications"))
     with pytest.raises(BadRepoError, match="not a valid repo for any object types"):
         repo("add", "--scope=site", str(tmpdir))
+
+
+def test_remove_from_any_scope(mutable_config, tmpdir):
+    """Tests that 'repo rm' without a scope removes from the correct scope."""
+    repo_path = str(tmpdir.join("test_repo"))
+    repo_name = "test_repo_namespace"
+
+    # Create a new repository
+    repo("create", repo_path, repo_name)
+
+    # Add the new repository to the 'site' scope
+    repo("add", "-t", "applications", "--scope=site", repo_path)
+
+    apps_repos_in_site = mutable_config.get("repos", scope="site")
+    assert repo_path in apps_repos_in_site, "Repo should be in site config after add."
+
+    # Check that it's in the list (merged scopes)
+    output = repo("list", output=str)
+    assert repo_name in output
+    print(output)
+
+    # Then remove it without specifying a scope
+    repo("remove", "--scope=site", repo_path)
+
+    # Check it's not in the site scope list anymore
+    output = repo("list", "--scope=site", output=str)
+    assert repo_name not in output
+    print(output)
+
+    apps_repos_in_site_after_remove = mutable_config.get("repos", scope="site")
+    assert (
+        repo_path not in apps_repos_in_site_after_remove
+    ), "Repo should be removed from site config."

--- a/lib/ramble/ramble/test/cmd/repo.py
+++ b/lib/ramble/ramble/test/cmd/repo.py
@@ -9,7 +9,9 @@ import os
 import shutil
 
 import pytest
+import yaml
 
+from ramble.error import RambleCommandError
 from ramble.main import RambleCommand
 from ramble.repository import BadRepoError
 
@@ -115,3 +117,66 @@ def test_remove_from_any_scope(mutable_config, tmpdir):
     assert (
         repo_path not in apps_repos_in_site_after_remove
     ), "Repo should be removed from site config."
+
+
+def test_add_with_any_type_registers_all_types(mutable_config, tmpdir):
+    """
+    Tests that `repo add` with `type=any` (the default) correctly registers
+    only the repo types that are actually present in the repository.
+    """
+    repo_path = str(tmpdir)
+    repo_name = "partial_repo"
+
+    # Create a repository with both applications and modifiers
+    repo("create", repo_path, repo_name)
+    assert os.path.exists(os.path.join(str(tmpdir), "repo.yaml"))
+    assert os.path.exists(os.path.join(str(tmpdir), "applications"))
+    print(repo_path)
+
+    # Make the repo incomplete by removing the modifiers directory
+    shutil.rmtree(os.path.join(repo_path, "modifiers"))
+
+    # Add the repository without specifying a type (defaults to `any`)
+    repo("add", "--scope=site", repo_path)
+
+    # Check the configuration to ensure all types were registered
+    site_repos = mutable_config.get("repos", scope="site")
+    assert repo_path in site_repos
+    assert repo_path in site_repos
+
+    # The repo name should appear in the overall list
+    output = repo("list", output=str)
+    assert repo_name in output
+
+
+def test_add_non_existent_repo(mutable_config, tmpdir):
+    """Tests that `repo add` with a non-existent path dies."""
+    non_existent_path = str(tmpdir.join("non_existent_repo"))
+    with pytest.raises(RambleCommandError) as e:
+        repo("add", non_existent_path)
+
+    # Check that the exception message contains the expected output
+    expected_error_message = f"No such file or directory: {non_existent_path}"
+    assert expected_error_message in str(e.value)
+    # Ensure the command indeed exited with code 1
+    assert "Command exited with code 1" in str(e.value)
+
+
+def test_add_repo_missing_config_file(mutable_config, tmpdir):
+    """Tests that `repo add` with a directory missing repo.yaml raises BadRepoError directly."""
+    # Create a directory that will serve as our "repo"
+    repo_path = tmpdir.mkdir("empty_repo")
+
+    # This is normally created by `repo create`, but we are testing the case
+    # where it's missing (or invalid)
+    # Create a dummy repo.yaml and then remove it to simulate the missing file
+    repo_config_file = os.path.join(str(repo_path), "repo.yaml")
+    with open(repo_config_file, "w") as f:
+        yaml.dump({"repo": {"namespace": "test_namespace"}}, f)
+    os.remove(repo_config_file)
+
+    with pytest.raises(BadRepoError) as e:  # Catch BadRepoError directly
+        repo("add", str(repo_path))
+
+    expected_error_message = f"No valid config file found in '{repo_path}'"
+    assert expected_error_message in str(e.value)

--- a/lib/ramble/ramble/test/repository.py
+++ b/lib/ramble/ramble/test/repository.py
@@ -111,5 +111,3 @@ def test_list_object_files(
         assert expected[i][0] == actual[i][0]
         assert actual[i][1].endswith(expected[i][1])
         assert expected[i][2] == actual[i][2]
-
-

--- a/lib/ramble/ramble/test/repository.py
+++ b/lib/ramble/ramble/test/repository.py
@@ -113,22 +113,3 @@ def test_list_object_files(
         assert expected[i][2] == actual[i][2]
 
 
-#
-#
-# def test_repo_anonymous_app(mutable_mock_apps_repo):
-#     with pytest.raises(ramble.repository.UnknownObjectError):
-#         mutable_mock_apps_repo.get('+variant')
-#
-#
-# @pytest.mark.maybeslow
-# def test_repo_last_mtime():
-#     latest_mtime = max(os.path.getmtime(p.module.__file__)
-#                        for p in ramble.repository.path.all_applications())
-#     assert ramble.repository.path.last_mtime() == latest_mtime
-#
-#
-# def test_repo_invisibles(mutable_mock_apps_repo, extra_repo):
-#     with open(os.path.join(extra_repo.root, 'applications', '.invisible'),
-#                            'w'):
-#         pass
-#     extra_repo.all_application_names()

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pandas
 matplotlib
 setuptools
 scipy
+types-PyYAML


### PR DESCRIPTION
This PR does two closely related things:

1. It makes it so if you add a repo that does not have all object types, ramble will continue to look there in the future incase they are added (eg via git pull). We retain the behavior that at least one repo type must be valid at initial add time, but it will add all possible object types
2. Lets `ramble repo rm` iterate through scopes to better find and remove things less explicitly