### PR TITLE
Add more tests for the shell wrappers

### DIFF
--- a/lib/ramble/ramble/test/end_to_end/shell_wrappers.py
+++ b/lib/ramble/ramble/test/end_to_end/shell_wrappers.py
@@ -12,7 +12,7 @@ import subprocess
 
 import pytest
 
-import ramble.paths
+from ramble import paths
 
 pytestmark = pytest.mark.maybeslow
 
@@ -32,7 +32,7 @@ def test_shell_wrapper_workspace_activate_missing(shell, tmpdir):
     if not shutil.which(shell):
         pytest.skip(f"{shell} not found")
 
-    setup_env = os.path.join(ramble.paths.prefix, "share", "ramble", _SETUP_ENV_FILE[shell])
+    setup_env = os.path.join(paths.ramble_root, "share", "ramble", _SETUP_ENV_FILE[shell])
     test_script_path = str(tmpdir.join("test_missing.sh"))
 
     with open(test_script_path, "w") as f:
@@ -49,3 +49,69 @@ ramble workspace activate non_existent_workspace
     )
 
     assert process.returncode == 1
+
+
+@pytest.mark.parametrize("shell", _SHELLS_TO_TEST)
+def test_shell_wrapper_workspace_lifecycle(shell, tmpdir):
+    """Test workspace creation, activation and deactivation."""
+    if not shutil.which(shell):
+        pytest.skip(f"{shell} not found")
+
+    setup_env = os.path.join(paths.ramble_root, "share", "ramble", _SETUP_ENV_FILE[shell])
+    test_script_path = str(tmpdir.join(f"test_lifecycle.{shell}"))
+    ws_name = f"test_ws_lifecycle_{shell}"
+
+    script_content = ""
+    if shell == "bash":
+        script_content = f"""
+source "{setup_env}"
+ramble workspace create {ws_name} || exit 1
+ramble workspace activate {ws_name} || exit 2
+ramble workspace deactivate || exit 3
+ramble workspace create -a {ws_name} && exit 4
+exit 0
+"""
+    elif shell == "tcsh":
+        # The set prompt is needed as tcsh doesn't tolerate undefined variables.
+        script_content = f"""
+set prompt=""
+source "{setup_env}"
+ramble workspace create {ws_name}
+if ( $status != 0 ) exit 1
+ramble workspace activate {ws_name}
+if ( $status != 0 ) exit 2
+ramble workspace deactivate
+if ( $status != 0 ) exit 3
+ramble workspace create -a {ws_name}
+if ( $status == 0 ) exit 4
+exit 0
+"""
+    elif shell == "fish":
+        script_content = f"""
+source "{setup_env}"
+ramble workspace create {ws_name}; or exit 1
+ramble workspace activate {ws_name}; or exit 2
+ramble workspace deactivate; or exit 3
+ramble workspace create -a {ws_name}; and exit 4
+exit 0
+"""
+
+    with open(test_script_path, "w") as f:
+        f.write(script_content)
+
+    try:
+        cmd = [shell, test_script_path]
+        process = subprocess.run(
+            cmd, capture_output=True, text=True, cwd=str(tmpdir), env=os.environ.copy()
+        )
+        if process.returncode != 0:
+            print(process.stdout)
+            print(process.stderr)
+        assert process.returncode == 0
+    finally:
+        ramble_exe = os.path.join(paths.ramble_root, "bin", "ramble")
+        subprocess.run(
+            [ramble_exe, "workspace", "rm", "-y", ws_name],
+            capture_output=True,
+            text=True,
+        )

--- a/lib/ramble/ramble/test/end_to_end/shell_wrappers.py
+++ b/lib/ramble/ramble/test/end_to_end/shell_wrappers.py
@@ -61,19 +61,17 @@ def test_shell_wrapper_workspace_lifecycle(shell, tmpdir):
     test_script_path = str(tmpdir.join(f"test_lifecycle.{shell}"))
     ws_name = f"test_ws_lifecycle_{shell}"
 
-    script_content = ""
-    if shell == "bash":
-        script_content = f"""
+    script_templates = {
+        "bash": f"""
 source "{setup_env}"
 ramble workspace create {ws_name} || exit 1
 ramble workspace activate {ws_name} || exit 2
 ramble workspace deactivate || exit 3
 ramble workspace create -a {ws_name} && exit 4
 exit 0
-"""
-    elif shell == "tcsh":
-        # The set prompt is needed as tcsh doesn't tolerate undefined variables.
-        script_content = f"""
+""",
+        "tcsh": f"""
+# The set prompt is needed as tcsh doesn't tolerate undefined variables.
 set prompt=""
 source "{setup_env}"
 ramble workspace create {ws_name}
@@ -85,16 +83,17 @@ if ( $status != 0 ) exit 3
 ramble workspace create -a {ws_name}
 if ( $status == 0 ) exit 4
 exit 0
-"""
-    elif shell == "fish":
-        script_content = f"""
+""",
+        "fish": f"""
 source "{setup_env}"
 ramble workspace create {ws_name}; or exit 1
 ramble workspace activate {ws_name}; or exit 2
 ramble workspace deactivate; or exit 3
 ramble workspace create -a {ws_name}; and exit 4
 exit 0
-"""
+""",
+    }
+    script_content = script_templates[shell]
 
     with open(test_script_path, "w") as f:
         f.write(script_content)


### PR DESCRIPTION
The tests now cover basic create-activate-deactivate flow, as well as ensuring create-with-activation returns non-zero exit code properly.