### PR TITLE
Simplify test setup for Ramble objects

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -152,57 +152,6 @@ def working_env():
 #
 
 
-#
-# Mock repository paths
-#
-@pytest.fixture(scope="function")
-def mock_apps_repo_path():
-    obj_type = ramble.repository.ObjectTypes.applications
-    yield ramble.repository.Repo(ramble.paths.mock_builtin_path, obj_type)
-
-
-@pytest.fixture(scope="function")
-def mock_mods_repo_path():
-    obj_type = ramble.repository.ObjectTypes.modifiers
-    yield ramble.repository.Repo(ramble.paths.mock_builtin_path, obj_type)
-
-
-@pytest.fixture(scope="function")
-def mock_pkg_mans_repo_path():
-    obj_type = ramble.repository.ObjectTypes.package_managers
-    yield ramble.repository.Repo(ramble.paths.mock_builtin_path, obj_type)
-
-
-@pytest.fixture(scope="function")
-def mock_wms_repo_path():
-    obj_type = ramble.repository.ObjectTypes.workflow_managers
-    yield ramble.repository.Repo(ramble.paths.mock_builtin_path, obj_type)
-
-
-@pytest.fixture(scope="function")
-def mock_base_apps_repo_path():
-    obj_type = ramble.repository.ObjectTypes.base_applications
-    yield ramble.repository.Repo(ramble.paths.mock_builtin_path, obj_type)
-
-
-@pytest.fixture(scope="function")
-def mock_base_mods_repo_path():
-    obj_type = ramble.repository.ObjectTypes.base_modifiers
-    yield ramble.repository.Repo(ramble.paths.mock_builtin_path, obj_type)
-
-
-@pytest.fixture(scope="function")
-def mock_base_pkg_mans_repo_path():
-    obj_type = ramble.repository.ObjectTypes.base_package_managers
-    yield ramble.repository.Repo(ramble.paths.mock_builtin_path, obj_type)
-
-
-@pytest.fixture(scope="function")
-def mock_base_wms_repo_path():
-    obj_type = ramble.repository.ObjectTypes.base_workflow_managers
-    yield ramble.repository.Repo(ramble.paths.mock_builtin_path, obj_type)
-
-
 @pytest.fixture
 def ensure_spack_runner():
     """Fixture to check for spack runner and skip if not found."""
@@ -225,294 +174,81 @@ def _get_obj_repo_path(obj_type, extra_repo_path):
     yield ramble.repository.RepoPath(*repos, object_type=obj_type)
 
 
-#
-# Mutable repository paths
-#
-@pytest.fixture(scope="function")
-def mutable_apps_repo_path(pytestconfig):
-    obj_type = ramble.repository.ObjectTypes.applications
-    extra_repo_path = pytestconfig.getoption("--repo-path")
-    yield from _get_obj_repo_path(obj_type, extra_repo_path)
+# Helpers for creating dynamic fixtures
+def _create_mock_repo_path_fixture(obj_type):
+    @pytest.fixture(scope="function")
+    def _fixture():
+        yield ramble.repository.Repo(ramble.paths.mock_builtin_path, obj_type)
+
+    return _fixture
 
 
-@pytest.fixture(scope="function")
-def mutable_mods_repo_path(pytestconfig):
-    obj_type = ramble.repository.ObjectTypes.modifiers
-    extra_repo_path = pytestconfig.getoption("--repo-path")
-    yield from _get_obj_repo_path(obj_type, extra_repo_path)
+def _create_mutable_repo_path_fixture(obj_type):
+    @pytest.fixture(scope="function")
+    def _fixture(pytestconfig):
+        extra_repo_path = pytestconfig.getoption("--repo-path")
+        yield from _get_obj_repo_path(obj_type, extra_repo_path)
+
+    return _fixture
 
 
-@pytest.fixture(scope="function")
-def mutable_pkg_mans_repo_path(pytestconfig):
-    obj_type = ramble.repository.ObjectTypes.package_managers
-    extra_repo_path = pytestconfig.getoption("--repo-path")
-    yield from _get_obj_repo_path(obj_type, extra_repo_path)
+def _create_mock_obj_fixture(obj_type, repo_path_fixture_name):
+    @pytest.fixture(scope="function")
+    def _fixture(request):
+        repo_path = request.getfixturevalue(repo_path_fixture_name)
+        with ramble.repository.use_repositories(repo_path, object_type=obj_type) as mock_repo:
+            yield mock_repo
+
+    return _fixture
 
 
-@pytest.fixture(scope="function")
-def mutable_wms_repo_path(pytestconfig):
-    obj_type = ramble.repository.ObjectTypes.workflow_managers
-    extra_repo_path = pytestconfig.getoption("--repo-path")
-    yield from _get_obj_repo_path(obj_type, extra_repo_path)
+def _create_mutable_obj_fixture(obj_type, repo_path_fixture_name):
+    @pytest.fixture(scope="function")
+    def _fixture(request):
+        repo_path = request.getfixturevalue(repo_path_fixture_name)
+        with ramble.repository.use_repositories(repo_path, object_type=obj_type) as repo:
+            yield repo
+
+    return _fixture
 
 
-@pytest.fixture(scope="function")
-def mutable_base_apps_repo_path(pytestconfig):
-    obj_type = ramble.repository.ObjectTypes.base_applications
-    extra_repo_path = pytestconfig.getoption("--repo-path")
-    yield from _get_obj_repo_path(obj_type, extra_repo_path)
+def _create_mutable_mock_repo_fixture(obj_type):
+    @pytest.fixture(scope="function")
+    def _fixture():
+        mock_repo = ramble.repository.Repo(ramble.paths.mock_builtin_path, object_type=obj_type)
+        with ramble.repository.use_repositories(mock_repo, object_type=obj_type) as mock_repo_path:
+            yield mock_repo_path
+
+    return _fixture
 
 
-@pytest.fixture(scope="function")
-def mutable_base_mods_repo_path(pytestconfig):
-    obj_type = ramble.repository.ObjectTypes.base_modifiers
-    extra_repo_path = pytestconfig.getoption("--repo-path")
-    yield from _get_obj_repo_path(obj_type, extra_repo_path)
+# Create dynamic fixtures for different object types
+for obj_type in ramble.repository.ObjectTypes:
+    if obj_type == ramble.repository.ObjectTypes.base_classes:
+        continue
 
+    abbrev = ramble.repository.type_definitions[obj_type]["abbrev"]
+    plural_abbrev = f"{abbrev}s"
 
-@pytest.fixture(scope="function")
-def mutable_base_pkg_mans_repo_path(pytestconfig):
-    obj_type = ramble.repository.ObjectTypes.base_package_managers
-    extra_repo_path = pytestconfig.getoption("--repo-path")
-    yield from _get_obj_repo_path(obj_type, extra_repo_path)
+    # mock_*_repo_path
+    mock_repo_path_name = f"mock_{plural_abbrev}_repo_path"
+    globals()[mock_repo_path_name] = _create_mock_repo_path_fixture(obj_type)
 
+    # mutable_*_repo_path
+    mutable_repo_path_name = f"mutable_{plural_abbrev}_repo_path"
+    globals()[mutable_repo_path_name] = _create_mutable_repo_path_fixture(obj_type)
 
-@pytest.fixture(scope="function")
-def mutable_base_wms_repo_path(pytestconfig):
-    obj_type = ramble.repository.ObjectTypes.base_workflow_managers
-    extra_repo_path = pytestconfig.getoption("--repo-path")
-    yield from _get_obj_repo_path(obj_type, extra_repo_path)
+    # mock_*
+    mock_obj_name = f"mock_{obj_type.name}"
+    globals()[mock_obj_name] = _create_mock_obj_fixture(obj_type, mock_repo_path_name)
 
+    # mutable_*
+    mutable_obj_name = f"mutable_{obj_type.name}"
+    globals()[mutable_obj_name] = _create_mutable_obj_fixture(obj_type, mutable_repo_path_name)
 
-#
-# Mock object types
-#
-@pytest.fixture(scope="function")
-def mock_applications(mock_apps_repo_path):
-    """Use the 'builtin.mock' repository for applications instead of 'builtin'"""
-    obj_type = ramble.repository.ObjectTypes.applications
-    with ramble.repository.use_repositories(
-        mock_apps_repo_path, object_type=obj_type
-    ) as mock_apps_repo:
-        yield mock_apps_repo
-
-
-@pytest.fixture(scope="function")
-def mock_modifiers(mock_mods_repo_path):
-    """Use the 'builtin.mock' repository for modifiers instead of 'builtin'"""
-    obj_type = ramble.repository.ObjectTypes.modifiers
-    with ramble.repository.use_repositories(
-        mock_mods_repo_path, object_type=obj_type
-    ) as mock_mods_repo:
-        yield mock_mods_repo
-
-
-@pytest.fixture(scope="function")
-def mock_package_managers(mock_pkg_mans_repo_path):
-    """Use the 'builtin.mock' repository for package managers of 'builtin'"""
-    obj_type = ramble.repository.ObjectTypes.package_managers
-    with ramble.repository.use_repositories(
-        mock_pkg_mans_repo_path, object_type=obj_type
-    ) as mock_pkg_mans_repo:
-        yield mock_pkg_mans_repo
-
-
-@pytest.fixture(scope="function")
-def mock_workflow_managers(mock_wms_repo_path):
-    """Use the 'builtin.mock' repository for workflow managers of 'builtin'"""
-    obj_type = ramble.repository.ObjectTypes.workflow_managers
-    with ramble.repository.use_repositories(mock_wms_repo_path, object_type=obj_type) as mock_repo:
-        yield mock_repo
-
-
-@pytest.fixture(scope="function")
-def mock_base_applications(mock_base_apps_repo_path):
-    """Use the 'builtin.mock' repository for base applications instead of 'builtin'"""
-    obj_type = ramble.repository.ObjectTypes.base_applications
-    with ramble.repository.use_repositories(
-        mock_base_apps_repo_path, object_type=obj_type
-    ) as mock_base_apps_repo:
-        yield mock_base_apps_repo
-
-
-@pytest.fixture(scope="function")
-def mock_base_modifiers(mock_base_mods_repo_path):
-    """Use the 'builtin.mock' repository for base modifiers instead of 'builtin'"""
-    obj_type = ramble.repository.ObjectTypes.base_modifiers
-    with ramble.repository.use_repositories(
-        mock_base_mods_repo_path, object_type=obj_type
-    ) as mock_base_mods_repo:
-        yield mock_base_mods_repo
-
-
-@pytest.fixture(scope="function")
-def mock_base_package_managers(mock_base_pkg_mans_repo_path):
-    """Use the 'builtin.mock' repository for base package managers of 'builtin'"""
-    obj_type = ramble.repository.ObjectTypes.base_package_managers
-    with ramble.repository.use_repositories(
-        mock_base_pkg_mans_repo_path, object_type=obj_type
-    ) as mock_base_pkg_mans_repo:
-        yield mock_base_pkg_mans_repo
-
-
-@pytest.fixture(scope="function")
-def mock_base_workflow_managers(mock_base_wms_repo_path):
-    """Use the 'builtin.mock' repository for base workflow managers of 'builtin'"""
-    obj_type = ramble.repository.ObjectTypes.base_workflow_managers
-    with ramble.repository.use_repositories(
-        mock_base_wms_repo_path, object_type=obj_type
-    ) as mock_base_wms_repo:
-        yield mock_base_wms_repo
-
-
-#
-# Mutable object types
-#
-@pytest.fixture(scope="function")
-def mutable_applications(mutable_apps_repo_path):
-    obj_type = ramble.repository.ObjectTypes.applications
-    with ramble.repository.use_repositories(
-        mutable_apps_repo_path, object_type=obj_type
-    ) as apps_repo:
-        yield apps_repo
-
-
-@pytest.fixture(scope="function")
-def mutable_modifiers(mutable_mods_repo_path):
-    obj_type = ramble.repository.ObjectTypes.modifiers
-    with ramble.repository.use_repositories(
-        mutable_mods_repo_path, object_type=obj_type
-    ) as mods_repo:
-        yield mods_repo
-
-
-@pytest.fixture(scope="function")
-def mutable_package_managers(mutable_pkg_mans_repo_path):
-    obj_type = ramble.repository.ObjectTypes.package_managers
-    with ramble.repository.use_repositories(
-        mutable_pkg_mans_repo_path, object_type=obj_type
-    ) as pkg_mans_repo:
-        yield pkg_mans_repo
-
-
-@pytest.fixture(scope="function")
-def mutable_workflow_managers(mutable_wms_repo_path):
-    obj_type = ramble.repository.ObjectTypes.workflow_managers
-    with ramble.repository.use_repositories(
-        mutable_wms_repo_path, object_type=obj_type
-    ) as wms_repo:
-        yield wms_repo
-
-
-@pytest.fixture(scope="function")
-def mutable_base_applications(mutable_base_apps_repo_path):
-    obj_type = ramble.repository.ObjectTypes.base_applications
-    with ramble.repository.use_repositories(
-        mutable_base_apps_repo_path, object_type=obj_type
-    ) as base_apps_repo:
-        yield base_apps_repo
-
-
-@pytest.fixture(scope="function")
-def mutable_base_modifiers(mutable_base_mods_repo_path):
-    obj_type = ramble.repository.ObjectTypes.base_modifiers
-    with ramble.repository.use_repositories(
-        mutable_base_mods_repo_path, object_type=obj_type
-    ) as base_mods_repo:
-        yield base_mods_repo
-
-
-@pytest.fixture(scope="function")
-def mutable_base_package_managers(mutable_base_pkg_mans_repo_path):
-    obj_type = ramble.repository.ObjectTypes.base_package_managers
-    with ramble.repository.use_repositories(
-        mutable_base_pkg_mans_repo_path, object_type=obj_type
-    ) as base_pkg_mans_repo:
-        yield base_pkg_mans_repo
-
-
-@pytest.fixture(scope="function")
-def mutable_base_workflow_managers(mutable_base_wms_repo_path):
-    obj_type = ramble.repository.ObjectTypes.base_workflow_managers
-    with ramble.repository.use_repositories(
-        mutable_base_wms_repo_path, object_type=obj_type
-    ) as base_wms_repo:
-        yield base_wms_repo
-
-
-#
-# Mutable repositories
-#
-@pytest.fixture(scope="function")
-def mutable_mock_apps_repo(mock_apps_repo_path):
-    """Function-scoped mock applications, for tests that need to modify them."""
-    obj_type = ramble.repository.ObjectTypes.applications
-    mock_repo = ramble.repository.Repo(ramble.paths.mock_builtin_path, object_type=obj_type)
-    with ramble.repository.use_repositories(mock_repo, object_type=obj_type) as mock_repo_path:
-        yield mock_repo_path
-
-
-@pytest.fixture(scope="function")
-def mutable_mock_mods_repo(mock_mods_repo_path):
-    """Function-scoped mock modifiers, for tests that need to modify them."""
-    obj_type = ramble.repository.ObjectTypes.modifiers
-    mock_repo = ramble.repository.Repo(ramble.paths.mock_builtin_path, object_type=obj_type)
-    with ramble.repository.use_repositories(mock_repo, object_type=obj_type) as mock_repo_path:
-        yield mock_repo_path
-
-
-@pytest.fixture(scope="function")
-def mutable_mock_pkg_mans_repo(mock_pkg_mans_repo_path):
-    """Function-scoped mock package managers, for tests that need to modify them."""
-    obj_type = ramble.repository.ObjectTypes.package_managers
-    mock_repo = ramble.repository.Repo(ramble.paths.mock_builtin_path, object_type=obj_type)
-    with ramble.repository.use_repositories(mock_repo, object_type=obj_type) as mock_repo_path:
-        yield mock_repo_path
-
-
-@pytest.fixture(scope="function")
-def mutable_mock_wms_repo(mock_wms_repo_path):
-    """Function-scoped mock package managers, for tests that need to modify them."""
-    obj_type = ramble.repository.ObjectTypes.workflow_managers
-    mock_repo = ramble.repository.Repo(ramble.paths.mock_builtin_path, object_type=obj_type)
-    with ramble.repository.use_repositories(mock_repo, object_type=obj_type) as mock_repo_path:
-        yield mock_repo_path
-
-
-@pytest.fixture(scope="function")
-def mutable_mock_base_apps_repo(mock_base_apps_repo_path):
-    """Function-scoped mock base applications, for tests that need to modify them."""
-    obj_type = ramble.repository.ObjectTypes.base_applications
-    mock_repo = ramble.repository.Repo(ramble.paths.mock_builtin_path, object_type=obj_type)
-    with ramble.repository.use_repositories(mock_repo, object_type=obj_type) as mock_repo_path:
-        yield mock_repo_path
-
-
-@pytest.fixture(scope="function")
-def mutable_mock_base_mods_repo(mock_base_mods_repo_path):
-    """Function-scoped mock base modifiers, for tests that need to modify them."""
-    obj_type = ramble.repository.ObjectTypes.base_modifiers
-    mock_repo = ramble.repository.Repo(ramble.paths.mock_builtin_path, object_type=obj_type)
-    with ramble.repository.use_repositories(mock_repo, object_type=obj_type) as mock_repo_path:
-        yield mock_repo_path
-
-
-@pytest.fixture(scope="function")
-def mutable_mock_base_pkg_mans_repo(mock_base_pkg_mans_repo_path):
-    """Function-scoped mock base package managers, for tests that need to modify them."""
-    obj_type = ramble.repository.ObjectTypes.base_package_managers
-    mock_repo = ramble.repository.Repo(ramble.paths.mock_builtin_path, object_type=obj_type)
-    with ramble.repository.use_repositories(mock_repo, object_type=obj_type) as mock_repo_path:
-        yield mock_repo_path
-
-
-@pytest.fixture(scope="function")
-def mutable_mock_base_wms_repo(mock_base_wms_repo_path):
-    """Function-scoped mock base workflow managers, for tests that need to modify them."""
-    obj_type = ramble.repository.ObjectTypes.base_workflow_managers
-    mock_repo = ramble.repository.Repo(ramble.paths.mock_builtin_path, object_type=obj_type)
-    with ramble.repository.use_repositories(mock_repo, object_type=obj_type) as mock_repo_path:
-        yield mock_repo_path
+    # mutable_mock_*_repo
+    mutable_mock_repo_name = f"mutable_mock_{plural_abbrev}_repo"
+    globals()[mutable_mock_repo_name] = _create_mutable_mock_repo_fixture(obj_type)
 
 
 @pytest.fixture(scope="function")

--- a/conftest.py
+++ b/conftest.py
@@ -64,7 +64,7 @@ def pytest_configure(config):
         return
     path = pathlib.Path(repo_path)
     # Define testpaths
-    testpaths = [p for p in path.rglob("test") if p.is_dir()]
+    testpaths = [str(p) for p in path.rglob("test") if p.is_dir()]
     testpaths.append("setup_analyze.py")
     config.args = testpaths
 


### PR DESCRIPTION
Dynamically generate object-related pytest fixtures, to reduce the boilerplate in `conftest`.

Also fix up an issue with the `--repo-path` option for `ramble unit-test`.