### PR TITLE
Avoid pinning to black 26.3.1 for older python versions

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,8 @@
 -r requirements.txt
 pytest
 flake8
-black==26.3.1
+black==26.3.1;python_version>="3.10"
+black;python_version<"3.10"
 coverage>=7.10;python_version>="3.9"
 coverage;python_version<"3.9"
 pre-commit


### PR DESCRIPTION
Otherwise this will cause errors as that version is incompatible with older pythons (<3.10)

The PR style check is based on Python 3.12, so black v26.3.1 is still the "enforced" version.