### PR TITLE
Ensure matrix vars are used in renderer filtering

### DIFF
--- a/lib/ramble/ramble/renderer.py
+++ b/lib/ramble/ramble/renderer.py
@@ -438,10 +438,14 @@ class Renderer:
             keep_object = True
             if exclude_where:
                 for where in exclude_where:
-                    evaluated = where_expander.expand_var(where)
-                    if evaluated == "True":
-                        keep_object = False
-                        break
+                    try:
+                        evaluated = where_expander.evaluate_predicate(where, extra_vars=obj)
+                        if evaluated:
+                            keep_object = False
+                            break
+                    except ramble.expander.RambleSyntaxError:
+                        # Fail-open to allow for late-binding of variables
+                        pass
 
             if keep_object:
                 repeats = ramble.repeats.Repeats()

--- a/lib/ramble/ramble/test/end_to_end/perf_tests/matrix_filter_perf.py
+++ b/lib/ramble/ramble/test/end_to_end/perf_tests/matrix_filter_perf.py
@@ -1,0 +1,62 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+
+import os
+
+import pytest
+
+from ramble.main import RambleCommand
+
+pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_path")
+workspace = RambleCommand("workspace")
+
+
+@pytest.mark.perf
+@pytest.mark.maybeslow
+def test_matrix_filter_perf(make_workspace_from_config):
+    # Create a matrix of 10000 experiments, but exclude 9999 of them.
+    # This test is to monitor the efficiency of the filtering.
+    test_config = (
+        """
+ramble:
+  variables:
+    mpi_command: ''
+    batch_submit: '{execute_experiment}'
+    processes_per_node: 1
+  applications:
+    hostname:
+      workloads:
+        local:
+          experiments:
+            test_{n_nodes}_{matrix_var}:
+              variables:
+                n_nodes: ["""
+        + ", ".join([f"'{i}'" for i in range(1, 101)])
+        + """]
+                matrix_var: ["""
+        + ", ".join([f"'{i}'" for i in range(1, 101)])
+        + """]
+              matrix:
+              - n_nodes
+              - matrix_var
+              exclude:
+                where:
+                - '{n_nodes} != 1 or {matrix_var} != 1'
+"""
+    )
+    ws, ws_name = make_workspace_from_config(test_config)
+
+    workspace("setup", "--dry-run", global_args=["-w", ws_name])
+
+    exp_dir = os.path.join(ws.root, "experiments", "hostname", "local", "test_1_1")
+    assert os.path.isdir(exp_dir)
+
+    # Pick one to assert the filtering is functional
+    exp_dir = os.path.join(ws.root, "experiments", "hostname", "local", "test_100_100")
+    assert not os.path.isdir(exp_dir)


### PR DESCRIPTION
Without this, the filtering functionally still works, since filtering is done in experiment_set as well. However this can cause unnecessary slowdown since it makes this early pruning ineffective.

Add in a perf test to safeguard future regression. Example run of the test (see the test time goes down from 5.72s -> 0.42s, with the fix in place):

```
$ ramble unit-test --perf -k matrix_filter -q
.                                                                                                                                                                                                                                                                                                     [100%]
=========================================================================================================================================== slowest 30 durations ============================================================================================================================================
0.42s call     lib/ramble/ramble/test/end_to_end/matrix_filter_perf.py::test_matrix_filter_perf
0.01s setup    lib/ramble/ramble/test/end_to_end/matrix_filter_perf.py::test_matrix_filter_perf

$ git stash push lib/ramble/ramble/renderer.py
Saved working directory and index state WIP on filter-perf: c414558c Merge pull request #1463 from douglasjacobsen/tutorial-update
$ ramble unit-test --perf -k matrix_filter -q
.                                                                                                                                                                                                                                                                                                     [100%]
=========================================================================================================================================== slowest 30 durations ============================================================================================================================================
5.72s call     lib/ramble/ramble/test/end_to_end/matrix_filter_perf.py::test_matrix_filter_perf
0.01s setup    lib/ramble/ramble/test/end_to_end/matrix_filter_perf.py::test_matrix_filter_perf

(1 durations < 0.005s hidden.  Use -vv to show these durations.)
1 passed, 2194 deselected in 8.18s
```