### PR TITLE
Allow optionally override an executable

### DIFF
--- a/lib/ramble/docs/configuration_files.rst
+++ b/lib/ramble/docs/configuration_files.rst
@@ -413,6 +413,7 @@ The format of the internals config section is as follows:
           use_mpi: [True/False] # Default: False
           redirect: 'where_to_redirect_output' # Default '{log_file}'
           output_capture: 'operator_to_use_for_redirection' # Default >>
+          force: [True/False] # Default: False
       executables:
       - list of
       - executables
@@ -423,11 +424,12 @@ The format of the internals config section is as follows:
         order: 'before' / 'after' # Default: 'after'
         [relative_to: <relative_executable_name>]
 
-Currently this section has two sub-sections.
+Currently this section has three sub-sections.
 
 The ``custom_executables`` sub-section can be used to define new executables
-that an experiment should use. It can also be used to override the definition
-of an internally defined executable within an experiment.
+that an experiment can use. It can also be used to override the definition
+of an internally defined executable within an experiment, when the ``force``
+property is set to ``True``.
 
 The ``executables`` sub-section can be used to control the order executables
 will be used in the experiment. This is also the mechanism to inject custom

--- a/lib/ramble/ramble/schema/internals.py
+++ b/lib/ramble/ramble/schema/internals.py
@@ -28,6 +28,7 @@ custom_executables_def = {
             "use_mpi": False,
             "redirect": "{log_file}",
             "variables": {},
+            "force": False,
             "output_capture": OUTPUT_CAPTURE.DEFAULT,
         },
         "properties": union_dicts(
@@ -35,6 +36,7 @@ custom_executables_def = {
                 "template": ramble.schema.types.array_or_scalar_of_strings_or_nums,
                 "use_mpi": {"type": "boolean"},
                 "redirect": ramble.schema.types.string_or_num,
+                "force": {"type": "boolean"},
             },
             ramble.schema.variables.properties,
         ),

--- a/lib/ramble/ramble/test/end_to_end/custom_executables.py
+++ b/lib/ramble/ramble/test/end_to_end/custom_executables.py
@@ -11,6 +11,7 @@ import re
 
 import pytest
 
+import ramble.error
 from ramble.main import RambleCommand
 
 # everything here uses the mock_workspace_path
@@ -133,3 +134,61 @@ ramble:
 
         assert custom_found and cmd_found and export_found
         assert all(inject_order_found)
+
+
+def test_executable_already_defined(make_workspace_from_config):
+    test_config = """
+ramble:
+  variables:
+    processes_per_node: 1
+    n_nodes: 1
+  applications:
+    hostname:
+      workloads:
+        local:
+          experiments:
+            test:
+              internals:
+                custom_executables:
+                  local:
+                    template:
+                    - 'hostname-not-overridden'
+"""
+    _, ws_name = make_workspace_from_config(test_config)
+    with pytest.raises(
+        ramble.error.ExecutableNameError, match='an executable "local" is already defined'
+    ):
+        workspace("setup", "--dry-run", global_args=["-w", ws_name])
+
+
+def test_executable_override_with_force(make_workspace_from_config):
+    test_config = """
+ramble:
+  variables:
+    processes_per_node: 1
+    n_nodes: 1
+  applications:
+    hostname:
+      workloads:
+        local:
+          experiments:
+            test:
+              internals:
+                custom_executables:
+                  local:
+                    template:
+                    - 'hostname-overridden'
+                    force: true
+"""
+    ws, ws_name = make_workspace_from_config(test_config)
+    workspace("setup", "--dry-run", global_args=["-w", ws_name])
+
+    experiment_root = ws.experiment_dir
+    exp_dir = os.path.join(experiment_root, "hostname", "local", "test")
+    exp_script = os.path.join(exp_dir, "execute_experiment")
+
+    with open(exp_script) as f:
+        content = f.read()
+        assert "hostname-overridden >>" in content
+        # The old executable should not be included
+        assert "hostname >>" not in content

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -1402,7 +1402,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                 if (
                     name in filtered_executabls
                     or name in self.custom_executables
-                ):
+                ) and not conf.get("force", False):
                     experiment_namespace = self.expander.expand_var_name(
                         "experiment_namespace"
                     )
@@ -1426,10 +1426,11 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             ExecutableGraph: Graph of executables for workload
         """
         self._define_custom_executables()
-        exec_order = self.get_workload(workload_name).executables
         # Use yaml defined executable order, if defined
         if namespace.executables in self.internals:
             exec_order = self.internals[namespace.executables]
+        else:
+            exec_order = self.get_workload(workload_name).executables
 
         builtin_objects = []
         all_builtins = []


### PR DESCRIPTION
The doc previously stated that `custom_executables` can override existing executables, but that's incorrect as re-define was not allowed.
    
Adding a `force` property to `executable`, to allow for such re-definition.
    
Update the docs, also add in a test to describe the current behavior.