### PR TITLE
Speed up tests by using a mock spack runner

### DIFF
--- a/lib/ramble/ramble/test/end_to_end/package_manager_provenance.py
+++ b/lib/ramble/ramble/test/end_to_end/package_manager_provenance.py
@@ -7,11 +7,14 @@
 # except according to those terms.
 
 import os
+from unittest.mock import patch
 
 import pytest
 
 import ramble.workspace
 from ramble.main import RambleCommand
+from ramble.pkg_man.builtin import spack_lightweight
+from ramble.test.mock_spack_runner import MockSpackRunner
 
 pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_path")
 
@@ -42,58 +45,59 @@ def test_spack_package_manager_provenance_zlib(mock_applications, workspace_name
     with open(os.path.join(aux_dir, "config.yaml"), "w") as f:
         f.write(spack_config)
 
-    workspace("concretize", global_args=global_args)
+    with patch.object(spack_lightweight, "SpackRunner", return_value=MockSpackRunner()):
+        workspace("concretize", global_args=global_args)
 
-    workspace("setup", global_args=global_args)
+        workspace("setup", global_args=global_args)
 
-    spack_yaml = os.path.join(ws.software_dir, pm, "zlib", "spack.yaml")
-    spack_lock = os.path.join(ws.software_dir, pm, "zlib", "spack.lock")
+        spack_yaml = os.path.join(ws.software_dir, pm, "zlib", "spack.yaml")
+        spack_lock = os.path.join(ws.software_dir, pm, "zlib", "spack.lock")
 
-    assert os.path.isfile(spack_yaml)
+        assert os.path.isfile(spack_yaml)
 
-    with open(spack_yaml) as f:
-        data = f.read()
-        assert "- zlib" in data
+        with open(spack_yaml) as f:
+            data = f.read()
+            assert "- zlib" in data
 
-    assert os.path.isfile(spack_lock)
+        assert os.path.isfile(spack_lock)
 
-    with open(spack_lock) as f:
-        data = f.read()
-        assert '"spec":"zlib"' in data
+        with open(spack_lock) as f:
+            data = f.read()
+            assert '"spec":"zlib"' in data
 
-    out_log = os.path.join(
-        ws.experiment_dir, "zlib", "ensure_installed", "generated", "generated.out"
-    )
+        out_log = os.path.join(
+            ws.experiment_dir, "zlib", "ensure_installed", "generated", "generated.out"
+        )
 
-    with open(out_log, "w+") as f:
-        f.write("libz.so.2\n")
+        with open(out_log, "w+") as f:
+            f.write("libz.so.2\n")
 
-    workspace("analyze", global_args=global_args)
+        workspace("analyze", global_args=global_args)
 
-    results_file = os.path.join(ws.root, "results.latest.txt")
-    assert os.path.isfile(results_file)
+        results_file = os.path.join(ws.root, "results.latest.txt")
+        assert os.path.isfile(results_file)
 
-    with open(results_file) as f:
-        data = f.read()
-        assert "Software definitions" in data
-        assert "spack packages:" in data
-        assert "zlib @" in data
+        with open(results_file) as f:
+            data = f.read()
+            assert "Software definitions" in data
+            assert "spack packages:" in data
+            assert "zlib @" in data
 
-    workspace("analyze", "-f", "json", global_args=global_args)
+        workspace("analyze", "-f", "json", global_args=global_args)
 
-    results_file = os.path.join(ws.root, "results.latest.json")
-    assert os.path.isfile(results_file)
+        results_file = os.path.join(ws.root, "results.latest.json")
+        assert os.path.isfile(results_file)
 
-    with open(results_file) as f:
-        import json
+        with open(results_file) as f:
+            import json
 
-        data = json.load(f)
-        for d in data["experiments"]:
-            pkg_list = d["SOFTWARE"]["spack"]
-            names = [pkg["name"] for pkg in pkg_list]
-            assert "SOFTWARE" in d
-            assert "spack" in d["SOFTWARE"]
-            assert "zlib" in names
+            data = json.load(f)
+            for d in data["experiments"]:
+                pkg_list = d["SOFTWARE"]["spack"]
+                names = [pkg["name"] for pkg in pkg_list]
+                assert "SOFTWARE" in d
+                assert "spack" in d["SOFTWARE"]
+                assert "zlib" in names
 
 
 def test_usermanged_package_manager_provenance_zlib(mock_applications, workspace_name):

--- a/lib/ramble/ramble/test/mock_spack_runner.py
+++ b/lib/ramble/ramble/test/mock_spack_runner.py
@@ -1,0 +1,109 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+
+class MockPackageInfo:
+    def __init__(self, data):
+        self.data = data
+
+    def to_dict(self):
+        return self.data
+
+    def to_version_text(self):
+        return f"{self.data.get('name', 'unknown')} @{self.data.get('version', 'unknown')}"
+
+
+class MockSpackRunner:
+    def __init__(self):
+        self.env_path = None
+        self.concretized = False
+        self.dry_run = False
+
+    def set_env(self, env_path, require_exists=True):
+        self.env_path = env_path
+
+    def set_dry_run(self, dry_run):
+        self.dry_run = dry_run
+
+    def set_compiler_config_dir(self, path):
+        pass
+
+    def activate(self):
+        pass
+
+    def deactivate(self):
+        pass
+
+    def concretize(self):
+        if not self.env_path:
+            return
+
+        # write dummy spack.yaml and spack.lock
+        spack_yaml = os.path.join(self.env_path, "spack.yaml")
+        with open(spack_yaml, "w") as f:
+            f.write("specs:\n  - zlib\n")
+
+        spack_lock = os.path.join(self.env_path, "spack.lock")
+        with open(spack_lock, "w") as f:
+            f.write('{"roots": [{"spec":"zlib"}]}')
+
+        self.concretized = True
+
+    def package_provenance(self):
+        return [MockPackageInfo({"name": "zlib", "version": "1.2.11"})]
+
+    def get_version(self):
+        return "0.0.0"
+
+    def generate_source_command(self):
+        return ["echo 'source spack'"]
+
+    def generate_activate_command(self):
+        return ["echo 'activate spack'"]
+
+    def generate_deactivate_command(self):
+        return ["echo 'deactivate spack'"]
+
+    def configure_env(self, env_path):
+        pass
+
+    def inventory_hash(self):
+        return "dummy_hash"
+
+    def package_definitions(self):
+        return []
+
+    def create_env(self, env_path):
+        if not os.path.exists(env_path):
+            os.makedirs(env_path)
+
+    def add_config(self, config):
+        pass
+
+    def add_include_file(self, path):
+        pass
+
+    def copy_from_external_env(self, env):
+        pass
+
+    def add_spec(self, spec):
+        pass
+
+    def generate_env_file(self):
+        pass
+
+    def added_packages(self):
+        return []
+
+    def install(self):
+        pass
+
+    def get_package_path(self, spec):
+        return "zlib", "/path/to/zlib"

--- a/lib/ramble/ramble/test/uploader.py
+++ b/lib/ramble/ramble/test/uploader.py
@@ -15,6 +15,8 @@ import ramble.config
 import ramble.pipeline
 import ramble.workspace
 from ramble.main import RambleCommand
+from ramble.pkg_man.builtin import spack_lightweight
+from ramble.test.mock_spack_runner import MockSpackRunner
 from ramble.uploader import BigQueryUploader, ConfigError, upload_results
 
 pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_path")
@@ -42,7 +44,6 @@ def test_upload_results_errs(upload_uri, upload_type, results, expected_err_msg)
 @pytest.mark.maybeslow
 def test_data_preparation(request, mock_applications):
     ws_name = request.node.name
-
     global_args = ["-w", ws_name]
 
     app_name = "zlib"
@@ -65,19 +66,21 @@ def test_data_preparation(request, mock_applications):
             "processes_per_node=1",
             global_args=global_args,
         )
-        workspace("concretize", global_args=global_args)
-        workspace("setup", global_args=global_args)
 
-        filters = ramble.filters.Filters()
-        ap = ramble.pipeline.AnalyzePipeline(ws, filters)
-        ap._prepare()
-        ap._execute()
+        with patch.object(spack_lightweight, "SpackRunner", return_value=MockSpackRunner()):
+            workspace("concretize", global_args=global_args)
+            workspace("setup", global_args=global_args)
 
-        formatted_data = ramble.uploader.format_data(ws.results)
-        uri = "not_used_in_test"
-        exp_table_id, exps_to_insert, fom_table_id, foms_to_insert = ramble.uploader._prepare_data(
-            formatted_data, uri
-        )
+            filters = ramble.filters.Filters()
+            ap = ramble.pipeline.AnalyzePipeline(ws, filters)
+            ap._prepare()
+            ap._execute()
+
+            formatted_data = ramble.uploader.format_data(ws.results)
+            uri = "not_used_in_test"
+            exp_table_id, exps_to_insert, fom_table_id, foms_to_insert = (
+                ramble.uploader._prepare_data(formatted_data, uri)
+            )
 
 
 @patch("google.cloud.bigquery.Client")


### PR DESCRIPTION
The provenance test can take beyond 50s, mostly spending time in spack calls. Now it gets down to 1s on my machine. Similar speedup for the uploader test.