### PR TITLE
Increase flexibility of object directory names

### DIFF
--- a/lib/ramble/ramble/repository.py
+++ b/lib/ramble/ramble/repository.py
@@ -1213,7 +1213,15 @@ class Repo:
     def dirname_for_object_name(self, obj_name):
         """Get the directory name for a particular object.  This is the
         directory that contains its object.py file."""
-        return os.path.join(self.objects_path, obj_name)
+        path_priorities = [
+            os.path.join(self.objects_path, obj_name),  # Default
+            os.path.join(self.objects_path, obj_name.replace("_", "-")),  # Hyphens
+            os.path.join(self.objects_path, obj_name.replace("-", "_")),  # Underscores
+        ]
+        for path in path_priorities:
+            if os.path.isdir(path):
+                return path
+        return path_priorities[0]
 
     def filename_for_object_name(self, obj_name):
         """Get the filename for the module we should load for a particular

--- a/lib/ramble/ramble/test/cmd/info.py
+++ b/lib/ramble/ramble/test/cmd/info.py
@@ -395,3 +395,16 @@ def test_info_directives(
             else:
                 for val in verbose_values:
                     assert val in section_content
+
+
+def test_info_object_name_formats(mutable_mock_apps_repo):
+    output = info("basic")
+    assert "basic" in output
+    output = info("basic-inherited")
+    assert "basic-inherited" in output
+    output = info("basic_inherited")
+    assert "basic-inherited" in output
+    output = info("basic_underscores")
+    assert "basic_underscores" in output
+    output = info("basic-underscores")
+    assert "basic_underscores" in output

--- a/lib/ramble/ramble/test/util/object_utils.py
+++ b/lib/ramble/ramble/test/util/object_utils.py
@@ -22,6 +22,7 @@ from ramble.util import object_utils
                 "basic",
                 "basic-inherited",
                 "basic-inherited-nolicense",
+                "basic_underscores",
                 "cleanup-test",
                 "import-test",
                 "input-test",

--- a/var/ramble/repos/builtin.mock/applications/basic_underscores/application.py
+++ b/var/ramble/repos/builtin.mock/applications/basic_underscores/application.py
@@ -1,0 +1,14 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.app.builtin.mock.basic import Basic as BaseBasic
+from ramble.appkit import *  # noqa
+
+
+class BasicUnderscores(BaseBasic):
+    name = "basic_underscores"


### PR DESCRIPTION
This merge updates the logic for constructing directory names from object names. Previously, object names and their directories had to match (i.e. if the object uses underscores, the dir needed underscores, or if the object uses hyphens, the dir needs hyphens).

This merge updates this logic to prioritize directory names as:
- matches object name
- only hyphens
- only underscores

The first existing option from this will be returned, and if none exist then the object name is used as is.