### PR TITLE
Fix repeat experiments in `workspace info`

### DIFF
--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -796,9 +796,7 @@ def workspace_info(args):
     # Build an index of experiments to avoid re-rendering them in the loops below
     experiment_index_map = defaultdict(list)
     for exp_name, app_inst, _ in experiment_set.all_experiments():
-        experiment_template_name = app_inst.variables[
-            app_inst.keywords.experiment_template_name
-        ]
+        experiment_template_name = app_inst.variables[app_inst.keywords.experiment_template_name]
         if app_inst.repeats.repeat_index:
             suffix = f".{app_inst.repeats.repeat_index}"
             if experiment_template_name.endswith(suffix):

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -796,10 +796,18 @@ def workspace_info(args):
     # Build an index of experiments to avoid re-rendering them in the loops below
     experiment_index_map = defaultdict(list)
     for exp_name, app_inst, _ in experiment_set.all_experiments():
+        experiment_template_name = app_inst.variables[
+            app_inst.keywords.experiment_template_name
+        ]
+        if app_inst.repeats.repeat_index:
+            suffix = f".{app_inst.repeats.repeat_index}"
+            if experiment_template_name.endswith(suffix):
+                experiment_template_name = experiment_template_name[: -len(suffix)]
+
         key = (
             app_inst.variables[app_inst.keywords.application_name],
             app_inst.variables[app_inst.keywords.workload_template_name],
-            app_inst.variables[app_inst.keywords.experiment_template_name],
+            experiment_template_name,
         )
         experiment_index_map[key].append(exp_name)
 

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -266,11 +266,13 @@ class ExperimentSet:
 
         experiment_suffix = ""
         # After generating the base experiment, append the index to repeat experiments
+        variables[self.keywords.is_repeat_parent] = repeats.is_repeat_base
+        variables[self.keywords.is_repeat_child] = False
+        variables[self.keywords.repeat_index] = 0
         if repeats.repeat_index:
             experiment_suffix = f".{repeats.repeat_index}"
+            variables[self.keywords.is_repeat_child] = True
             variables[self.keywords.repeat_index] = repeats.repeat_index
-        else:
-            variables[self.keywords.repeat_index] = 0
 
         app_inst = self._setup_experiment_minimal(workload_template_name, variables, context)
 

--- a/lib/ramble/ramble/keywords.py
+++ b/lib/ramble/ramble/keywords.py
@@ -50,6 +50,8 @@ default_keys = {
     "err_file": {"type": key_type.reserved, "level": output_level.variable},
     "env_path": {"type": key_type.reserved, "level": output_level.variable},
     "input_name": {"type": key_type.reserved, "level": output_level.variable},
+    "is_repeat_parent": {"type": key_type.reserved, "level": output_level.variable},
+    "is_repeat_child": {"type": key_type.reserved, "level": output_level.variable},
     "repeat_index": {"type": key_type.reserved, "level": output_level.variable},
     "spec_name": {"type": key_type.optional, "level": output_level.variable},
     "env_name": {"type": key_type.optional, "level": output_level.variable},

--- a/lib/ramble/ramble/test/end_to_end/experiment_repeats.py
+++ b/lib/ramble/ramble/test/end_to_end/experiment_repeats.py
@@ -246,3 +246,35 @@ ramble:
             assert "summary::max = 2.0 minutes" in data
             assert "summary::mean = 1.5 minutes" in data
             assert "mode:\n      value = Sleep" in data
+
+
+def test_repeat_info(mutable_config, mutable_mock_workspace_path, workspace_name):
+    test_config = """
+ramble:
+  variables:
+    n_nodes: 1
+    processes_per_node: 1
+    mpi_command: ''
+    batch_submit: '{execute_experiment}'
+  applications:
+    sleep:
+      workloads:
+        sleep:
+          experiments:
+            sleep_test:
+              n_repeats: 3
+"""
+
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+        config_path = os.path.join(ws.config_dir, ramble.workspace.CONFIG_FILE_NAME)
+        with open(config_path, "w+") as f:
+            f.write(test_config)
+        ws._re_read()
+
+        output = workspace("info", global_args=["-w", workspace_name])
+
+        assert "Experiment 1:" in output
+        assert "Experiment 2:" in output
+        assert "Experiment 3:" in output
+        assert "Experiment 4:" in output


### PR DESCRIPTION
This merge fixes an issue introduced in 20f1ae9be5997318a82ae054983f7a32e3d6f6dc that prevented child experiments of a repeat base from showing up in `workspace info` output.

Additionally, a test was added to ensure this behavior remains fixed, and two additional keyword variables are added:
 - is_repeat_parent
 - is_repeat_child

Which can be used to filter out parent / children experiments when repeats are included in a workspace.