### PR TITLE
Ensure the sh wrapper preserves return code correctly

### DIFF
--- a/lib/ramble/ramble/test/end_to_end/shell_wrappers.py
+++ b/lib/ramble/ramble/test/end_to_end/shell_wrappers.py
@@ -1,0 +1,45 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+import shutil
+import subprocess
+
+import pytest
+
+import ramble.paths
+
+pytestmark = pytest.mark.maybeslow
+
+# TODO: add tests for other supported shells
+_SHELLS_TO_TEST = ["bash"]
+
+
+@pytest.mark.parametrize("shell", _SHELLS_TO_TEST)
+def test_shell_wrapper_workspace_activate_missing(shell, tmpdir):
+    """Test activation of missing workspace fails with proper exit code."""
+    if not shutil.which(shell):
+        pytest.skip(f"{shell} not found")
+
+    setup_env = os.path.join(ramble.paths.prefix, "share", "ramble", "setup-env.sh")
+    test_script_path = str(tmpdir.join("test_missing.sh"))
+
+    with open(test_script_path, "w") as f:
+        f.write(
+            f"""
+. "{setup_env}"
+ramble workspace activate non_existent_workspace
+"""
+        )
+
+    cmd = [shell, test_script_path]
+    process = subprocess.run(
+        cmd, capture_output=True, text=True, cwd=str(tmpdir), env=os.environ.copy()
+    )
+
+    assert process.returncode == 1

--- a/share/ramble/setup-env.sh
+++ b/share/ramble/setup-env.sh
@@ -122,7 +122,10 @@ _ramble_shell_wrapper() {
                             command ramble workspace activate "$@"
                         else
                             # Actual call to activate: source the output.
-                            eval $(command ramble $_rmb_flags workspace activate --sh "$@")
+                            _activate_cmd=$(command ramble $_rmb_flags workspace activate --sh "$@")
+                            _rs=$?
+                            eval "$_activate_cmd" || return $?
+                            return $_rs
                         fi
                         ;;
                     deactivate)
@@ -143,7 +146,10 @@ _ramble_shell_wrapper() {
                             command ramble workspace deactivate -h
                         else
                             # No args: source the output of the command.
-                            eval $(command ramble $_rmb_flags workspace deactivate --sh)
+                            _deactivate_cmd=$(command ramble $_rmb_flags workspace deactivate --sh)
+                            _rs=$?
+                            eval "$_deactivate_cmd" || return $?
+                            return $_rs
                         fi
                         ;;
                     create)
@@ -156,18 +162,22 @@ _ramble_shell_wrapper() {
                             # into stdout (`ramble workspace activate <ws>`.)
                             # And the eval routes that command back to the wrapper to
                             # inject shell args, etc.
-                            _activate_cmd="$(command ramble $_rmb_flags workspace create "$@")"
-                            if [ $? -eq 0 ]; then
+                            _create_activate_cmd="$(command ramble $_rmb_flags workspace create "$@")"
+                            _rs=$?
+                            if [ $_rs -eq 0 ]; then
                                 unset RAMBLE_WORKSPACES
-                                eval $_activate_cmd
-                                _workspace="$(echo $_activate_cmd | awk '{print $NF}')"
+                                eval "$_create_activate_cmd" || return $?
+                                _workspace="$(echo $_create_activate_cmd | awk '{print $NF}')"
                                 echo "==> Created and activated workspace in $_workspace"
                             fi
+                            return $_rs
                         else
                             command ramble $_rmb_flags workspace create "$@"
-                            if [ $? -eq 0 ]; then
+                            _rs=$?
+                            if [ $_rs -eq 0 ]; then
                                 unset RAMBLE_WORKSPACES
                             fi
+                            return $_rs
                         fi
                         ;;
                     *)


### PR DESCRIPTION
Test:

```
// with the fix
$ bash -c 'source share/ramble/setup-env.sh; ramble workspace activate not-exist >/dev/null 2>&1; echo $?'
1
//  without the fix
$ bash -c 'git stash; source share/ramble/setup-env.sh; ramble workspace activate not-exist >/dev/null 2>&1; echo $?'
Saved working directory and index state WIP on shell-wrapper: 31aa356b Merge pull request #1423 from douglasjacobsen/fix-repeat-info
0
```

Note: I only fix this for sh. The fish and csh wrappers likely have the same issue.