### PR TITLE
Properly handle builtin registration that returns a single string

### DIFF
--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -1746,6 +1746,8 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                 else:  # All Builtins
                     func = exec_node.attribute
                     func_cmds = func()
+                    if isinstance(func_cmds, str):
+                        func_cmds = [func_cmds]
                     for cmd in func_cmds:
                         expanded = self.expander.expand_var(cmd, exec_vars)
                         self._command_list.append(expanded)

--- a/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
@@ -309,7 +309,7 @@ class Slurm(WorkflowManagerBase):
     )
 
     def capture_sbatch_script_end_time(self):
-        return ["date +%s > {experiment_run_dir}/.slurm_script_end_time"]
+        return "date +%s > {experiment_run_dir}/.slurm_script_end_time"
 
     # Capture slurm configs before the workload runs, just so that the configs
     # match closer when the job is submitted.
@@ -318,9 +318,7 @@ class Slurm(WorkflowManagerBase):
     )
 
     def capture_slurm_config(self):
-        return [
-            "scontrol show config > {experiment_run_dir}/.slurm_config",
-        ]
+        return "scontrol show config > {experiment_run_dir}/.slurm_config"
 
     for fom in ["TopologyParam", "TopologyPlugin"]:
         figure_of_merit(


### PR DESCRIPTION
The prior behavior chunks up the string, as it assumes it's handling a collection instead.