### PR TITLE
Specify `python_version` to mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,9 @@ omit = [
 directory = "htmlcov"
 
 [tool.mypy]
+# Use a common version (3.10 is the lowest supported version)
+# Otherwise mypy uses the running python's version
+python_version = "3.10"
 # TODO: Add in more files for type-checking
 # For now, only type-check the util directory
 files = [


### PR DESCRIPTION
This makes the mypy result more consistent. Without it mypy picks the target version based on the running python instance.