### PR TITLE
Fix up a doc-build error

### DIFF
--- a/lib/ramble/ramble/cmd/repo.py
+++ b/lib/ramble/ramble/cmd/repo.py
@@ -175,8 +175,8 @@ def repo_add(args):
                     )
         except Exception as e:
             raise ramble.repository.BadRepoError(
-                f"Error reading or parsing {repo_config_name} in '{path}': {e}"
-            )
+                f"Error reading or parsing {repo_config_name} in '{path}'"
+            ) from e
 
         # Now that we have a valid namespace, check for at least one object type directory
         at_least_one_object_type_found = False

--- a/lib/ramble/ramble/test/cmd/repo.py
+++ b/lib/ramble/ramble/test/cmd/repo.py
@@ -9,11 +9,12 @@ import os
 import shutil
 
 import pytest
-import yaml
 
 from ramble.error import RambleCommandError
 from ramble.main import RambleCommand
 from ramble.repository import BadRepoError
+
+import spack.util.spack_yaml as syaml
 
 repo = RambleCommand("repo")
 
@@ -172,7 +173,7 @@ def test_add_repo_missing_config_file(mutable_config, tmpdir):
     # Create a dummy repo.yaml and then remove it to simulate the missing file
     repo_config_file = os.path.join(str(repo_path), "repo.yaml")
     with open(repo_config_file, "w") as f:
-        yaml.dump({"repo": {"namespace": "test_namespace"}}, f)
+        syaml.dump({"repo": {"namespace": "test_namespace"}}, f)
     os.remove(repo_config_file)
 
     with pytest.raises(BadRepoError) as e:  # Catch BadRepoError directly


### PR DESCRIPTION
The rtd build env does not have the yaml module, so use spack_yaml instead.

Also a minor fix from `ruff check` complaint.