### PR TITLE
Fix the fom regex for bus bw and oob values for nccl test

### DIFF
--- a/var/ramble/repos/builtin/applications/nccl-tests/application.py
+++ b/var/ramble/repos/builtin/applications/nccl-tests/application.py
@@ -170,13 +170,13 @@ class NcclTests(ExecutableApplication):
 
     figure_of_merit(
         "Avg. Bus Bandwidth",
-        fom_regex=r"\s*Avg bus bandwidth\s+:\s+(?P<bw>[0-9]+\.?[0-9]+)",
+        fom_regex=r".*Avg bus bandwidth\s+:\s+(?P<bw>[0-9]+\.?[0-9]+)",
         group_name="bw",
         units="GB/s",
     )
     figure_of_merit(
         "Out of bounds values",
-        fom_regex=r"\s*Out of bounds values\s*:\s+(?P<count>[0-9]+)",
+        fom_regex=r".*Out of bounds values\s*:\s+(?P<count>[0-9]+)",
         group_name="count",
         units="",
     )


### PR DESCRIPTION
The defined fom regex fails to capture when the log lines has non whitespace characters. NCCL test prefix '#' in the log lines for bus bw and oob values

Before
```
import re
old_regex=r"\s*Avg bus bandwidth\s+:\s+(?P<bw>[0-9]+\.?[0-9]+)"
lines = ["# Avg bus bandwidth    : 83.1069", "Avg bus bandwidth    : 83.1069"]; 
for line in lines:
    match = re.match(old_regex, line)
    print(f"Line: {line}\nMatch: {match.groupdict() if match else None}\n")
```

Output
Line: # Avg bus bandwidth    : 83.1069
Match: None

Line: Avg bus bandwidth    : 83.1069
Match: {'bw': '83.1069'}

After

```
import re
new_regex=r".*Avg bus bandwidth\s+:\s+(?P<bw>[0-9]+\.?[0-9]+)"
lines = ["# Avg bus bandwidth    : 83.1069", "Avg bus bandwidth    : 83.1069", "[INFO] Avg bus bandwidth : 83.1069", " Some random prefix Avg bus bandwidth : 83.1069"]; 
for line in lines:
    match = re.match(new_regex, line)
    print(f"Line: {line}\nMatch: {match.groupdict() if match else None}\n")
```

Output

Line: # Avg bus bandwidth    : 83.1069
Match: {'bw': '83.1069'}

Line: Avg bus bandwidth    : 83.1069
Match: {'bw': '83.1069'}

Line: [INFO] Avg bus bandwidth : 83.1069
Match: {'bw': '83.1069'}

Line:  Some random prefix Avg bus bandwidth : 83.1069
Match: {'bw': '83.1069'}
