### PR TITLE
Collect perf test execution time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ var/ramble/workspaces
 
 # bash autocomplete with user-defined aliases
 share/ramble/custom-ramble-completion.bash
+
+# artifacts from tests
+perf_test_metrics.json

--- a/conftest.py
+++ b/conftest.py
@@ -86,9 +86,10 @@ def pytest_runtest_makereport(item, call):
 
 
 def pytest_sessionfinish(session, exitstatus):
-    perf_file = os.path.join(ramble.paths.ramble_root, "perf_test_metrics.json")
-    with open(perf_file, "w") as f:
-        json.dump(session.perf_metrics, f, indent=2)
+    if session.perf_metrics:
+        perf_file = os.path.join(ramble.paths.ramble_root, "perf_test_metrics.json")
+        with open(perf_file, "w") as f:
+            json.dump(session.perf_metrics, f, indent=2)
 
 
 def pytest_configure(config):

--- a/conftest.py
+++ b/conftest.py
@@ -9,6 +9,7 @@
 import builtins
 import collections
 import io
+import json
 import os
 import os.path
 import pathlib
@@ -62,6 +63,32 @@ def pytest_addoption(parser):
         default=False,
         help="runs perf tests",
     )
+
+
+def pytest_sessionstart(session):
+    session.perf_metrics = []
+
+
+# Extract execution time of perf tests
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    outcome = yield
+    res = outcome.get_result()
+
+    if res.when == "call" and "perf" in item.keywords:
+        metric = {
+            "test_name": item.name,
+            "test_id": item.nodeid,
+            "duration": res.duration,
+            "outcome": res.outcome,
+        }
+        item.session.perf_metrics.append(metric)
+
+
+def pytest_sessionfinish(session, exitstatus):
+    perf_file = os.path.join(ramble.paths.ramble_root, "perf_test_metrics.json")
+    with open(perf_file, "w") as f:
+        json.dump(session.perf_metrics, f, indent=2)
 
 
 def pytest_configure(config):


### PR DESCRIPTION
```
$ ramble unit-test --perf
$ cat perf_test_metrics.json
[
  {
    "test_name": "test_many_experiments",
    "test_id": "lib/ramble/ramble/test/end_to_end/many_experiments.py::test_many_experiments",
    "duration": 10.628011291999428,
    "outcome": "passed"
  }
]
```

Next step after this is to create CI build that runs the perf tests and upload the metrics to BigQuery, for continuous monitoring of Ramble perf.