### PR TITLE
Allow double colons in expander

### DIFF
--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -143,7 +143,7 @@ supported_scalar_function_pointers = {
 }
 
 # Format Spec Regex:
-format_spec_regex = re.compile(r"(?P<kw>.*):(?P<format_spec>\S+)$")
+format_spec_regex = re.compile(r"(?P<kw>[^:]+(?:::[^:]+)*):(?P<format_spec>[^:]+)$")
 
 # Functions that need to be supplied with the expander
 supported_scalar_function_with_self_arg_pointers = {
@@ -281,7 +281,11 @@ class ExpansionNode:
                     return
 
                 keyword = replaced_contents[1:-1]
-                format_match = format_spec_regex.search(keyword)
+                format_match = None
+
+                # Only search for format specs if the keyword is not already a variable
+                if keyword not in expansion_dict:
+                    format_match = format_spec_regex.search(keyword)
                 required_passthrough = False
 
                 if format_match:

--- a/lib/ramble/ramble/test/expander.py
+++ b/lib/ramble/ramble/test/expander.py
@@ -38,6 +38,7 @@ def exp_dict():
         "test_dict": {"test_key1": "test_val1", "test_key2": "test_val2"},
         "experiment_index": 5,
         "var4": "a-b",
+        "test::var": "value",
     }
 
 
@@ -158,6 +159,7 @@ def build_variant_set():
         ("replace('abc', 'a', 'd')", "dbc", set(), 1),
         ("replace('{application_name}', 'f', 'F')", "Foo", set(), 1),
         ("str_upper({var4})", "A-B", set(), 1),
+        ("{test::var}", "value", set(), 1),
     ],
 )
 def test_expansions(input, output, no_expand_vars, passes):

--- a/lib/ramble/ramble/test/expander.py
+++ b/lib/ramble/ramble/test/expander.py
@@ -160,6 +160,7 @@ def build_variant_set():
         ("replace('{application_name}', 'f', 'F')", "Foo", set(), 1),
         ("str_upper({var4})", "A-B", set(), 1),
         ("{test::var}", "value", set(), 1),
+        ("{n_ranks:05d}", "00004", set(), 1),
     ],
 )
 def test_expansions(input, output, no_expand_vars, passes):


### PR DESCRIPTION
This merge adds additional tests for the expander, and fixes an edge case where `::` is passed in as part of an expansion keyword.