### PR TITLE
Suppress coloring for the `commands` command

### DIFF
--- a/lib/ramble/ramble/cmd/commands.py
+++ b/lib/ramble/ramble/cmd/commands.py
@@ -198,7 +198,7 @@ class BashCompletionWriter(ArgparseCompletionWriter):
 
 @formatter
 def subcommands(args, out):
-    parser = ramble.main.make_argument_parser()
+    parser = ramble.main.make_argument_parser(color=False)
     ramble.main.add_all_commands(parser)
     writer = SubcommandWriter(parser.prog, out, args.aliases)
     writer.write(parser)
@@ -234,7 +234,7 @@ def rst_index(out):
 @formatter
 def rst(args, out):
     # create a parser with all commands
-    parser = ramble.main.make_argument_parser()
+    parser = ramble.main.make_argument_parser(color=False)
     ramble.main.add_all_commands(parser)
 
     # extract cross-refs of the form `_cmd-ramble-<cmd>:` from rst files
@@ -269,7 +269,7 @@ def names(args, out):
 
 @formatter
 def bash(args, out):
-    parser = ramble.main.make_argument_parser()
+    parser = ramble.main.make_argument_parser(color=False)
     ramble.main.add_all_commands(parser)
 
     writer = BashCompletionWriter(parser.prog, out, args.aliases)

--- a/lib/ramble/ramble/main.py
+++ b/lib/ramble/ramble/main.py
@@ -329,6 +329,11 @@ class RambleArgumentParser(argparse.ArgumentParser):
 
 def make_argument_parser(**kwargs):
     """Create an basic argument parser without any subcommands added."""
+    if "color" in kwargs and sys.version_info < (3, 14):
+        # The color argument was only added since Python 3.14.
+        # See https://docs.python.org/3/library/argparse.html#color.
+        kwargs.pop("color")
+
     parser = RambleArgumentParser(
         formatter_class=RambleHelpFormatter,
         add_help=False,


### PR DESCRIPTION
Since python 3.14, the argpasrse help formatter by default adds color code into the help text: https://docs.python.org/3/library/argparse.html#color, when it thinks it's running in a pseudo terminal. This causes commands like `ramble commands --update-completion` to generate bad auto-completion code. The current fix is to use the `color=False` argument to suppress this behavior, for the `commands` command only, as this command is used to generate auto-completion and documentation.