### PR TITLE
Ensure precedence (and merging) apply to environment variables

### DIFF
--- a/lib/ramble/ramble/test/end_to_end/env_var_builtin.py
+++ b/lib/ramble/ramble/test/end_to_end/env_var_builtin.py
@@ -163,7 +163,7 @@ ramble:
             assert "FROM_DIRECTIVE" in f.read()
 
 
-def test_object_env_var_order(
+def test_object_env_var_definitions(
     workspace_name,
     mutable_mock_apps_repo,
     mutable_mock_mods_repo,
@@ -207,32 +207,26 @@ def test_object_env_var_order(
         ws._re_read()
         workspace("setup", "--dry-run", global_args=global_args)
 
-        regex_order = [
+        regex_defs = [
             re.compile(r"export APP_ENV_VAR=APP_ENV_VAR_SET;"),
             re.compile(r"export PACKAGE_ENV_VAR=PKG_ENV_VAR_SET;"),
             re.compile(r"export WORKFLOW_ENV_VAR=WF_ENV_VAR_SET;"),
             re.compile(r"export MOD_ENV_VAR=MOD_ENV_VAR_SET;"),
         ]
 
-        found_order = [False for _ in regex_order]
-
-        found_idx = 0
+        found_defs = [False for _ in regex_defs]
 
         rendered_script = os.path.join(
             ws.experiment_dir, "when-directives", "test_wl", "generated", "execute_experiment"
         )
 
         with open(rendered_script) as f:
-            for line in f.readlines():
-                cur_regex = regex_order[found_idx]
-                if cur_regex.search(line):
-                    found_order[found_idx] = True
-                    found_idx += 1
+            data = f.read()
+            for idx, regex in enumerate(regex_defs):
+                if regex.search(data):
+                    found_defs[idx] = True
 
-                if found_idx == len(found_order):
-                    break
-
-        assert all(found_order)
+        assert all(found_defs)
 
 
 def test_object_env_var_methods(

--- a/lib/ramble/ramble/test/modifier_functionality/repeat_env_var.py
+++ b/lib/ramble/ramble/test/modifier_functionality/repeat_env_var.py
@@ -1,0 +1,72 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import ramble.workspace
+from ramble.main import RambleCommand
+
+workspace = RambleCommand("workspace")
+
+
+def test_modifier_repeat_env_var(
+    workspace_name, mutable_mock_workspace_path, mutable_mock_apps_repo, mutable_mock_mods_repo
+):
+    global_args = ["-w", workspace_name]
+
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+        workspace(
+            "manage",
+            "experiments",
+            "basic",
+            "--wf",
+            "test_wl",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "n_ranks=1",
+            global_args=global_args,
+        )
+
+        workspace(
+            "manage",
+            "modifiers",
+            "--add",
+            "--scope",
+            "workspace",
+            "-n",
+            "test-mod",
+            global_args=global_args,
+        )
+
+        workspace(
+            "manage",
+            "modifiers",
+            "--add",
+            "--scope",
+            "workspace",
+            "-n",
+            "test-mod-2",
+            global_args=global_args,
+        )
+
+        template_path = os.path.join(ws.config_dir, "test.tpl")
+
+        with open(template_path, "w+") as f:
+            f.write("{command}\n{modeless_variable}")
+
+        workspace("setup", "--dry-run", global_args=global_args)
+
+        rendered_path = os.path.join(ws.experiment_dir, "basic", "test_wl", "generated", "test")
+
+        with open(rendered_path) as f:
+            data = f.read()
+            assert "MODELESS_ENV_VAR" in data
+            assert "is_defined" not in data
+            assert "from_test_mod_2 defined" in data

--- a/var/ramble/repos/builtin.mock/modifiers/test-mod-2/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/test-mod-2/modifier.py
@@ -29,3 +29,10 @@ class TestMod2(BasicModifier):
         method="append",
         modes=["test"],
     )
+
+    modifier_variable(
+        "modeless_variable",
+        default="from_test_mod_2 defined",
+        environment_variable_name="MODELESS_ENV_VAR",
+        description="Test a modifier variable without a mode",
+    )

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -513,77 +513,6 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
         self._env_variable_sets = env_variable_sets.copy()
 
-        new_env_vars = {
-            "set": {},
-            "append": [],
-            "prepend": [],
-        }
-        for env_var in self.selected_environment_variables.values():
-            action = env_var.method
-            value = env_var.value
-            # Pull out base group from the new_env_vars dict, based on the env_var's action.
-            new_group = new_env_vars[action]
-
-            if action == "append":
-                # If action is append, we need to pull out the append actions.
-                # Here, the value in the dict is a list (instead of a dict) to allow
-                # for different separators.
-                # We need to find the group (if it exists) with the correct separator,
-                # and add the new env-var to that group.
-                found = False
-                for group in new_group:
-                    if (
-                        "var-separator" in group
-                        and group["var-separator"] == env_var.separator
-                    ):
-                        found = True
-                        new_group = group["vars"]
-                        break
-
-                if not found:
-                    # Create a group, if it wasn't found previously, and
-                    # add to the append action's group.
-                    append_set = {
-                        "var-separator": env_var.separator,
-                        "vars": {},
-                    }
-                    new_group.append(append_set)
-                    new_group = append_set["vars"]
-            elif action == "prepend":
-                # If action is prepend, we need to pull out the prepend actions.
-                # Here, the value is again a list instead of a dict.
-                # However, we don't allow different separators
-                # when prepending. So, here we simply grab the first entry in the list.
-                if not new_group:
-                    prepend_set = {"paths": {}}
-                    new_group.append(prepend_set)
-
-                new_group = new_group[0]["paths"]
-            else:
-                # If action is set, just pull out the value
-                new_group = new_env_vars["set"]
-
-            add = True
-            # Find the env var set with a matching action, and
-            # decide of the env-var should be added or not.
-            for env_var_set in self._env_variable_sets:
-                if action in env_var_set:
-                    if env_var.name in env_var_set[action]:
-                        add = False
-
-            if add:
-                new_group[env_var.name] = value
-
-        # Remove any actions that don't have env-vars, to prevent them
-        # from being actioned later.
-        for action in ["set", "append", "prepend"]:
-            if not new_env_vars[action]:
-                del new_env_vars[action]
-
-        # Add the new env vars to the object's environment variable sets.
-        if new_env_vars:
-            self._env_variable_sets.append(new_env_vars)
-
     def set_variables_and_variants(self, variables, variants, experiment_set):
         """Set internal reference to variables and variants
 
@@ -1644,18 +1573,45 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         Returns:
             (list) List of environment variable sets from all objects
         """
-        obj_env_var_sets = self._env_variable_sets.copy()
-        for _, obj in self._objects(
-            exclude_types=[ramble.repository.ObjectTypes.applications]
-        ):
-            obj_env_vars = {}
+
+        flattened_env_vars = {
+            "set": {},
+            "append": [],
+            "prepend": [],
+            "unset": set(),
+        }
+
+        for _, obj in self._objects():
             for env_var in obj.selected_environment_variables.values():
-                obj_env_vars[env_var.name] = env_var.value
+                action = env_var.method
 
-            if obj_env_vars:
-                obj_env_var_sets.append({"set": obj_env_vars})
+                if action == "set":
+                    flattened_env_vars[action][env_var.name] = env_var.value
+                elif action == "unset":
+                    flattened_env_vars[action].add(env_var.name)
+                else:
+                    sub_dict = {}
+                    if action == "append":
+                        sub_dict["var-separator"] = env_var.separator
+                        sub_dict["vars"] = {env_var.name: env_var.value}
+                    else:
+                        sub_dict["paths"] = {env_var.name: env_var.value}
+                    flattened_env_vars[action].append(sub_dict)
 
-        return obj_env_var_sets
+        # YAML defined env_vars override object defined env_vars
+        for env_var_set in self._env_variable_sets:
+            for action, conf in env_var_set.items():
+                if action == "set":
+                    flattened_env_vars[action].update(conf)
+                elif action == "unset":
+                    flattened_env_vars[action] = flattened_env_vars[
+                        action
+                    ].union(set(conf))
+                else:
+                    flattened_env_vars[action].extend(conf)
+
+        flattened_env_vars["unset"] = list(flattened_env_vars["unset"])
+        return [flattened_env_vars]
 
     def _define_commands(self, exec_graph=None, success_list=None):
         """Populate the internal list of commands based on executables


### PR DESCRIPTION
This merge updates the environment variable application logic so that the various sets of environment variable definitions are merged together into a single set rather than being repeated (with the exception of append / prepend sets).

Additionally, this ensures that the precedence ordering of environment variables is correct (for objects, and YAML defined env-vars).