### PR TITLE
Select baseline commit for codecov

### DIFF
--- a/share/ramble/cloud-build/ramble-pr-unit-tests.yaml
+++ b/share/ramble/cloud-build/ramble-pr-unit-tests.yaml
@@ -95,6 +95,8 @@ steps:
     - 'COMMIT_SHA=$_COMMIT_SHA'
     - 'CODECOV_TOKEN=$_CODECOV_TOKEN'
     - 'PUSH_CODECOV=$_PUSH_CODECOV'
+    - 'BASE_BRANCH=$_BASE_BRANCH'
+    - 'PR_NUMBER=$_PR_NUMBER'
 substitutions:
   _SPACK_REF: v0.21.2
   _PYTHON_VER: 3.11.6

--- a/share/ramble/qa/run-unit-tests
+++ b/share/ramble/qa/run-unit-tests
@@ -81,7 +81,25 @@ if [[ "$PUSH_CODECOV" ]]; then
   if [[ -z "$COMMIT_SHA" ]]; then
     export COMMIT_SHA=`git -C $(dirname $0) log -n 1 --format="%H"`
   fi
+
+  DEFAULT_BASE_BRANCH="develop"
+  TARGET_BRANCH=${BASE_BRANCH:-$DEFAULT_BASE_BRANCH}
+
+  echo "Comparing against base branch: origin/$TARGET_BRANCH"
+
+  # Calculate merge base against origin/$TARGET_BRANCH
+  MERGE_BASE_SHA=`git merge-base HEAD origin/$TARGET_BRANCH`
+  
   echo "Processing codecov upload for commit $COMMIT_SHA"
+
+  if [[ -n "$MERGE_BASE_SHA" ]]; then
+    echo "Picking PR base: $MERGE_BASE_SHA"
+    if [[ -n "$PR_NUMBER" ]]; then
+      codecovcli pr-base-picking --base-sha $MERGE_BASE_SHA --pr $PR_NUMBER --slug "GoogleCloudPlatform/ramble"
+    else
+      echo "Skipping pr-base-picking: PR_NUMBER not set"
+    fi
+  fi
 
   codecovcli upload-process -C $COMMIT_SHA
 fi

--- a/share/ramble/qa/run-unit-tests
+++ b/share/ramble/qa/run-unit-tests
@@ -88,7 +88,7 @@ if [[ "$PUSH_CODECOV" ]]; then
   echo "Comparing against base branch: origin/$TARGET_BRANCH"
 
   # Calculate merge base against origin/$TARGET_BRANCH
-  MERGE_BASE_SHA=`git merge-base HEAD origin/$TARGET_BRANCH`
+  MERGE_BASE_SHA=$(git merge-base HEAD "origin/$TARGET_BRANCH" || echo "")
   
   echo "Processing codecov upload for commit $COMMIT_SHA"
 


### PR DESCRIPTION
The default selection logic from codecov seems to be to "find the closest ancestor to the PR commit", which can be problematic when there are multiple commits for a PR.