### PR TITLE
Update docs for issues found by Gemini

### DIFF
--- a/lib/ramble/docs/configuration_files.rst
+++ b/lib/ramble/docs/configuration_files.rst
@@ -275,10 +275,10 @@ the set of repeats. Its format is as follows:
 
     config:
       n_repeats: 'int'
-      repeats_success_strict: [True/False]
+      repeat_success_strict: [True/False]
 
 By default, a set of repeats is successful if all individual repeats are successful.
-When ``repeats_success_strict`` is set to false, the set will be considered successful
+When ``repeat_success_strict`` is set to false, the set will be considered successful
 if any repeat succeeds, and statistics will be calculated over the successful experiments
 only.
 

--- a/lib/ramble/docs/configuration_files.rst
+++ b/lib/ramble/docs/configuration_files.rst
@@ -178,7 +178,7 @@ The current default configuration is as follows:
           flags: ''
         env_create:
           flags: ''
-        global
+        global:
           flags: ''
         env_view:
           link_type: 'symlink'

--- a/lib/ramble/docs/success_criteria.rst
+++ b/lib/ramble/docs/success_criteria.rst
@@ -132,8 +132,9 @@ Mode: String
 
 Success criteria with ``mode='string'`` allow experiments to define expected
 string regular expression matching. This criteria mode is useful if an
-application prints a string whenever it successfully completes. Defining these
-criteria within a workspace configuration file is as follows:
+application prints a string whenever it successfully completes, or if it
+prints an error message when it fails. Defining these criteria within a
+workspace configuration file is as follows:
 
 .. code-block:: yaml
 
@@ -141,16 +142,25 @@ criteria within a workspace configuration file is as follows:
     - name: my_criteria
       mode: 'string'
       match: '\s+Completed\s+'
-      [file: '{log_file}]
+      [file: '{log_file}']
 
 
-The above shows the full interface for degining success criteria with
+The above shows the full interface for defining success criteria with
 ``mode='string'``. The available attributes are:
 
 * ``name``: The name of the specific criteria.
 * ``mode``: The mode of the specific criteria.
-* ``match``: The regular expression used to test for success.
-* ``file``: (Optional) The file (or variable that refers to a file) to test for the ``match`` in.
+* ``match``: The regular expression used to test for success. If this is found
+  the criteria is marked as a success.
+* ``anti_match``: The regular expression used to test for failure. If this is
+  found the criteria is marked as a failure.
+* ``file``: (Optional) The file (or variable that refers to a file) to test
+  for the ``match`` or ``anti_match`` in.
 
-If ``match`` is found inside ``file`` this criteria is marked as success. If it
-is not found, then the criteria is marked as failed.
+Note that ``match`` and ``anti_match`` are mutually exclusive.
+
+If ``match`` is used, and found inside ``file`` this criteria is marked as
+success. If it is not found, then the criteria is marked as failed.
+
+If ``anti_match`` is used, and found inside ``file`` this criteria is marked as
+failed. If it is not found, then the criteria is marked as success.

--- a/lib/ramble/docs/workspace_config.rst
+++ b/lib/ramble/docs/workspace_config.rst
@@ -545,7 +545,7 @@ level.
     ramble:
       config:
         n_repeats: int
-        repeats_success_strict: [True/False]
+        repeat_success_strict: [True/False]
       applications:
         hostname:
           n_repeats: int

--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -113,6 +113,7 @@ supported_math_operators = {
     ast.BitAnd: operator.and_,
     ast.BitOr: operator.or_,
     ast.BitXor: operator.xor,
+    ast.Invert: operator.invert,
     ast.LShift: operator.lshift,
     ast.RShift: operator.rshift,
 }

--- a/lib/ramble/ramble/test/expander.py
+++ b/lib/ramble/ramble/test/expander.py
@@ -133,6 +133,8 @@ def build_variant_set():
         ("0b10 & 0b01", "0", set(), 1),
         ("0b10 | 0b01", "3", set(), 1),
         ("0b10 ^ 0b01", "3", set(), 1),
+        ("~0", "-1", set(), 1),
+        ("~2", "-3", set(), 1),
         ("0b10 << 1", "4", set(), 1),
         ("0b10 >> 1", "1", set(), 1),
         # Can be a handy way to select experiments to run
@@ -212,6 +214,8 @@ def test_expansions(input, output, no_expand_vars, passes):
         ("2 or 1", 2, set(), 1),
         ("randrange(2, 3, 1)", 2, set(), 1),
         ("randint(3, 3)", 3, set(), 1),
+        ("~0", -1, set(), 1),
+        ("~2", -3, set(), 1),
     ],
 )
 def test_typed_expansions(input, output, no_expand_vars, passes):


### PR DESCRIPTION
Address several issues pointed out by Gemini:

* The missing bit-not expander support
* The missing documentation on `anti_match`
* The wrong `repeats_success_strict` name
* An invalid yaml config due to missing `:`