### PR TITLE
Fix test errors due to panda 2 -> 3

### DIFF
--- a/lib/ramble/ramble/reports.py
+++ b/lib/ramble/ramble/reports.py
@@ -463,15 +463,15 @@ class PlotGenerator:
         """When using summary statistics from repeats, adds columns fom_value_min and fom_value_max
         to the selected data.
         """
-        min_data.loc[:, scale_var] = to_numeric_if_possible(min_data[scale_var])
+        min_data[scale_var] = to_numeric_if_possible(min_data[scale_var])
         min_data = min_data.set_index(scale_var)
-        max_data.loc[:, scale_var] = to_numeric_if_possible(max_data[scale_var])
+        max_data[scale_var] = to_numeric_if_possible(max_data[scale_var])
         max_data = max_data.set_index(scale_var)
 
-        selected_data.loc[:, ReportVars.FOM_VALUE_MIN.value] = to_numeric_if_possible(
+        selected_data[ReportVars.FOM_VALUE_MIN.value] = to_numeric_if_possible(
             min_data[ReportVars.FOM_VALUE.value]
         )
-        selected_data.loc[:, ReportVars.FOM_VALUE_MAX.value] = to_numeric_if_possible(
+        selected_data[ReportVars.FOM_VALUE_MAX.value] = to_numeric_if_possible(
             max_data[ReportVars.FOM_VALUE.value]
         )
 
@@ -652,10 +652,10 @@ class ScalingPlotGenerator(PlotGenerator):
                 'or fom_origin_type == "modifier" or fom_origin_type == "summary::mean")'
             ).copy()
 
-            series_results.loc[:, ReportVars.FOM_VALUE.value] = to_numeric_if_possible(
+            series_results[ReportVars.FOM_VALUE.value] = to_numeric_if_possible(
                 series_results[ReportVars.FOM_VALUE.value]
             )
-            series_results.loc[:, scale_var] = to_numeric_if_possible(series_results[scale_var])
+            series_results[scale_var] = to_numeric_if_possible(series_results[scale_var])
             series_results = series_results.set_index(scale_var)
 
             self.validate_data(series_results)
@@ -823,11 +823,11 @@ class FomPlot(PlotGenerator):
 
             scale_var = "experiment_namespace"
 
-            series_results.loc[:, ReportVars.FOM_VALUE.value] = to_numeric_if_possible(
+            series_results[ReportVars.FOM_VALUE.value] = to_numeric_if_possible(
                 series_results[ReportVars.FOM_VALUE.value]
             )
 
-            series_results.loc[:, scale_var] = to_numeric_if_possible(series_results[scale_var])
+            series_results[scale_var] = to_numeric_if_possible(series_results[scale_var])
 
             series_results = series_results.set_index(scale_var)
 

--- a/lib/ramble/ramble/test/reports.py
+++ b/lib/ramble/ramble/test/reports.py
@@ -301,8 +301,6 @@ def test_scaling_plots(mutable_mock_workspace_path, tmpdir_factory, values):
     # Update index to match
     ideal_df = ideal_df.set_index("n_nodes")
 
-    ideal_df[["fom_units"]] = ideal_df[["fom_units"]].astype(object)
-
     logx = False
     logy = False
     split_by = "workload_namespace"


### PR DESCRIPTION
panda3 seems to be using stricter typing, so the `as_type(object)` is causing test failure with it. Also update accessing methods to conform with panda3.

The change should work with both panda2 and 3.