### PR TITLE
make get_newest_experiment_file more resilient to deletes

### DIFF
--- a/lib/ramble/ramble/test/experiment_result.py
+++ b/lib/ramble/ramble/test/experiment_result.py
@@ -134,3 +134,63 @@ def test_experiment_result_get_newest_experiment_file(tmpdir):
     # Test that ramble_file is ignored
     newest_file, _ = get_newest_experiment_file(str(experiment_dir))
     assert "ramble_file" not in newest_file
+
+
+def test_get_newest_experiment_file_outer_file_not_found(tmpdir, monkeypatch):
+    """Test that FileNotFoundError is handled in outer loop of get_newest_experiment_file"""
+    experiment_dir = tmpdir.mkdir("experiment")
+    sub_dir = os.path.join(str(experiment_dir), "sub")
+    os.mkdir(sub_dir)
+
+    file1 = os.path.join(str(experiment_dir), "file1")
+    with open(file1, "w") as f:
+        f.write("test")
+
+    orig_scandir = os.scandir
+
+    def mock_scandir(path):
+        if str(path) == sub_dir:
+            raise FileNotFoundError("Mock file not found")
+        return orig_scandir(path)
+
+    monkeypatch.setattr(os, "scandir", mock_scandir)
+
+    # Should not raise exception and should find file1
+    newest_file, _ = get_newest_experiment_file(str(experiment_dir))
+    assert newest_file == file1
+
+
+def test_get_newest_experiment_file_inner_file_not_found(tmpdir, monkeypatch):
+    """Test that FileNotFoundError is handled in inner loop of get_newest_experiment_file"""
+    experiment_dir = tmpdir.mkdir("experiment")
+
+    class MockEntry:
+        def __init__(self, path):
+            self.path = path
+            self.name = os.path.basename(path)
+
+        def is_file(self):
+            return True
+
+        def is_dir(self, follow_symlinks=False):
+            return False
+
+        def stat(self):
+            raise FileNotFoundError("Mock file not found")
+
+    class MockScandir:
+        def __init__(self, path):
+            self.path = path
+
+        def __enter__(self):
+            return iter([MockEntry(os.path.join(self.path, "phantom_file"))])
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            pass
+
+    monkeypatch.setattr(os, "scandir", MockScandir)
+
+    # Should not raise exception and should return None, None as no valid file is found
+    newest_file, max_mtime = get_newest_experiment_file(str(experiment_dir))
+    assert newest_file is None
+    assert max_mtime is None

--- a/lib/ramble/ramble/util/file_util.py
+++ b/lib/ramble/ramble/util/file_util.py
@@ -7,7 +7,6 @@
 # except according to those terms.
 
 import os
-from pathlib import Path
 
 _DRY_RUN_PATH_PREFIX = os.path.join("dry-run", "path", "to")
 
@@ -53,14 +52,32 @@ def get_newest_experiment_file(base_directory):
         (str): Path to newest file (or None if not found)
         (int): Timestamp of file in seconds (or None if no file is found)
     """
-    files = Path(base_directory).rglob("*")
-    files = [f for f in files if f.is_file() and not os.path.basename(f).startswith("ramble_")]
+    newest_file = None
+    max_mtime = -1.0
 
-    if not files:
+    stack = [base_directory]
+
+    while stack:
+        current_dir = stack.pop()
+        try:
+            with os.scandir(current_dir) as entries:
+                for entry in entries:
+                    try:
+                        if entry.is_file():
+                            if not entry.name.startswith("ramble_"):
+                                mtime = entry.stat().st_mtime
+                                if mtime > max_mtime:
+                                    max_mtime = mtime
+                                    newest_file = entry.path
+                        elif entry.is_dir(follow_symlinks=False):
+                            stack.append(entry.path)
+                    except FileNotFoundError:
+                        # File was deleted concurrently
+                        continue
+        except FileNotFoundError:
+            continue
+
+    if newest_file is None:
         return None, None
 
-    newest_file_path = max(files, key=os.path.getmtime)
-
-    timestamp_seconds = os.path.getmtime(newest_file_path)
-
-    return str(newest_file_path), timestamp_seconds
+    return newest_file, max_mtime


### PR DESCRIPTION
Previously this function got a list of files, and then got the times. This left us open to a TOCTOU race and would lead to a crash. This version should be faster and more resilient (but it's hard to test diligently..) 