### PR TITLE
Fix up fish shell wrapper to return exit code properly

### DIFF
--- a/lib/ramble/ramble/test/end_to_end/shell_wrappers.py
+++ b/lib/ramble/ramble/test/end_to_end/shell_wrappers.py
@@ -17,7 +17,12 @@ import ramble.paths
 pytestmark = pytest.mark.maybeslow
 
 # TODO: add tests for other supported shells
-_SHELLS_TO_TEST = ["bash"]
+_SHELLS_TO_TEST = ["bash", "fish"]
+
+_SETUP_ENV_FILE = {
+    "bash": "setup-env.sh",
+    "fish": "setup-env.fish",
+}
 
 
 @pytest.mark.parametrize("shell", _SHELLS_TO_TEST)
@@ -26,7 +31,7 @@ def test_shell_wrapper_workspace_activate_missing(shell, tmpdir):
     if not shutil.which(shell):
         pytest.skip(f"{shell} not found")
 
-    setup_env = os.path.join(ramble.paths.prefix, "share", "ramble", "setup-env.sh")
+    setup_env = os.path.join(ramble.paths.prefix, "share", "ramble", _SETUP_ENV_FILE[shell])
     test_script_path = str(tmpdir.join("test_missing.sh"))
 
     with open(test_script_path, "w") as f:

--- a/share/ramble/cloud-build/Dockerfile-apt
+++ b/share/ramble/cloud-build/Dockerfile-apt
@@ -5,7 +5,7 @@ FROM ${BASE_IMG}:${BASE_VER} AS builder
 ARG SPACK_REF=releases/latest
 ARG PYTHON_VER=3.11.14
 
-RUN apt-get update && apt-get install -yq build-essential make git python3 python3-venv python3-pip wget mercurial which subversion curl gcc tar bzip2 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -yq build-essential make git python3 python3-venv python3-pip wget mercurial which subversion curl gcc tar bzip2 fish && rm -rf /var/lib/apt/lists/*
 RUN cd /opt && \
     git clone https://github.com/spack/spack && \
     cd spack && \

--- a/share/ramble/cloud-build/Dockerfile-yum
+++ b/share/ramble/cloud-build/Dockerfile-yum
@@ -5,6 +5,7 @@ FROM ${BASE_IMG}:${BASE_VER} as builder
 ARG SPACK_REF=releases/latest
 ARG PYTHON_VER=3.11.14
 
+# TODO: install fish shell. Building from spack takes a long time, and a simple yum install doesn't work. Right now fish is installed on the debian-based image only
 RUN yum install -yq make git python3 python3-pip wget mercurial which svn curl gcc tar bzip2 gcc-c++ gcc-gfortran xz gzip patch findutils && yum clean all && rm -rf /var/cache/yum
 RUN cd /opt && \
     git clone https://github.com/spack/spack && \

--- a/share/ramble/setup-env.fish
+++ b/share/ramble/setup-env.fish
@@ -449,13 +449,21 @@ function ramble_runner -d "Runner function for the `ramble` wrapper"
                         if check_workspace_activate_flags $_a
                             # no args or args contain -h/--help, --sh, or --csh: just execute
                             command ramble workspace activate $_a
+                            return $status
                         else
                             # actual call to activate: source the output
                             set -l rmb_workspace_cmd "command ramble $rmb_flags workspace activate --fish $__rmb_remaining_args"
                             capture_all $rmb_workspace_cmd __rmb_stat __rmb_stdout __rmb_stderr
+                            set -l rmb_eval_stat 0
                             eval $__rmb_stdout
+                            set rmb_eval_stat $status
                             if test -n "$__rmb_stderr"
                                 echo -s \n$__rmb_stderr 1>&2  # current fish bug: handle stderr manually
+                            end
+                            if test $__rmb_stat -eq 0
+                                return $rmb_eval_stat
+                            else
+                                return $__rmb_stat
                             end
                         end
 
@@ -465,6 +473,7 @@ function ramble_runner -d "Runner function for the `ramble` wrapper"
                         if check_workspace_deactivate_flags $_a
                             # just  execute the command if --sh, --csh, or --fish are provided
                             command ramble workspace deactivate $_a
+                            return $status
 
                         # Test of further (unparsed arguments). Any other
                         # arguments are an error or help, so just run help
@@ -473,16 +482,21 @@ function ramble_runner -d "Runner function for the `ramble` wrapper"
                         # -> Notes: [1] (cf. EOF).
                         else if test -n "$__rmb_remaining_args"
                             command ramble workspace deactivate -h
+                            return $status
                         else
                             # no args: source the output of the command
                             set -l rmb_workspace_cmd "command ramble $rmb_flags workspace deactivate --fish"
                             capture_all $rmb_workspace_cmd __rmb_stat __rmb_stdout __rmb_stderr
+                            set -l rmb_eval_stat 0
                             eval $__rmb_stdout
-                            if test $__rmb_stat -ne 0
-                                if test -n "$__rmb_stderr"
-                                    echo -s \n$__rmb_stderr 1>&2  # current fish bug: handle stderr manually
-                                end
-                                return 1
+                            set rmb_eval_stat $status
+                            if test -n "$__rmb_stderr"
+                                echo -s \n$__rmb_stderr 1>&2  # current fish bug: handle stderr manually
+                            end
+                            if test $__rmb_stat -eq 0
+                                return $rmb_eval_stat
+                            else
+                                return $__rmb_stat
                             end
                         end
 
@@ -495,12 +509,21 @@ function ramble_runner -d "Runner function for the `ramble` wrapper"
                             if test -n "$__rmb_stderr"
                                 echo -s \n$__rmb_stderr 1>&2  # current fish bug: handle stderr manually
                             end
-                            set -l activate_cmd $__rmb_stdout
-                            eval $activate_cmd
-                            set -l ws (echo $activate_cmd | awk '{print $NF}')
-                            echo "==> Created and activated workspace in $ws"
+                            if test $__rmb_stat -eq 0
+                                set -l activate_cmd $__rmb_stdout
+                                set -l rmb_eval_stat 0
+                                eval $activate_cmd
+                                set rmb_eval_stat $status
+                                if test $rmb_eval_stat -eq 0
+                                    set -l ws (echo $activate_cmd | awk '{print $NF}')
+                                    echo "==> Created and activated workspace in $ws"
+                                end
+                                return $rmb_eval_stat
+                            end
+                            return $__rmb_stat
                         else
                             command ramble workspace create $_a
+                            return $status
                         end
 
                     case "*"
@@ -512,6 +535,7 @@ function ramble_runner -d "Runner function for the `ramble` wrapper"
                         else
                             command ramble workspace $rmb_arg
                         end
+                        return $status
                 end
             end
 
@@ -519,6 +543,7 @@ function ramble_runner -d "Runner function for the `ramble` wrapper"
 
         case "*"
             command ramble $argv
+            return $status
 
     end
 


### PR DESCRIPTION
Add in a spack install for `fish`. (Still need to rebuild the docker image.) This is used by the unit-test.