### PR TITLE
Add CI builds around Ramble perf tests

### DIFF
--- a/share/ramble/cloud-build/ramble-perf-tests.yaml
+++ b/share/ramble/cloud-build/ramble-perf-tests.yaml
@@ -1,0 +1,106 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+steps:
+  # Cancel older builds (only for PR builds)
+  - name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - 'share/ramble/cloud-build/cancel-older-builds.sh'
+    env:
+      - 'PR_NUMBER=$_PR_NUMBER'
+      - 'TRIGGER_NAME=$TRIGGER_NAME'
+      - 'BUILD_ID=$BUILD_ID'
+      - 'PROJECT_ID=$PROJECT_ID'
+  - name: gcr.io/cloud-builders/git
+    args:
+      - fetch
+      - '--unshallow'
+    id: ramble-clone
+  - name: us-central1-docker.pkg.dev/$PROJECT_ID/ramble-repo/ramble-${_BASE_IMG}-${_BASE_VER}-spack${_SPACK_REF}-python${_PYTHON_VER}:latest
+    args:
+      - '-c'
+      - |
+        cd /workspace
+
+        git branch develop origin/develop
+
+        . /opt/spack/share/spack/setup-env.sh
+
+        spack load py-pip ^python
+
+        pip install -r /workspace/requirements-dev.txt
+
+        export SPACK_PYTHON=`which python3`
+
+        . /workspace/share/ramble/setup-env.sh
+
+        echo "Spack version is $(spack --version)"
+        echo "Python version is $(python3 --version)"
+
+        echo "Running Perf Tests..."
+        ramble unit-test --perf
+        test_err=$$?
+
+        if [ $$test_err -eq 0 ]; then
+          echo "Perf tests passed."
+
+          if [ -f "$$RAMBLE_ROOT/perf_test_metrics.json" ]; then
+            echo "Generated Metrics:"
+            cat "$$RAMBLE_ROOT/perf_test_metrics.json"
+            echo ""
+          fi
+
+          if [ -z "$_PR_NUMBER" ] && [ "$_UPLOAD_TO_BQ" == "true" ]; then
+            echo "Uploading metrics to BigQuery..."
+            # This dependency should already exist, but just in case.
+            pip install google-cloud-bigquery
+            
+            python3 share/ramble/qa/upload_perf_metrics.py \
+              --metrics-file "$$RAMBLE_ROOT/perf_test_metrics.json" \
+              --project-id "$_PROJECT_ID" \
+              --dataset-id "$_DATASET_ID" \
+              --table-id "$_TABLE_ID" \
+              --commit-sha "$COMMIT_SHA"
+            
+            upload_err=$$?
+            if [ $$upload_err -ne 0 ]; then
+              echo "Failed to upload metrics."
+              exit $$upload_err
+            fi
+          else
+            echo "Skipping metric upload."
+          fi
+        else
+          echo "Perf tests failed."
+          exit $$test_err
+        fi
+
+    id: ramble-perf-tests
+    entrypoint: /bin/bash
+    env:
+    - 'COMMIT_SHA=$COMMIT_SHA'
+    - 'PR_NUMBER=$_PR_NUMBER'
+
+substitutions:
+  _SPACK_REF: 'v1.0.0'
+  _PYTHON_VER: '3.13.5'
+  _BASE_IMG: 'rockylinux'
+  _BASE_VER: '8'
+  _PROJECT_ID: 'ramble-eng'
+  _DATASET_ID: 'ramble_metrics'
+  _TABLE_ID: 'perf_test_durations'
+  _PR_NUMBER: ''
+  # This is only set to true when pushing to develop branch
+  _UPLOAD_TO_BQ: 'false'
+
+timeout: 3600s
+options:
+  # TODO: Maybe use a higher SKU for more consistent performance?
+  machineType: N1_HIGHCPU_8

--- a/share/ramble/cloud-build/ramble-perf-tests.yaml
+++ b/share/ramble/cloud-build/ramble-perf-tests.yaml
@@ -90,9 +90,9 @@ substitutions:
   _PYTHON_VER: '3.13.5'
   _BASE_IMG: 'rockylinux'
   _BASE_VER: '8'
-  _PROJECT_ID: 'ramble-eng'
-  _DATASET_ID: 'ramble_metrics'
-  _TABLE_ID: 'perf_test_durations'
+  _PROJECT_ID: ''
+  _DATASET_ID: ''
+  _TABLE_ID: ''
   _PR_NUMBER: ''
   # This is only set to true when pushing to develop branch
   _UPLOAD_TO_BQ: 'false'

--- a/share/ramble/cloud-build/ramble-perf-tests.yaml
+++ b/share/ramble/cloud-build/ramble-perf-tests.yaml
@@ -37,7 +37,7 @@ steps:
 
         pip install -r /workspace/requirements-dev.txt
 
-        export SPACK_PYTHON=`which python3`
+        export SPACK_PYTHON=$(which python3)
 
         . /workspace/share/ramble/setup-env.sh
 
@@ -59,9 +59,6 @@ steps:
 
           if [ -z "$_PR_NUMBER" ] && [ "$_UPLOAD_TO_BQ" == "true" ]; then
             echo "Uploading metrics to BigQuery..."
-            # This dependency should already exist, but just in case.
-            pip install google-cloud-bigquery
-            
             python3 share/ramble/qa/upload_perf_metrics.py \
               --metrics-file "$$RAMBLE_ROOT/perf_test_metrics.json" \
               --project-id "$_PROJECT_ID" \

--- a/share/ramble/qa/setup_bq.sh
+++ b/share/ramble/qa/setup_bq.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# Script to setup BigQuery dataset and table for Ramble perf metrics.
+
+PROJECT_ID=${1:-$GOOGLE_CLOUD_PROJECT}
+DATASET_ID=${2:-ramble_metrics}
+TABLE_ID=${3:-perf_test_durations}
+
+if [ -z "$PROJECT_ID" ]; then
+    echo "Usage: $0 <PROJECT_ID> [DATASET_ID] [TABLE_ID]"
+    exit 1
+fi
+
+echo "Setting up BigQuery for project: $PROJECT_ID"
+echo "Dataset: $DATASET_ID"
+echo "Table: $TABLE_ID"
+
+if ! bq ls --project_id="$PROJECT_ID" "$DATASET_ID" &>/dev/null; then
+    echo "Creating dataset $DATASET_ID..."
+    bq --project_id="$PROJECT_ID" mk --dataset \
+        --description "Ramble Performance Metrics" \
+        --location=US \
+        "$DATASET_ID"
+else
+    echo "Dataset $DATASET_ID already exists."
+fi
+
+SCHEMA="test_name:STRING,test_id:STRING,duration:FLOAT,outcome:STRING,timestamp:TIMESTAMP,commit_sha:STRING"
+
+if ! bq ls --project_id="$PROJECT_ID" "$DATASET_ID" | grep -w "$TABLE_ID" &>/dev/null; then
+    echo "Creating table $TABLE_ID..."
+    bq --project_id="$PROJECT_ID" mk --table \
+        --description "Durations of Ramble perf tests" \
+        "${DATASET_ID}.${TABLE_ID}" \
+        "$SCHEMA"
+else
+    echo "Table $TABLE_ID already exists."
+fi
+
+echo "Done."

--- a/share/ramble/qa/upload_perf_metrics.py
+++ b/share/ramble/qa/upload_perf_metrics.py
@@ -69,7 +69,7 @@ def upload_metrics(metrics_file, project_id, dataset_id, table_id, commit_sha=No
 
 def main():
     parser = argparse.ArgumentParser(description="Upload Ramble perf metrics to BigQuery")
-    parser.add_argument("--metrics-file", default="perf_test_metrics.json", help="Path to metrics JSON file")
+    parser.add_argument("--metrics-file", required=True, help="Path to metrics JSON file")
     parser.add_argument("--project-id", required=True, help="GCP Project ID")
     parser.add_argument("--dataset-id", required=True, help="BigQuery Dataset ID")
     parser.add_argument("--table-id", required=True, help="BigQuery Table ID")

--- a/share/ramble/qa/upload_perf_metrics.py
+++ b/share/ramble/qa/upload_perf_metrics.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import argparse
+import datetime
+import json
+import os
+import sys
+
+try:
+    # This is a dependency for Ramble, so it should be installed in the CI pipeline already
+    from google.cloud import bigquery
+except ImportError:
+    bigquery = None
+
+
+def upload_metrics(metrics_file, project_id, dataset_id, table_id, commit_sha=None, dry_run=False):
+    if not os.path.exists(metrics_file):
+        print(f"Metrics file {metrics_file} not found.")
+        return
+
+    with open(metrics_file, "r") as f:
+        metrics = json.load(f)
+
+    if not metrics:
+        print("No metrics to upload.")
+        return
+
+    rows = []
+    timestamp = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    
+    for m in metrics:
+        row = {
+            "test_name": m.get("test_name"),
+            "test_id": m.get("test_id"),
+            "duration": m.get("duration"),
+            "outcome": m.get("outcome"),
+            "timestamp": timestamp,
+            "commit_sha": commit_sha
+        }
+        rows.append(row)
+
+    if dry_run:
+        print(f"[DRY RUN] Would upload {len(rows)} rows to {project_id}.{dataset_id}.{table_id}:")
+        for row in rows:
+            print(json.dumps(row, indent=2))
+        return
+
+    if bigquery is None:
+        print("google-cloud-bigquery not installed. Cannot upload.")
+        sys.exit(1)
+
+    client = bigquery.Client(project=project_id)
+    table_ref = f"{project_id}.{dataset_id}.{table_id}"
+    
+    errors = client.insert_rows_json(table_ref, rows)
+    if errors:
+        print(f"Encountered errors while inserting rows: {errors}")
+        sys.exit(1)
+    
+    print(f"Successfully uploaded {len(rows)} rows to {table_ref}.")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Upload Ramble perf metrics to BigQuery")
+    parser.add_argument("--metrics-file", default="perf_test_metrics.json", help="Path to metrics JSON file")
+    parser.add_argument("--project-id", required=True, help="GCP Project ID")
+    parser.add_argument("--dataset-id", required=True, help="BigQuery Dataset ID")
+    parser.add_argument("--table-id", required=True, help="BigQuery Table ID")
+    parser.add_argument("--commit-sha", help="Git commit SHA")
+    parser.add_argument("--dry-run", action="store_true", help="Print metrics instead of uploading")
+
+    args = parser.parse_args()
+
+    upload_metrics(
+        args.metrics_file,
+        args.project_id,
+        args.dataset_id,
+        args.table_id,
+        args.commit_sha,
+        args.dry_run
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I create two cloud builds around the perf tests:

1. Triggered upon code push to develop. This will upload the perf test durations into BigQuery. My intent is to keep tab of the develop branch for any perf regressions.

2. Triggered upon each PR builds (into main or develop.) This currently just ensures the perf tests passed (but not really looking at assessing the perf.) Once we have enough historical data, this can be updated to diff between the current PR time vs. existing data.