### PR TITLE
Use chainmap for updating variables

### DIFF
--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -7,6 +7,7 @@
 # except according to those terms.
 
 import ast
+import collections
 import itertools
 import math
 import operator
@@ -687,10 +688,11 @@ class Expander:
         logger.debug(f"BEGINNING OF EXPAND_VAR STACK ON {var}")
         logger.debug(f" REPLACE VAR (1): {replace_escaped_braces}")
         logger.debug(f" REPLACE VAR (2): {self._replace_escaped_braces}")
-        expansions = self._variables
+
         if extra_vars:
-            expansions = self._variables.copy()
-            expansions.update(extra_vars)
+            expansions = collections.ChainMap(extra_vars, self._variables)
+        else:
+            expansions = self._variables
 
         try:
             value = self._partial_expand(


### PR DESCRIPTION
`Chainmap` is designed to replace the use of "copy, then update": https://docs.python.org/3/library/collections.html#chainmap-objects

From local benchmarking, when the set of variables is large (>1000), this change gives a good speed up of 30% on variable expansion.