### PR TITLE
Perform simple string matching to short-circuit regex match

### DIFF
--- a/lib/ramble/ramble/test/util/foms.py
+++ b/lib/ramble/ramble/test/util/foms.py
@@ -29,6 +29,8 @@ from ramble.util.foms import get_literal_from_regex
         (r"^[0-9]+$", ""),
         (r"^\s*$", ""),
         (r"hello\sworld", "hello"),
+        # Invalid regex
+        (r"hello(w", ""),
     ],
 )
 def test_get_literal_from_regex_functionality(regex_str, expected):

--- a/lib/ramble/ramble/test/util/foms.py
+++ b/lib/ramble/ramble/test/util/foms.py
@@ -1,0 +1,45 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import pytest
+
+from ramble.util.foms import get_literal_from_regex
+
+
+@pytest.mark.parametrize(
+    "regex_str, expected",
+    [
+        (r"foo bar", "foo bar"),
+        (r"Sleep for (?P<time>[0-9]+) seconds", "Sleep for"),
+        (r".*?(?P<mins>[0-9]+):(?P<secs>[0-9]+)\.(?P<millisecs>[0-9]+) elapsed", ":"),
+        (r"a|b", ""),
+        (r"(ab|c)def", "def"),
+        (r"def(a|b)c", "def"),
+        (r"ab?c", "a"),
+        (r"a*bc", "bc"),
+        (r"a+b?c", "c"),
+        (r"(optional)? required", "required"),
+        (r"a(?:bc)?d", "a"),
+        (r".*", ""),
+        (r"^[0-9]+$", ""),
+        (r"^\s*$", ""),
+        (r"hello\sworld", "hello"),
+    ],
+)
+def test_get_literal_from_regex_functionality(regex_str, expected):
+    """Test functionality of get_literal_from_regex helper logic"""
+    assert get_literal_from_regex(regex_str) == expected
+
+
+def test_get_literal_from_regex_missing_sre_parse(monkeypatch):
+    """Test fallback logic when sre_parse is unavailable."""
+    import ramble.util.foms
+
+    monkeypatch.setattr(ramble.util.foms, "sre_parse", None)
+
+    assert get_literal_from_regex(r"Sleep for (?P<time>[0-9]+) seconds") == ""

--- a/lib/ramble/ramble/util/foms.py
+++ b/lib/ramble/ramble/util/foms.py
@@ -7,6 +7,7 @@
 # except according to those terms.
 
 import copy
+import re
 from enum import Enum
 
 
@@ -64,3 +65,44 @@ class SummaryFoms(Enum):
     SUMMARY = "Experiment Summary"
     N_TOTAL = "n_total_repeats"
     N_SUCCESS = "n_success_repeats"
+
+
+# Try to import the internal parser for the re module
+try:
+    # See https://github.com/python/cpython/issues/91308
+    import re._parser as sre_parse
+except ImportError:
+    try:
+        # This is for Python 3.10 or earlier
+        import sre_parse
+    except ImportError:
+        sre_parse = None
+
+
+def get_literal_from_regex(regex_str: str) -> str:
+    """
+    Extracts a first-encountered required literal string from a regex pattern.
+
+    This is used to create fast string pre-filters to avoid executing complex regex matching.
+    This is not exhaustive, as it doesn't recurse into sub-patterns. It is only intended as a
+    heuristic to short-circuit the matching process.
+    """
+    if not sre_parse:
+        return ""
+
+    try:
+        tree = sre_parse.parse(regex_str)
+    # re.error is renamed, but it's kept around for backward compatibility
+    # See https://docs.python.org/3/library/re.html#exceptions
+    except re.error:
+        return ""
+
+    current_literal = ""
+    for node in tree:
+        node_name = str(node[0])
+        if node_name == "LITERAL":
+            current_literal += chr(node[1])
+        elif current_literal:
+            break
+
+    return current_literal.strip()

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -59,7 +59,7 @@ from ramble.language.shared_language import (
     register_phase,
 )
 from ramble.util import conversions
-from ramble.util.foms import FomType, SummaryFoms
+from ramble.util.foms import FomType, SummaryFoms, get_literal_from_regex
 from ramble.util.logger import logger
 from ramble.util.naming import NS_SEPARATOR
 from ramble.util.output_capture import output_mapper
@@ -2606,7 +2606,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                 ]
 
                 with open(file) as f:
-                    for line in f.readlines():
+                    for line in f:
                         new_per_file_crit_objs = []
                         for crit_obj in per_file_crit_objs:
                             if crit_obj.passed(line, self):
@@ -2621,9 +2621,15 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                         for context, foms in file_conf["contexts"].items():
                             if not context == _NULL_CONTEXT:
                                 context_conf = f_defs[context]["definition"]
-                                context_match = context_conf["regex"].match(
-                                    line
-                                )
+                                if (
+                                    context_conf.get("pre_filter", "")
+                                    not in line
+                                ):
+                                    context_match = None
+                                else:
+                                    context_match = context_conf[
+                                        "regex"
+                                    ].match(line)
 
                                 if context_match:
                                     context_name = format_context(
@@ -2642,7 +2648,10 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
                             for fom in foms:
                                 fom_conf = f_defs[context]["foms"][fom]
-                                fom_match = fom_conf["regex"].match(line)
+                                if fom_conf.get("pre_filter", "") not in line:
+                                    fom_match = None
+                                else:
+                                    fom_match = fom_conf["regex"].match(line)
 
                                 if fom_match:
                                     fom_vars = {}
@@ -3203,6 +3212,9 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                                     )
                                     dest_def_dict[context]["definition"] = {
                                         "regex": re.compile(regex_str),
+                                        "pre_filter": get_literal_from_regex(
+                                            regex_str
+                                        ),
                                         "format": all_contexts[context][
                                             "output_format"
                                         ],
@@ -3236,6 +3248,11 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                                 except ramble.expander.RambleSyntaxError:
                                     return None
 
+                            expanded_regex = (
+                                ""
+                                if is_inmem
+                                else _expand_var(source_def["regex"])
+                            )
                             fom_def = {
                                 "origin": source.name,
                                 "origin_type": source.origin_type,
@@ -3249,9 +3266,12 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                                 "regex": (
                                     ""
                                     if is_inmem
-                                    else re.compile(
-                                        _expand_var(source_def["regex"])
-                                    )
+                                    else re.compile(expanded_regex)
+                                ),
+                                "pre_filter": (
+                                    ""
+                                    if is_inmem
+                                    else get_literal_from_regex(expanded_regex)
                                 ),
                                 "fom_type": source_def["fom_type"].to_dict(),
                                 "fom_map_key": source_def["fom_map_key"],


### PR DESCRIPTION
This aims to speed up fom (and context) matching, by (conservatively) extracing a required literal from the given regex, and skips any lines that don't contain the literal.

Separately, it also updates to iterate over a file instead of `readlines` for less eager memory footprint.

This optimization reduces the analyze_perf test runtime from 41s to 31s.