### PR TITLE
Include inventory and metadata artifacts in deployments

### DIFF
--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -236,6 +236,20 @@ class Pipeline:
         self._complete()
         logger.remove_log()
 
+    def _copy_workspace_root_files(self, workspace, dest_dir):
+        root_files = [
+            ramble.workspace.Workspace.inventory_file_name,
+            ramble.workspace.Workspace.hash_file_name,
+            self.workspace.inventory_file_name,
+            self.workspace.hash_file_name,
+            ramble.workspace.METADATA_FILE_NAME,
+        ]
+        for filename in root_files:
+            src = os.path.join(workspace.root, filename)
+            if os.path.exists(src):
+                dest = os.path.join(dest_dir, filename)
+                shutil.copyfile(src, dest)
+
 
 class AnalyzePipeline(Pipeline):
     """Class for the analyze pipeline"""
@@ -358,14 +372,7 @@ class ArchivePipeline(Pipeline):
         archive_path = os.path.join(self.workspace.archive_dir, self.archive_name)
         fs.mkdirp(archive_path)
 
-        for filename in (
-            ramble.workspace.Workspace.inventory_file_name,
-            ramble.workspace.Workspace.hash_file_name,
-        ):
-            src = os.path.join(self.workspace.root, filename)
-            if os.path.exists(src):
-                dest = src.replace(self.workspace.root, archive_path)
-                shutil.copyfile(src, dest)
+        self._copy_workspace_root_files(self.workspace, archive_path)
 
         # Copy current configs
         archive_configs = os.path.join(
@@ -688,6 +695,7 @@ class PushDeploymentPipeline(Pipeline):
 
         self.action_string = "Pushing deployment of"
         self.create_tar = create_tar
+        self.force_inventory = True
 
         if upload_url:
             expanded_url = workspace_expander.expand_var(upload_url)
@@ -723,6 +731,10 @@ class PushDeploymentPipeline(Pipeline):
 
     def _complete(self):
         super()._complete()
+
+        # Copy inventory files into deployment
+        self._copy_workspace_root_files(self.workspace, self.workspace.named_deployment)
+
         # Create an index.json of the deployment
         deployment_index = {self.index_namespace: []}
         for file in self._deployment_files():

--- a/lib/ramble/ramble/test/test_deployment.py
+++ b/lib/ramble/ramble/test/test_deployment.py
@@ -1,0 +1,67 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+import shutil
+import tempfile
+import unittest
+from unittest import mock
+
+import ramble.workspace
+from ramble.filters import Filters
+from ramble.pipeline import PushDeploymentPipeline
+
+
+class TestPushDeploymentPipeline(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.workspace = ramble.workspace.Workspace(self.test_dir)
+        self.deployment_name = "test_deployment"
+        self.deployment_path = os.path.join(
+            self.workspace.root, "deployments", self.deployment_name
+        )
+        self.workspace.deployment = self.deployment_name
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_complete_copies_inventory_files(self):
+        # Create dummy inventory files
+        inventory_file = os.path.join(self.workspace.root, self.workspace.inventory_file_name)
+        hash_file = os.path.join(self.workspace.root, self.workspace.hash_file_name)
+        metadata_file = os.path.join(self.workspace.root, ramble.workspace.METADATA_FILE_NAME)
+
+        with open(inventory_file, "w") as f:
+            f.write("inventory")
+        with open(hash_file, "w") as f:
+            f.write("hash")
+        with open(metadata_file, "w") as f:
+            f.write("metadata")
+
+        pipeline = PushDeploymentPipeline(
+            self.workspace,
+            filters=Filters([]),
+            deployment_name=self.deployment_name,
+            create_tar=False,
+        )
+        pipeline._deployment_files = lambda: []
+        pipeline._construct_experiment_hashes = lambda: False
+        with mock.patch("ramble.expander.Expander.expand_var", return_value=self.deployment_name):
+            pipeline._execute()
+        pipeline._complete()
+
+        # Check if the files were copied
+        self.assertTrue(
+            os.path.exists(os.path.join(self.deployment_path, self.workspace.inventory_file_name))
+        )
+        self.assertTrue(
+            os.path.exists(os.path.join(self.deployment_path, self.workspace.hash_file_name))
+        )
+        self.assertTrue(
+            os.path.exists(os.path.join(self.deployment_path, ramble.workspace.METADATA_FILE_NAME))
+        )


### PR DESCRIPTION
This merge includes workspace metadata and inventories in deployments, to help users understand what version of Ramble (and other tools) they used when they created the deployment.