### PR TITLE
Add scoped version variables to objects

### DIFF
--- a/lib/ramble/docs/dev_guides/application_dev_guide.rst
+++ b/lib/ramble/docs/dev_guides/application_dev_guide.rst
@@ -361,16 +361,16 @@ from PEP 440 format for the purpose of version comparisons:
 
     with when("package_manager_family=spack"):
         software_spec(
-            "iozone-{application_version}",
-            pkg_spec="iozone@{application_version}",
+            "iozone-{application::iozone::version}",
+            pkg_spec="iozone@{application::iozone::version}",
             compiler="gcc15",
         )
     
 .. _Python packaging.version: https://packaging.python.org/en/latest/specifications/version-specifiers/
 .. _PEP 440 version specifiers: https://peps.python.org/pep-0440/
 
-Versions can be set for any object by substituting ``application_version`` for
-``<object_name>_version``.
+Versions can be set for any object by substituting ``application::iozone::version`` with
+``<object_type>::<object_name>::version``.
 
 By default, users must select from versions defined in the ``application.py``.
 Strict version checking can be disabled for the entire application using the

--- a/lib/ramble/docs/workspace_config.rst
+++ b/lib/ramble/docs/workspace_config.rst
@@ -1090,6 +1090,8 @@ Ramble automatically generates definitions for the following variables:
 * ``workspace_shared`` - Path to the workspace shared directory
 * ``workspace_archives`` - Path to the workspace archives directory
 * ``workspace_deployments`` - Path to the workspace deployments directory
+* ``<object_type>_version`` - Version of the object (i.e. ``application_version``)
+* ``<object_type>::<object_name>::version`` - Version of the object (i.e. ``application::wrf::version``)
 
 
 Package Manager Specific Generated Variables

--- a/lib/ramble/ramble/definitions/versions.py
+++ b/lib/ramble/ramble/definitions/versions.py
@@ -74,6 +74,9 @@ class ObjectVersion:
     def __str__(self):
         return self.get_version_num()
 
+    def __eq__(self, other):
+        return str(self) == str(other)
+
     def as_str(self, n_indent: int = 0, verbose: bool = False):
         """String representation of this version
 

--- a/lib/ramble/ramble/keywords.py
+++ b/lib/ramble/ramble/keywords.py
@@ -6,9 +6,11 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+import re
 from enum import Enum
 
 import ramble.error
+from ramble.repository import type_definitions
 from ramble.util.logger import logger
 
 key_type = Enum("key_type", ["reserved", "optional", "required"])
@@ -158,6 +160,11 @@ class Keywords:
         if extra_keys is None:
             extra_keys = {}
         self.update_keys(extra_keys)
+        self.reserved_patterns = set()
+        for type_definition in type_definitions.values():
+            object_type = type_definition["singular"]
+            self.reserved_patterns.add(re.compile(rf"{object_type}::\S+::version"))
+            self.reserved_patterns.add(re.compile(rf"{object_type}_version"))
 
     def copy(self):
         new_inst = type(self)()
@@ -177,9 +184,12 @@ class Keywords:
 
     def is_reserved(self, key):
         """Check if a key is reserved"""
-        if not self.is_valid(key):
-            return False
-        return self.keys[key]["type"] == key_type.reserved
+        if self.is_valid(key):
+            return self.keys[key]["type"] == key_type.reserved
+        for reserved_pattern in self.reserved_patterns:
+            if reserved_pattern.match(key):
+                return True
+        return False
 
     def is_optional(self, key):
         """Check if a key is optional"""

--- a/lib/ramble/ramble/test/experiment_set.py
+++ b/lib/ramble/ramble/test/experiment_set.py
@@ -1937,3 +1937,68 @@ def test_validation_in_render_repeat_experiments(workspace_name):
         match_str = r"Invalid number of required variables defined"
         with pytest.raises(ramble.error.ObjectValidationError, match=match_str):
             exp_set.set_experiment_context(experiment_context)
+
+
+def test_modifiers_no_version_set_correctly(workspace_name, mock_modifiers):
+    workspace("create", workspace_name)
+
+    assert workspace_name in workspace("list")
+
+    with ramble.workspace.read(workspace_name) as ws:
+        exp_set = ramble.experiment_set.ExperimentSet(ws)
+
+        application_context = ramble.context.Context()
+        application_context.context_name = "basic"
+        application_context.variables = {
+            "app_var1": "1",
+            "app_var2": "2",
+            "processes_per_node": "1",
+            "mpi_command": "",
+            "batch_submit": "",
+        }
+        application_context.modifiers = [
+            {
+                "name": "test-mod-no-version",
+                "mode": "app-scope",
+                "on_executable": ["builtin::env_vars"],
+            }
+        ]
+
+        workload_context = ramble.context.Context()
+        workload_context.context_name = "test_wl"
+        workload_context.variables = {
+            "wl_var1": "1",
+            "wl_var2": "2",
+        }
+        workload_context.modifiers = [
+            {
+                "name": "test-mod-no-version",
+                "mode": "wl-scope",
+                "on_executable": ["builtin::env_vars"],
+            }
+        ]
+
+        experiment_context = ramble.context.Context()
+        experiment_context.context_name = "test1"
+        experiment_context.variables = {"n_ranks": "2"}
+        experiment_context.modifiers = [
+            {
+                "name": "test-mod-no-version",
+                "mode": "exp-scope",
+                "on_executable": ["builtin::env_vars"],
+            }
+        ]
+
+        exp_set.set_application_context(application_context)
+        exp_set.set_workload_context(workload_context)
+        exp_set.set_experiment_context(experiment_context)
+
+        assert "basic.test_wl.test1" in exp_set.experiments
+        app_inst = exp_set.experiments["basic.test_wl.test1"]
+        assert app_inst.modifiers is not None
+
+        expected_modifier_modes = {"app-scope", "wl-scope", "exp-scope"}
+        for mod_def in app_inst.modifiers:
+            assert mod_def["mode"] in expected_modifier_modes
+            expected_modifier_modes.remove(mod_def["mode"])
+        assert len(expected_modifier_modes) == 0

--- a/lib/ramble/ramble/test/version.py
+++ b/lib/ramble/ramble/test/version.py
@@ -10,6 +10,7 @@ import os
 
 import pytest
 
+import ramble.variants
 import ramble.workspace
 from ramble.appkit import ExecutableApplication
 from ramble.definitions.versions import ObjectVersion
@@ -339,3 +340,141 @@ def test_version_variable_expansion_info(workspace_name):
         exp2_path = os.path.join(ws.experiment_dir, "versions@2.0a1", "test_wl", "generated")
         assert os.path.exists(exp1_path)
         assert os.path.exists(exp2_path)
+
+
+def test_repeat_modifier_versions_error(workspace_name):
+    global_args = ["-w", workspace_name]
+
+    ramble.workspace.create(workspace_name)
+    workspace(
+        "manage",
+        "experiments",
+        "versions@0.9",
+        "--wf",
+        "test_wl",
+        "-v",
+        "n_ranks=1",
+        "-v",
+        "n_nodes=1",
+        "-v",
+        "processes_per_node=1",
+        global_args=global_args,
+    )
+
+    workspace(
+        "manage",
+        "modifiers",
+        "--add",
+        "--scope",
+        "workspace",
+        "--name",
+        "versions-mod@1.0",
+        "--on-executable",
+        "foo",
+        global_args=global_args,
+    )
+
+    workspace(
+        "manage",
+        "modifiers",
+        "--add",
+        "--scope",
+        "workspace",
+        "--name",
+        "versions-mod@2.0",
+        "--on-executable",
+        "bar",
+        global_args=global_args,
+    )
+
+    err_str = (
+        "Two modifier definitions conflict by having the same name and different version numbers."
+    )
+    with pytest.raises(ramble.error.ConflictingModifiersError, match=err_str):
+        workspace("info", global_args=global_args)
+
+
+def test_multi_modifier_versions(workspace_name):
+    global_args = ["-w", workspace_name, "--overwrite-inventories"]
+
+    with ramble.workspace.create(workspace_name) as ws:
+        workspace(
+            "manage",
+            "experiments",
+            "versions@0.9",
+            "--wf",
+            "test_wl",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "processes_per_node=1",
+            global_args=global_args,
+        )
+
+        workspace(
+            "manage",
+            "modifiers",
+            "--add",
+            "--scope",
+            "workspace",
+            "--name",
+            "versions-mod@1.0",
+            global_args=global_args,
+        )
+
+        workspace(
+            "manage",
+            "modifiers",
+            "--add",
+            "--scope",
+            "workspace",
+            "--name",
+            "info@2.0",
+            global_args=global_args,
+        )
+
+        exec_tpl = os.path.join(ws.config_dir, "execute_experiment.tpl")
+        with open(exec_tpl, "a+") as f:
+            f.write("versions-mod version: {modifier::versions-mod::version}\n")
+            f.write("info version: {modifier::info::version}\n")
+
+        workspace("setup", "--dry-run", global_args=global_args)
+
+        exec_script = os.path.join(
+            ws.experiment_dir, "versions@0.9", "test_wl", "generated", "execute_experiment"
+        )
+
+        with open(exec_script) as f:
+            data = f.read()
+            assert "versions-mod version: 1.0" in data
+            assert "info version: 2.0" in data
+
+
+def test_define_version_variables_errors(workspace_name):
+    global_args = ["-w", workspace_name, "--overwrite-inventories"]
+
+    ramble.workspace.create(workspace_name)
+    workspace(
+        "manage",
+        "experiments",
+        "versions@0.9",
+        "--wf",
+        "test_wl",
+        "-v",
+        "n_ranks=1",
+        "-v",
+        "n_nodes=1",
+        "-v",
+        "processes_per_node=1",
+        "-v",
+        "application::versions::version=foo",
+        global_args=global_args,
+    )
+
+    err_str = (
+        'Keyword "application::versions::version" has been defined, but is reserved by ramble'
+    )
+    with pytest.raises(ramble.experiment_set.RambleVariableDefinitionError, match=err_str):
+        workspace("info", global_args=global_args)

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -2404,8 +2404,8 @@ ramble:
 
     def add_modifier(
         self,
+        name_pattern: str,
         scope: Optional[str] = None,
-        name_pattern: Optional[str] = None,
         mode: Optional[str] = None,
         on_executable: Optional[str] = None,
         dry_run: bool = False,
@@ -2436,7 +2436,9 @@ ramble:
             base_section[namespace.modifiers] = syaml.syaml_list()
 
         mod_type = ramble.repository.ObjectTypes.modifiers
-        mod_names = object_utils.filter_by_name([name_pattern], False, mod_type)
+        if isinstance(name_pattern, str):
+            spec_parts = name_pattern.partition("@")
+        mod_names = object_utils.filter_by_name([spec_parts[0]], False, mod_type)
 
         if len(mod_names) < 1:
             logger.error(f"No modifiers found matching name pattern of {name_pattern}")
@@ -2445,6 +2447,8 @@ ramble:
         for mod_name in mod_names:
             mod_def = syaml.syaml_dict()
             mod_def["name"] = mod_name
+            if spec_parts[2]:
+                mod_def["name"] += f"@{spec_parts[2]}"
             if mode is not None:
                 mod_def["mode"] = mode
             if on_exec_list is not None:

--- a/var/ramble/repos/builtin.mock/applications/versions-nonstandard/application.py
+++ b/var/ramble/repos/builtin.mock/applications/versions-nonstandard/application.py
@@ -41,8 +41,8 @@ class VersionsNonstandard(VersionsBase):
     with default_args(when=["package_manager_family=spack"]):
 
         software_spec(
-            "versions-nonstandard-{application_version}",
-            pkg_spec="versions-nonstandard@{application_version}",
+            "versions-nonstandard-{application::versions-nonstandard::version}",
+            pkg_spec="versions-nonstandard@{application::versions-nonstandard::version}",
         )
 
         required_package("versions-nonstandard")

--- a/var/ramble/repos/builtin.mock/modifiers/test-mod-no-version/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/test-mod-no-version/modifier.py
@@ -1,0 +1,32 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.modkit import *
+
+
+class TestModNoVersion(BasicModifier):
+    """Define a test modifier that has no version
+
+    This modifier is just a test of various aspects of the modifier language.
+    """
+
+    name = "test-mod-no-version"
+    tags("test")
+    mode("test", description="This is a test mode")
+    default_mode("test")
+    modifier_conflict(MODIFIER_CONFLICT.name_mode_executables)
+
+    mode(
+        "app-scope", description="This is a test mode at the application scope"
+    )
+
+    mode("wl-scope", description="This is a test mode at the workload scope")
+
+    mode(
+        "exp-scope", description="This is a test mode at the experiment scope"
+    )

--- a/var/ramble/repos/builtin/applications/babelstream/application.py
+++ b/var/ramble/repos/builtin/applications/babelstream/application.py
@@ -29,8 +29,8 @@ class Babelstream(ExecutableApplication):
         define_compiler("gcc12", pkg_spec="gcc@12.2.0")
 
         software_spec(
-            "babelstream-{application_version}",
-            pkg_spec="babelstream@{application_version} +omp",
+            "babelstream-{application::babelstream::version}",
+            pkg_spec="babelstream@{application::babelstream::version} +omp",
             compiler="gcc12",
         )
     stage_files(

--- a/var/ramble/repos/builtin/applications/cloverleaf/application.py
+++ b/var/ramble/repos/builtin/applications/cloverleaf/application.py
@@ -33,8 +33,8 @@ class Cloverleaf(ExecutableApplication):
             compiler="gcc12",
         )
         software_spec(
-            "cloverleaf-{application_version}",
-            pkg_spec="cloverleaf@{application_version} build=ref",
+            "cloverleaf-{application::cloverleaf::version}",
+            pkg_spec="cloverleaf@{application::cloverleaf::version} build=ref",
             compiler="gcc12",
         )
 

--- a/var/ramble/repos/builtin/applications/fio/application.py
+++ b/var/ramble/repos/builtin/applications/fio/application.py
@@ -31,8 +31,8 @@ class Fio(ExecutableApplication):
     with when("package_manager_family=spack"):
         define_compiler("gcc13", pkg_spec="gcc@13.1.0")
         software_spec(
-            "fio-{application_version}",
-            pkg_spec="fio@{application_version} +libaio",
+            "fio-{application::fio::version}",
+            pkg_spec="fio@{application::fio::version} +libaio",
             compiler="gcc13",
         )
 

--- a/var/ramble/repos/builtin/applications/gromacs/application.py
+++ b/var/ramble/repos/builtin/applications/gromacs/application.py
@@ -47,8 +47,8 @@ class Gromacs(ExecutableApplication):
 
         with default_args(compiler="gcc9"):
             software_spec(
-                "gromacs-{application_version}",
-                pkg_spec="gromacs@{application_version}",
+                "gromacs-{application::gromacs::version}",
+                pkg_spec="gromacs@{application::gromacs::version}",
             )
 
     software_spec(

--- a/var/ramble/repos/builtin/applications/hmmer/application.py
+++ b/var/ramble/repos/builtin/applications/hmmer/application.py
@@ -37,8 +37,8 @@ class Hmmer(ExecutableApplication):
         software_spec("impi_2018", pkg_spec="intel-oneapi-mpi@2021.13.1")
 
         software_spec(
-            "hmmer-{application_version}",
-            pkg_spec="hmmer@{application_version}",
+            "hmmer-{application::hmmer::version}",
+            pkg_spec="hmmer@{application::hmmer::version}",
             compiler="gcc9",
         )
 

--- a/var/ramble/repos/builtin/applications/hp2p/application.py
+++ b/var/ramble/repos/builtin/applications/hp2p/application.py
@@ -26,7 +26,8 @@ class Hp2p(ExecutableApplication):
 
     with when("package_manager_family=spack"):
         software_spec(
-            "hp2p-{application_version}", pkg_spec="hp2p@{application_version}"
+            "hp2p-{application::hp2p::version}",
+            pkg_spec="hp2p@{application::hp2p::version}",
         )
         software_spec("openmpi412", pkg_spec="openmpi@4.1.2")
 

--- a/var/ramble/repos/builtin/applications/hpcc/application.py
+++ b/var/ramble/repos/builtin/applications/hpcc/application.py
@@ -37,8 +37,8 @@ class Hpcc(ExecutableApplication):
         software_spec("intel-mpi", pkg_spec="intel-oneapi-mpi@2021.13.1")
 
         software_spec(
-            "hpcc-{application_version}",
-            pkg_spec="hpcc@{application_version}",
+            "hpcc-{application::hpcc::version}",
+            pkg_spec="hpcc@{application::hpcc::version}",
             compiler="gcc9",
         )
 

--- a/var/ramble/repos/builtin/applications/hpcg/application.py
+++ b/var/ramble/repos/builtin/applications/hpcg/application.py
@@ -34,8 +34,8 @@ class Hpcg(BaseHpcg):
         software_spec("intel-mpi", pkg_spec="intel-oneapi-mpi@2021.13.1")
 
         software_spec(
-            "hpcg-{application_version}",
-            pkg_spec="hpcg@{application_version} +openmp",
+            "hpcg-{application::hpcg::version}",
+            pkg_spec="hpcg@{application::hpcg::version} +openmp",
             compiler="gcc9",
         )
 

--- a/var/ramble/repos/builtin/applications/hpl/application.py
+++ b/var/ramble/repos/builtin/applications/hpl/application.py
@@ -25,8 +25,8 @@ class Hpl(HplBase):
         software_spec("impi_2018", pkg_spec="intel-oneapi-mpi@2021.13.1")
 
         software_spec(
-            "hpl-{application_version}",
-            pkg_spec="hpl@{application_version} +openmp",
+            "hpl-{application::hpl::version}",
+            pkg_spec="hpl@{application::hpl::version} +openmp",
             compiler="gcc9",
         )
 

--- a/var/ramble/repos/builtin/applications/intel-hpl/application.py
+++ b/var/ramble/repos/builtin/applications/intel-hpl/application.py
@@ -20,21 +20,21 @@ class IntelHpl(HplBase):
     tags("intel-optimized")
 
     version(
-        "2021.11.0",
-        "Version 2021.11.0 of intel-oneapi-mpi with HPL",
+        "2024.2.0",
+        "Version 2024.2.0 of intel-oneapi-mkl with HPL",
         preferred=True,
     )
 
     with when("package_manager_family=spack"):
         define_compiler("gcc13p2", pkg_spec="gcc@13.2.0")
         software_spec(
-            "imkl_2024p2",
-            pkg_spec="intel-oneapi-mkl@2024.2.0 threads=openmp",
+            "imkl_{application::intel-hpl::version}",
+            pkg_spec="intel-oneapi-mkl@{application::intel-hpl::version} threads=openmp",
             compiler="gcc13p2",
         )
         software_spec(
-            "impi-{application_version}",
-            pkg_spec="intel-oneapi-mpi@{application_version}",
+            "impi-mpi",
+            pkg_spec="intel-oneapi-mpi@2021.13.1",
         )
 
         required_package("intel-oneapi-mkl")

--- a/var/ramble/repos/builtin/applications/intel-mpi-benchmarks/application.py
+++ b/var/ramble/repos/builtin/applications/intel-mpi-benchmarks/application.py
@@ -36,8 +36,8 @@ class IntelMpiBenchmarks(ExecutableApplication):
         define_compiler("gcc9", pkg_spec="gcc@9.3.0")
         software_spec("intel-mpi", pkg_spec="intel-oneapi-mpi@2021.13.1")
         software_spec(
-            "intel-mpi-benchmarks-{application_version}",
-            pkg_spec="intel-mpi-benchmarks@{application_version}",
+            "intel-mpi-benchmarks-{application::intel-mpi-benchmarks::version}",
+            pkg_spec="intel-mpi-benchmarks@{application::intel-mpi-benchmarks::version}",
             compiler="gcc9",
         )
 

--- a/var/ramble/repos/builtin/applications/iozone/application.py
+++ b/var/ramble/repos/builtin/applications/iozone/application.py
@@ -34,8 +34,8 @@ class Iozone(ExecutableApplication):
         # gcc >= 10 compilation errors were addressed in https://github.com/spack/spack-packages/pull/2073.
         define_compiler("gcc15", pkg_spec="gcc@15.2.0")
         software_spec(
-            "iozone-{application_version}",
-            pkg_spec="iozone@{application_version}",
+            "iozone-{application::iozone::version}",
+            pkg_spec="iozone@{application::iozone::version}",
             compiler="gcc15",
         )
         required_package("iozone")

--- a/var/ramble/repos/builtin/applications/iperf2/application.py
+++ b/var/ramble/repos/builtin/applications/iperf2/application.py
@@ -27,8 +27,8 @@ class Iperf2(ExecutableApplication):
 
     with when("package_manager_family=spack"):
         software_spec(
-            "iperf2-{application_version}",
-            pkg_spec="iperf2@{application_version}",
+            "iperf2-{application::iperf2::version}",
+            pkg_spec="iperf2@{application::iperf2::version}",
             compiler="gcc9",
         )
 

--- a/var/ramble/repos/builtin/applications/lammps/application.py
+++ b/var/ramble/repos/builtin/applications/lammps/application.py
@@ -82,8 +82,8 @@ class Lammps(ExecutableApplication):
         software_spec("intel-mpi", pkg_spec="intel-oneapi-mpi@2021.13.1")
 
         software_spec(
-            "lammps-{application_version}",
-            pkg_spec="lammps@{application_version} +opt+manybody+molecule+kspace+rigid+openmp+openmp-package+asphere+dpd-basic+dpd-meso+dpd-react+dpd-smooth",
+            "lammps-{application::lammps::version}",
+            pkg_spec="lammps@{application::lammps::version} +opt+manybody+molecule+kspace+rigid+openmp+openmp-package+asphere+dpd-basic+dpd-meso+dpd-react+dpd-smooth",
             compiler="gcc9",
         )
 

--- a/var/ramble/repos/builtin/applications/lulesh/application.py
+++ b/var/ramble/repos/builtin/applications/lulesh/application.py
@@ -29,8 +29,8 @@ class Lulesh(ExecutableApplication):
         software_spec("intel-mpi", pkg_spec="intel-oneapi-mpi@2021.13.1")
 
         software_spec(
-            "lulesh-{application_version}",
-            pkg_spec="lulesh@{application_version} +openmp",
+            "lulesh-{application::lulesh::version}",
+            pkg_spec="lulesh@{application::lulesh::version} +openmp",
             compiler="gcc13",
         )
 

--- a/var/ramble/repos/builtin/applications/minixyce/application.py
+++ b/var/ramble/repos/builtin/applications/minixyce/application.py
@@ -33,8 +33,8 @@ class Minixyce(ExecutableApplication):
         )
 
         software_spec(
-            "minixyce-{application_version}",
-            pkg_spec="minixyce@{application_version} +mpi",
+            "minixyce-{application::minixyce::version}",
+            pkg_spec="minixyce@{application::minixyce::version} +mpi",
             compiler="gcc12",
         )
 

--- a/var/ramble/repos/builtin/applications/namd/application.py
+++ b/var/ramble/repos/builtin/applications/namd/application.py
@@ -40,8 +40,8 @@ class Namd(ExecutableApplication):
         )
 
         software_spec(
-            "namd-{application_version}",
-            pkg_spec="namd@{application_version} interface=tcl",
+            "namd-{application::namd::version}",
+            pkg_spec="namd@{application::namd::version} interface=tcl",
             compiler="gcc12",
         )
 

--- a/var/ramble/repos/builtin/applications/ngspice/application.py
+++ b/var/ramble/repos/builtin/applications/ngspice/application.py
@@ -32,8 +32,8 @@ class Ngspice(ExecutableApplication):
         )
 
         software_spec(
-            "ngspice-{application_version}",
-            pkg_spec="ngspice@{application_version} build=bin",
+            "ngspice-{application::ngspice::version}",
+            pkg_spec="ngspice@{application::ngspice::version} build=bin",
             compiler="gcc14",
         )
 

--- a/var/ramble/repos/builtin/applications/openfoam-org/application.py
+++ b/var/ramble/repos/builtin/applications/openfoam-org/application.py
@@ -25,8 +25,8 @@ class OpenfoamOrg(OpenfoamBase):
         software_spec("intel-mpi", pkg_spec="intel-oneapi-mpi@2021.13.1")
 
         software_spec(
-            "openfoam-org-{application_version}",
-            pkg_spec="openfoam-org@{application_version}",
+            "openfoam-org-{application::openfoam-org::version}",
+            pkg_spec="openfoam-org@{application::openfoam-org::version}",
             compiler="gcc9",
         )
 

--- a/var/ramble/repos/builtin/applications/openfoam/application.py
+++ b/var/ramble/repos/builtin/applications/openfoam/application.py
@@ -25,8 +25,8 @@ class Openfoam(OpenfoamBase):
         software_spec("intel-mpi", pkg_spec="intel-oneapi-mpi@2021.13.1")
 
         software_spec(
-            "openfoam-{application_version}",
-            pkg_spec="openfoam@{application_version}",
+            "openfoam-{application::openfoam::version}",
+            pkg_spec="openfoam@{application::openfoam::version}",
             compiler="gcc9",
         )
 

--- a/var/ramble/repos/builtin/applications/orca/application.py
+++ b/var/ramble/repos/builtin/applications/orca/application.py
@@ -25,7 +25,8 @@ class Orca(ExecutableApplication):
 
     with when("package_manager_family=spack"):
         software_spec(
-            "orca-{application_version}", pkg_spec="orca@{application_version}"
+            "orca-{application::orca::version}",
+            pkg_spec="orca@{application::orca::version}",
         )
         software_spec("openmpi412", pkg_spec="openmpi@4.1.2")
 

--- a/var/ramble/repos/builtin/applications/py-espresso/application.py
+++ b/var/ramble/repos/builtin/applications/py-espresso/application.py
@@ -23,8 +23,8 @@ class PyEspresso(ExecutableApplication):
 
     with when("package_manager_family=spack"):
         software_spec(
-            "py-espresso-{application_version}",
-            pkg_spec="py-espresso@{application_version}",
+            "py-espresso-{application::py-espresso::version}",
+            pkg_spec="py-espresso@{application::py-espresso::version}",
         )
 
     software_spec(

--- a/var/ramble/repos/builtin/applications/quantum-espresso/application.py
+++ b/var/ramble/repos/builtin/applications/quantum-espresso/application.py
@@ -37,8 +37,8 @@ class QuantumEspresso(ExecutableApplication):
             pkg_spec="intel-oneapi-mpi@2021.8.0",
         )
         software_spec(
-            "quantum-espresso-{application_version}",
-            pkg_spec="quantum-espresso@{application_version}",
+            "quantum-espresso-{application::quantum-espresso::version}",
+            pkg_spec="quantum-espresso@{application::quantum-espresso::version}",
             compiler="gcc13",
         )
 

--- a/var/ramble/repos/builtin/applications/roms/application.py
+++ b/var/ramble/repos/builtin/applications/roms/application.py
@@ -29,7 +29,8 @@ class Roms(ExecutableApplication):
 
     with when("package_manager_family=spack"):
         software_spec(
-            "roms-{application_version}", pkg_spec="roms@{application_version}"
+            "roms-{application::roms::version}",
+            pkg_spec="roms@{application::roms::version}",
         )
         software_spec("openmpi412", pkg_spec="openmpi@4.1.2")
 

--- a/var/ramble/repos/builtin/applications/streamc/application.py
+++ b/var/ramble/repos/builtin/applications/streamc/application.py
@@ -27,8 +27,8 @@ class Streamc(ExecutableApplication):
         define_compiler("gcc12", pkg_spec="gcc@12.2.0")
 
         software_spec(
-            "streamc-{application_version}",
-            pkg_spec='stream@{application_version} +openmp cflags="-O3 -DSTREAM_ARRAY_SIZE=80000000 -DNTIMES=20"',
+            "streamc-{application::streamc::version}",
+            pkg_spec='stream@{application::streamc::version} +openmp cflags="-O3 -DSTREAM_ARRAY_SIZE=80000000 -DNTIMES=20"',
             compiler="gcc12",
         )
 

--- a/var/ramble/repos/builtin/applications/su2/application.py
+++ b/var/ramble/repos/builtin/applications/su2/application.py
@@ -28,8 +28,8 @@ class Su2(ExecutableApplication):
         # See https://github.com/spack/spack/pull/50601 for building with intel mpi.
         software_spec("impi2021p13", pkg_spec="intel-oneapi-mpi@2021.13.0")
         software_spec(
-            "su2-{application_version}",
-            pkg_spec="su2@{application_version} +mpi +openmp",
+            "su2-{application::su2::version}",
+            pkg_spec="su2@{application::su2::version} +mpi +openmp",
             compiler="gcc12",
         )
         required_package("su2")

--- a/var/ramble/repos/builtin/applications/ufs-weather-model/application.py
+++ b/var/ramble/repos/builtin/applications/ufs-weather-model/application.py
@@ -44,8 +44,8 @@ class UfsWeatherModel(ExecutableApplication):
         )
 
         software_spec(
-            "ufs-weather-model-{application_version}",
-            pkg_spec="ufs-weather-model@{application_version} +openmp",
+            "ufs-weather-model-{application::ufs-weather-model::version}",
+            pkg_spec="ufs-weather-model@{application::ufs-weather-model::version} +openmp",
             compiler="gcc9",
         )
 

--- a/var/ramble/repos/builtin/applications/wrf/application.py
+++ b/var/ramble/repos/builtin/applications/wrf/application.py
@@ -37,8 +37,8 @@ class Wrf(ExecutableApplication):
             )
 
             software_spec(
-                "wrfv4-{application_version}",
-                pkg_spec="wrf@{application_version} build_type=dm+sm compile_type=em_real nesting=basic ~pnetcdf",
+                "wrfv4-{application::wrf::version}",
+                pkg_spec="wrf@{application::wrf::version} build_type=dm+sm compile_type=em_real nesting=basic ~pnetcdf",
                 compiler="gcc14",
             )
 
@@ -54,8 +54,8 @@ class Wrf(ExecutableApplication):
             )
 
             software_spec(
-                "wrfv3-{application_version}",
-                pkg_spec="wrf@{application_version} build_type=dm+sm compile_type=em_real nesting=basic ~pnetcdf",
+                "wrfv3-{application::wrf::version}",
+                pkg_spec="wrf@{application::wrf::version} build_type=dm+sm compile_type=em_real nesting=basic ~pnetcdf",
                 compiler="gcc8",
             )
 

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -2234,6 +2234,10 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             "RAMBLE_STATUS",
         ]
 
+        for _, obj in self._objects():
+            remove_variables.append(f"{obj.origin_type}_version")
+            remove_variables.append(f"{obj.origin_type}::{obj.name}::version")
+
         # Remove some variables that don't affect the experiment, and change
         # frequently (or are actually output variables)
         for var in remove_variables:

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -702,13 +702,32 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             if var not in self.variables:
                 default_variables[var] = val.default
 
+        # TODO: Remove the {origin_type}_version variable when we can
+        self.define_variable(
+            f"{self.origin_type}_version", str(self.selected_version)
+        )
+        self.define_variable(
+            f"{self.origin_type}::{self.name}::version",
+            str(self.selected_version),
+        )
+
         # Extract a merged set of when_keys from objects that are not
         # applications.
+        # Also, define object version variables
         object_when_map = {}
         for _, obj in self._objects(
             exclude_types=[ramble.repository.ObjectTypes.applications]
         ):
             object_when_map[obj] = []
+
+            # TODO: Remove the {origin_type}_version variable when we can
+            self.define_variable(
+                f"{obj.origin_type}_version", str(obj.selected_version)
+            )
+            self.define_variable(
+                f"{obj.origin_type}::{obj.name}::version",
+                str(obj.selected_version),
+            )
 
             for when_key, var_list in obj.object_variables.items():
                 keep = False
@@ -1297,8 +1316,8 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                 self.expander.add_no_expand_var(var)
                 mod_inst.expander.add_no_expand_var(var)
 
-            # Define any missing modifier variables
-            self.define_missing_variables()
+        # Define any missing modifier variables
+        self.define_missing_variables()
 
     @property
     def inventory_file(self):

--- a/var/ramble/repos/builtin/base_classes/modifier-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/modifier-base/base_class.py
@@ -200,17 +200,20 @@ class ModifierBase(ObjectMixin, metaclass=ModifierMeta):
                 self_idx = mod_idx
                 continue
 
+            # Don't check conflicts if they are different modifiers
+            if mod_inst.name != self.name:
+                continue
+
             if conflict_value == MODIFIER_CONFLICT.name_only:
-                if mod_inst.name == self.name:
-                    comp_str = mod_inst.config_str(index=mod_idx, indent=4)
-                    self_str = self.config_str(index=self_idx, indent=4)
-                    raise ConflictingModifiersError(
-                        f"Two modifier definitions conflict by having the same name.\n"
-                        f"Modifier 1:\n"
-                        f"{comp_str}"
-                        f"Modifier 2:\n"
-                        f"{self_str}"
-                    )
+                comp_str = mod_inst.config_str(index=mod_idx, indent=4)
+                self_str = self.config_str(index=self_idx, indent=4)
+                raise ConflictingModifiersError(
+                    f"Two modifier definitions conflict by having the same name.\n"
+                    f"Modifier 1:\n"
+                    f"{comp_str}"
+                    f"Modifier 2:\n"
+                    f"{self_str}"
+                )
 
             elif conflict_value == MODIFIER_CONFLICT.name_mode:
                 if (
@@ -283,11 +286,28 @@ class ModifierBase(ObjectMixin, metaclass=ModifierMeta):
                             f"{self_str}"
                         )
 
+            if self.selected_version != mod_inst.selected_version:
+                comp_str = mod_inst.config_str(
+                    index=mod_idx, include_version=True, indent=4
+                )
+                self_str = self.config_str(
+                    index=self_idx, include_version=True, indent=4
+                )
+                raise ConflictingModifiersError(
+                    "Two modifier definitions conflict by having the same name "
+                    "and different version numbers.\n"
+                    f"Modifier 1:\n"
+                    f"{comp_str}"
+                    f"Modifier 2:\n"
+                    f"{self_str}"
+                )
+
     def config_str(
         self,
         index=None,
         include_mode=False,
         include_executables=False,
+        include_version=False,
         indent=0,
     ):
         """Construct a string representation of this modifier's configuration
@@ -296,6 +316,7 @@ class ModifierBase(ObjectMixin, metaclass=ModifierMeta):
             index (int): Index of this modifier to include if provided
             include_mode (bool): Whether to include the mode of the modifier in the configuration or not
             include_executables (bool): Whether to include the on_executables attribute or not
+            include_version (bool): Whether to include the version attribute or not
             indent (int): Number of spaces to prefix the config with
 
         Returns:
@@ -303,6 +324,8 @@ class ModifierBase(ObjectMixin, metaclass=ModifierMeta):
         """
         indentation = " " * indent
         out_str = f"{indentation}Name: {self.name}\n"
+        if include_version:
+            out_str += f"{indentation}Version: {str(self.selected_version)}\n"
         if index is not None:
             out_str += f"{indentation}Index: {index}\n"
         if include_mode:

--- a/var/ramble/repos/builtin/base_classes/object-mixin/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/object-mixin/base_class.py
@@ -30,6 +30,10 @@ class ObjectMixin:
 
     _verbosity = "short"
 
+    def __init__(self):
+        if not hasattr(self, "selected_version"):
+            self.selected_version = None
+
     def __str__(self):
         return self.name
 
@@ -131,12 +135,10 @@ class ObjectMixin:
             version (ramble.definitions.versions.ObjectVersion): Version to set
             description: Description of this version
         """
-        version_inst = None
-
         if version:
-            version_inst = version
+            self.selected_version = version
         else:
-            version_inst = ObjectVersion(
+            self.selected_version = ObjectVersion(
                 version_number=version_number,
                 description=description,
                 origin_type=self.origin_type,
@@ -145,12 +147,8 @@ class ObjectMixin:
             )
 
         self.object_variants.version_variant(
-            f"{self.origin_type}_version", version_inst
+            f"{self.origin_type}_version", self.selected_version
         )
-        if hasattr(self, "define_variable"):
-            self.define_variable(
-                f"{self.origin_type}_version", str(version_inst)
-            )
 
     @staticmethod
     def version_to_pep440(version_str):


### PR DESCRIPTION
This merge handles several things with respect to versions. Primarily, it add scoped version variables in the form of ``{object_type}::{object_name}::version`` to replace the ``{object_type}_version`` variables. For example ``application::wrf::version``.

Modifiers will also now conflict when two modifiers have the same name, but different version strings.

Additionally, it fixes the following issues:
 - Modifiers were not previously allowed (they would error with a variable definition call)
 - `manage modifiers` wouldn't add versioned modifiers
 - Experiments could define version variables

This also updates documentation, and adds tests.