### PR TITLE
Remove the `elapsed_time` FOM from slurm workflow manager

### DIFF
--- a/var/ramble/repos/builtin/workflow_managers/slurm/batch_query.tpl
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/batch_query.tpl
@@ -30,7 +30,7 @@ echo "  job_status: $status" | tee -a $saved
 
 # To avoid nodelist truncation, use a big number. `xargs` handles the extra space correctly.
 paste -d ":" \
-  <(echo "job_nodes job_start job_end job_elapsed_time job_elapsed_seconds job_exit_code" | xargs -n1) \
-  <(sacct -j "${job_id}" -o 'nodelist%4096,start,end,elapsed,elapsedraw,exitcode' -X -n | xargs -n1) \
+  <(echo "job_nodes job_start job_end job_elapsed_seconds job_exit_code" | xargs -n1) \
+  <(sacct -j "${job_id}" -o 'nodelist%4096,start,end,elapsedraw,exitcode' -X -n | xargs -n1) \
   | sed "s/^/  /" \
   | tee -a $saved

--- a/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
@@ -290,7 +290,6 @@ class Slurm(WorkflowManagerBase):
         "nodes",
         "start",
         "end",
-        "elapsed_time",
         "exit_code",
     ]:
         figure_of_merit(


### PR DESCRIPTION
It already captures the `elapsed_time_raw` (duration in seconds) FOM, which is better than this as the former allows for easier aggregation.