### PR TITLE
Add a `make_workspace` pytest fixture

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -715,7 +715,7 @@ def mock_file_auto_create(monkeypatch):
 
 
 @pytest.fixture
-def make_workspace(workspace_name, mutable_config, mutable_mock_workspace_path):
+def make_workspace_from_config(workspace_name, mutable_config, mutable_mock_workspace_path):
     """Fixture to create a workspace with a specific configuration."""
 
     def _create(config_str=None, name=None, activate=False):

--- a/conftest.py
+++ b/conftest.py
@@ -714,6 +714,28 @@ def mock_file_auto_create(monkeypatch):
     monkeypatch.setattr(builtins, "open", open_or_create_inmem)
 
 
+@pytest.fixture
+def make_workspace(workspace_name, mutable_config, mutable_mock_workspace_path):
+    """Fixture to create a workspace with a specific configuration."""
+
+    def _create(config_str=None, name=None, activate=False):
+        ws_name = name or workspace_name
+        ws = ramble.workspace.create(ws_name)
+        ws.write()
+
+        if config_str:
+            config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+            with open(config_path, "w+") as f:
+                f.write(config_str)
+            ws._re_read()
+
+        if activate:
+            ramble.workspace.activate(ws)
+        return ws, ws_name
+
+    return _create
+
+
 def pytest_generate_tests(metafunc):
     import re
 

--- a/lib/ramble/ramble/test/end_to_end/gromacs_size_expansion.py
+++ b/lib/ramble/ramble/test/end_to_end/gromacs_size_expansion.py
@@ -10,7 +10,6 @@ import os
 
 import pytest
 
-import ramble.workspace
 from ramble.main import RambleCommand
 
 # everything here uses the mock_workspace_path
@@ -19,7 +18,7 @@ pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_p
 workspace = RambleCommand("workspace")
 
 
-def test_gromacs_size_expansion(mutable_config, mutable_mock_workspace_path, workspace_name):
+def test_gromacs_size_expansion(make_workspace):
     test_config = """
 ramble:
   variants:
@@ -56,21 +55,13 @@ ramble:
         - intel-mpi
 """
 
-    with ramble.workspace.create(workspace_name) as ws1:
-        ws1.write()
+    ws, ws_name = make_workspace(test_config)
 
-        config_path = os.path.join(ws1.config_dir, ramble.workspace.config_file_name)
+    workspace("setup", "--dry-run", global_args=["-w", ws_name])
 
-        with open(config_path, "w+") as f:
-            f.write(test_config)
+    exec_script_path = os.path.join(
+        ws.experiment_dir, "gromacs", "water_bare", "expansion_test", "execute_experiment"
+    )
 
-        ws1._re_read()
-
-        workspace("setup", "--dry-run", global_args=["-w", workspace_name])
-
-        exec_script_path = os.path.join(
-            ws1.experiment_dir, "gromacs", "water_bare", "expansion_test", "execute_experiment"
-        )
-
-        with open(exec_script_path) as f:
-            assert "0000.96" in f.read()
+    with open(exec_script_path) as f:
+        assert "0000.96" in f.read()

--- a/lib/ramble/ramble/test/end_to_end/gromacs_size_expansion.py
+++ b/lib/ramble/ramble/test/end_to_end/gromacs_size_expansion.py
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_p
 workspace = RambleCommand("workspace")
 
 
-def test_gromacs_size_expansion(make_workspace):
+def test_gromacs_size_expansion(make_workspace_from_config):
     test_config = """
 ramble:
   variants:
@@ -55,7 +55,7 @@ ramble:
         - intel-mpi
 """
 
-    ws, ws_name = make_workspace(test_config)
+    ws, ws_name = make_workspace_from_config(test_config)
 
     workspace("setup", "--dry-run", global_args=["-w", ws_name])
 

--- a/lib/ramble/ramble/test/end_to_end/vector_workloads.py
+++ b/lib/ramble/ramble/test/end_to_end/vector_workloads.py
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_p
 workspace = RambleCommand("workspace")
 
 
-def test_vector_workloads(make_workspace):
+def test_vector_workloads(make_workspace_from_config):
     test_config = """
 ramble:
   variables:
@@ -40,7 +40,7 @@ ramble:
     packages: {}
     environments: {}
 """
-    ws, ws_name = make_workspace(test_config)
+    ws, ws_name = make_workspace_from_config(test_config)
 
     workspace("setup", "--dry-run", global_args=["-w", ws_name])
 

--- a/lib/ramble/ramble/test/end_to_end/vector_workloads.py
+++ b/lib/ramble/ramble/test/end_to_end/vector_workloads.py
@@ -10,7 +10,6 @@ import os
 
 import pytest
 
-import ramble.workspace
 from ramble.main import RambleCommand
 
 # everything here uses the mock_workspace_path
@@ -19,7 +18,7 @@ pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_p
 workspace = RambleCommand("workspace")
 
 
-def test_vector_workloads(mutable_config, mutable_mock_workspace_path, workspace_name):
+def test_vector_workloads(make_workspace):
     test_config = """
 ramble:
   variables:
@@ -41,20 +40,13 @@ ramble:
     packages: {}
     environments: {}
 """
-    with ramble.workspace.create(workspace_name) as ws:
-        ws.write()
+    ws, ws_name = make_workspace(test_config)
 
-        config_path = os.path.join(ws.config_dir, ramble.workspace.config_file_name)
+    workspace("setup", "--dry-run", global_args=["-w", ws_name])
 
-        with open(config_path, "w+") as f:
-            f.write(test_config)
-        ws._re_read()
-
-        workspace("setup", "--dry-run", global_args=["-w", workspace_name])
-
-        experiment_root = ws.experiment_dir
-        expected_workloads = ["parallel", "serial", "local"]
-        for workload in expected_workloads:
-            exp1_dir = os.path.join(experiment_root, "hostname", workload, "simple_test")
-            exp1_script = os.path.join(exp1_dir, "execute_experiment")
-            assert os.path.isfile(exp1_script)
+    experiment_root = ws.experiment_dir
+    expected_workloads = ["parallel", "serial", "local"]
+    for workload in expected_workloads:
+        exp1_dir = os.path.join(experiment_root, "hostname", workload, "simple_test")
+        exp1_script = os.path.join(exp1_dir, "execute_experiment")
+        assert os.path.isfile(exp1_script)


### PR DESCRIPTION
This aims to reduce duplications in tests, for creating a test workspace.