### PR TITLE
Stage default var values to allow precedence

### DIFF
--- a/lib/ramble/ramble/test/application.py
+++ b/lib/ramble/ramble/test/application.py
@@ -81,7 +81,7 @@ def test_basic_app(mutable_mock_apps_repo):
     example_input = basic_inst.workloads[_FS]["test_wl"].find_input("input")
     assert example_input is not None
 
-    assert len(basic_inst.workloads[_FS]["test_wl"].variables[_FS]) == 6
+    assert len(basic_inst.workloads[_FS]["test_wl"].variables[_FS]) == 7
     possible_vars = basic_inst.workloads[_FS]["test_wl"].find_variable("my_var")
     assert len(possible_vars) == 1
     assert possible_vars[0].default == "1.0"

--- a/lib/ramble/ramble/test/end_to_end/object_precedence.py
+++ b/lib/ramble/ramble/test/end_to_end/object_precedence.py
@@ -1,0 +1,79 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.error
+import ramble.workspace
+from ramble.main import RambleCommand
+
+pytestmark = pytest.mark.usefixtures(
+    "mutable_config",
+    "mutable_mock_workspace_path",
+    "mutable_mock_apps_repo",
+    "mutable_mock_mods_repo",
+    "mutable_mock_pkg_mans_repo",
+    "mutable_mock_wms_repo",
+)
+
+workspace = RambleCommand("workspace")
+
+
+@pytest.mark.parametrize(
+    "test_args,disabled_value,enabled_value",
+    [
+        (
+            ["--wm", "when-workflow-manager"],
+            "object_precedence_var from application",
+            "object_precedence_var from workflow_manager",
+        ),
+    ],
+)
+def test_object_precedence_variables(workspace_name, test_args, disabled_value, enabled_value):
+    global_args = ["-w", workspace_name]
+
+    ws = ramble.workspace.create(workspace_name)
+    workspace(
+        "manage",
+        "experiments",
+        "basic",
+        "-v",
+        "n_nodes=3",
+        "-v",
+        "processes_per_node=1",
+        "-v",
+        "batch_submit={execute_experiment}",
+        "--wf",
+        "test_wl",
+        *test_args,
+        global_args=global_args,
+    )
+
+    with open(os.path.join(ws.config_dir, "test.tpl"), "w+") as f:
+        f.write("{object_precedence_var}")
+
+    variants_file = os.path.join(ws.config_dir, "variants.yaml")
+    test_file = os.path.join(ws.experiment_dir, "basic", "test_wl", "generated", "test")
+
+    workspace("setup", "--dry-run", global_args=global_args)
+
+    with open(test_file) as f:
+        assert disabled_value in f.read()
+
+    with open(variants_file, "w+") as f:
+        f.write(
+            """variants:
+  set_precedence_var: True"""
+        )
+
+    workspace("setup", "--dry-run", global_args=global_args)
+
+    with open(test_file) as f:
+        assert enabled_value in f.read()

--- a/var/ramble/repos/builtin.mock/applications/basic/application.py
+++ b/var/ramble/repos/builtin.mock/applications/basic/application.py
@@ -75,6 +75,13 @@ class Basic(ExecutableApplication):
         },
     )
 
+    workload_variable(
+        "object_precedence_var",
+        default="object_precedence_var from application",
+        description="Variable to exercise object precedence",
+        workloads=["*"],
+    )
+
     environment_variable(
         "TEST_ENV", value="1", description="test var", workload="test_wl"
     )

--- a/var/ramble/repos/builtin.mock/workflow_managers/info/workflow_manager.py
+++ b/var/ramble/repos/builtin.mock/workflow_managers/info/workflow_manager.py
@@ -92,7 +92,7 @@ class Info(WorkflowManagerBase):
 
     register_builtin("builtin_name", required=True)
 
-    def builtin_name():
+    def builtin_name(self):
         return ['echo "builtin"']
 
     register_phase(

--- a/var/ramble/repos/builtin.mock/workflow_managers/when-workflow-manager/workflow_manager.py
+++ b/var/ramble/repos/builtin.mock/workflow_managers/when-workflow-manager/workflow_manager.py
@@ -65,6 +65,20 @@ class WhenWorkflowManager(WorkflowManagerBase):
         when=["+wf_man_required_key"],
     )
 
+    variant(
+        "set_precedence_var",
+        default=False,
+        values=[True, False],
+        description="Variant to control the value of object_precedence_var",
+    )
+
+    with when("+set_precedence_var"):
+        workflow_manager_variable(
+            "object_precedence_var",
+            default="object_precedence_var from workflow_manager",
+            description="Variable to exercise object precedence",
+        )
+
     def get_status(self, workspace):
         """Return status of a given job"""
         return None

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -664,10 +664,11 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         """Iterate over missing variable definitions, and add them until there
         are no more to add."""
 
+        default_variables = {}
         # Process the application variables that are missing
         for var, val in self.selected_variables.items():
             if var not in self.variables:
-                self.define_variable(var, val.default)
+                default_variables[var] = val.default
 
         # Extract a merged set of when_keys from objects that are not
         # applications.
@@ -691,6 +692,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
         while True:
             to_define = {}
+            changed_definitions = False
             # Process any missing variables from other objects
             for obj, when_keys in object_when_map.items():
                 to_remove = set()
@@ -700,17 +702,21 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                         for var in obj.object_variables[when_key]:
                             if var.name not in self.variables:
                                 to_define[var.name] = var.default
+                                changed_definitions = True
 
                 # Remove any satisfied when_keys, as we won't need to check
                 # them (since their variables have already been defined).
                 for when_key in to_remove:
                     when_keys.remove(when_key)
 
-            if not to_define:
+            if not changed_definitions:
                 break
 
             for var, val in to_define.items():
-                self.define_variable(var, val)
+                default_variables[var] = val
+
+        for var, val in default_variables.items():
+            self.define_variable(var, val)
 
     def set_internals(self, internals):
         """Set internal reference to application internals"""


### PR DESCRIPTION
This merge changes way missing variables are defined, by staging them into a default_variables dict. This allows more complex / higher precedence definitions to override lower precedence ones (when they come from object definitions).

Config file defined variables still override any object definitions.