### PR TITLE
Fix gcp-metadata modifier if running in local mode

### DIFF
--- a/var/ramble/repos/builtin/modifiers/gcp-metadata/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/gcp-metadata/modifier.py
@@ -120,10 +120,7 @@ class GcpMetadata(BasicModifier):
                 suffix = self.expander.expand_var("{metadata_parallel_suffix}")
 
                 if suffix and not suffix.startswith("'"):
-                    if suffix:
-                        suffix = "' " + suffix
-                    else:
-                        suffix = "' "
+                    suffix = "' " + suffix
 
             log_name = (
                 log_name if log_name is not None else end_point.split("/")[-1]

--- a/var/ramble/repos/builtin/modifiers/gcp-metadata/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/gcp-metadata/modifier.py
@@ -114,12 +114,12 @@ class GcpMetadata(BasicModifier):
                 if include_hostname and "pdsh" in prefix:
                     prefix = prefix.replace(" -N ", " ")
 
-                if not prefix.endswith(" '"):
+                if prefix and not prefix.endswith(" '"):
                     prefix += " '"
 
                 suffix = self.expander.expand_var("{metadata_parallel_suffix}")
 
-                if not suffix.startswith("'"):
+                if suffix and not suffix.startswith("'"):
                     if suffix:
                         suffix = "' " + suffix
                     else:


### PR DESCRIPTION
Removes single quote (') prefix and suffix from curl commands to get the instance id and physical host.

Before fix:
```
...
'curl -s -f -w "\n" "http://metadata.google.internal/computeMetadata/v1/instance/id" -H "Metadata-Flavor: Google" '  > "/home/duncanspani_google_com/workspaces/megatron-bridge/experiments/megatron-bridge/pretraining/llama3-1-405b-pretraining.1/gcp-metadata.id.log"
...
'curl -s -f -w "\n" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/physical_host" -H "Metadata-Flavor: Google" '  > "/home/duncanspani_google_com/workspaces/megatron-bridge/experiments/megatron-bridge/pretraining/llama3-1-405b-pretraining.1/gcp-metadata.physical_host.log"
...
```

After fix:
```
...
curl -s -f -w "\n" "http://metadata.google.internal/computeMetadata/v1/instance/id" -H "Metadata-Flavor: Google"  > "/home/duncanspani_google_com/workspaces/megatron-bridge/experiments/megatron-bridge/pretraining/llama3-1-405b-pretraining.1/gcp-metadata.id.log"
...
curl -s -f -w "\n" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/physical_host" -H "Metadata-Flavor: Google"  > "/home/duncanspani_google_com/workspaces/megatron-bridge/experiments/megatron-bridge/pretraining/llama3-1-405b-pretraining.1/gcp-metadata.physical_host.log"
...
```