### PR TITLE
Remove repo warning based on file path

### DIFF
--- a/lib/ramble/ramble/repository.py
+++ b/lib/ramble/ramble/repository.py
@@ -999,10 +999,6 @@ class Repo:
         )
 
         self.objects_path = os.path.join(self.root, objects_dir)
-        check(
-            os.path.isdir(self.objects_path),
-            f"Objects directory '{self.objects_path}' not found or is not a directory.",
-        )
 
         # Set up 'full_namespace' to include the super-namespace
         self.full_namespace = f"{self.base_namespace}.{self.namespace}"


### PR DESCRIPTION
#1367  made it so "missing" subdirs from a parent can both be added and tolerated incase they are added later, so this warning is no longer appropriate 