### PR TITLE
Avoid accessing the https metadata server endpoint

### DIFF
--- a/lib/ramble/spack/util/gcs.py
+++ b/lib/ramble/spack/util/gcs.py
@@ -27,6 +27,11 @@ def gcs_client():
                   ' Please install to use the gs:// backend.')
         sys.exit(1)
 
+    # Disable GCE mTLS for the metadata server to workaround cert errors
+    # thrown by google-auth on some GCP VMs. The change on the auth side was introduced in
+    # https://github.com/googleapis/google-auth-library-python/pull/1856.
+    os.environ.setdefault("GCE_METADATA_MTLS_MODE", "none")
+
     storage_credentials, storage_project = google.auth.default()
     storage_client = storage.Client(storage_project,
                                     storage_credentials)


### PR DESCRIPTION
For newer releases of `google-auth` lib, it attempts to connect using mTLS when it can find the certs in well-known locations. This causes our fetcher to fail with cert error. The mTLS change was introduced by https://github.com/googleapis/google-auth-library-python/pull/1856.

We probably need to upstream this to Spack as well.