### PR TITLE
Enable stricter type-checking for some modules

### DIFF
--- a/lib/ramble/ramble/error.py
+++ b/lib/ramble/ramble/error.py
@@ -8,6 +8,7 @@
 
 import inspect
 import sys
+from typing import Optional, Tuple, Type
 
 from ramble.util.logger import logger
 
@@ -21,26 +22,26 @@ class RambleError(Exception):
     Subclasses can be found in the modules they have to do with.
     """
 
-    def __init__(self, message, long_message=None):
+    def __init__(self, message: str, long_message: Optional[str] = None) -> None:
         super().__init__()
-        self.message = message
-        self._long_message = long_message
+        self.message: str = message
+        self._long_message: Optional[str] = long_message
 
         # for exceptions raised from child build processes, we save the
         # traceback as a string and print it in the parent.
-        self.traceback = None
+        self.traceback: Optional[str] = None
 
         # we allow exceptions to print debug info via print_context()
         # before they are caught at the top level. If they *haven't*
         # printed context early, we do it by default when die() is
         # called, so we need to remember whether it's been called.
-        self.printed = False
+        self.printed: bool = False
 
     @property
-    def long_message(self):
+    def long_message(self) -> Optional[str]:
         return self._long_message
 
-    def print_context(self):
+    def print_context(self) -> None:
         """Print extended debug information about this exception.
 
         This is usually printed when the top-level Ramble error handler
@@ -70,23 +71,27 @@ class RambleError(Exception):
         sys.stderr.flush()
         self.printed = True
 
-    def die(self):
+    def die(self) -> None:
         self.print_context()
         sys.exit(1)
 
-    def __str__(self):
+    def __str__(self) -> str:
         msg = self.message
         if self._long_message:
             msg += "\n    %s" % self._long_message
         return msg
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         args = [repr(self.message), repr(self.long_message)]
         args = ",".join(args)
-        qualified_name = inspect.getmodule(self).__name__ + "." + type(self).__name__
+        module = inspect.getmodule(self)
+        if module:
+            qualified_name = f"{module.__name__}.{type(self).__name__}"
+        else:
+            qualified_name = type(self).__name__
         return qualified_name + "(" + args + ")"
 
-    def __reduce__(self):
+    def __reduce__(self) -> Tuple[Type["RambleError"], Tuple[str, Optional[str]]]:
         return type(self), (self.message, self.long_message)
 
 

--- a/lib/ramble/ramble/filters.py
+++ b/lib/ramble/ramble/filters.py
@@ -7,8 +7,9 @@
 # except according to those terms.
 
 import itertools
+from typing import List, Optional, Set
 
-ALL_PHASES = ["*"]
+ALL_PHASES: List[str] = ["*"]
 
 
 class Filters:
@@ -16,17 +17,18 @@ class Filters:
 
     def __init__(
         self,
-        phase_filters=None,
-        include_where_filters=None,
-        exclude_where_filters=None,
-        tags=None,
-    ):
+        phase_filters: Optional[List[str]] = None,
+        include_where_filters: Optional[List[List[str]]] = None,
+        exclude_where_filters: Optional[List[List[str]]] = None,
+        tags: Optional[List[List[str]]] = None,
+    ) -> None:
         """Create a new filter instance"""
 
-        self.phases = ALL_PHASES if phase_filters is None else phase_filters
-        self.include_where = None
-        self.exclude_where = None
-        self.tags = set()
+        self.phases: List[str] = ALL_PHASES if phase_filters is None else phase_filters
+        self.include_where: Optional[List[str]] = None
+        self.exclude_where: Optional[List[str]] = None
+        self.tags: Set[str] = set()
+
         if include_where_filters:
             self.include_where = list(itertools.chain.from_iterable(include_where_filters))
         if exclude_where_filters:

--- a/lib/ramble/ramble/paths.py
+++ b/lib/ramble/ramble/paths.py
@@ -17,39 +17,39 @@ import os
 from llnl.util.filesystem import ancestor
 
 #: This file lives in $prefix/lib/ramble/ramble/__file__
-prefix = ancestor(__file__, 4)
+prefix: str = ancestor(__file__, 4)
 
 #: synonym for prefix
-ramble_root = prefix
+ramble_root: str = prefix
 
 #: bin directory in the ramble prefix
-bin_path = os.path.join(prefix, "bin")
+bin_path: str = os.path.join(prefix, "bin")
 
 #: The ramble script itself
-ramble_script = os.path.join(bin_path, "ramble")
+ramble_script: str = os.path.join(bin_path, "ramble")
 
 #: The sbang script in the ramble installation
-sbang_script = os.path.join(bin_path, "sbang")
+sbang_script: str = os.path.join(bin_path, "sbang")
 
 # ramble directory hierarchy
-lib_path = os.path.join(prefix, "lib", "ramble")
-external_path = os.path.join(lib_path, "external")
-build_env_path = os.path.join(lib_path, "env")
-module_path = os.path.join(lib_path, "ramble")
-command_path = os.path.join(module_path, "cmd")
-test_path = os.path.join(module_path, "test")
-var_path = os.path.join(prefix, "var", "ramble")
-tests_path = os.path.join(var_path, "tests")
-share_path = os.path.join(prefix, "share", "ramble")
-repos_path = os.path.join(var_path, "repos")
+lib_path: str = os.path.join(prefix, "lib", "ramble")
+external_path: str = os.path.join(lib_path, "external")
+build_env_path: str = os.path.join(lib_path, "env")
+module_path: str = os.path.join(lib_path, "ramble")
+command_path: str = os.path.join(module_path, "cmd")
+test_path: str = os.path.join(module_path, "test")
+var_path: str = os.path.join(prefix, "var", "ramble")
+tests_path: str = os.path.join(var_path, "tests")
+share_path: str = os.path.join(prefix, "share", "ramble")
+repos_path: str = os.path.join(var_path, "repos")
 
 # Paths to built-in Ramble repositories.
-builtin_path = os.path.join(repos_path, "builtin")
-mock_builtin_path = os.path.join(repos_path, "builtin.mock")
+builtin_path: str = os.path.join(repos_path, "builtin")
+mock_builtin_path: str = os.path.join(repos_path, "builtin.mock")
 
 #: User configuration location
-user_config_path = os.path.expanduser("~/.ramble")
+user_config_path: str = os.path.expanduser("~/.ramble")
 
-opt_path = os.path.join(prefix, "opt")
-etc_path = os.path.join(prefix, "etc")
-system_etc_path = "/etc"
+opt_path: str = os.path.join(prefix, "opt")
+etc_path: str = os.path.join(prefix, "etc")
+system_etc_path: str = "/etc"

--- a/lib/ramble/ramble/util/env.py
+++ b/lib/ramble/ramble/util/env.py
@@ -58,7 +58,7 @@ def _get_env_append_commands(var_conf, expander, var_set, shell="sh"):
                     if expanded_var not in var_set:
                         env_mods.set(expanded_var, "${%s}" % expanded_var)
                         var_set.add(expanded_var)
-                    append_funcs[group](expanded_var, val, sep=sep)
+                    append_funcs[group](expanded_var, val, sep=sep)  # type: ignore[operator]
 
     env_cmds_arr = env_mods.shell_modifications(shell=shell, explicit=True)
 

--- a/lib/ramble/ramble/util/hashing.py
+++ b/lib/ramble/ramble/util/hashing.py
@@ -30,7 +30,7 @@ def hash_string(string):
     return hashlib.sha256(string.encode("UTF-8")).hexdigest()
 
 
-def hash_json(in_json):
+def hash_json(in_json: Any) -> str:
     _json_dump_args: Dict[str, Any] = {"indent": 2, "separators": (",", ": "), "sort_keys": True}
 
     data = sjson._strify(in_json)

--- a/lib/ramble/ramble/util/hashing.py
+++ b/lib/ramble/ramble/util/hashing.py
@@ -8,6 +8,7 @@
 
 import hashlib
 import json
+from typing import Any, Dict
 
 import spack.util.spack_json as sjson
 
@@ -30,7 +31,7 @@ def hash_string(string):
 
 
 def hash_json(in_json):
-    _json_dump_args = {"indent": 2, "separators": (",", ": "), "sort_keys": True}
+    _json_dump_args: Dict[str, Any] = {"indent": 2, "separators": (",", ": "), "sort_keys": True}
 
     data = sjson._strify(in_json)
     json_data = json.dumps(data, **_json_dump_args)

--- a/lib/ramble/ramble/util/imp/importlib_importer.py
+++ b/lib/ramble/ramble/util/imp/importlib_importer.py
@@ -20,7 +20,7 @@ class PrependFileLoader(SourceFileLoader):
         self.prepend = prepend
 
     def path_stats(self, path):
-        stats = super().path_stats(path)
+        stats = dict(super().path_stats(path))
         if self.prepend:
             stats["size"] += len(self.prepend) + 1
         return stats

--- a/lib/ramble/ramble/util/imp/importlib_importer.py
+++ b/lib/ramble/ramble/util/imp/importlib_importer.py
@@ -12,6 +12,7 @@
 """
 import types
 from importlib.machinery import SourceFileLoader  # novm
+from typing import Any, Dict
 
 
 class PrependFileLoader(SourceFileLoader):
@@ -19,7 +20,7 @@ class PrependFileLoader(SourceFileLoader):
         super().__init__(full_name, path)
         self.prepend = prepend
 
-    def path_stats(self, path):
+    def path_stats(self, path: str) -> Dict[str, Any]:
         stats = dict(super().path_stats(path))
         if self.prepend:
             stats["size"] += len(self.prepend) + 1

--- a/lib/ramble/ramble/util/lock.py
+++ b/lib/ramble/ramble/util/lock.py
@@ -46,10 +46,6 @@ class Lock(llnl.util.lock.Lock):
         if self._enable:
             super()._unlock()
 
-    def _debug(self, *args):
-        if self._enable:
-            super()._debug(*args)  # type: ignore[misc]
-
     def cleanup(self, *args):
         if self._enable:
             super().cleanup(*args)

--- a/lib/ramble/ramble/util/lock.py
+++ b/lib/ramble/ramble/util/lock.py
@@ -48,7 +48,7 @@ class Lock(llnl.util.lock.Lock):
 
     def _debug(self, *args):
         if self._enable:
-            super()._debug(*args)
+            super()._debug(*args)  # type: ignore[misc]
 
     def cleanup(self, *args):
         if self._enable:

--- a/lib/ramble/ramble/util/object_utils.py
+++ b/lib/ramble/ramble/util/object_utils.py
@@ -36,11 +36,11 @@ def filter_by_name(glob_patterns, search_description, obj_type):
                 r = fnmatch.translate(f)
             rc = re.compile(r, flags=re.IGNORECASE)
             patts.append(rc)
-        obj_names = [
+        obj_names = {
             obj_name
             for obj_name in obj_names
             if any(_match(obj_name, patt, search_description, obj_type) for patt in patts)
-        ]
+        }
     return sorted(obj_names, key=lambda s: s.lower())
 
 

--- a/lib/ramble/ramble/util/object_utils.py
+++ b/lib/ramble/ramble/util/object_utils.py
@@ -10,11 +10,12 @@
 
 import fnmatch
 import re
+from typing import Any, List
 
 import ramble.repository
 
 
-def filter_by_name(glob_patterns, search_description, obj_type):
+def filter_by_name(glob_patterns: List[str], search_description: bool, obj_type: Any) -> List[str]:
     """
     Filters the sequence of object names by the given glob patterns.
 

--- a/lib/ramble/ramble/util/web.py
+++ b/lib/ramble/ramble/util/web.py
@@ -17,6 +17,7 @@ import ssl
 import sys
 import traceback
 from html.parser import HTMLParser
+from typing import Any, Dict, List, Set, Tuple
 from urllib.error import URLError
 from urllib.request import Request, urlopen
 
@@ -109,13 +110,13 @@ def read_from_url(url, accept_content_type=None):
         # It would be nice to do this with the HTTP Accept header to avoid
         # one round-trip.  However, most servers seem to ignore the header
         # if you ask for a tarball with Accept: text/html.
-        req.get_method = lambda: "HEAD"
+        req.method = "HEAD"
         resp = _urlopen(req, timeout=timeout, context=context)
 
         content_type = get_header(resp.headers, "Content-type")
 
     # Do the real GET request when we know it's just HTML.
-    req.get_method = lambda: "GET"
+    req.method = "GET"
 
     try:
         response = _urlopen(req, timeout=timeout, context=context)
@@ -254,7 +255,7 @@ def remove_url(url, recursive=False):
             paginator = s3.get_paginator("list_objects_v2")
             pages = paginator.paginate(Bucket=bucket, Prefix=prefix)
 
-            delete_request = {"Objects": []}
+            delete_request: Dict[str, List[Dict[str, Any]]] = {"Objects": []}
             for item in pages.search("Contents"):
                 if not item:
                     continue
@@ -401,9 +402,9 @@ def spider(root_urls, depth=0, concurrency=32):
             - links: set of links encountered while visiting the pages.
             - spider_args: argument for subsequent call to spider
         """
-        pages = {}  # dict from page URL -> text content.
-        links = set()  # set of all links seen on visited pages.
-        subcalls = []
+        pages: Dict[str, str] = {}  # dict from page URL -> text content.
+        links: Set[str] = set()  # set of all links seen on visited pages.
+        subcalls: List[Tuple] = []
 
         try:
             response_url, _, response = read_from_url(url, "text/html")
@@ -512,11 +513,11 @@ def _urlopen(req, *args, **kwargs):
     if url_util.parse(url).scheme == "s3":
         import spack.s3_handler
 
-        opener = spack.s3_handler.open
+        opener = spack.s3_handler.open  # type: ignore[assignment]
     elif url_util.parse(url).scheme == "gs":
         import spack.gcs_handler
 
-        opener = spack.gcs_handler.gcs_open
+        opener = spack.gcs_handler.gcs_open  # type: ignore[assignment]
 
     try:
         return opener(req, *args, **kwargs)

--- a/lib/ramble/ramble/util/yaml_generation.py
+++ b/lib/ramble/ramble/util/yaml_generation.py
@@ -92,14 +92,12 @@ def _type_value(input_value):
     """
 
     try:
-        out = int(input_value)
-        return out
+        return int(input_value)
     except ValueError:
         pass
 
     try:
-        out = float(input_value)
-        return out
+        return float(input_value)
     except ValueError:
         pass
 

--- a/lib/ramble/ramble/util/yaml_generation.py
+++ b/lib/ramble/ramble/util/yaml_generation.py
@@ -23,7 +23,7 @@ Would translate to `foo.bar.baz = 1.0` in Ramble syntax.
 
 """
 
-from typing import Any, Dict
+from typing import Any, Dict, Union
 
 import ruamel.yaml as yaml
 
@@ -79,7 +79,7 @@ def all_config_options(config_data: Dict):
     return all_configs
 
 
-def _type_value(input_value):
+def _type_value(input_value: str) -> Union[int, float, str]:
     """Attempt to convert an input value to other types.
 
     Precedence order is:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,13 @@ allow_redefinition = true
 module = "ramble.*"
 ignore_errors = false
 
+[[tool.mypy.overrides]]
+# TODO: Add more modules here for exhaustive type-checking
+module = [
+    "ramble.util.*",
+]
+check_untyped_defs = true
+
 # TODO: Add ruff into `ramble style` once it reaches v1.
 # For now, the ruff check can be invoked manually with `ruff check`.
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,9 @@ ignore_errors = false
 # TODO: Add more modules here for exhaustive type-checking
 module = [
     "ramble.util.*",
+    "ramble.error",
+    "ramble.paths",
+    "ramble.filters",
 ]
 check_untyped_defs = true
 


### PR DESCRIPTION
Previously mypy is configured to not check for functions without explicit type hints specified. Enable this for a few easy modules as a first step.

Some relevant code changes for passing the type checks:

* In web.py, instead of overriding `get_method`, simply set the `req.method` attribute
* The object_util utility chagnes to use set instead of list
* In a few places where it's difficult to improve on the typing (for instance when they reuse Spack's utils,) use type ignore comments
* Remove the unused (and erroneous) `_debug` method from `util.lock`
* In error.py, safeguard a potential none reply from inspect_module