### PR TITLE
Tweak on image build triggers

### DIFF
--- a/share/ramble/cloud-build/ramble-pr-image-builds.yaml
+++ b/share/ramble/cloud-build/ramble-pr-image-builds.yaml
@@ -25,23 +25,11 @@ steps:
       - 'BUILD_ID=$BUILD_ID'
       - 'PROJECT_ID=$PROJECT_ID'
   - name: 'gcr.io/cloud-builders/docker'
-    id: build-apt
+    id: build-image
     args:
       - 'build'
       - '-f'
-      - 'share/ramble/cloud-build/Dockerfile-apt'
-      - '--build-arg'
-      - 'SPACK_REF=${_SPACK_REF}'
-      - '--build-arg'
-      - 'PYTHON_VER=${_PYTHON_VER}'
-      - '.'
-    waitFor: ['-']
-  - name: 'gcr.io/cloud-builders/docker'
-    id: build-yum
-    args:
-      - 'build'
-      - '-f'
-      - 'share/ramble/cloud-build/Dockerfile-yum'
+      - 'share/ramble/cloud-build/Dockerfile-${_PKG_MANAGER}'
       - '--build-arg'
       - 'SPACK_REF=${_SPACK_REF}'
       - '--build-arg'
@@ -53,6 +41,7 @@ steps:
 substitutions:
   _SPACK_REF: v1.1.1
   _PYTHON_VER: 3.11.14
+  _PKG_MANAGER: apt
 
 timeout: 3600s
 options:

--- a/share/ramble/cloud-build/terraform/triggers/image_builds.tf
+++ b/share/ramble/cloud-build/terraform/triggers/image_builds.tf
@@ -14,7 +14,9 @@ resource "google_cloudbuild_trigger" "image_builders" {
 
   included_files = [
     "share/ramble/cloud-build/ramble-image-builder.yaml",
-    "share/ramble/cloud-build/Dockerfile-${local.pm_map[each.value.base]}"
+    "share/ramble/cloud-build/Dockerfile-${local.pm_map[each.value.base]}",
+    "requirements.txt",
+    "requirements-dev.txt"
   ]
 
   filename = "share/ramble/cloud-build/ramble-image-builder.yaml"

--- a/share/ramble/cloud-build/terraform/triggers/pr_image_build.tf
+++ b/share/ramble/cloud-build/terraform/triggers/pr_image_build.tf
@@ -1,6 +1,6 @@
-resource "google_cloudbuild_trigger" "pr_image_build_tests" {
-  name        = "PR-Image-Build-Tests"
-  description = "A presubmit check for building images used by other cloud build triggers"
+resource "google_cloudbuild_trigger" "pr_image_build_tests_debian" {
+  name        = "PR-Image-Build-Tests-Debian"
+  description = "A presubmit check for building Debian image used by other cloud build triggers"
 
   github {
     owner = var.github_owner
@@ -16,8 +16,42 @@ resource "google_cloudbuild_trigger" "pr_image_build_tests" {
   filename = "share/ramble/cloud-build/ramble-pr-image-builds.yaml"
 
   included_files = [
-    "share/ramble/cloud-build/**",
+    "share/ramble/cloud-build/ramble-pr-image-builds.yaml",
+    "share/ramble/cloud-build/Dockerfile-apt",
     "requirements.txt",
     "requirements-dev.txt"
   ]
+
+  substitutions = {
+    _PKG_MANAGER = "apt"
+  }
+}
+
+resource "google_cloudbuild_trigger" "pr_image_build_tests_rocky" {
+  name        = "PR-Image-Build-Tests-Rocky"
+  description = "A presubmit check for building Rocky image used by other cloud build triggers"
+
+  github {
+    owner = var.github_owner
+    name  = var.github_repo
+    pull_request {
+      branch          = "(?:main|develop)"
+      comment_control = "COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY"
+    }
+  }
+
+  include_build_logs = "INCLUDE_BUILD_LOGS_WITH_STATUS"
+
+  filename = "share/ramble/cloud-build/ramble-pr-image-builds.yaml"
+
+  included_files = [
+    "share/ramble/cloud-build/ramble-pr-image-builds.yaml",
+    "share/ramble/cloud-build/Dockerfile-yum",
+    "requirements.txt",
+    "requirements-dev.txt"
+  ]
+
+  substitutions = {
+    _PKG_MANAGER = "yum"
+  }
 }

--- a/share/ramble/cloud-build/terraform/triggers/pr_image_build.tf
+++ b/share/ramble/cloud-build/terraform/triggers/pr_image_build.tf
@@ -16,6 +16,8 @@ resource "google_cloudbuild_trigger" "pr_image_build_tests" {
   filename = "share/ramble/cloud-build/ramble-pr-image-builds.yaml"
 
   included_files = [
-    "share/ramble/cloud-build/**"
+    "share/ramble/cloud-build/**",
+    "requirements.txt",
+    "requirements-dev.txt"
   ]
 }


### PR DESCRIPTION
Changes involved:

1. Ensure requirements* changes cause these triggers to run
2. Split up the PR image build so that debian and rocky image builds happen in two separate triggers. This is to speed up the tests.