### PR TITLE
Set up a `perf` category of unit tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -56,6 +56,12 @@ def pytest_addoption(parser):
         default=None,
         help="runs only tests under the given Ramble object repo path",
     )
+    group.addoption(
+        "--perf",
+        action="store_true",
+        default=False,
+        help="runs perf tests",
+    )
 
 
 def pytest_configure(config):
@@ -70,6 +76,17 @@ def pytest_configure(config):
 
 
 def pytest_collection_modifyitems(config, items):
+    if config.getoption("--perf"):
+        skip_non_perf = pytest.mark.skip(reason="skipped non-perf test [remove --perf to run]")
+        for item in items:
+            if "perf" not in item.keywords:
+                item.add_marker(skip_non_perf)
+    else:
+        skip_perf = pytest.mark.skip(reason="skipped perf test [use --perf to run]")
+        for item in items:
+            if "perf" in item.keywords:
+                item.add_marker(skip_perf)
+
     if not config.getoption("--fast"):
         # --fast not given, run all the tests
         return

--- a/lib/ramble/ramble/test/end_to_end/many_experiments.py
+++ b/lib/ramble/ramble/test/end_to_end/many_experiments.py
@@ -20,7 +20,8 @@ pytestmark = pytest.mark.usefixtures(
 workspace = RambleCommand("workspace")
 
 
-@pytest.mark.maybeslow
+@pytest.mark.perf
+@pytest.mark.long
 def test_many_experiments(workspace_name):
     ws = ramble.workspace.create(workspace_name)
     ws.write()

--- a/pytest.ini
+++ b/pytest.ini
@@ -29,3 +29,4 @@ markers =
   enable_compiler_link_paths: verifies compiler link paths within unit tests
   disable_clean_stage_check: avoid failing tests if there are leftover files in the stage area
   long: mark test as long running
+  perf: mark test as performance test


### PR DESCRIPTION
Now the `test_many_experiments` test is only selected when run with `ramble unit-test --perf`. This means it's excluded for regular unit test runs.

(TODO) In a future PR, we will set up PR builds that runs exclusively the `perf`-tagged tests, and ensure relevant metrics are uploaded for continuous monitoring.