### PR TITLE
Refactor for more pythonic code

### DIFF
--- a/lib/ramble/ramble/cmd/software_definitions.py
+++ b/lib/ramble/ramble/cmd/software_definitions.py
@@ -122,8 +122,8 @@ def count_conflicts():
 
 def print_conflicts():
     """Print conflict information, if any exist"""
-    if len(conflicts) > 0 or len(unused_compilers) > 0:
-        if len(conflicts) > 0:
+    if conflicts or unused_compilers:
+        if conflicts:
             color.cprint(rucolor.section_title("Software Definition Conflicts:"))
             for pkg_name in conflicts:
 
@@ -139,7 +139,7 @@ def print_conflicts():
                 color.cprint("\tConflicts with objects:")
                 colify(conflicts[pkg_name], indent=24, output=sys.stdout)
 
-        if len(unused_compilers) > 0:
+        if unused_compilers:
             color.cprint(rucolor.section_title("Unused Compilers:"))
             for compiler_name, object_names in unused_compilers.items():
                 color.cprint(

--- a/lib/ramble/ramble/config.py
+++ b/lib/ramble/ramble/config.py
@@ -307,7 +307,7 @@ class SingleFileScope(ConfigScope):
             for section_key, data in section_data.items():
                 self.sections[section_key] = {section_key: data}
 
-        return self.sections.get(section, None)
+        return self.sections.get(section)
 
     def _write_section(self, section):
         data_to_write = self._raw_data
@@ -1153,7 +1153,7 @@ def merge_yaml(dest, source):
     elif they_are(dict):
         # save dest keys to reinsert later -- this ensures that  source items
         # come *before* dest in OrderedDicts
-        dest_keys = [dk for dk in dest.keys() if dk not in source]
+        dest_keys = [dk for dk in dest if dk not in source]
 
         for sk, sv in source.items():
             # always remove the dest items. Python dicts do not overwrite

--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -435,7 +435,7 @@ class ExpansionGraph:
                 cur_match.contents = self.str[left_idx : right_idx + 1]  # Define contents
                 cur_match.root = self.root
 
-                if len(opened) > 0:
+                if opened:
                     children[-1].append(cur_match)
                 else:
                     self.root.add_children(cur_match)
@@ -447,7 +447,7 @@ class ExpansionGraph:
             elif escaped:
                 escaped = False
 
-        if len(opened) > 0:
+        if opened:
             self.root.add_children(children.pop())
 
     def walk(self, in_node=None):
@@ -1096,13 +1096,13 @@ class Expander:
                 kw.value, expansion_vars=expansion_vars
             )
 
-        if node.func.id in supported_scalar_function_pointers.keys():
+        if node.func.id in supported_scalar_function_pointers:
             func = supported_scalar_function_pointers[node.func.id]
             return func(*args, **kwargs)
-        elif node.func.id in supported_list_function_pointers.keys():
+        elif node.func.id in supported_list_function_pointers:
             func = supported_list_function_pointers[node.func.id]
             return list(func(*args, **kwargs))
-        elif node.func.id in supported_scalar_function_with_self_arg_pointers.keys():
+        elif node.func.id in supported_scalar_function_with_self_arg_pointers:
             func = supported_scalar_function_with_self_arg_pointers[node.func.id]
             return func(self, *args, **kwargs)
         else:

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -819,7 +819,7 @@ class ExperimentSet:
         return filtered_list
 
     def add_chained_experiment(self, name, instance):
-        if name in self.chained_experiments.keys():
+        if name in self.chained_experiments:
             raise RambleExperimentSetError(
                 "Cannot add already defined chained "
                 + f"experiment {name} to this experiment set."
@@ -835,9 +835,9 @@ class ExperimentSet:
         return fnmatch.filter(self.experiment_order, pattern)
 
     def get_experiment(self, experiment):
-        if experiment in self.experiments.keys():
+        if experiment in self.experiments:
             return self.experiments[experiment]
-        if experiment in self.chained_experiments.keys():
+        if experiment in self.chained_experiments:
             return self.chained_experiments[experiment]
         return None
 
@@ -852,7 +852,7 @@ class ExperimentSet:
             variable: Name of variable to look up
         """
 
-        if experiment not in self.experiments.keys():
+        if experiment not in self.experiments:
             return None
 
         exp_app = self.experiments[experiment]

--- a/lib/ramble/ramble/fetch_strategy.py
+++ b/lib/ramble/ramble/fetch_strategy.py
@@ -277,7 +277,7 @@ class URLFetchStrategy(FetchStrategy):
         self.extra_options = kwargs.get("fetch_options", {})
         self._curl = None
 
-        self.extension = kwargs.get("extension", None)
+        self.extension = kwargs.get("extension")
 
         if not self.url:
             raise ValueError("URLFetchStrategy requires a url for fetching.")
@@ -692,12 +692,12 @@ class VCSFetchStrategy(FetchStrategy):
         super().__init__(**kwargs)
 
         # Set a URL based on the type of fetch strategy.
-        self.url = kwargs.get(self.url_attr, None)
+        self.url = kwargs.get(self.url_attr)
         if not self.url:
             raise ValueError(f"{self.__class__} requires {self.url_attr} argument.")
 
         for attr in self.optional_attrs:
-            setattr(self, attr, kwargs.get(attr, None))
+            setattr(self, attr, kwargs.get(attr))
 
     @_needs_stage
     def check(self):
@@ -714,7 +714,7 @@ class VCSFetchStrategy(FetchStrategy):
 
         tar = which("tar", required=True)
 
-        patterns = kwargs.get("exclude", None)
+        patterns = kwargs.get("exclude")
         if patterns is not None:
             if isinstance(patterns, str):
                 patterns = [patterns]

--- a/lib/ramble/ramble/graphs.py
+++ b/lib/ramble/ramble/graphs.py
@@ -445,7 +445,7 @@ class ExecutableGraph(AttributeGraph):
     def _resolve_builtin_node(self, builtin_name):
         if builtin_name in self.node_definitions:
             return self.node_definitions[builtin_name]
-        full_names = self._builtin_aliases.get(builtin_name, None)
+        full_names = self._builtin_aliases.get(builtin_name)
         if full_names is None:
             raise GraphNodeNotFoundError(f"builtin {builtin_name} does not exist")
         if len(full_names) > 1:
@@ -487,7 +487,7 @@ class FormattedExecutableGraph(AttributeGraph):
                     expansion_strs.update(expansion_pattern.findall(line))
             dep_nodes = []
             for expansion_str in expansion_strs:
-                if expansion_str in self.node_definitions.keys():
+                if expansion_str in self.node_definitions:
                     dep_node = self.node_definitions[expansion_str]
                     dep_nodes.append(dep_node)
 

--- a/lib/ramble/ramble/keywords.py
+++ b/lib/ramble/ramble/keywords.py
@@ -175,12 +175,12 @@ class Keywords:
     def update_keys(self, extra_keys):
         self.keys.update(extra_keys)
         # Define class attributes for all of the keys
-        for key in self.keys.keys():
+        for key in self.keys:
             setattr(self, key, key)
 
     def is_valid(self, key):
         """Check if a key is valid as a known keyword"""
-        return key in self.keys.keys()
+        return key in self.keys
 
     def is_reserved(self, key):
         """Check if a key is reserved"""
@@ -221,7 +221,7 @@ class Keywords:
         Yields:
             (str): Key name
         """
-        for key in self.keys.keys():
+        for key in self.keys:
             if self.is_required(key):
                 yield key
 
@@ -231,7 +231,7 @@ class Keywords:
         Yields:
             (str): Key name
         """
-        for key in self.keys.keys():
+        for key in self.keys:
             if self.is_reserved(key):
                 yield key
 
@@ -240,7 +240,7 @@ class Keywords:
         if not definitions:
             return
 
-        for definition in definitions.keys():
+        for definition in definitions:
             if self.is_reserved(definition):
                 raise RambleKeywordError(
                     f'Keyword "{definition}" has been defined, ' + "but is reserved by ramble."
@@ -252,15 +252,15 @@ class Keywords:
             return
 
         required_set = set()
-        for key in self.keys.keys():
+        for key in self.keys:
             if self.is_required(key):
                 required_set.add(key)
 
-        for definition in definitions.keys():
+        for definition in definitions:
             if definition in required_set:
                 required_set.remove(definition)
 
-        if len(required_set) > 0:
+        if required_set:
             if warn_validation:
                 for key in required_set:
                     logger.warn(f'Required key "{key}" is not defined')

--- a/lib/ramble/ramble/language/language_base.py
+++ b/lib/ramble/ramble/language/language_base.py
@@ -127,11 +127,11 @@ class DirectiveMeta(abc.ABCMeta):
                 "_directive_names": DirectiveMeta._directive_names.copy(),
             }
 
-            for attr in directive_attrs.keys():
+            for attr in directive_attrs:
                 if hasattr(DirectiveMeta, attr):
                     directive_attrs[attr].update(getattr(DirectiveMeta, attr))
 
-            for attr in directive_attrs.keys():
+            for attr in directive_attrs:
                 setattr(cls, attr, directive_attrs[attr])
 
             # Lazily execute directives

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -962,7 +962,7 @@ def environment_variable(
                         wl_group_when_map[wl_name].append(wl_group_when_set)
 
                 for when_set, app_workloads in obj.workloads.items():
-                    for app_wl_name in app_workloads.keys():
+                    for app_wl_name in app_workloads:
                         if app_wl_name in wl_group_when_map:
                             # Add each variation of merged 'when' set for each workload
                             for wl_group_when_set in wl_group_when_map[app_wl_name]:

--- a/lib/ramble/ramble/main.py
+++ b/lib/ramble/ramble/main.py
@@ -763,7 +763,7 @@ class RambleCommand:
         if tty.is_verbose():
             fmt = self.command_name + ": {0}"
             for ln in out.getvalue().split("\n"):
-                if len(ln) > 0:
+                if ln:
                     logger.verbose(fmt.format(ln.replace("==> ", "")))
 
 
@@ -907,7 +907,7 @@ def _main(argv=None):
             os.environ[var] = os.environ[stored_var_name]
 
     # Just print help and exit if run with no arguments at all
-    no_args = (len(sys.argv) == 1) if argv is None else (len(argv) == 0)
+    no_args = (len(sys.argv) == 1) if argv is None else (not argv)
     if no_args:
         parser.print_help()
         return 1

--- a/lib/ramble/ramble/mirror.py
+++ b/lib/ramble/ramble/mirror.py
@@ -141,8 +141,8 @@ class Mirror:
     def get_profile(self, url_type):
         if isinstance(self._fetch_url, dict):
             if url_type == "push":
-                return self._push_url.get("profile", None)
-            return self._fetch_url.get("profile", None)
+                return self._push_url.get("profile")
+            return self._fetch_url.get("profile")
         else:
             return None
 
@@ -155,8 +155,8 @@ class Mirror:
     def get_access_pair(self, url_type):
         if isinstance(self._fetch_url, dict):
             if url_type == "push":
-                return self._push_url.get("access_pair", None)
-            return self._fetch_url.get("access_pair", None)
+                return self._push_url.get("access_pair")
+            return self._fetch_url.get("access_pair")
         else:
             return None
 
@@ -169,8 +169,8 @@ class Mirror:
     def get_endpoint_url(self, url_type):
         if isinstance(self._fetch_url, dict):
             if url_type == "push":
-                return self._push_url.get("endpoint_url", None)
-            return self._fetch_url.get("endpoint_url", None)
+                return self._push_url.get("endpoint_url")
+            return self._fetch_url.get("endpoint_url")
         else:
             return None
 
@@ -183,8 +183,8 @@ class Mirror:
     def get_access_token(self, url_type):
         if isinstance(self._fetch_url, dict):
             if url_type == "push":
-                return self._push_url.get("access_token", None)
-            return self._fetch_url.get("access_token", None)
+                return self._push_url.get("access_token")
+            return self._fetch_url.get("access_token")
         else:
             return None
 

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -632,7 +632,7 @@ class LogsPipeline(Pipeline):
     def _execute(self):
         def print_archive_files(app_inst, pattern_title, patterns):
             print_header = True
-            if len(patterns) > 0:
+            if patterns:
                 for pattern in patterns:
                     exp_pattern = app_inst.expander.expand_var(pattern)
                     for file in glob.glob(exp_pattern):
@@ -823,7 +823,7 @@ _pipeline_map = {
 def pipeline_class(name):
     """Factory for determining a pipeline class from its name"""
 
-    if name not in _pipeline_map.keys():
+    if name not in _pipeline_map:
         logger.die(
             f"Pipeline {name} is not valid.\n" f"Valid pipelines are {_pipeline_map.keys()}"
         )

--- a/lib/ramble/ramble/renderer.py
+++ b/lib/ramble/ramble/renderer.py
@@ -106,7 +106,7 @@ class RenderGroup:
             f"{self.action} {self.object}", name_template, in_dict
         )
 
-        if len(self.matrices) > 0:
+        if self.matrices:
             extracted = True
 
         return extracted
@@ -187,7 +187,7 @@ class Renderer:
                         f"Variable {var_name} in zip {zip_group} " "does not refer to a vector."
                     )
 
-                if len(object_variables[var_name]) == 0:
+                if not object_variables[var_name]:
                     logger.die(
                         f"Variable {var_name} in zip {zip_group} " "has an invalid length of 0"
                     )

--- a/lib/ramble/ramble/reports.py
+++ b/lib/ramble/ramble/reports.py
@@ -226,12 +226,12 @@ def generate_result_index(experiments: list, all_vars=False, where_query=None):
         if all_vars:
             if "All Variables" not in app_dict[exp["workload_name"]]:
                 app_dict[exp["workload_name"]]["All Variables"] = set()
-            for var_name in exp.keys():
+            for var_name in exp:
                 if is_key_to_skip(var_name):
                     continue
                 app_dict[exp["workload_name"]]["All Variables"].add(var_name)
 
-            for var_name in exp["RAMBLE_VARIABLES"].keys():
+            for var_name in exp["RAMBLE_VARIABLES"]:
                 if is_key_to_skip(var_name):
                     continue
                 app_dict[exp["workload_name"]]["All Variables"].add(var_name)
@@ -268,7 +268,7 @@ def generate_result_index(experiments: list, all_vars=False, where_query=None):
                         app_dict[exp["workload_name"]]["FOMs"].add(fom["name"])
                 else:
                     # All other objects
-                    if fom["origin_type"] in OBJECT_NAMES.keys():
+                    if fom["origin_type"] in OBJECT_NAMES:
                         obj_dict = result_index[OBJECT_NAMES[fom["origin_type"]]]
                         if fom["origin"] not in obj_dict:
                             obj_dict[fom["origin"]] = {"FOMs": set()}
@@ -359,7 +359,7 @@ def extract_data(experiments: List[dict], foms: List[str], variables: List[str],
 
                         if variables:
                             for var in variables:
-                                if var in exp.keys():
+                                if var in exp:
                                     exp_data[var] = exp[var]
                                 elif var in exp["RAMBLE_VARIABLES"]:
                                     exp_data[var] = exp["RAMBLE_VARIABLES"][var]
@@ -872,7 +872,7 @@ class FomPlot(PlotGenerator):
 
         # ax.set_label('Label via method')
         legend_text = perf_measure
-        if len(unit) > 0:
+        if unit:
             legend_text = f"{perf_measure} ({unit})"
 
         ax.legend([legend_text])

--- a/lib/ramble/ramble/results_table.py
+++ b/lib/ramble/ramble/results_table.py
@@ -235,7 +235,7 @@ class ResultsTable:
                 remaining_columns.remove(col_name)
                 self._data[col_name].append(col_value)
 
-            elif col_name not in self._data.keys():
+            elif col_name not in self._data:
                 self._data[col_name] = [None] * self._num_rows + [col_value]
 
             column_values[col_name] = col_value

--- a/lib/ramble/ramble/schema/config.py
+++ b/lib/ramble/ramble/schema/config.py
@@ -230,20 +230,20 @@ def update(data: Dict[str, Any]) -> bool:
 
     # Convert `spack_flags` to `spack:command_flags`
 
-    spack_flags = data.get("spack_flags", None)
+    spack_flags = data.get("spack_flags")
     if isinstance(spack_flags, dict):
-        if data.get("spack", None) is None:
+        if data.get("spack") is None:
             data["spack"] = {"flags": {}}
 
-        global_args = spack_flags.get("global_args", None)
+        global_args = spack_flags.get("global_args")
         if global_args is not None:
             data["spack"]["global"] = {"flags": global_args}
 
-        install_flags = spack_flags.get("install", None)
+        install_flags = spack_flags.get("install")
         if install_flags is not None:
             data["spack"]["install"] = {"flags": install_flags}
 
-        concretize_flags = spack_flags.get("concretize", None)
+        concretize_flags = spack_flags.get("concretize")
         if concretize_flags is not None:
             data["spack"]["concretize"] = {"flags": concretize_flags}
 

--- a/lib/ramble/ramble/test/application.py
+++ b/lib/ramble/ramble/test/application.py
@@ -168,13 +168,13 @@ def test_application_copy_is_deep(app_name, wl_name, mutable_mock_apps_repo):
 
     # Test variables
     for var, val in src_inst.variables.items():
-        assert var in clone_inst.variables.keys()
+        assert var in clone_inst.variables
         assert clone_inst.variables[var] == val
 
     # Test env-vars
     def _compare_env_var_groups(src_group, clone_group):
-        for var_set in src_group.keys():
-            assert var_set in clone_group.keys()
+        for var_set in src_group:
+            assert var_set in clone_group
             # Test set sets
             if var_set == "set":
                 for var, val in src_group[var_set].items():
@@ -225,7 +225,7 @@ def test_required_builtins(mutable_mock_apps_repo, app):
         if conf[app_inst._builtin_required_key]:
             required_builtins.append(builtin)
 
-    for workload in app_inst.workloads[_FS].keys():
+    for workload in app_inst.workloads[_FS]:
         app_inst.define_variable("workload_name", workload)
         exec_graph = app_inst._get_executable_graph(workload)
         for builtin in required_builtins:
@@ -246,7 +246,7 @@ def test_register_builtin_app(mutable_mock_apps_repo):
         else:
             excluded_builtins.append(builtin)
 
-    for workload in app_inst.workloads[_FS].keys():
+    for workload in app_inst.workloads[_FS]:
         exec_graph = app_inst._get_executable_graph(workload)
         app_inst.define_variable("workload_name", workload)
 

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -679,13 +679,13 @@ ramble:
 
     ws1._re_read()
 
-    assert search_files_for_string([config_path], "packages: {}") is True
-    assert search_files_for_string([config_path], "pkg_spec: zlib") is False
+    assert search_files_for_string([config_path], "packages: {}")
+    assert not search_files_for_string([config_path], "pkg_spec: zlib")
 
     workspace("concretize", global_args=["-w", workspace_name])
 
-    assert search_files_for_string([config_path], "packages: {}") is False
-    assert search_files_for_string([config_path], "pkg_spec: zlib") is True
+    assert not search_files_for_string([config_path], "packages: {}")
+    assert search_files_for_string([config_path], "pkg_spec: zlib")
 
 
 def test_concretize_nothing():
@@ -697,13 +697,13 @@ def test_concretize_nothing():
         add_basic(ws)
         check_basic(ws)
 
-        assert search_files_for_string([ws.config_file_path], "packages: {}") is True
-        assert search_files_for_string([ws.config_file_path], "pkg_spec:") is False
+        assert search_files_for_string([ws.config_file_path], "packages: {}")
+        assert not search_files_for_string([ws.config_file_path], "pkg_spec:")
 
         ws.concretize()
 
-        assert search_files_for_string([ws.config_file_path], "packages: {}") is True
-        assert search_files_for_string([ws.config_file_path], "pkg_spec:") is False
+        assert search_files_for_string([ws.config_file_path], "packages: {}")
+        assert not search_files_for_string([ws.config_file_path], "pkg_spec:")
 
 
 def test_concretize_concrete_config(workspace_name):
@@ -815,13 +815,13 @@ ramble:
 
     workspace("concretize", "-f", global_args=["-w", workspace_name])
 
-    assert search_files_for_string([config_path], "zlib:") is True
-    assert search_files_for_string([config_path], "zlib-test") is True
+    assert search_files_for_string([config_path], "zlib:")
+    assert search_files_for_string([config_path], "zlib-test")
 
     workspace("concretize", "--simplify", global_args=["-w", workspace_name])
 
-    assert search_files_for_string([config_path], "zlib:") is True
-    assert search_files_for_string([config_path], "zlib-test") is False
+    assert search_files_for_string([config_path], "zlib:")
+    assert not search_files_for_string([config_path], "zlib-test")
 
 
 def test_setup_command():
@@ -2263,25 +2263,25 @@ software:
 
     ws1._re_read()
 
-    assert search_files_for_string([ws_config_path], "pkg_spec: zlib") is True
-    assert search_files_for_string([ws_config_path], "unused-pkg") is True
-    assert search_files_for_string([ws_config_path], "unused-env") is True
-    assert search_files_for_string([ws_config_path], "unused_exp_template") is True
-    assert search_files_for_string([ws_config_path], "pkg_spec: zlib-configs") is True
-    assert search_files_for_string([ws_config_path], "app_not_in_ws_config") is False
-    assert search_files_for_string([ws_config_path], "pkg_not_in_ws_config") is False
+    assert search_files_for_string([ws_config_path], "pkg_spec: zlib")
+    assert search_files_for_string([ws_config_path], "unused-pkg")
+    assert search_files_for_string([ws_config_path], "unused-env")
+    assert search_files_for_string([ws_config_path], "unused_exp_template")
+    assert search_files_for_string([ws_config_path], "pkg_spec: zlib-configs")
+    assert not search_files_for_string([ws_config_path], "app_not_in_ws_config")
+    assert not search_files_for_string([ws_config_path], "pkg_not_in_ws_config")
 
     workspace("concretize", "--simplify", global_args=["-w", workspace_name])
 
-    assert search_files_for_string([ws_config_path], "pkg_spec: zlib") is True  # keep used pkg
-    assert search_files_for_string([ws_config_path], "unused-pkg") is False  # remove unused pkg
-    assert search_files_for_string([ws_config_path], "unused-env") is False  # remove unused env
+    assert search_files_for_string([ws_config_path], "pkg_spec: zlib")  # keep used pkg
+    assert not search_files_for_string([ws_config_path], "unused-pkg")  # remove unused pkg
+    assert not search_files_for_string([ws_config_path], "unused-env")  # remove unused env
     # remove unused experiment template and associated pkgs/envs
-    assert search_files_for_string([ws_config_path], "unused_exp_template") is False
-    assert search_files_for_string([ws_config_path], "pkg_spec: zlib-configs") is False
+    assert not search_files_for_string([ws_config_path], "unused_exp_template")
+    assert not search_files_for_string([ws_config_path], "pkg_spec: zlib-configs")
     # ensure apps/pkgs/envs are not merged into workspace config from other config files
-    assert search_files_for_string([ws_config_path], "app_not_in_ws_config") is False
-    assert search_files_for_string([ws_config_path], "pkg_not_in_ws_config") is False
+    assert not search_files_for_string([ws_config_path], "app_not_in_ws_config")
+    assert not search_files_for_string([ws_config_path], "pkg_not_in_ws_config")
 
 
 def write_variables_config_file(file_path, levels, value):

--- a/lib/ramble/ramble/test/end_to_end/experiment_hashes.py
+++ b/lib/ramble/ramble/test/end_to_end/experiment_hashes.py
@@ -74,7 +74,7 @@ def test_experiment_hashes(mutable_config, mutable_mock_workspace_path, workspac
             assert attr["digest"] is not None
             expected_attrs.remove(attr["name"])
 
-    assert len(expected_attrs) == 0
+    assert not expected_attrs
 
     # Test Templates
     expected_templates = {"execute_experiment"}
@@ -85,7 +85,7 @@ def test_experiment_hashes(mutable_config, mutable_mock_workspace_path, workspac
             assert temp["digest"] is not None
             expected_templates.remove(temp["name"])
 
-    assert len(expected_templates) == 0
+    assert not expected_templates
 
     # Test software environments
     expected_envs = {"software/spack/gromacs"}
@@ -96,7 +96,7 @@ def test_experiment_hashes(mutable_config, mutable_mock_workspace_path, workspac
             assert env["digest"] is not None
             expected_envs.remove(env["name"])
 
-    assert len(expected_envs) == 0
+    assert not expected_envs
 
     # Test objects
     expected_objects = {}
@@ -112,7 +112,7 @@ def test_experiment_hashes(mutable_config, mutable_mock_workspace_path, workspac
                 assert object_def["digest"] is not None
 
     for obj_set in expected_objects.values():
-        assert len(obj_set) == 0
+        assert not obj_set
 
     # Test workspace inventory
     assert os.path.isfile(workspace_inventory)
@@ -130,7 +130,7 @@ def test_experiment_hashes(mutable_config, mutable_mock_workspace_path, workspac
             assert "contents" in exp
             expected_experiments.remove(exp["name"])
 
-    assert len(expected_experiments) == 0
+    assert not expected_experiments
 
     # Test versions
     expected_versions = {"ramble"}
@@ -141,4 +141,4 @@ def test_experiment_hashes(mutable_config, mutable_mock_workspace_path, workspac
             assert ver["digest"] != ""
             assert ver["digest"] is not None
             expected_versions.remove(ver["name"])
-    assert len(expected_versions) == 0
+    assert not expected_versions

--- a/lib/ramble/ramble/test/end_to_end/known_applications.py
+++ b/lib/ramble/ramble/test/end_to_end/known_applications.py
@@ -50,7 +50,7 @@ def test_known_applications(application, package_manager, mock_file_auto_create,
         ]
         if package_manager == "user-managed":
             app_inst = ramble.repository.get(application)
-            for pkg in app_inst.required_packages.keys():
+            for pkg in app_inst.required_packages:
                 args.append("-v")
                 args.append(f"{pkg}_path='/not/real/path'")
 
@@ -114,7 +114,7 @@ def test_known_workflow_managers(
         ]
         # Handle `user-managed` package manager
         app_inst = ramble.repository.get("gromacs")
-        for pkg in app_inst.required_packages.keys():
+        for pkg in app_inst.required_packages:
             args.append("-v")
             args.append(f"{pkg}_path='/not/real/path'")
 

--- a/lib/ramble/ramble/test/end_to_end/nested_compilers_are_installed.py
+++ b/lib/ramble/ramble/test/end_to_end/nested_compilers_are_installed.py
@@ -94,6 +94,6 @@ ramble:
 
         out_files = glob.glob(os.path.join(ws.log_dir, "**", "*.out"), recursive=True)
 
-        assert search_files_for_string(out_files, gcc8_str) is True
-        assert search_files_for_string(out_files, gcc9_str) is True
-        assert search_files_for_string(out_files, gcc10_str) is True
+        assert search_files_for_string(out_files, gcc8_str)
+        assert search_files_for_string(out_files, gcc9_str)
+        assert search_files_for_string(out_files, gcc10_str)

--- a/lib/ramble/ramble/test/end_to_end/setup_analyze.py
+++ b/lib/ramble/ramble/test/end_to_end/setup_analyze.py
@@ -111,7 +111,7 @@ def test_setup_analyze(test_case_path, workspace_name):
         actual_content = f.read().strip()
     with open(str(expected_analyze)) as f:
         expected_content = f.read().strip()
-    assert len(expected_content) > 0
+    assert expected_content
     # The actual_content can contain some extra executor output, so only assert
     # the expected output is included.
     assert expected_content in actual_content

--- a/lib/ramble/ramble/test/end_to_end/unused_compilers_are_skipped.py
+++ b/lib/ramble/ramble/test/end_to_end/unused_compilers_are_skipped.py
@@ -89,6 +89,6 @@ ramble:
 
         out_files = glob.glob(os.path.join(ws.log_dir, "**", "*.out"), recursive=True)
 
-        assert search_files_for_string(out_files, required_compiler_str) is True
-        assert search_files_for_string(out_files, unused_gcc9_str) is False
-        assert search_files_for_string(out_files, unused_gcc10_str) is False
+        assert search_files_for_string(out_files, required_compiler_str)
+        assert not search_files_for_string(out_files, unused_gcc9_str)
+        assert not search_files_for_string(out_files, unused_gcc10_str)

--- a/lib/ramble/ramble/test/experiment_set.py
+++ b/lib/ramble/ramble/test/experiment_set.py
@@ -59,7 +59,7 @@ def test_single_experiment_in_set():
         exp_set.set_experiment_context(experiment_context)
         exp_set.build_experiment_chains()
 
-        assert "basic.test_wl.series1_4" in exp_set.experiments.keys()
+        assert "basic.test_wl.series1_4" in exp_set.experiments
 
 
 def test_vector_experiment_in_set():
@@ -92,8 +92,8 @@ def test_vector_experiment_in_set():
         exp_set.set_experiment_context(experiment_context)
         exp_set.build_experiment_chains()
 
-        assert "basic.test_wl.series1_4" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_8" in exp_set.experiments.keys()
+        assert "basic.test_wl.series1_4" in exp_set.experiments
+        assert "basic.test_wl.series1_8" in exp_set.experiments
 
 
 def test_vector_length_mismatch_errors(workspace_name, capsys):
@@ -200,8 +200,8 @@ def test_zipped_vector_experiments(workspace_name):
         exp_set.set_experiment_context(experiment_context)
         exp_set.build_experiment_chains()
 
-        assert "basic.test_wl.series1_4_2" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_16_4" in exp_set.experiments.keys()
+        assert "basic.test_wl.series1_4_2" in exp_set.experiments
+        assert "basic.test_wl.series1_16_4" in exp_set.experiments
 
 
 def test_matrix_experiments(workspace_name):
@@ -235,8 +235,8 @@ def test_matrix_experiments(workspace_name):
         exp_set.set_experiment_context(experiment_context)
         exp_set.build_experiment_chains()
 
-        assert "basic.test_wl.series1_4" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_6" in exp_set.experiments.keys()
+        assert "basic.test_wl.series1_4" in exp_set.experiments
+        assert "basic.test_wl.series1_6" in exp_set.experiments
 
 
 def test_matrix_multiplication_experiments(workspace_name):
@@ -274,12 +274,12 @@ def test_matrix_multiplication_experiments(workspace_name):
         exp_set.set_experiment_context(experiment_context)
         exp_set.build_experiment_chains()
 
-        assert "basic.test_wl.series1_2" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_8" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_12" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_4" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_16" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_24" in exp_set.experiments.keys()
+        assert "basic.test_wl.series1_2" in exp_set.experiments
+        assert "basic.test_wl.series1_8" in exp_set.experiments
+        assert "basic.test_wl.series1_12" in exp_set.experiments
+        assert "basic.test_wl.series1_4" in exp_set.experiments
+        assert "basic.test_wl.series1_16" in exp_set.experiments
+        assert "basic.test_wl.series1_24" in exp_set.experiments
 
 
 def test_matrix_vector_experiments(workspace_name):
@@ -317,10 +317,10 @@ def test_matrix_vector_experiments(workspace_name):
         exp_set.set_experiment_context(experiment_context)
         exp_set.build_experiment_chains()
 
-        assert "basic.test_wl.series1_4" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_8" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_6" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_12" in exp_set.experiments.keys()
+        assert "basic.test_wl.series1_4" in exp_set.experiments
+        assert "basic.test_wl.series1_8" in exp_set.experiments
+        assert "basic.test_wl.series1_6" in exp_set.experiments
+        assert "basic.test_wl.series1_12" in exp_set.experiments
 
 
 def test_multi_matrix_experiments(workspace_name):
@@ -358,8 +358,8 @@ def test_multi_matrix_experiments(workspace_name):
         exp_set.set_experiment_context(experiment_context)
         exp_set.build_experiment_chains()
 
-        assert "basic.test_wl.series1_4_2" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_12_4" in exp_set.experiments.keys()
+        assert "basic.test_wl.series1_4_2" in exp_set.experiments
+        assert "basic.test_wl.series1_12_4" in exp_set.experiments
 
 
 def test_full_experiments_from_dict(workspace_name):
@@ -397,10 +397,10 @@ def test_full_experiments_from_dict(workspace_name):
         exp_set.set_workload_context(wlContext)
         exp_set.set_experiment_context(expContext)
 
-        assert "basic.test_wl.test_4_2_1" in exp_set.experiments.keys()
-        assert "basic.test_wl.test_6_2_2" in exp_set.experiments.keys()
-        assert "basic.test_wl.test_8_4_3" in exp_set.experiments.keys()
-        assert "basic.test_wl.test_12_4_4" in exp_set.experiments.keys()
+        assert "basic.test_wl.test_4_2_1" in exp_set.experiments
+        assert "basic.test_wl.test_6_2_2" in exp_set.experiments
+        assert "basic.test_wl.test_8_4_3" in exp_set.experiments
+        assert "basic.test_wl.test_12_4_4" in exp_set.experiments
 
         assert exp_set._context[exp_set._contexts.workspace].context_name is not None
 
@@ -481,8 +481,8 @@ def test_experiment_names_match(workspace_name):
         exp_set.set_experiment_context(experiment_context)
         exp_set.build_experiment_chains()
 
-        assert "basic.test_wl.series1_4_2" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_12_4" in exp_set.experiments.keys()
+        assert "basic.test_wl.series1_4_2" in exp_set.experiments
+        assert "basic.test_wl.series1_12_4" in exp_set.experiments
 
         for exp, app, _ in exp_set.all_experiments():
             assert exp == app.expander.expand_var("{experiment_namespace}")
@@ -547,8 +547,8 @@ def test_cross_experiment_variable_references(workspace_name):
         exp_set.set_experiment_context(experiment2_context)
         exp_set.build_experiment_chains()
 
-        assert "basic.test_wl.series1_4" in exp_set.experiments.keys()
-        assert "basic.test_wl.series2_4" in exp_set.experiments.keys()
+        assert "basic.test_wl.series1_4" in exp_set.experiments
+        assert "basic.test_wl.series2_4" in exp_set.experiments
 
         exp2_app = exp_set.experiments["basic.test_wl.series2_4"]
         assert exp2_app.expander.expand_var("{test_var}") == "success"
@@ -633,8 +633,8 @@ def test_n_ranks_correct_defaults(workspace_name):
         exp_set.set_experiment_context(experiment_context)
         exp_set.build_experiment_chains()
 
-        assert "basic.test_wl.series1_4" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_6" in exp_set.experiments.keys()
+        assert "basic.test_wl.series1_4" in exp_set.experiments
+        assert "basic.test_wl.series1_6" in exp_set.experiments
 
 
 def test_n_nodes_correct_defaults(workspace_name):
@@ -671,8 +671,8 @@ def test_n_nodes_correct_defaults(workspace_name):
         exp_set.set_experiment_context(experiment_context)
         exp_set.build_experiment_chains()
 
-        assert "basic.test_wl.series1_4_2" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_6_3" in exp_set.experiments.keys()
+        assert "basic.test_wl.series1_4_2" in exp_set.experiments
+        assert "basic.test_wl.series1_6_3" in exp_set.experiments
 
 
 def test_processes_per_node_correct_defaults(workspace_name):
@@ -710,8 +710,8 @@ def test_processes_per_node_correct_defaults(workspace_name):
         exp_set.set_experiment_context(experiment_context)
         exp_set.build_experiment_chains()
 
-        assert "basic.test_wl.series1_4_2" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_6_2" in exp_set.experiments.keys()
+        assert "basic.test_wl.series1_4_2" in exp_set.experiments
+        assert "basic.test_wl.series1_6_2" in exp_set.experiments
 
 
 @pytest.mark.parametrize("var", ["env_path"])
@@ -1130,7 +1130,7 @@ def test_modifiers_set_correctly(workspace_name, mock_modifiers):
         for mod_def in app_inst.modifiers:
             assert mod_def["mode"] in expected_modifier_modes
             expected_modifier_modes.remove(mod_def["mode"])
-        assert len(expected_modifier_modes) == 0
+        assert not expected_modifier_modes
 
 
 def test_explicit_zips_work(workspace_name):
@@ -1165,8 +1165,8 @@ def test_explicit_zips_work(workspace_name):
         exp_set.set_experiment_context(experiment_context)
         exp_set.build_experiment_chains()
 
-        assert "basic.test_wl.series1_4" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_8" in exp_set.experiments.keys()
+        assert "basic.test_wl.series1_4" in exp_set.experiments
+        assert "basic.test_wl.series1_8" in exp_set.experiments
 
 
 def test_explicit_zips_in_matrix(workspace_name):
@@ -1206,12 +1206,12 @@ def test_explicit_zips_in_matrix(workspace_name):
         exp_set.set_experiment_context(experiment_context)
         exp_set.build_experiment_chains()
 
-        assert "basic.test_wl.series1_4_1" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_4_a" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_4_3" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_8_1" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_8_a" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_8_3" in exp_set.experiments.keys()
+        assert "basic.test_wl.series1_4_1" in exp_set.experiments
+        assert "basic.test_wl.series1_4_a" in exp_set.experiments
+        assert "basic.test_wl.series1_4_3" in exp_set.experiments
+        assert "basic.test_wl.series1_8_1" in exp_set.experiments
+        assert "basic.test_wl.series1_8_a" in exp_set.experiments
+        assert "basic.test_wl.series1_8_3" in exp_set.experiments
 
 
 def test_explicit_zips_unconsumed(workspace_name):
@@ -1251,12 +1251,12 @@ def test_explicit_zips_unconsumed(workspace_name):
         exp_set.set_experiment_context(experiment_context)
         exp_set.build_experiment_chains()
 
-        assert "basic.test_wl.series1_4_1" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_4_a" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_4_3" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_8_1" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_8_a" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_8_3" in exp_set.experiments.keys()
+        assert "basic.test_wl.series1_4_1" in exp_set.experiments
+        assert "basic.test_wl.series1_4_a" in exp_set.experiments
+        assert "basic.test_wl.series1_4_3" in exp_set.experiments
+        assert "basic.test_wl.series1_8_1" in exp_set.experiments
+        assert "basic.test_wl.series1_8_a" in exp_set.experiments
+        assert "basic.test_wl.series1_8_3" in exp_set.experiments
 
 
 def test_single_var_explicit_zip(workspace_name):
@@ -1293,8 +1293,8 @@ def test_single_var_explicit_zip(workspace_name):
         exp_set.set_experiment_context(experiment_context)
         exp_set.build_experiment_chains()
 
-        assert "basic.test_wl.series1_4" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_8" in exp_set.experiments.keys()
+        assert "basic.test_wl.series1_4" in exp_set.experiments
+        assert "basic.test_wl.series1_8" in exp_set.experiments
 
 
 def test_zip_multi_use_var_errors(workspace_name, capsys):
@@ -1445,8 +1445,8 @@ def test_vector_experiment_with_explicit_excludes(workspace_name):
         exp_set.set_experiment_context(experiment_context)
         exp_set.build_experiment_chains()
 
-        assert "basic.test_wl.series1_4" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_8" not in exp_set.experiments.keys()
+        assert "basic.test_wl.series1_4" in exp_set.experiments
+        assert "basic.test_wl.series1_8" not in exp_set.experiments
 
 
 def test_matrix_experiments_explicit_excludes(workspace_name):
@@ -1487,8 +1487,8 @@ def test_matrix_experiments_explicit_excludes(workspace_name):
         exp_set.set_experiment_context(experiment_context)
         exp_set.build_experiment_chains()
 
-        assert "basic.test_wl.series1_4" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_6" not in exp_set.experiments.keys()
+        assert "basic.test_wl.series1_4" in exp_set.experiments
+        assert "basic.test_wl.series1_6" not in exp_set.experiments
 
 
 def test_vector_experiment_with_where_excludes(workspace_name):
@@ -1527,11 +1527,11 @@ def test_vector_experiment_with_where_excludes(workspace_name):
         exp_set.set_experiment_context(experiment_context)
         exp_set.build_experiment_chains()
 
-        assert "basic.test_wl.series1_2" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_4" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_6" not in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_8" not in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_10" in exp_set.experiments.keys()
+        assert "basic.test_wl.series1_2" in exp_set.experiments
+        assert "basic.test_wl.series1_4" in exp_set.experiments
+        assert "basic.test_wl.series1_6" not in exp_set.experiments
+        assert "basic.test_wl.series1_8" not in exp_set.experiments
+        assert "basic.test_wl.series1_10" in exp_set.experiments
 
 
 def test_vector_experiment_with_late_where_excludes(workspace_name):
@@ -1570,12 +1570,12 @@ def test_vector_experiment_with_late_where_excludes(workspace_name):
         exp_set.set_experiment_context(experiment_context)
         exp_set.build_experiment_chains()
 
-        assert len(exp_set.experiments) == 0
-        assert "basic.test_wl.series1_2" not in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_4" not in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_6" not in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_8" not in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_10" not in exp_set.experiments.keys()
+        assert not exp_set.experiments
+        assert "basic.test_wl.series1_2" not in exp_set.experiments
+        assert "basic.test_wl.series1_4" not in exp_set.experiments
+        assert "basic.test_wl.series1_6" not in exp_set.experiments
+        assert "basic.test_wl.series1_8" not in exp_set.experiments
+        assert "basic.test_wl.series1_10" not in exp_set.experiments
 
 
 def test_vector_experiment_with_multi_where_excludes(workspace_name):
@@ -1614,11 +1614,11 @@ def test_vector_experiment_with_multi_where_excludes(workspace_name):
         exp_set.set_experiment_context(experiment_context)
         exp_set.build_experiment_chains()
 
-        assert "basic.test_wl.series1_2" not in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_4" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_6" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_8" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_10" not in exp_set.experiments.keys()
+        assert "basic.test_wl.series1_2" not in exp_set.experiments
+        assert "basic.test_wl.series1_4" in exp_set.experiments
+        assert "basic.test_wl.series1_6" in exp_set.experiments
+        assert "basic.test_wl.series1_8" in exp_set.experiments
+        assert "basic.test_wl.series1_10" not in exp_set.experiments
 
 
 def test_unused_vector_no_error(workspace_name):
@@ -1658,11 +1658,11 @@ def test_unused_vector_no_error(workspace_name):
         exp_set.set_experiment_context(experiment_context)
         exp_set.build_experiment_chains()
 
-        assert "basic.test_wl.series1_2" not in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_4" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_6" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_8" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_10" not in exp_set.experiments.keys()
+        assert "basic.test_wl.series1_2" not in exp_set.experiments
+        assert "basic.test_wl.series1_4" in exp_set.experiments
+        assert "basic.test_wl.series1_6" in exp_set.experiments
+        assert "basic.test_wl.series1_8" in exp_set.experiments
+        assert "basic.test_wl.series1_10" not in exp_set.experiments
 
 
 def test_unused_zip_no_error(workspace_name):
@@ -1706,11 +1706,11 @@ def test_unused_zip_no_error(workspace_name):
         exp_set.set_experiment_context(experiment_context)
         exp_set.build_experiment_chains()
 
-        assert "basic.test_wl.series1_2" not in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_4" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_6" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_8" in exp_set.experiments.keys()
-        assert "basic.test_wl.series1_10" not in exp_set.experiments.keys()
+        assert "basic.test_wl.series1_2" not in exp_set.experiments
+        assert "basic.test_wl.series1_4" in exp_set.experiments
+        assert "basic.test_wl.series1_6" in exp_set.experiments
+        assert "basic.test_wl.series1_8" in exp_set.experiments
+        assert "basic.test_wl.series1_10" not in exp_set.experiments
 
 
 def test_unused_var_propagates_to_chain(workspace_name):
@@ -2002,4 +2002,4 @@ def test_modifiers_no_version_set_correctly(workspace_name, mock_modifiers):
         for mod_def in app_inst.modifiers:
             assert mod_def["mode"] in expected_modifier_modes
             expected_modifier_modes.remove(mod_def["mode"])
-        assert len(expected_modifier_modes) == 0
+        assert not expected_modifier_modes

--- a/lib/ramble/ramble/uploader.py
+++ b/lib/ramble/ramble/uploader.py
@@ -136,7 +136,7 @@ class Uploader:
             (errors1, errors2, errors3, errors4),
             ("exp", "fom", "experiment_metadata", "software"),
         ):
-            if errors is not None and len(errors) == 0:
+            if errors is not None and not errors:
                 logger.msg(f"New rows have been added in {name}")
             elif errors:
                 logger.die(f"Encountered errors while inserting rows: {errors}")
@@ -268,7 +268,7 @@ def upload_results(results):
         formatted_data = format_data(results)
     except (KeyError, TypeError) as e:
         raise ConfigError("Error parsing file: Does not contain valid data to upload.") from e
-    if len(formatted_data) == 0:
+    if not formatted_data:
         logger.warn("No data to upload")
         return
 

--- a/lib/ramble/ramble/util/logger.py
+++ b/lib/ramble/ramble/util/logger.py
@@ -71,7 +71,7 @@ class Logger:
         If any logs are in the log stack, return the filepath of the active log.
         Otherwise, return the string 'stdout'
         """
-        if len(self.log_stack) > 0:
+        if self.log_stack:
             return self.log_stack[-1][0]
         return "stdout"
 
@@ -81,7 +81,7 @@ class Logger:
         If any logs are in the log stack, return the stream object of the active log.
         Otherwise, return None to indicate the system is handling printing.
         """
-        if len(self.log_stack) > 0:
+        if self.log_stack:
             return self.log_stack[-1][1]
         return None
 
@@ -118,7 +118,7 @@ class Logger:
                 )
 
         else:
-            if len(self.log_stack) > 0:
+            if self.log_stack:
                 stream_index = len(self.log_stack) - 1
 
         if stream_index is not None:

--- a/lib/ramble/ramble/util/spec_utils.py
+++ b/lib/ramble/ramble/util/spec_utils.py
@@ -24,7 +24,7 @@ def specs_conflict(new, existing, prefix="", skip_conflicting_when=False):
             return False
 
     prefixed_keys = {}
-    for key in new.keys():
+    for key in new:
         if new[key] is not None:
             prefixed_keys[key] = f"{prefix}{key}"
 

--- a/lib/ramble/ramble/util/yaml_generation.py
+++ b/lib/ramble/ramble/util/yaml_generation.py
@@ -216,7 +216,7 @@ def apply_default_config_values(config_data, app_inst, default_config_string):
                                      should be used in place of the current value.
     """
     # Set all '{default_config_value}' values to value from the base config
-    for var_name in app_inst.selected_variables.keys():
+    for var_name in app_inst.selected_variables:
         if len(var_name.split(".")) > 1:
             var_val = app_inst.expander.expand_var(app_inst.expander.expansion_str(var_name))
 

--- a/lib/ramble/ramble/workload.py
+++ b/lib/ramble/ramble/workload.py
@@ -187,7 +187,7 @@ class Workload:
         Returns:
             (bool): True if workload is valid, False otherwise
         """
-        if len(self.executables) == 0:
+        if not self.executables:
             return False
 
         return True

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -735,14 +735,14 @@ ramble:
         error_sections = []
         deprecated_sections = []
 
-        if len(deprecated_sections) > 0:
+        if deprecated_sections:
             logger.warn("Your workspace configuration contains deprecated sections:")
             for section in deprecated_sections:
                 logger.warn(f"     {section}")
             logger.warn("Please see the current workspace documentation and update")
             logger.warn("to ensure your workspace continues to function properly")
 
-        if len(error_sections) > 0:
+        if error_sections:
             logger.warn("Your workspace configuration contains invalid sections:")
             for section in deprecated_sections:
                 logger.warn(f"     {section}")
@@ -1280,7 +1280,7 @@ ramble:
         # Unpack all workload names from `when` sets
         all_workload_names = set()
         for _, workloads in app_inst.workloads.items():
-            for workload in workloads.keys():
+            for workload in workloads:
                 all_workload_names.add(workload)
 
         workload_names = []
@@ -1722,7 +1722,7 @@ ramble:
                                 fom_summary = {}
                                 for fom in context["foms"]:
                                     name = fom["name"]
-                                    if name not in fom_summary.keys():
+                                    if name not in fom_summary:
                                         fom_summary[name] = []
                                     stat_name = fom["origin_type"]
                                     if not stat_name.startswith("summary::"):
@@ -2176,7 +2176,7 @@ ramble:
         return os.path.join(self.shared_dir, WORKSPACE_SHARED_LICENSE_PATH)
 
     def template_path(self, name):
-        if name in self._templates.keys():
+        if name in self._templates:
             return os.path.join(self.config_dir, name + TEMPLATE_EXTENSION)
         return None
 
@@ -2764,7 +2764,7 @@ def no_active_workspace():
     effect when there is no active workspace."""
     ws = active_workspace()
     env_var = None
-    if RAMBLE_WORKSPACE_VAR in os.environ.keys():
+    if RAMBLE_WORKSPACE_VAR in os.environ:
         env_var = os.environ[RAMBLE_WORKSPACE_VAR]
         del os.environ[RAMBLE_WORKSPACE_VAR]
 

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -1040,7 +1040,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                         + f"be one of {str(possible_orders)}\n"
                     )
 
-            if "command" not in cur_exp_def.keys():
+            if "command" not in cur_exp_def:
                 raise InvalidChainError(
                     "Invalid experiment chain defined:\n"
                     + f"    Primary experiment {parent_namespace}\n"
@@ -1368,7 +1368,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
         when_satisfied = {
             when_set
-            for when_set in all_executables.keys()
+            for when_set in all_executables
             if self.expander.satisfies(
                 when_set, variant_set=self.experiment_variants()
             )
@@ -1621,7 +1621,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         Populates self._command_list with a list of the executable commands that
         should be executed by this experiment.
         """
-        if len(self._command_list) > 0:
+        if self._command_list:
             return
 
         exec_graph = getattr(self, "_executable_graph", exec_graph)
@@ -1891,7 +1891,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             if hasattr(obj, "template_render_vars"):
                 render_vars = obj.template_render_vars
                 self.variables.update(render_vars)
-                for name in render_vars.keys():
+                for name in render_vars:
                     self.keywords.update_keys({name: var_attr})
 
     def _inputs_and_fetchers(self, workload=None):
@@ -1909,7 +1909,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         # Batch 'when' evaluation to avoid repeat expander calls
         when_satisfied = {
             when_set
-            for when_set in self.inputs.keys()
+            for when_set in self.inputs
             if self.expander.satisfies(
                 when_set, variant_set=self.experiment_variants()
             )
@@ -2454,18 +2454,18 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             # Copy all figure of merit files
             criteria_list = self.success_list
             analysis_files, _, _ = self._analysis_dicts(criteria_list)
-            for file in analysis_files.keys():
+            for file in analysis_files:
                 if os.path.exists(file):
                     shutil.copy(file, archive_experiment_dir)
 
             # Copy all archive patterns
             archive_patterns = set(self.archive_patterns.keys())
             if self.package_manager:
-                for pattern in self.package_manager.archive_patterns.keys():
+                for pattern in self.package_manager.archive_patterns:
                     archive_patterns.add(pattern)
 
             for mod in self._modifier_instances:
-                for pattern in mod.archive_patterns.keys():
+                for pattern in mod.archive_patterns:
                     archive_patterns.add(pattern)
 
             for pattern in archive_patterns:
@@ -2857,8 +2857,8 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         # Create a list of all repeats by inserting repeat index
         for n in range(1, self.repeats.n_repeats + 1):
             if (
-                base_exp_name in self.experiment_set.chained_experiments.keys()
-                and base_exp_name not in self.experiment_set.experiments.keys()
+                base_exp_name in self.experiment_set.chained_experiments
+                and base_exp_name not in self.experiment_set.experiments
             ):
                 insert_idx = base_exp_name.find(".chain")
                 repeat_exp_namespace = (
@@ -2880,10 +2880,10 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         # If repeat_success_strict is false, any passing experiment will pass the whole set
         repeat_success = False
         exp_status_list = []
-        for exp in repeat_experiments.keys():
-            if exp in self.experiment_set.experiments.keys():
+        for exp in repeat_experiments:
+            if exp in self.experiment_set.experiments:
                 exp_inst = self.experiment_set.experiments[exp]
-            elif exp in self.experiment_set.chained_experiments.keys():
+            elif exp in self.experiment_set.chained_experiments:
                 exp_inst = self.experiment_set.chained_experiments[exp]
             else:
                 continue
@@ -2915,10 +2915,10 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         results = []
 
         # Iterate through repeat experiment instances, extract foms, and aggregate them
-        for exp in repeat_experiments.keys():
-            if exp in self.experiment_set.experiments.keys():
+        for exp in repeat_experiments:
+            if exp in self.experiment_set.experiments:
                 exp_inst = self.experiment_set.experiments[exp]
-            elif exp in self.experiment_set.chained_experiments.keys():
+            elif exp in self.experiment_set.chained_experiments:
                 exp_inst = self.experiment_set.chained_experiments[exp]
             else:
                 continue
@@ -2931,7 +2931,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                 for context in exp_inst.result.contexts:
                     context_name = context["name"]
 
-                    if context_name not in repeat_foms.keys():
+                    if context_name not in repeat_foms:
                         repeat_foms[context_name] = {}
 
                     for fom in context["foms"]:
@@ -2943,7 +2943,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                         )
 
                         # Stats will not be calculated for non-numeric foms so they're skipped
-                        if fom_key not in repeat_foms[context_name].keys():
+                        if fom_key not in repeat_foms[context_name]:
                             repeat_foms[context_name][fom_key] = {
                                 "fom_type": fom["fom_type"],
                                 "fom_values": [],
@@ -3689,7 +3689,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
             if len(required_vars_defined) < 2:
                 required_keys = "Two or more of the following are required to be defined.\n"
-                for var in required_vars.keys():
+                for var in required_vars:
                     required_keys += f"  - {var}\n"
 
                 defined_keys = f"Experiment {self.expander.experiment_namespace} only has:\n"

--- a/var/ramble/repos/builtin/package_managers/pip/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/pip/package_manager.py
@@ -508,7 +508,7 @@ class PipRunner(CommandRunner):
             raise RunnerError(f"Lock file {lock_file} is missing")
         pkgs = []
         with open(lock_file) as f:
-            for line in f.readlines():
+            for line in f:
                 # pip freeze generates such a comment, which serves as a divider
                 # for packages that are added as deps of the ones defined directly.
                 # This is a crude way to avoid defining path vars for
@@ -607,7 +607,7 @@ class PipRunner(CommandRunner):
                     pkgs.add(pkg_name)
         else:
             with open(os.path.join(self.env_path, self._lock_file_name)) as f:
-                reqs = f.readlines()
+                reqs = f
                 for req in reqs:
                     if "==" in req:
                         pkgs.add(req.split("==")[0].strip())
@@ -627,7 +627,7 @@ class PipRunner(CommandRunner):
 
         if os.path.exists(lock_file):
             with open(lock_file) as f:
-                for line in f.readlines():
+                for line in f:
                     software_info = PipSoftwareInfo()
                     software_info.parse_from_string(line.replace("\n", ""))
 


### PR DESCRIPTION
A few refactors:

* Iterate over file object instead of using `readlines`, for the pip package manager. This is a continuation of https://github.com/GoogleCloudPlatform/ramble/pull/1457

* Avoid using `len(thing) > 0` check, instead simply checking `thing` itself

* Do not use `get(key, None)`, as the `None` is redundant

* Avoid the unnecessary use of `keys()`