### PR TITLE
Cancel older PR builds for unit-tests

### DIFF
--- a/share/ramble/cloud-build/ramble-pr-unit-tests.yaml
+++ b/share/ramble/cloud-build/ramble-pr-unit-tests.yaml
@@ -6,8 +6,41 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+tags:
+  # This is used for filtering builds related to a specific PR
+  - '$TRIGGER_NAME-$_PR_NUMBER'
+steps: 
+  # Cancel older builds
+  - name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        # Only attempt cancellation for PR builds
+        if [ -z "$_PR_NUMBER" ]; then
+          echo "Skipping build cancellation."
+          exit 0
+        fi
 
-steps:
+        target_tag="${TRIGGER_NAME}-${_PR_NUMBER}"
+
+        echo "Current Build ID: $BUILD_ID"
+        echo "Filtering for tag: $$target_tag in project: $PROJECT_ID"
+
+        builds_to_cancel=$(gcloud builds list \
+          --project="$PROJECT_ID" \
+          --filter="tags='$$target_tag' AND (status=WORKING OR status=QUEUED) AND id!=$BUILD_ID" \
+          --format="value(id)")
+
+        if [ -z "$$builds_to_cancel" ]; then
+          echo "No older builds found to cancel."
+          exit 0
+        fi
+
+        for build in $$builds_to_cancel; do
+          echo "Cancelling obsolete build: $$build"
+          gcloud builds cancel $$build --project="$PROJECT_ID" || echo "Failed to cancel $$build"
+        done
   - name: gcr.io/cloud-builders/git
     args:
       - fetch


### PR DESCRIPTION
For now only add the cancellation for unit-test runs, as other checks finish quite quickly anyway.

Example run:

First build of the PR

```
Current Build ID: 58abaa15-78d2-4a22-8390-6aa834326ce2
Filtering for tag: PR-Unit-Tests-debian12-5-v0-21-2spack-3-12-0python-1378 in project: ramble-eng
No older builds found to cancel.
```

Second build of the same PR

```
Already have image (with digest): gcr.io/cloud-builders/gcloud
Current Build ID: 27fb2195-d71c-445d-9e69-218c213e84ae
Filtering for tag: PR-Unit-Tests-debian12-5-v0-21-2spack-3-12-0python-1378 in project: ramble-eng
Cancelling obsolete build: 58abaa15-78d2-4a22-8390-6aa834326ce2
Cancelled [https://cloudbuild.googleapis.com/v1/projects/ramble-eng/locations/global/builds/58abaa15-78d2-4a22-8390-6aa834326ce2].
```