### PR TITLE
Display perf results as PR comment

### DIFF
--- a/share/ramble/cloud-build/ramble-perf-tests.yaml
+++ b/share/ramble/cloud-build/ramble-perf-tests.yaml
@@ -71,8 +71,26 @@ steps:
               echo "Failed to upload metrics."
               exit $$upload_err
             fi
+          elif [ -n "$_PR_NUMBER" ]; then
+            echo "Posting metrics to PR $_PR_NUMBER..."
+            # Based on https://pyjwt.readthedocs.io/en/stable/installation.html#cryptographic-dependencies-optional
+            pip install pyjwt[crypto]
+            python3 share/ramble/qa/post_perf_pr_comment.py \
+              --metrics-file "$$RAMBLE_ROOT/perf_test_metrics.json" \
+              --commit-sha "$COMMIT_SHA" \
+              --project-id "$_PROJECT_ID" \
+              --dataset-id "$_DATASET_ID" \
+              --table-id "$_TABLE_ID" \
+              --pr-number "$_PR_NUMBER" \
+              --repo "GoogleCloudPlatform/ramble"
+            
+            post_err=$$?
+            if [ $$post_err -ne 0 ]; then
+              echo "Failed to post PR comment."
+              exit $$post_err
+            fi
           else
-            echo "Skipping metric upload."
+            echo "Skipping metric upload and PR comment."
           fi
         else
           echo "Perf tests failed."
@@ -84,6 +102,8 @@ steps:
     env:
     - 'COMMIT_SHA=$COMMIT_SHA'
     - 'PR_NUMBER=$_PR_NUMBER'
+    - 'GITHUB_CLIENT_ID=$_GITHUB_CLIENT_ID'
+    secretEnv: ['GITHUB_APP_PRIVATE_KEY']
 
 substitutions:
   _SPACK_REF: 'v1.0.0'
@@ -93,11 +113,18 @@ substitutions:
   _PROJECT_ID: ''
   _DATASET_ID: ''
   _TABLE_ID: ''
-  _PR_NUMBER: ''
   # This is only set to true when pushing to develop branch
   _UPLOAD_TO_BQ: 'false'
+  # client_id is recommended over app id.
+  # client_id is not a secret.
+  _GITHUB_CLIENT_ID: 'Iv23limpijbNRXQzHurG'
 
 timeout: 3600s
 options:
   # TODO: Maybe use a higher SKU for more consistent performance?
   machineType: N1_HIGHCPU_8
+
+availableSecrets:
+  secretManager:
+  - versionName: projects/$PROJECT_ID/secrets/ramble-pr-bot-private-key/versions/latest
+    env: 'GITHUB_APP_PRIVATE_KEY'

--- a/share/ramble/qa/post_perf_pr_comment.py
+++ b/share/ramble/qa/post_perf_pr_comment.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+import jwt
+from google.cloud import bigquery
+
+# This is used to dedupe comments
+_COMMENT_MARKER = "<!-- ramble-perf-test-metrics -->"
+_RECENT_RESULTS_COUNT = 5
+
+def get_bq_averages(project_id, dataset_id, table_id):
+    client = bigquery.Client(project=project_id)
+    query = f"""
+        SELECT test_name, AVG(duration) as avg_duration
+        FROM (
+            SELECT test_name, duration,
+                   ROW_NUMBER() OVER(PARTITION BY test_name ORDER BY timestamp DESC) as rn
+            FROM `{project_id}.{dataset_id}.{table_id}`
+            WHERE duration IS NOT NULL
+        )
+        WHERE rn <= {_RECENT_RESULTS_COUNT}
+        GROUP BY test_name
+    """
+    try:
+        query_job = client.query(query)
+        results = query_job.result()
+        return {row.test_name: row.avg_duration for row in results}
+    except Exception as e:
+        print(f"Error querying BigQuery: {e}")
+        return {}
+
+def make_github_request(url, token, method="GET", data=None):
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "X-GitHub-Api-Version": "2026-03-10",
+    }
+    
+    if data is not None:
+        data = json.dumps(data).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+        
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        error_msg = e.read().decode("utf-8")
+        print(f"GitHub API Error: {e.code} - {error_msg}")
+        raise
+
+def get_installation_token(client_id, private_key, repo):
+    if not jwt:
+        print("PyJWT is required for GitHub App authentication. Please pip install PyJWT cryptography")
+        sys.exit(1)
+        
+    now = int(time.time())
+    payload = {
+        "iat": now - 60,
+        "exp": now + (10 * 60),
+        "iss": client_id
+    }
+    
+    encoded_jwt = jwt.encode(payload, private_key, algorithm="RS256")
+    
+    url_install = f"https://api.github.com/repos/{repo}/installation"
+    print(f"Fetching installation ID for {repo}...")
+    install_data = make_github_request(url_install, encoded_jwt)
+    install_id = install_data["id"]
+    
+    url_token = f"https://api.github.com/app/installations/{install_id}/access_tokens"
+    print(f"Fetching installation access token...")
+    token_data = make_github_request(url_token, encoded_jwt, method="POST")
+    return token_data["token"]
+
+
+
+def format_markdown(metrics, averages, commit_sha=None):
+    lines = [
+        "## Ramble Performance Test Metrics",
+    ]
+    if commit_sha:
+        lines.append(f"Results produced with commit: {commit_sha}")
+    lines.extend([
+        "",
+        f"| Test Name | Outcome | Duration (s) | Last {_RECENT_RESULTS_COUNT} Avg (s) |",
+        "|---|---|---|---|"
+    ])
+    
+    for m in metrics:
+        name = m.get("test_name", "Unknown")
+        duration = m.get("duration", "N/A")
+        outcome = m.get("outcome", "N/A")
+        
+        avg_dur = averages.get(name)
+        avg_str = f"{avg_dur:.4f}" if avg_dur is not None else "N/A"
+        
+        if isinstance(duration, float):
+            duration = f"{duration:.4f}"
+            
+        lines.append(f"| {name} | {outcome} | {duration} | {avg_str} |")
+        
+    lines.append("")
+    lines.append(_COMMENT_MARKER)
+    
+    return "\n".join(lines)
+
+def main():
+    parser = argparse.ArgumentParser(description="Post Ramble perf metrics to a GitHub PR")
+    parser.add_argument("--metrics-file", required=True, help="Path to metrics JSON file")
+    parser.add_argument("--project-id", help="GCP Project ID")
+    parser.add_argument("--dataset-id", help="BigQuery Dataset ID")
+    parser.add_argument("--table-id", help="BigQuery Table ID")
+    parser.add_argument("--pr-number", required=True, help="GitHub Pull Request number")
+    parser.add_argument("--repo", default="GoogleCloudPlatform/ramble", help="GitHub repository (owner/repo)")
+    parser.add_argument("--commit-sha", help="Commit SHA results were produced with")
+    parser.add_argument("--dry-run", action="store_true", help="Print only")
+    
+    args = parser.parse_args()
+
+    client_id = os.environ.get("GITHUB_CLIENT_ID")
+    private_key = os.environ.get("GITHUB_APP_PRIVATE_KEY")
+    
+    if (not client_id or not private_key) and not args.dry_run:
+        print("GITHUB_CLIENT_ID and GITHUB_APP_PRIVATE_KEY environment variables must be set.")
+        sys.exit(1)
+        
+    if not os.path.exists(args.metrics_file):
+        print(f"Metrics file {args.metrics_file} not found.")
+        sys.exit(0)
+        
+    with open(args.metrics_file, "r") as f:
+        metrics = json.load(f)
+
+    if not metrics:
+        print("No metrics to post.")
+        sys.exit(0)
+
+    averages = get_bq_averages(args.project_id, args.dataset_id, args.table_id)
+    
+    body = format_markdown(metrics, averages, args.commit_sha)
+    
+    if args.dry_run:
+        print("[DRY RUN] Would post the following comment:")
+        print(body)
+        sys.exit(0)
+        
+    token = get_installation_token(client_id, private_key, args.repo)
+        
+    # Avoid posting multiple comments
+    url_comments = f"https://api.github.com/repos/{args.repo}/issues/{args.pr_number}/comments"
+    comments = make_github_request(url_comments, token)
+    
+    existing_comment = None
+    for c in comments:
+        if _COMMENT_MARKER in c.get("body", ""):
+            existing_comment = c
+            break
+            
+    if existing_comment:
+        print(f"Found existing comment (ID: {existing_comment['id']}). Updating...")
+        update_url = f"https://api.github.com/repos/{args.repo}/issues/comments/{existing_comment['id']}"
+        res = make_github_request(update_url, token, method="PATCH", data={"body": body})
+        print("Comment updated successfully.")
+    else:
+        print("Creating new comment...")
+        res = make_github_request(url_comments, token, method="POST", data={"body": body})
+        print("Comment created successfully.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The PR build will create (or update if exists) a comment displaying the perf test durations from the current PR, against the historical data we have.