### PR TITLE
Improve experiment render performance

### DIFF
--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -11,6 +11,7 @@ import itertools
 import os
 import sys
 import tempfile
+from collections import defaultdict
 from typing import Callable, Dict
 
 import llnl.util.tty as tty
@@ -794,8 +795,6 @@ def workspace_info(args):
     color.cprint(rucolor.section_title("Experiments:"))
 
     # Build an index of experiments to avoid re-rendering them in the loops below
-    from collections import defaultdict
-
     experiment_index_map = defaultdict(list)
     for exp_name, app_inst, _ in experiment_set.all_experiments():
         key = (

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -792,26 +792,30 @@ def workspace_info(args):
     all_pipelines = {}
     color.cprint("")
     color.cprint(rucolor.section_title("Experiments:"))
+
+    # Build an index of experiments to avoid re-rendering them in the loops below
+    from collections import defaultdict
+
+    experiment_index_map = defaultdict(list)
+    for exp_name, app_inst, _ in experiment_set.all_experiments():
+        key = (
+            app_inst.variables[app_inst.keywords.application_name],
+            app_inst.variables[app_inst.keywords.workload_template_name],
+            app_inst.variables[app_inst.keywords.experiment_template_name],
+        )
+        experiment_index_map[key].append(exp_name)
+
+    # Construct filters here...
+    filters = ramble.filters.Filters(
+        phase_filters=[],
+        include_where_filters=args.where,
+        exclude_where_filters=args.exclude_where,
+        tags=args.filter_tags,
+    )
+
     for workloads, application_context in ws.all_applications():
         for experiments, workload_context in ws.all_workloads(workloads):
             for _, experiment_context in ws.all_experiments(experiments):
-                print_experiment_set = ramble.experiment_set.ExperimentSet(ws)
-                print_experiment_set.set_application_context(application_context)
-                print_experiment_set.set_workload_context(workload_context)
-                print_experiment_set.set_experiment_context(experiment_context)
-                print_experiment_set.build_experiment_chains()
-
-                # Reindex the experiments in the print set to match the overall set
-                for exp_name, print_app_inst, _ in print_experiment_set.all_experiments():
-                    app_inst = experiment_set.get_experiment(exp_name)
-                    experiment_index = app_inst.expander.expand_var_name(
-                        app_inst.keywords.experiment_index
-                    )
-
-                    print_app_inst.define_variable(
-                        print_app_inst.keywords.experiment_index, experiment_index
-                    )
-
                 print_header = True
                 # Define variable printing groups.
                 var_indent = "        "
@@ -825,16 +829,42 @@ def workspace_info(args):
                 header_base = rucolor.nested_4("Variables from")
                 config_vars = ramble.config.config.get("config:variables")
 
-                # Construct filters here...
-                filters = ramble.filters.Filters(
-                    phase_filters=[],
-                    include_where_filters=args.where,
-                    exclude_where_filters=args.exclude_where,
-                    tags=args.filter_tags,
+                # Retrieve experiments from index
+                key = (
+                    application_context.context_name,
+                    workload_context.context_name,
+                    experiment_context.context_name,
                 )
+                matching_experiments = experiment_index_map.get(key, [])
 
-                for exp_name, _, _ in print_experiment_set.filtered_experiments(filters):
+                for exp_name in matching_experiments:
                     app_inst = experiment_set.get_experiment(exp_name)
+
+                    # Apply filters manually since we are iterating a raw list
+                    active = True
+                    if filters.include_where:
+                        for expression in filters.include_where:
+                            if not app_inst.expander.evaluate_predicate(expression):
+                                active = False
+                                break
+                    if not active:
+                        continue
+
+                    if filters.exclude_where:
+                        for expression in filters.exclude_where:
+                            if app_inst.expander.evaluate_predicate(expression):
+                                active = False
+                                break
+                    if not active:
+                        continue
+
+                    if filters.tags:
+                        if not app_inst.has_tags(filters.tags):
+                            active = False
+
+                    if not active:
+                        continue
+
                     if app_inst.package_manager is not None:
                         software_environments.render_environment(
                             app_inst.expander.expand_var("{env_name}"),

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -540,9 +540,11 @@ class ExperimentSet:
         tracking_group.used_variables = set()
 
         used_variables: Set[str] = set()
-        for tracking_vars, _ in renderer.render_objects(
+        tracking_gen = renderer.render_objects(
             tracking_group, exclude_where=exclude_where, ignore_used=False, fatal=False
-        ):
+        )
+        try:
+            tracking_vars, _ = next(tracking_gen)
             exp_used_variables = self._get_used_variables(
                 workload_template_name,
                 experiment_template_name,
@@ -550,6 +552,22 @@ class ExperimentSet:
                 final_context,
             )
             used_variables = used_variables.union(exp_used_variables)
+        except StopIteration:
+            pass
+
+        if exclude_where:
+            temp_vars = final_context.variables.copy()
+            if "tracking_vars" in locals():
+                temp_vars.update(tracking_vars)
+
+            temp_expander = ramble.expander.Expander(temp_vars, self)
+            for where in exclude_where:
+                try:
+                    temp_expander.expand_var(where)
+                except ramble.error.RambleError:
+                    pass
+            used_variables.update(temp_expander._used_variables)
+
         render_group.used_variables = used_variables.copy()
 
         workload_names = set()

--- a/lib/ramble/ramble/renderer.py
+++ b/lib/ramble/ramble/renderer.py
@@ -292,6 +292,7 @@ class Renderer:
                     cur_zip["vars"][var_name] = object_variables[var_name]
                     del object_variables[var_name]
 
+        matrix_generator = None
         if matrices:
             """Matrix syntax is:
             matrix:
@@ -349,6 +350,7 @@ class Renderer:
                         matrix_size = matrix_size * zip_len
                         vectors.append(idx_vector)
                         variable_names.append(var)
+                        consumed_zips.add(var)
                     else:
                         err_context = object_variables[render_group.context]
                         logger.die(
@@ -369,26 +371,51 @@ class Renderer:
                 matrix_vectors.append(vectors)
                 matrix_variables.append(variable_names)
 
-            # Create the empty initial dictionairies
-            matrix_objects = []
-            for _ in range(matrix_size):
-                matrix_objects.append({})
-
             # Generate all of the obj var dicts
-            for names, vectors in zip(matrix_variables, matrix_vectors):
-                for obj_idx, entry in enumerate(itertools.product(*vectors)):
-                    for name_idx, name in enumerate(names):
-                        if name in defined_zips.keys():
-                            # Replace the zip name with the constituent variables
-                            for zip_var in defined_zips[name]["vars"]:
-                                matrix_objects[obj_idx][zip_var] = defined_zips[name]["vars"][
-                                    zip_var
-                                ][entry[name_idx]]
+            matrix_product_iters = [itertools.product(*vectors) for vectors in matrix_vectors]
 
-                            # Consume the defined zip
-                            consumed_zips.add(name)
-                        else:
-                            matrix_objects[obj_idx][name] = entry[name_idx]
+            # Prepare fast mapping data
+            matrix_col_maps = []
+            for names in matrix_variables:
+                col_map = []
+                for name_idx, name in enumerate(names):
+                    if name in defined_zips:
+                        # It's a zip
+                        zip_info = defined_zips[name]
+                        col_map.append(
+                            {
+                                "type": "zip",
+                                "vars": zip_info["vars"],  # dict of var -> list of values
+                            }
+                        )
+                    else:
+                        col_map.append({"type": "var", "name": name})
+                matrix_col_maps.append(col_map)
+
+            def _matrix_generator_func():
+                for entry_tuple in zip(*matrix_product_iters):
+                    obj = {}
+                    for mat_idx, entry in enumerate(entry_tuple):
+                        col_map = matrix_col_maps[mat_idx]
+                        for name_idx, val in enumerate(entry):
+                            # entry is a tuple of indices or values?
+                            # Wait, vectors contained:
+                            # if var in object_variables:
+                            #    vectors.append(object_variables[var]) -> values
+                            # if var in defined_zips: vectors.append(idx_vector) -> indices
+
+                            info = col_map[name_idx]
+                            if info["type"] == "zip":
+                                # val is an index
+                                idx = val
+                                for zip_var, zip_vals in info["vars"].items():
+                                    obj[zip_var] = zip_vals[idx]
+                            else:
+                                # val is the value
+                                obj[info["name"]] = val
+                    yield obj
+
+            matrix_generator = _matrix_generator_func()
 
         # Remove all consumed zips and return all remaining zipped variables
         # back to real vector definitions
@@ -429,6 +456,9 @@ class Renderer:
                     err_str += f"\tVariable {var} has length {len(val)}\n"
                 logger.die(err_str)
 
+            # Materialize matrix objects if we have vector vars
+            matrix_objects = list(matrix_generator) if matrix_generator else None
+
             # Iterate over the vector length, and set the value in the
             # object dict to the index value.
             for i in range(0, max_vector_size):
@@ -439,30 +469,34 @@ class Renderer:
 
                 if matrix_objects:
                     for matrix_object in matrix_objects:
-                        for var, val in matrix_object.items():
-                            obj_vars[var] = val
-
-                        new_objects.append(obj_vars.copy())
+                        # Combine vector vars with matrix object
+                        # Matrix object overrides vector vars if collision
+                        # (though collision shouldn't happen)
+                        combined = obj_vars.copy()
+                        combined.update(matrix_object)
+                        new_objects.append(combined)
                 else:
                     new_objects.append(obj_vars.copy())
 
-        elif matrix_objects:
-            new_objects = matrix_objects
+        elif matrix_generator:
+            # If no vector vars, use generator directly
+            new_objects = matrix_generator
         else:
             # Ensure at least one object is rendered, if everything was a scalar
-            new_objects.append({})
+            new_objects = [{}]
 
         where_expander = ramble.expander.Expander(object_variables, None)
 
         for obj in new_objects:
             logger.debug(f"Rendering {render_group.object}:")
-            for var, val in obj.items():
-                object_variables[var] = val
+
+            # Avoid mutating object_variables
+            # Use extra_vars for evaluation
 
             keep_object = True
             if exclude_where:
                 for where in exclude_where:
-                    evaluated = where_expander.expand_var(where)
+                    evaluated = where_expander.expand_var(where, extra_vars=obj)
                     if evaluated == "True":
                         keep_object = False
                         break
@@ -472,7 +506,11 @@ class Renderer:
                 repeats = ramble.repeats.Repeats()
                 if n_repeats > 0:
                     repeats.set_repeats(True, n_repeats)
-                yield object_variables.copy(), repeats
+
+                # Merge object_variables and obj
+                # object_variables contains the base variables
+                # obj contains the specific variables for this iteration
+                yield {**object_variables, **obj}, repeats
 
 
 class RambleRendererError(ramble.error.RambleError):

--- a/lib/ramble/ramble/renderer.py
+++ b/lib/ramble/ramble/renderer.py
@@ -496,7 +496,7 @@ class Renderer:
             keep_object = True
             if exclude_where:
                 for where in exclude_where:
-                    evaluated = where_expander.expand_var(where, extra_vars=obj)
+                    evaluated = where_expander.expand_var(where)
                     if evaluated == "True":
                         keep_object = False
                         break

--- a/lib/ramble/ramble/test/end_to_end/many_experiments.py
+++ b/lib/ramble/ramble/test/end_to_end/many_experiments.py
@@ -1,0 +1,54 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import pytest
+
+import ramble.workspace
+from ramble.main import RambleCommand
+
+# everything here uses the mock_workspace_path
+pytestmark = pytest.mark.usefixtures(
+    "mutable_config",
+    "mutable_mock_workspace_path",
+)
+
+workspace = RambleCommand("workspace")
+
+
+@pytest.mark.maybeslow
+def test_many_experiments(workspace_name):
+    ws = ramble.workspace.create(workspace_name)
+    ws.write()
+    global_args = ["-w", workspace_name]
+
+    workspace(
+        "manage",
+        "experiments",
+        "hostname",
+        "--wf",
+        "local",
+        "-e",
+        "test-{n_nodes}-{var1}-{var2}-{var3}",
+        "-v",
+        "n_ranks='{n_nodes}*{processes_per_node}'",
+        "-v",
+        "n_nodes=[1,2,4,8,16,32,64,128,256]",
+        "-v",
+        "var1=[1,2,3,4,5,6,7,8,9,10]",
+        "-v",
+        "var2=[1,2,3,4,5,6,7,8,9,10]",
+        "-v",
+        "var3=[1,2,3,4,5,6,7,8,9,10]",
+        "-m",
+        "n_nodes,var1,var2,var3",
+        global_args=global_args,
+    )
+
+    output = workspace("info", global_args=global_args)
+
+    assert "Experiment 8100" in output


### PR DESCRIPTION
This merge performs several optimizations to improve performance of experiment rendering. It adds a new test (which is arguably slow) that renders a large number of experiments to help evaluate performance improvments.

Additionally, some minor improvements are made to the expander, and the Renderer, but some more significant performance improvements are made to the workspace info command, and the ExperimentSet objects.

Using the unit test in this PR locally on my laptop, the baseline performance is:
149.67s

And the final performance is:
25.38s