### PR TITLE
Add `fom-origin-types` to filter FOMs analyze output

### DIFF
--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -545,7 +545,9 @@ def workspace_analyze_setup_parser(subparser):
         "--fom-origin-types",
         dest="fom_origin_types",
         nargs="+",
-        help="list of FOM origin types to include in analysis",
+        action="append",
+        help="FOM origin types to include in analysis output. "
+        + "Accepts space-delimited lists and can be specified multiple times.",
         required=False,
     )
 
@@ -582,6 +584,11 @@ def workspace_analyze(args):
         tags=args.filter_tags,
     )
 
+    if args.fom_origin_types:
+        fom_origin_types = [item for sublist in args.fom_origin_types for item in sublist]
+    else:
+        fom_origin_types = None
+
     pipeline_cls = ramble.pipeline.pipeline_class(current_pipeline)
 
     logger.debug("Analyzing workspace")
@@ -592,7 +599,7 @@ def workspace_analyze(args):
         upload=args.upload,
         print_results=args.print_results,
         summary_only=args.summary_only,
-        fom_origin_types=args.fom_origin_types,
+        fom_origin_types=fom_origin_types,
     )
 
     with ws.read_transaction():

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -542,6 +542,14 @@ def workspace_analyze_setup_parser(subparser):
     )
 
     subparser.add_argument(
+        "--fom-origin-types",
+        dest="fom_origin_types",
+        nargs="+",
+        help="list of FOM origin types to include in analysis",
+        required=False,
+    )
+
+    subparser.add_argument(
         "-s",
         "--summary-only",
         dest="summary_only",
@@ -584,6 +592,7 @@ def workspace_analyze(args):
         upload=args.upload,
         print_results=args.print_results,
         summary_only=args.summary_only,
+        fom_origin_types=args.fom_origin_types,
     )
 
     with ws.read_transaction():

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -250,6 +250,7 @@ class AnalyzePipeline(Pipeline):
         upload=False,
         print_results=False,
         summary_only=False,
+        fom_origin_types=None,
     ):
         super().__init__(workspace, filters)
         self.action_string = "Analyzing"
@@ -257,6 +258,7 @@ class AnalyzePipeline(Pipeline):
         self.upload_results = upload
         self.print_results = print_results
         self.summary_only = summary_only
+        self.fom_origin_types = fom_origin_types
 
     def _prepare(self):
 
@@ -303,6 +305,7 @@ class AnalyzePipeline(Pipeline):
             output_formats=self.output_formats,
             print_results=self.print_results,
             summary_only=self.summary_only,
+            fom_origin_types=self.fom_origin_types,
         )
 
         self.workspace.dump_tables(self.experiment_set, self.filters)

--- a/lib/ramble/ramble/test/end_to_end/analyze_fom_output.py
+++ b/lib/ramble/ramble/test/end_to_end/analyze_fom_output.py
@@ -166,7 +166,12 @@ ramble:
     with open(os.path.join(exp_dir, "test.out"), "w+") as f:
         f.write("12.3 seconds\n")
 
-    output = workspace(
+    output = workspace("analyze", "-p", global_args=workspace_flags)
+    assert "default (null) context figures of merit" in output
+    assert "test_fom = 12.3" in output
+
+    # Ensure application FOMs are displayed
+    output_filtered = workspace(
         "analyze", "--fom-origin-types", "application", "-p", global_args=workspace_flags
     )
     assert "default (null) context figures of merit" in output
@@ -179,3 +184,24 @@ ramble:
     # Ensure context without FOMs is not displayed
     assert "default (null) context figures of merit" not in output_filtered
     assert "test_fom = 12.3" not in output_filtered
+
+    # Test option handling
+    output_filtered = workspace(
+        "analyze",
+        "--fom-origin-types",
+        "application",
+        "--fom-origin-types",
+        "foo",
+        "-p",
+        global_args=workspace_flags,
+    )
+
+    assert "default (null) context figures of merit" in output_filtered
+    assert "test_fom = 12.3" in output_filtered
+
+    output_filtered = workspace(
+        "analyze", "--fom-origin-types", "application", "foo", "-p", global_args=workspace_flags
+    )
+
+    assert "default (null) context figures of merit" in output_filtered
+    assert "test_fom = 12.3" in output_filtered

--- a/lib/ramble/ramble/test/end_to_end/analyze_fom_output.py
+++ b/lib/ramble/ramble/test/end_to_end/analyze_fom_output.py
@@ -134,3 +134,48 @@ def test_analyze_fail_with_no_fom_detected(mock_applications, workspace_name):
     with open(result_file) as f:
         content = f.read()
         assert "Status = FAILED" in content
+
+
+def test_analyze_fom_origin_types_filter(mock_applications, make_workspace_from_config):
+    test_config = """
+ramble:
+  variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
+    processes_per_node: '1'
+    n_ranks: '{processes_per_node}*{n_nodes}'
+  applications:
+    basic:
+      workloads:
+        test_wl:
+          experiments:
+            test:
+              variables:
+                n_nodes: '1'
+  software:
+    packages: {}
+    environments: {}
+"""
+    ws, ws_name = make_workspace_from_config(test_config)
+
+    workspace_flags = ["-w", ws_name]
+
+    workspace("setup", "--dry-run", global_args=workspace_flags)
+
+    exp_dir = os.path.join(ws.root, "experiments", "basic", "test_wl", "test")
+    with open(os.path.join(exp_dir, "test.out"), "w+") as f:
+        f.write("12.3 seconds\n")
+
+    output = workspace(
+        "analyze", "--fom-origin-types", "application", "-p", global_args=workspace_flags
+    )
+    assert "default (null) context figures of merit" in output
+    assert "test_fom = 12.3" in output
+
+    # Use a non-existent origin type to filter out all FOMs
+    output_filtered = workspace(
+        "analyze", "--fom-origin-types", "foo", "-p", global_args=workspace_flags
+    )
+    # Ensure context without FOMs is not displayed
+    assert "default (null) context figures of merit" not in output_filtered
+    assert "test_fom = 12.3" not in output_filtered

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1665,7 +1665,9 @@ ramble:
         latest_file_parent = os.path.join(self.root, latest_base + file_extension)
         self.symlink_result(out_file, latest_file_parent)
 
-    def dump_results(self, output_formats=None, print_results=False, summary_only=False):
+    def dump_results(
+        self, output_formats=None, print_results=False, summary_only=False, fom_origin_types=None
+    ):
         """
         Write out result file in desired format
 
@@ -1681,7 +1683,9 @@ ramble:
         if not self.results:
             self.results = {}
 
-        results = _filter_results(self.results, summary_only=summary_only)
+        results = _filter_results(
+            self.results, summary_only=summary_only, fom_origin_types=fom_origin_types
+        )
         fs.mkdirp(self.results_dir)
 
         results_written = []
@@ -2763,13 +2767,31 @@ def no_active_workspace():
             activate(ws)
 
 
-def _filter_results(results, summary_only):
-    if not summary_only or namespace.experiment not in results:
+def _filter_results(results, summary_only, fom_origin_types=None):
+    if (not summary_only and not fom_origin_types) or namespace.experiment not in results:
         return results
     results = copy.deepcopy(results)
-    results[namespace.experiment] = [
-        r for r in results[namespace.experiment] if r["N_REPEATS"] > 0
-    ]
+
+    filtered_experiments = []
+    for r in results[namespace.experiment]:
+        if summary_only and r["N_REPEATS"] == 0:
+            continue
+
+        if fom_origin_types:
+            filtered_contexts = []
+            for context in r.get("CONTEXTS", []):
+                filtered_foms = []
+                for fom in context.get("foms", []):
+                    if fom.get("origin_type") in fom_origin_types:
+                        filtered_foms.append(fom)
+                if filtered_foms:
+                    context["foms"] = filtered_foms
+                    filtered_contexts.append(context)
+            r["CONTEXTS"] = filtered_contexts
+
+        filtered_experiments.append(r)
+
+    results[namespace.experiment] = filtered_experiments
     return results
 
 

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -667,7 +667,7 @@ _ramble_workspace_setup() {
 }
 
 _ramble_workspace_analyze() {
-    RAMBLE_COMPREPLY="-h --help -f --formats -u --upload -p --print-results -s --summary-only --phases --include-phase-dependencies --where --exclude-where --filter-tags --profile-phase"
+    RAMBLE_COMPREPLY="-h --help -f --formats -u --upload -p --print-results --fom-origin-types -s --summary-only --phases --include-phase-dependencies --where --exclude-where --filter-tags --profile-phase"
 }
 
 _ramble_workspace_push_to_cache() {


### PR DESCRIPTION
The filtering applies to analyze output, but not to tables, since tables already can select FOMs flexibly.

The filtering is done when dumping the output instead of during FOM definitions. Otherwise it may cause issues when FOMs are used as variables in certain cases.