### PR TITLE
Add a FOM for the total job time in seconds

### DIFF
--- a/var/ramble/repos/builtin/workflow_managers/slurm/batch_query.tpl
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/batch_query.tpl
@@ -30,7 +30,7 @@ echo "  job_status: $status" | tee -a $saved
 
 # To avoid nodelist truncation, use a big number. `xargs` handles the extra space correctly.
 paste -d ":" \
-  <(echo "job_nodes job_start job_end job_elapsed_time job_exit_code" | xargs -n1) \
-  <(sacct -j "${job_id}" -o 'nodelist%4096,start,end,elapsed,exitcode' -X -n | xargs -n1) \
+  <(echo "job_nodes job_start job_end job_elapsed_time job_elapsed_seconds job_exit_code" | xargs -n1) \
+  <(sacct -j "${job_id}" -o 'nodelist%4096,start,end,elapsed,elapsedraw,exitcode' -X -n | xargs -n1) \
   | sed "s/^/  /" \
   | tee -a $saved

--- a/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
@@ -301,6 +301,15 @@ class Slurm(WorkflowManagerBase):
             fom_type=FomType.INFO,
         )
 
+    figure_of_merit(
+        "job-elapsed-seconds",
+        fom_regex=r"\s*job_elapsed_seconds:\s*(?P<val>\d+)",
+        group_name="val",
+        units="s",
+        log_file="{experiment_run_dir}/.slurm_job_info",
+        fom_type=FomType.TIME,
+    )
+
     # Capture sbatch script end time, in epoch seconds
     register_builtin(
         "capture_sbatch_script_end_time",


### PR DESCRIPTION
This is backed by Slurm `sacct`'s `ElapsedRaw`, which always returns a whole integer.

Example output:

```
    job-elapsed-seconds:
      summary::min = 458.0 s
      summary::max = 460.0 s
      summary::mean = 459.3 s
      summary::harmonic_mean = 459.3 s
      summary::median = 460.0 s
      summary::variance = 1.3 s^2
      summary::stdev = 1.2 s
      summary::cv = 0.0
      summary::ci_99_upper = 465.9 s
      summary::ci_95_upper = 462.2 s
      summary::ci_90_upper = 461.3 s
      summary::ci_50_upper = 459.9 s
      summary::ci_50_lower = 458.8 s
      summary::ci_90_lower = 457.4 s
      summary::ci_95_lower = 456.5 s
      summary::ci_99_lower = 452.7 s
```