### PR TITLE
Update color escaping logic to be more maintainable [AI]

### DIFF
--- a/lib/ramble/ramble/cmd/attributes.py
+++ b/lib/ramble/ramble/cmd/attributes.py
@@ -10,10 +10,10 @@
 import argparse
 from collections import defaultdict
 
-import llnl.util.tty.color as color
 from llnl.util.tty.colify import colify
 
 import ramble.repository
+import ramble.util.colors as color
 from ramble.util.logger import logger
 
 description = "get information about object attributes"

--- a/lib/ramble/ramble/cmd/common/__init__.py
+++ b/lib/ramble/ramble/cmd/common/__init__.py
@@ -6,9 +6,8 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-import llnl.util.tty.color as color
-
 import ramble.paths
+import ramble.util.colors as color
 from ramble.util.logger import logger
 
 

--- a/lib/ramble/ramble/cmd/common/info.py
+++ b/lib/ramble/ramble/cmd/common/info.py
@@ -136,7 +136,7 @@ def print_object_header(obj_type, obj):
     singular = ramble.repository.type_definitions[obj_type]["singular"]
     parts = [part[0].upper() + part[1:] for part in singular.split()]
     type_name = color.section_title(" ".join(parts))
-    color.cprint(f"{type_name}: %s\n", obj.name)
+    color.cprint(f"{type_name}: {obj.name}\n")
 
     color.cprint(color.section_title("Description:"))
     if obj.__doc__:
@@ -144,7 +144,7 @@ def print_object_header(obj_type, obj):
         for part in obj.__doc__.split("\n"):
             doc_str += f"    {part}\n"
 
-        color.cprint("%s", doc_str)
+        color.cprint(f"{doc_str}")
 
 
 def print_object_overview(obj):
@@ -154,7 +154,7 @@ def print_object_overview(obj):
     """
     color.cprint("Available attributes:")
     for name in all_object_attributes(obj):
-        color.cprint("\t%s", name)
+        color.cprint(f"\t{name}")
 
 
 def _unpack_when_set_if_needed(internal_attr: dict):
@@ -184,9 +184,9 @@ def _unpack_when_set_if_needed(internal_attr: dict):
 def _print_nonverbose_list_attr(internal_attr, pattern="*", format=supported_formats.text):
     to_print = fnmatch.filter(map(str, internal_attr), pattern)
     if format == supported_formats.lists:
-        color.cprint("    %s", str(list(to_print)))
+        color.cprint(f"    {list(to_print)}")
     elif format == supported_formats.text:
-        color.cprint("%s", colified(to_print, tty=True, indent=4))
+        color.cprint(f"{colified(to_print, tty=True, indent=4)}")
 
 
 def _print_verbose_dict_attr(internal_attr, pattern="*", indentation=(" " * 4)):
@@ -205,10 +205,10 @@ def _print_verbose_dict_attr(internal_attr, pattern="*", indentation=(" " * 4)):
             for sub_name, sub_val in vals.items():
                 # Avoid showing duplicate names for variables
                 if isinstance(sub_val, Variable) and sub_name == sub_val.name:
-                    color.cprint(f"{indentation}%s", sub_val)
+                    color.cprint(f"{indentation}{sub_val}")
                 else:
                     color_sub_name = color.nested_1(sub_name)
-                    color.cprint(f"{indentation}{color_sub_name}: %s", sub_val)
+                    color.cprint(f"{indentation}{color_sub_name}: {sub_val}")
             color.cprint("")
         elif isinstance(vals, set):
             color_name = color.section_title(name)
@@ -224,12 +224,12 @@ def _print_verbose_dict_attr(internal_attr, pattern="*", indentation=(" " * 4)):
                 if hasattr(val, "as_str"):
                     color.cprint(val.as_str(verbose=True))
                 else:
-                    color.cprint("%s", str(val))
+                    color.cprint(f"{val}")
         else:
             if hasattr(vals, "as_str"):
                 color.cprint(vals.as_str(verbose=True))
             else:
-                color.cprint("%s", str(vals))
+                color.cprint(f"{vals}")
                 #  Necessary to add a line break after unformmated sections
                 if i == len(internal_attr.keys()):
                     color.cprint("")
@@ -266,10 +266,10 @@ def _print_phases(obj, attr, verbose=False, pattern="*", format=supported_format
         color_pipeline = color_func(pipeline)
         if format == supported_formats.lists:
             color.cprint(f"{indentation}{color_pipeline}:")
-            color.cprint(f"{indentation}    %s", str(list(to_print)))
+            color.cprint(f"{indentation}    {list(to_print)}")
         elif format == supported_formats.text:
             color.cprint(f"{indentation}{color_pipeline}:")
-            color.cprint("%s", colified(to_print, tty=True, indent=base_indent + 4))
+            color.cprint(f"{colified(to_print, tty=True, indent=base_indent + 4)}")
 
 
 def _print_figures_of_merit(obj, attr, verbose=False, pattern="*", format=supported_formats.text):
@@ -294,7 +294,7 @@ def _print_figures_of_merit(obj, attr, verbose=False, pattern="*", format=suppor
                 if isinstance(to_print, list):
                     _print_nonverbose_list_attr(to_print, pattern=pattern, format=format)
                 else:
-                    color.cprint("    %s\n", str(to_print))
+                    color.cprint(f"    {to_print}\n")
             else:
                 _print_verbose_dict_attr(fom_dict, pattern=pattern, indentation=indentation)
 
@@ -339,7 +339,7 @@ def print_single_attribute(obj, attr, verbose=False, pattern="*", format=support
                 to_print = [key for attr_dict in internal_attr for key in attr_dict]
             _print_nonverbose_list_attr(to_print, pattern=pattern, format=format)
         else:
-            color.cprint("    %s\n", str(to_print))
+            color.cprint(f"    {to_print}\n")
     else:
         if isinstance(internal_attr, dict):
             _print_verbose_dict_attr(internal_attr, pattern=pattern, indentation=indentation)
@@ -359,15 +359,15 @@ def print_single_attribute(obj, attr, verbose=False, pattern="*", format=support
                 else:
                     to_print = fnmatch.filter(map(str, internal_attr), pattern)
                     if format == supported_formats.lists:
-                        color.cprint("    %s", str(list(to_print)))
+                        color.cprint(f"    {list(to_print)}")
                     elif format == supported_formats.text:
-                        color.cprint("%s", colified(to_print, tty=True, indent=4))
+                        color.cprint(f"{colified(to_print, tty=True, indent=4)}")
                     color.cprint("")
         else:
             if hasattr(internal_attr, "as_str"):
                 color.cprint(internal_attr.as_str(verbose=True))
             else:
-                color.cprint("%s\n", f"{indentation}{str(internal_attr)}")
+                color.cprint(f"{indentation}{internal_attr}\n")
 
 
 def print_attribute_header(attr, verbose=False):
@@ -381,9 +381,9 @@ def print_attribute_header(attr, verbose=False):
     if verbose:
         num = len(attr) + 4
         banner = f"{banner_char}" * num
-        color.cprint("%s", banner)
-        color.cprint(f"{banner_char} %s {banner_char}", attr)
-        color.cprint("%s", banner)
+        color.cprint(f"{banner}")
+        color.cprint(f"{banner_char} {attr} {banner_char}")
+        color.cprint(f"{banner}")
     else:
         attr_name = color.section_title(attr)
         color.cprint(f"{attr_name}:")

--- a/lib/ramble/ramble/cmd/common/info.py
+++ b/lib/ramble/ramble/cmd/common/info.py
@@ -9,12 +9,11 @@
 import enum
 import fnmatch
 
-import llnl.util.tty.color as color
 from llnl.util.tty.colify import colified
 
 import ramble.cmd.common.arguments as arguments
 import ramble.repository
-import ramble.util.colors as rucolor
+import ramble.util.colors as color
 from ramble.definitions.variables import Variable
 from ramble.util.logger import logger
 
@@ -136,16 +135,16 @@ def print_object_header(obj_type, obj):
     """Print an object header"""
     singular = ramble.repository.type_definitions[obj_type]["singular"]
     parts = [part[0].upper() + part[1:] for part in singular.split()]
-    type_name = rucolor.section_title(" ".join(parts))
-    color.cprint(f"{type_name}: {obj.name}\n")
+    type_name = color.section_title(" ".join(parts))
+    color.cprint(f"{type_name}: %s\n", obj.name)
 
-    color.cprint(rucolor.section_title("Description:"))
+    color.cprint(color.section_title("Description:"))
     if obj.__doc__:
         doc_str = ""
         for part in obj.__doc__.split("\n"):
             doc_str += f"    {part}\n"
 
-        color.cprint(doc_str)
+        color.cprint("%s", doc_str)
 
 
 def print_object_overview(obj):
@@ -155,7 +154,7 @@ def print_object_overview(obj):
     """
     color.cprint("Available attributes:")
     for name in all_object_attributes(obj):
-        color.cprint(f"\t{name}")
+        color.cprint("\t%s", name)
 
 
 def _unpack_when_set_if_needed(internal_attr: dict):
@@ -185,9 +184,9 @@ def _unpack_when_set_if_needed(internal_attr: dict):
 def _print_nonverbose_list_attr(internal_attr, pattern="*", format=supported_formats.text):
     to_print = fnmatch.filter(map(str, internal_attr), pattern)
     if format == supported_formats.lists:
-        color.cprint("    " + str(list(to_print)))
+        color.cprint("    %s", str(list(to_print)))
     elif format == supported_formats.text:
-        color.cprint(colified(to_print, tty=True, indent=4))
+        color.cprint("%s", colified(to_print, tty=True, indent=4))
 
 
 def _print_verbose_dict_attr(internal_attr, pattern="*", indentation=(" " * 4)):
@@ -201,48 +200,36 @@ def _print_verbose_dict_attr(internal_attr, pattern="*", indentation=(" " * 4)):
         if pattern and not fnmatch.fnmatch(name, pattern):
             continue
         if isinstance(vals, dict):
-            color_name = rucolor.section_title(name)
+            color_name = color.section_title(name)
             color.cprint(f"{color_name}:")
             for sub_name, sub_val in vals.items():
                 # Avoid showing duplicate names for variables
                 if isinstance(sub_val, Variable) and sub_name == sub_val.name:
-                    to_print = f"{indentation}{sub_val}"
+                    color.cprint(f"{indentation}%s", sub_val)
                 else:
-                    color_sub_name = rucolor.nested_1(sub_name)
-                    to_print = f"{indentation}{color_sub_name}: {sub_val}"
-                try:
-                    color.cprint(to_print)
-                except color.ColorParseError:
-                    if not isinstance(sub_val, str) and hasattr(sub_val, "__iter__"):
-                        escaped_sub_val = [rucolor.plaintext(str(item)) for item in sub_val]
-                    else:
-                        escaped_sub_val = rucolor.plaintext(str(sub_val))
-                    color.cprint(f"{indentation}{color_sub_name}: {escaped_sub_val}")
+                    color_sub_name = color.nested_1(sub_name)
+                    color.cprint(f"{indentation}{color_sub_name}: %s", sub_val)
             color.cprint("")
         elif isinstance(vals, set):
-            color_name = rucolor.section_title(name)
+            color_name = color.section_title(name)
             color.cprint(f"{color_name}:")
             for sub_name in vals:
                 # Avoid showing duplicate names for variables
-                color_sub_name = rucolor.nested_1(sub_name)
+                color_sub_name = color.nested_1(sub_name)
                 to_print = f"{indentation}{color_sub_name}"
-                try:
-                    color.cprint(to_print)
-                except color.ColorParseError:
-                    escaped_sub_name = rucolor.nested_1(sub_name)
-                    color.cprint(f"{indentation}{escaped_sub_name}")
+                color.cprint(to_print)
             color.cprint("")
         elif isinstance(vals, list):
             for val in vals:
                 if hasattr(val, "as_str"):
-                    color.cprint(f"{val.as_str(verbose=True)}")
+                    color.cprint(val.as_str(verbose=True))
                 else:
-                    color.cprint(f"{str(val)}")
+                    color.cprint("%s", str(val))
         else:
             if hasattr(vals, "as_str"):
-                color.cprint(f"{vals.as_str(verbose=True)}")
+                color.cprint(vals.as_str(verbose=True))
             else:
-                color.cprint(f"{str(vals)}")
+                color.cprint("%s", str(vals))
                 #  Necessary to add a line break after unformmated sections
                 if i == len(internal_attr.keys()):
                     color.cprint("")
@@ -260,10 +247,10 @@ def _print_phases(obj, attr, verbose=False, pattern="*", format=supported_format
     print_attribute_header(attr, verbose)
 
     if not verbose:
-        color_func = rucolor.level_func(1)
+        color_func = color.level_func(1)
         base_indent = 4
     else:
-        color_func = rucolor.level_func(0)
+        color_func = color.level_func(0)
         base_indent = 0
 
     indentation = " " * base_indent
@@ -279,10 +266,10 @@ def _print_phases(obj, attr, verbose=False, pattern="*", format=supported_format
         color_pipeline = color_func(pipeline)
         if format == supported_formats.lists:
             color.cprint(f"{indentation}{color_pipeline}:")
-            color.cprint(f"{indentation}    {str(list(to_print))}")
+            color.cprint(f"{indentation}    %s", str(list(to_print)))
         elif format == supported_formats.text:
             color.cprint(f"{indentation}{color_pipeline}:")
-            color.cprint(colified(to_print, tty=True, indent=base_indent + 4))
+            color.cprint("%s", colified(to_print, tty=True, indent=base_indent + 4))
 
 
 def _print_figures_of_merit(obj, attr, verbose=False, pattern="*", format=supported_formats.text):
@@ -307,7 +294,7 @@ def _print_figures_of_merit(obj, attr, verbose=False, pattern="*", format=suppor
                 if isinstance(to_print, list):
                     _print_nonverbose_list_attr(to_print, pattern=pattern, format=format)
                 else:
-                    color.cprint(f"    {str(to_print)}\n")
+                    color.cprint("    %s\n", str(to_print))
             else:
                 _print_verbose_dict_attr(fom_dict, pattern=pattern, indentation=indentation)
 
@@ -352,7 +339,7 @@ def print_single_attribute(obj, attr, verbose=False, pattern="*", format=support
                 to_print = [key for attr_dict in internal_attr for key in attr_dict]
             _print_nonverbose_list_attr(to_print, pattern=pattern, format=format)
         else:
-            color.cprint(f"    {str(to_print)}\n")
+            color.cprint("    %s\n", str(to_print))
     else:
         if isinstance(internal_attr, dict):
             _print_verbose_dict_attr(internal_attr, pattern=pattern, indentation=indentation)
@@ -368,19 +355,19 @@ def print_single_attribute(obj, attr, verbose=False, pattern="*", format=support
                         if pattern and not fnmatch.fnmatch(obj.name, pattern):
                             continue
 
-                        color.cprint(f"{obj.as_str(verbose=True)}")
+                        color.cprint(obj.as_str(verbose=True))
                 else:
                     to_print = fnmatch.filter(map(str, internal_attr), pattern)
                     if format == supported_formats.lists:
-                        color.cprint("    " + str(list(to_print)))
+                        color.cprint("    %s", str(list(to_print)))
                     elif format == supported_formats.text:
-                        color.cprint(colified(to_print, tty=True, indent=4))
+                        color.cprint("%s", colified(to_print, tty=True, indent=4))
                     color.cprint("")
         else:
             if hasattr(internal_attr, "as_str"):
-                color.cprint(f"{internal_attr.as_str(verbose=True)}")
+                color.cprint(internal_attr.as_str(verbose=True))
             else:
-                color.cprint(f"{indentation}" + str(internal_attr) + "\n")
+                color.cprint("%s\n", f"{indentation}{str(internal_attr)}")
 
 
 def print_attribute_header(attr, verbose=False):
@@ -394,11 +381,11 @@ def print_attribute_header(attr, verbose=False):
     if verbose:
         num = len(attr) + 4
         banner = f"{banner_char}" * num
-        color.cprint(banner)
-        color.cprint(f"{banner_char} {attr} {banner_char}")
-        color.cprint(banner)
+        color.cprint("%s", banner)
+        color.cprint(f"{banner_char} %s {banner_char}", attr)
+        color.cprint("%s", banner)
     else:
-        attr_name = rucolor.section_title(attr)
+        attr_name = color.section_title(attr)
         color.cprint(f"{attr_name}:")
 
 

--- a/lib/ramble/ramble/cmd/help.py
+++ b/lib/ramble/ramble/cmd/help.py
@@ -8,7 +8,7 @@
 
 import sys
 
-from llnl.util.tty.color import colorize
+from ramble.util.colors import colorize
 
 description = "get help on ramble and its commands"
 section = "help"

--- a/lib/ramble/ramble/cmd/results.py
+++ b/lib/ramble/ramble/cmd/results.py
@@ -9,13 +9,12 @@
 import json
 import os
 
-import llnl.util.tty.color as color
 from llnl.util.tty.colify import colified
 
 import ramble.cmd
 import ramble.reports
 import ramble.uploader
-import ramble.util.colors as rucolor
+import ramble.util.colors as color
 from ramble.util.logger import logger
 
 import spack.util.spack_yaml as syaml
@@ -229,7 +228,7 @@ def _load_results(args):
 def _print_attr_dict(attr_dict: dict, n_indent=0):
     for attr, values in attr_dict.items():
         indentation = " " * n_indent
-        color.cprint(f"{indentation}{rucolor.title_color(attr, n_indent)}:")
+        color.cprint(f"{indentation}{color.title_color(attr, n_indent)}:")
         if isinstance(values, dict):
             _print_attr_dict(values, n_indent + 4)
         else:
@@ -245,7 +244,7 @@ def results_index(args):
     )
     for obj_name, obj_dict in result_index.items():
         if obj_dict:
-            color.cprint(rucolor.title_color(f'{obj_name.replace("_", " ").title()}:'))
+            color.cprint(color.title_color(f'{obj_name.replace("_", " ").title()}:'))
             if obj_name == "All Variables" and not args.all_vars:
                 continue
             _print_attr_dict(obj_dict, n_indent=4)

--- a/lib/ramble/ramble/cmd/software_definitions.py
+++ b/lib/ramble/ramble/cmd/software_definitions.py
@@ -9,11 +9,10 @@
 import sys
 from typing import Dict, List
 
-import llnl.util.tty.color as color
 from llnl.util.tty.colify import colify
 
 import ramble.repository
-import ramble.util.colors as rucolor
+import ramble.util.colors as color
 from ramble.util.logger import logger
 
 description = "inspect software definitions in object definitions"
@@ -99,12 +98,12 @@ def collect_definitions():
 
 def print_summary():
     """Print a summary of all software definitions"""
-    color.cprint(rucolor.section_title("Software Summary:"))
+    color.cprint(color.section_title("Software Summary:"))
     color.cprint("\n")
     for spec_name in specs:
-        color.cprint(rucolor.nested_1(spec_headers[spec_name]) + ":")
+        color.cprint(color.nested_1(spec_headers[spec_name]) + ":")
         for spec_def in specs[spec_name]:
-            color.cprint(f'\t{rucolor.nested_2("Spec:")} {rucolor.plaintext(spec_def)}')
+            color.cprint(f'\t{color.nested_2("Spec:")} %s', spec_def)
             color.cprint("\tIn object:")
             colify(specs[spec_name][spec_def], indent=16, output=sys.stdout)
         color.cprint("\n")
@@ -124,31 +123,31 @@ def print_conflicts():
     """Print conflict information, if any exist"""
     if conflicts or unused_compilers:
         if conflicts:
-            color.cprint(rucolor.section_title("Software Definition Conflicts:"))
+            color.cprint(color.section_title("Software Definition Conflicts:"))
             for pkg_name in conflicts:
 
-                color.cprint(f'{rucolor.nested_1("Package")}: {pkg_name}:')
+                color.cprint(f'{color.nested_1("Package")}: {pkg_name}:')
                 color.cprint("\tDefined as:")
                 for attr in ["pkg_spec", "compiler_spec", "compiler"]:
                     if hasattr(definitions[pkg_name], attr):
                         attr_def = getattr(definitions[pkg_name], attr)
                         if attr_def:
-                            color.cprint(f"\t\t{attr} = {rucolor.plaintext(attr_def)}")
+                            color.cprint(f"\t\t{attr} = {attr_def}")
                 color.cprint("\tIn objects:")
                 colify(used_by[pkg_name], indent=24, output=sys.stdout)
                 color.cprint("\tConflicts with objects:")
                 colify(conflicts[pkg_name], indent=24, output=sys.stdout)
 
         if unused_compilers:
-            color.cprint(rucolor.section_title("Unused Compilers:"))
+            color.cprint(color.section_title("Unused Compilers:"))
             for compiler_name, object_names in unused_compilers.items():
                 color.cprint(
-                    rucolor.nested_1(f"    Compiler {compiler_name} is not used in packages:")
+                    color.nested_1(f"    Compiler {compiler_name} is not used in packages:")
                 )
                 colify(object_names, indent=8, output=sys.stdout)
                 color.cprint("\n")
     else:
-        color.cprint(rucolor.section_title("No Conflicts Detected"))
+        color.cprint(color.section_title("No Conflicts Detected"))
 
 
 def setup_parser(subparser):

--- a/lib/ramble/ramble/cmd/software_definitions.py
+++ b/lib/ramble/ramble/cmd/software_definitions.py
@@ -103,7 +103,7 @@ def print_summary():
     for spec_name in specs:
         color.cprint(color.nested_1(spec_headers[spec_name]) + ":")
         for spec_def in specs[spec_name]:
-            color.cprint(f'\t{color.nested_2("Spec:")} %s', spec_def)
+            color.cprint(f'\t{color.nested_2("Spec:")} {spec_def}')
             color.cprint("\tIn object:")
             colify(specs[spec_name][spec_def], indent=16, output=sys.stdout)
         color.cprint("\n")

--- a/lib/ramble/ramble/cmd/unit_test.py
+++ b/lib/ramble/ramble/cmd/unit_test.py
@@ -14,11 +14,11 @@ import os
 import shutil
 import sys
 
-import llnl.util.tty.color as color
 from llnl.util.filesystem import working_dir
 from llnl.util.tty.colify import colify
 
 import ramble.paths
+import ramble.util.colors as color
 import ramble.workspace
 from ramble.util.logger import logger
 

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -15,7 +15,6 @@ from collections import defaultdict
 from typing import Callable, Dict
 
 import llnl.util.tty as tty
-import llnl.util.tty.color as color
 from llnl.util.tty.colify import colified, colify
 
 import ramble.cmd
@@ -25,7 +24,7 @@ import ramble.expander
 import ramble.filters
 import ramble.pipeline
 import ramble.software_environments
-import ramble.util.colors as rucolor
+import ramble.util.colors as color
 import ramble.workspace
 import ramble.workspace.shell
 from ramble.namespace import namespace
@@ -775,14 +774,14 @@ def workspace_info(args):
         args.phases = True
         args.executables = True
 
-    color.cprint(rucolor.section_title("Workspace: ") + ws.name)
+    color.cprint(color.section_title("Workspace: ") + "%s", ws.name)
     color.cprint("")
-    color.cprint(rucolor.section_title("Location: ") + ws.path)
+    color.cprint(color.section_title("Location: ") + "%s", ws.path)
 
     # Print workspace templates that currently exist
     if args.templates:
         color.cprint("")
-        color.cprint(rucolor.section_title("Workspace Templates:"))
+        color.cprint(color.section_title("Workspace Templates:"))
         for template, _ in ws.all_templates():
             color.cprint(f"    {template}")
 
@@ -798,7 +797,7 @@ def workspace_info(args):
     if args.tags:
         color.cprint("")
         all_tags = experiment_set.all_experiment_tags()
-        color.cprint(rucolor.section_title("All experiment tags:"))
+        color.cprint(color.section_title("All experiment tags:"))
         color.cprint(colified(all_tags, indent=4))
 
     # Print experiment information
@@ -807,7 +806,7 @@ def workspace_info(args):
     # The base experiment_set is used to list *all* experiments.
     all_pipelines = {}
     color.cprint("")
-    color.cprint(rucolor.section_title("Experiments:"))
+    color.cprint(color.section_title("Experiments:"))
 
     # Build an index of experiments to avoid re-rendering them in the loops below
     experiment_index_map = defaultdict(list)
@@ -840,13 +839,13 @@ def workspace_info(args):
                 # Define variable printing groups.
                 var_indent = "        "
                 var_group_names = [
-                    rucolor.config_title("Config"),
-                    rucolor.section_title("Workspace"),
-                    rucolor.nested_1("Application"),
-                    rucolor.nested_2("Workload"),
-                    rucolor.nested_3("Experiment"),
+                    color.config_title("Config"),
+                    color.section_title("Workspace"),
+                    color.nested_1("Application"),
+                    color.nested_2("Workload"),
+                    color.nested_3("Experiment"),
                 ]
-                header_base = rucolor.nested_4("Variables from")
+                header_base = color.nested_4("Variables from")
                 config_vars = ramble.config.config.get("config:variables")
 
                 # Retrieve experiments from index
@@ -899,10 +898,10 @@ def workspace_info(args):
 
                     if print_header:
                         color.cprint(
-                            rucolor.nested_1("  Application: ") + application_context.escaped_name
+                            color.nested_1("  Application: ") + application_context.escaped_name
                         )
                         color.cprint(
-                            rucolor.nested_2("    Workload: ") + workload_context.escaped_name
+                            color.nested_2("    Workload: ") + workload_context.escaped_name
                         )
                         print_header = False
 
@@ -919,41 +918,43 @@ def workspace_info(args):
 
                     if app_inst.is_template:
                         color.cprint(
-                            rucolor.nested_3(f"      Template Experiment {experiment_index}: ")
-                            + rucolor.plaintext(exp_name)
+                            color.nested_3(f"      Template Experiment {experiment_index}: ")
+                            + "%s",
+                            exp_name,
                         )
                     elif app_inst.repeats.is_repeat_base:
                         color.cprint(
-                            rucolor.nested_3(f"      Repeat Base Experiment {experiment_index}: ")
-                            + rucolor.plaintext(exp_name)
+                            color.nested_3(f"      Repeat Base Experiment {experiment_index}: ")
+                            + "%s",
+                            exp_name,
                         )
                     else:
                         color.cprint(
-                            rucolor.nested_3(f"      Experiment {experiment_index}: ")
-                            + rucolor.plaintext(exp_name)
+                            color.nested_3(f"      Experiment {experiment_index}: ") + "%s",
+                            exp_name,
                         )
 
                     if args.tags:
-                        color.cprint("        Experiment Tags: " + str(app_inst.experiment_tags))
+                        color.cprint("        Experiment Tags: %s", str(app_inst.experiment_tags))
 
                     if args.variants:
-                        color.cprint(rucolor.nested_4("        Variants: "))
+                        color.cprint(color.nested_4("        Variants: "))
                         variant_set = set()
                         for _, obj in app_inst._objects():
                             variant_set = variant_set.union(
                                 obj.experiment_variants().as_set(expander=app_inst.expander)
                             )
                         for variant in variant_set:
-                            color.cprint(f"          - {rucolor.plaintext(variant)}")
+                            color.cprint("          - %s", variant)
 
                     if args.executables:
-                        color.cprint(rucolor.nested_4("        Executables: "))
+                        color.cprint(color.nested_4("        Executables: "))
                         app_inst.define_variables_for_template_path(ws)
                         exec_graph = app_inst._get_executable_graph(
                             app_inst.expander.workload_name
                         )
                         for executable in exec_graph.walk():
-                            color.cprint(f"          {executable.key}")
+                            color.cprint("          %s", executable.key)
 
                     if args.expansions:
                         var_groups = [
@@ -978,13 +979,13 @@ def workspace_info(args):
     if args.phases:
         for pipeline in sorted(all_pipelines.keys()):
             color.cprint("")
-            color.cprint(rucolor.section_title(f"Phases for {pipeline} pipeline:"))
+            color.cprint(color.section_title(f"Phases for {pipeline} pipeline:"))
             colify(all_pipelines[pipeline], indent=4)
 
     # Print software stack information
     if args.software or args.all_software:
         color.cprint("")
-        color.cprint(rucolor.section_title("Software Stack:"))
+        color.cprint(color.section_title("Software Stack:"))
         only_used_software = args.software
         color.cprint(
             software_environments.info(

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -774,9 +774,9 @@ def workspace_info(args):
         args.phases = True
         args.executables = True
 
-    color.cprint(color.section_title("Workspace: ") + "%s", ws.name)
+    color.cprint(f'{color.section_title("Workspace: ")}{ws.name}')
     color.cprint("")
-    color.cprint(color.section_title("Location: ") + "%s", ws.path)
+    color.cprint(f'{color.section_title("Location: ")}{ws.path}')
 
     # Print workspace templates that currently exist
     if args.templates:
@@ -917,25 +917,17 @@ def workspace_info(args):
                     )
 
                     if app_inst.is_template:
-                        color.cprint(
-                            color.nested_3(f"      Template Experiment {experiment_index}: ")
-                            + "%s",
-                            exp_name,
-                        )
+                        prefix = f"      Template Experiment {experiment_index}: "
+                        color.cprint(f"{color.nested_3(prefix)}{exp_name}")
                     elif app_inst.repeats.is_repeat_base:
-                        color.cprint(
-                            color.nested_3(f"      Repeat Base Experiment {experiment_index}: ")
-                            + "%s",
-                            exp_name,
-                        )
+                        prefix = f"      Repeat Base Experiment {experiment_index}: "
+                        color.cprint(f"{color.nested_3(prefix)}{exp_name}")
                     else:
-                        color.cprint(
-                            color.nested_3(f"      Experiment {experiment_index}: ") + "%s",
-                            exp_name,
-                        )
+                        prefix = f"      Experiment {experiment_index}: "
+                        color.cprint(f"{color.nested_3(prefix)}{exp_name}")
 
                     if args.tags:
-                        color.cprint("        Experiment Tags: %s", str(app_inst.experiment_tags))
+                        color.cprint(f"        Experiment Tags: {app_inst.experiment_tags}")
 
                     if args.variants:
                         color.cprint(color.nested_4("        Variants: "))
@@ -945,7 +937,7 @@ def workspace_info(args):
                                 obj.experiment_variants().as_set(expander=app_inst.expander)
                             )
                         for variant in variant_set:
-                            color.cprint("          - %s", variant)
+                            color.cprint(f"          - {variant}")
 
                     if args.executables:
                         color.cprint(color.nested_4("        Executables: "))
@@ -954,7 +946,7 @@ def workspace_info(args):
                             app_inst.expander.workload_name
                         )
                         for executable in exec_graph.walk():
-                            color.cprint("          %s", executable.key)
+                            color.cprint(f"          {executable.key}")
 
                     if args.expansions:
                         var_groups = [
@@ -1010,7 +1002,7 @@ def workspace_list(args):
     color_names = []
     for name in names:
         if ramble.workspace.active(name):
-            name = color.colorize("@*g{%s}" % name)
+            name = color.colorize(f"@*g{{{name}}}")
         color_names.append(name)
 
     # say how many there are if writing to a tty

--- a/lib/ramble/ramble/context.py
+++ b/lib/ramble/ramble/context.py
@@ -6,7 +6,7 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-import ramble.util.colors as rucolor
+import ramble.util.colors as color
 import ramble.util.matrices
 from ramble.namespace import namespace
 
@@ -64,7 +64,7 @@ class Context:
 
     @property
     def escaped_name(self):
-        return rucolor.escape_str(self.context_name)
+        return color.escape_str(self.context_name)
 
     def merge_context(self, in_context):
         """Merges another Context into this Context."""

--- a/lib/ramble/ramble/definitions/requirements.py
+++ b/lib/ramble/ramble/definitions/requirements.py
@@ -6,7 +6,7 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-import ramble.util.colors as rucolor
+import ramble.util.colors as color
 
 
 class PackageManagerRequirement:
@@ -51,14 +51,13 @@ class PackageManagerRequirement:
         if verbose:
             print_attrs = ["command", "validation_type", "package_manager", "regex"]
 
-            out_str = f"{indentation}{rucolor.section_title('When:')} {self.when}\n"
+            out_str = f"{indentation}{color.section_title('When:')} {self.when}\n"
             for print_attr in print_attrs:
                 attr_val = getattr(self, print_attr, None)
 
                 if attr_val:
                     out_str += (
-                        f"{indentation}    {rucolor.nested_1(print_attr)}: "
-                        f"{rucolor.plaintext(str(attr_val))}\n"
+                        f"{indentation}    {color.nested_1(print_attr)}: " f"{str(attr_val)}\n"
                     )
         else:
             out_str = f"{indentation}{self.when}"

--- a/lib/ramble/ramble/definitions/variables.py
+++ b/lib/ramble/ramble/definitions/variables.py
@@ -76,7 +76,7 @@ class Variable:
                 if attr_val:
                     out_str += (
                         f"{indentation}    {color.title_color(name, n_indent=n_indent + 4)}: "
-                        f"{color.plaintext(str(attr_val))}\n"
+                        f"{str(attr_val)}\n"
                     )
         else:
             out_str = f"{indentation}{self.name}"
@@ -217,7 +217,7 @@ class EnvironmentVariable:
                 if attr_val:
                     out_str += (
                         f"{indentation}    {color.title_color(name, n_indent=n_indent + 4)}: "
-                        f"{color.plaintext(str(attr_val))}\n"
+                        f"{str(attr_val)}\n"
                     )
         else:
             out_str = f"{indentation}{self.name}"

--- a/lib/ramble/ramble/definitions/variables.py
+++ b/lib/ramble/ramble/definitions/variables.py
@@ -9,7 +9,7 @@
 import copy
 from typing import Any, Dict, List, Optional, Set
 
-import ramble.util.colors as rucolor
+import ramble.util.colors as color
 
 
 class Variable:
@@ -65,7 +65,7 @@ class Variable:
         if verbose:
             print_attrs = ["Description", "Default", "Values"]
 
-            out_str = rucolor.title_color(f"{indentation}{self.name}:\n", n_indent)
+            out_str = color.title_color(f"{indentation}{self.name}:\n", n_indent)
             for print_attr in print_attrs:
                 name = print_attr
                 if print_attr == "Values":
@@ -75,8 +75,8 @@ class Variable:
                 attr_val = getattr(self, attr_name, None)
                 if attr_val:
                     out_str += (
-                        f"{indentation}    {rucolor.title_color(name, n_indent=n_indent + 4)}: "
-                        f"{rucolor.plaintext(str(attr_val))}\n"
+                        f"{indentation}    {color.title_color(name, n_indent=n_indent + 4)}: "
+                        f"{color.plaintext(str(attr_val))}\n"
                     )
         else:
             out_str = f"{indentation}{self.name}"
@@ -140,7 +140,7 @@ class VariableModification:
 
         print_attrs = ["Modification", "Method", "Separator", "When"]
 
-        out_str = rucolor.title_color(f"{indentation}{self.name}:\n", n_indent)
+        out_str = color.title_color(f"{indentation}{self.name}:\n", n_indent)
         for print_attr in print_attrs:
             name = print_attr
             attr_name = print_attr.lower()
@@ -150,8 +150,8 @@ class VariableModification:
                 if print_attr == "Separator":
                     attr_val = f"'{attr_val}'"
                 out_str += (
-                    f"{indentation}    {rucolor.title_color(name, n_indent=n_indent + 4)}: "
-                    f"{rucolor.plaintext(str(attr_val))}\n"
+                    f"{indentation}    {color.title_color(name, n_indent=n_indent + 4)}: "
+                    f"{str(attr_val)}\n"
                 )
         return out_str
 
@@ -210,14 +210,14 @@ class EnvironmentVariable:
             print_attrs = ["Description", "Value", "Method"]
             if self.method == "append":
                 print_attrs.append("Separator")
-            out_str = rucolor.title_color(f"{indentation}{self.name}:\n", n_indent)
+            out_str = color.title_color(f"{indentation}{self.name}:\n", n_indent)
             for name in print_attrs:
                 attr_name = name.lower()
                 attr_val = getattr(self, attr_name, None)
                 if attr_val:
                     out_str += (
-                        f"{indentation}    {rucolor.title_color(name, n_indent=n_indent + 4)}: "
-                        f"{rucolor.plaintext(str(attr_val))}\n"
+                        f"{indentation}    {color.title_color(name, n_indent=n_indent + 4)}: "
+                        f"{color.plaintext(str(attr_val))}\n"
                     )
         else:
             out_str = f"{indentation}{self.name}"
@@ -291,20 +291,20 @@ class EnvironmentVariableModifications:
 
         if verbose:
             n = 0
-            out_str = rucolor.title_color(f"{indentation}{self.name}:\n", n_indent)
+            out_str = color.title_color(f"{indentation}{self.name}:\n", n_indent)
             for method in self.all_methods:
                 if getattr(self, method):
                     if n > 0:
                         out_str += "\n"
                     out_str += (
                         f"{indentation}    "
-                        f"{rucolor.title_color('method', n_indent=n_indent + 4)}: {method}\n"
+                        f"{color.title_color('method', n_indent=n_indent + 4)}: {method}\n"
                     )
                     n += 1
                     if method == "set":
                         out_str += (
                             f"{indentation}    "
-                            f"{rucolor.title_color('modification', n_indent=n_indent + 4)}: "
+                            f"{color.title_color('modification', n_indent=n_indent + 4)}: "
                             f"{self.set[self.name]}\n"
                         )
                     elif method in ["prepend", "append"]:
@@ -312,12 +312,12 @@ class EnvironmentVariableModifications:
                             for attr, val in method_dict.items():
                                 out_str += (
                                     f"{indentation}    "
-                                    f"{rucolor.title_color(attr, n_indent=n_indent + 4)}: {val}\n"
+                                    f"{color.title_color(attr, n_indent=n_indent + 4)}: {val}\n"
                                 )
                     if self.when:
                         out_str += (
                             f"{indentation}    "
-                            f"{rucolor.title_color('when', n_indent=n_indent + 4)}: {self.when}\n"
+                            f"{color.title_color('when', n_indent=n_indent + 4)}: {self.when}\n"
                         )
         else:
             out_str = f"{indentation}{self.name}"

--- a/lib/ramble/ramble/definitions/versions.py
+++ b/lib/ramble/ramble/definitions/versions.py
@@ -11,7 +11,7 @@ from typing import Callable, Optional
 from packaging.specifiers import SpecifierSet
 from packaging.version import InvalidVersion, Version
 
-import ramble.util.colors as rucolor
+import ramble.util.colors as color
 from ramble.language.language_base import DirectiveError
 
 
@@ -88,9 +88,9 @@ class ObjectVersion:
             (str): Representation of this version
         """
         indentation = " " * n_indent
-        out_str = rucolor.section_title(f"{indentation}{self.version}") + "\n"
-        out_str += rucolor.nested_1(f"{indentation}    Description: ") + f"{self.description}\n"
-        out_str += rucolor.nested_1(f"{indentation}    Preferred: ") + f"{self.preferred}\n"
+        out_str = color.section_title(f"{indentation}{self.version}") + "\n"
+        out_str += color.nested_1(f"{indentation}    Description: ") + f"{self.description}\n"
+        out_str += color.nested_1(f"{indentation}    Preferred: ") + f"{self.preferred}\n"
 
         return out_str
 

--- a/lib/ramble/ramble/main.py
+++ b/lib/ramble/ramble/main.py
@@ -30,7 +30,6 @@ import ruamel
 import llnl.util.lang
 import llnl.util.tty as tty
 import llnl.util.tty.colify
-import llnl.util.tty.color as color
 from llnl.util.tty.log import log_output
 
 import ramble.cmd
@@ -38,6 +37,7 @@ import ramble.cmd.common.arguments
 import ramble.config
 import ramble.paths
 import ramble.repository
+import ramble.util.colors as color
 import ramble.util.version
 import ramble.workspace
 import ramble.workspace.shell

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -18,7 +18,6 @@ import py.path
 
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
-from llnl.util.tty.color import cprint
 
 import ramble.config
 import ramble.expander
@@ -30,6 +29,7 @@ import ramble.uploader
 import ramble.util.hashing
 import ramble.util.path
 import ramble.workspace
+from ramble.util.colors import cprint
 from ramble.util.file_util import create_symlink
 from ramble.util.logger import logger
 

--- a/lib/ramble/ramble/software_environments.py
+++ b/lib/ramble/ramble/software_environments.py
@@ -216,11 +216,11 @@ class RenderedPackage(SoftwarePackage):
 
         indentation = " " * (indent + SUB_INDENT)
         out_str = super().info(indent, verbosity, color_level, only_used)
-        out_str += f"{indentation}Spec: {color.plaintext(self.spec)}\n"
+        out_str += f"{indentation}Spec: {self.spec}\n"
         if self.compiler:
-            out_str += f"{indentation}Compiler: {color.plaintext(self.compiler)}\n"
+            out_str += f"{indentation}Compiler: {self.compiler}\n"
         if self.compiler_spec:
-            out_str += f"{indentation}Compiler Spec: {color.plaintext(self.compiler_spec)}\n"
+            out_str += f"{indentation}Compiler Spec: {self.compiler_spec}\n"
         return out_str
 
     def __eq__(self, other):

--- a/lib/ramble/ramble/software_environments.py
+++ b/lib/ramble/ramble/software_environments.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 from typing import DefaultDict, Dict, List, Set
 
 import ramble.error
-import ramble.util.colors as rucolor
+import ramble.util.colors as color
 from ramble.expander import Expander
 from ramble.namespace import namespace
 from ramble.util.logger import logger
@@ -107,11 +107,13 @@ class SoftwarePackage:
             return ""
 
         indentation = " " * indent
-        color = rucolor.level_func(color_level)
+        color_func = color.level_func(color_level)
 
         injected_str = "" if not self.injected else " (injected by ramble)"
 
-        out_str = color(f"{indentation}{self._package_type} package: {self.name} {injected_str}\n")
+        out_str = color_func(
+            f"{indentation}{self._package_type} package: {self.name} {injected_str}\n"
+        )
         return out_str
 
     def __str__(self):
@@ -214,11 +216,11 @@ class RenderedPackage(SoftwarePackage):
 
         indentation = " " * (indent + SUB_INDENT)
         out_str = super().info(indent, verbosity, color_level, only_used)
-        out_str += rucolor.plaintext(f"{indentation}Spec: {self.spec}\n")
+        out_str += f"{indentation}Spec: {color.plaintext(self.spec)}\n"
         if self.compiler:
-            out_str += rucolor.plaintext(f"{indentation}Compiler: {self.compiler}\n")
+            out_str += f"{indentation}Compiler: {color.plaintext(self.compiler)}\n"
         if self.compiler_spec:
-            out_str += rucolor.plaintext(f"{indentation}Compiler Spec: {self.compiler_spec}\n")
+            out_str += f"{indentation}Compiler Spec: {color.plaintext(self.compiler_spec)}\n"
         return out_str
 
     def __eq__(self, other):
@@ -283,10 +285,10 @@ class TemplatePackage(SoftwarePackage):
         out_str = ""
         pkg_man_indent = indent + SUB_INDENT
         indentation = " " * pkg_man_indent
-        color = rucolor.level_func(color_level + 1)
+        color_func = color.level_func(color_level + 1)
         for pkg_man, pkgs in self._rendered_packages.items():
             if pkgs:
-                out_str += color(f"{indentation}{pkg_man} packages:\n")
+                out_str += color_func(f"{indentation}{pkg_man} packages:\n")
 
             for pkg in pkgs.values():
                 out_str += pkg.info(
@@ -428,8 +430,8 @@ class SoftwareEnvironment:
             return ""
 
         indentation = " " * indent
-        color = rucolor.level_func(color_level)
-        out_str = color(f"{indentation}{self._environment_type} environment: {self.name}\n")
+        color_func = color.level_func(color_level)
+        out_str = color_func(f"{indentation}{self._environment_type} environment: {self.name}\n")
 
         if self._packages:
             indentation = " " * (indent + SUB_INDENT)
@@ -437,9 +439,9 @@ class SoftwareEnvironment:
 
         for pkg in self._packages:
             if verbosity >= 1:
-                out_str += rucolor.plaintext(f"{indentation}- {pkg.name} = {pkg.spec_str()}\n")
+                out_str += f"{indentation}- {pkg.name} = {pkg.spec_str()}\n"
             else:
-                out_str += rucolor.plaintext(f"{indentation}- {pkg.name}\n")
+                out_str += f"{indentation}- {pkg.name}\n"
         return out_str
 
     def __str__(self):

--- a/lib/ramble/ramble/spec.py
+++ b/lib/ramble/ramble/spec.py
@@ -9,9 +9,8 @@
 import io
 from typing import Mapping
 
-import llnl.util.tty.color as clr
-
 import ramble.error
+import ramble.util.colors as clr
 
 color_formats: Mapping[str, str] = {}
 default_format = "{name}"

--- a/lib/ramble/ramble/test/util/colors.py
+++ b/lib/ramble/ramble/test/util/colors.py
@@ -1,0 +1,53 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import pytest
+
+from ramble.util.colors import auto_escape
+
+
+@pytest.mark.parametrize(
+    "input_str,expected",
+    [
+        # Literal @
+        ("@@", "@@"),
+        ("@@@", "@@@@"),
+        # Valid color code (blue) within a string
+        ("foo@bar", "foo@bar"),
+        ("email@example.com", "email@@example.com"),  # @e is not a color
+        # Valid color codes (should NOT be escaped)
+        ("@r", "@r"),
+        ("@R", "@R"),
+        ("@. ", "@. "),
+        ("@*r", "@*r"),
+        ("@_g", "@_g"),
+        ("@*K", "@*K"),
+        ("@*W", "@*W"),
+        ("@*", "@*"),
+        ("@_", "@_"),
+        # Valid color codes with braces
+        ("@{text}", "@{text}"),
+        ("@r{text}", "@r{text}"),
+        ("@*b{text}", "@*b{text}"),
+        ("@_{text}", "@_{text}"),
+        ("@*R{text}", "@*R{text}"),
+        ("@*r{text}", "@*r{text}"),
+        # Complex cases
+        ("Error at @r{@*line 10}@. in @*file.py", "Error at @r{@*line 10}@. in @*file.py"),
+        ("Multiple @@ characters", "Multiple @@ characters"),
+        # Missing closing brace: @r is matched by itself
+        ("Missing brace: @r{text", "Missing brace: @r{text"),
+    ],
+)
+def test_auto_escape(input_str, expected):
+    assert auto_escape(input_str) == expected
+
+
+def test_auto_escape_unsupported_color():
+    # @e is not supported.
+    assert auto_escape("@e") == "@@e"

--- a/lib/ramble/ramble/test/util/colors.py
+++ b/lib/ramble/ramble/test/util/colors.py
@@ -17,9 +17,11 @@ from ramble.util.colors import auto_escape
         # Literal @
         ("@@", "@@"),
         ("@@@", "@@@@"),
-        # Valid color code (blue) within a string
-        ("foo@bar", "foo@bar"),
+        # Valid color code (blue) within a string - now escaped because it looks like a version
+        ("foo@bar", "foo@@bar"),
         ("email@example.com", "email@@example.com"),  # @e is not a color
+        # Preceded by special chars (should NOT be escaped if valid color)
+        (" (@gLinked@.)", " (@gLinked@.)"),
         # Valid color codes (should NOT be escaped)
         ("@r", "@r"),
         ("@R", "@R"),
@@ -30,7 +32,8 @@ from ramble.util.colors import auto_escape
         ("@*W", "@*W"),
         ("@*", "@*"),
         ("@_", "@_"),
-        # Valid color codes with braces
+        # Valid color codes with braces (should NOT be escaped even if preceded by alnum)
+        ("foo@r{text}", "foo@r{text}"),
         ("@{text}", "@{text}"),
         ("@r{text}", "@r{text}"),
         ("@*b{text}", "@*b{text}"),
@@ -42,6 +45,10 @@ from ramble.util.colors import auto_escape
         ("Multiple @@ characters", "Multiple @@ characters"),
         # Missing closing brace: @r is matched by itself
         ("Missing brace: @r{text", "Missing brace: @r{text"),
+        # Versions and specs
+        ("gromacs@2021", "gromacs@@2021"),
+        ("package-name@version", "package-name@@version"),
+        ("package_name@version", "package_name@@version"),
     ],
 )
 def test_auto_escape(input_str, expected):

--- a/lib/ramble/ramble/util/colors.py
+++ b/lib/ramble/ramble/util/colors.py
@@ -6,6 +6,41 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+import re
+
+import llnl.util.tty.color
+from llnl.util.tty.color import (
+    ColorParseError,
+    cescape,
+    cextra,
+    clen,
+    get_color_when,
+    set_color_when,
+)
+
+__all__ = [
+    "ColorParseError",
+    "cescape",
+    "cextra",
+    "clen",
+    "get_color_when",
+    "set_color_when",
+    "auto_escape",
+    "colorize",
+    "cprint",
+    "cwrite",
+    "escape_str",
+    "level_func",
+    "config_title",
+    "section_title",
+    "nested_1",
+    "nested_2",
+    "nested_3",
+    "nested_4",
+    "title_color",
+    "plaintext",
+]
+
 config_color = "@*Y"
 header_color = "@*b"
 level1_color = "@*g"
@@ -14,9 +49,66 @@ level3_color = "@*c"
 level4_color = "@*m"
 plain_format = "@."
 
+_valid_color_re = re.compile(
+    r"("
+    r"@@|"
+    r"@\.|"
+    r"@[*_]?[krgybmcwKRGYBMCW]?\{(?:[^}]|}})*\}|"
+    r"@[*_][krgybmcwKRGYBMCW]?|"
+    r"@[krgybmcwKRGYBMCW]"
+    r")"
+)
+
+
+def auto_escape(s):
+    """Escapes `@` characters that are not part of valid color formats."""
+    s = str(s)
+    parts = _valid_color_re.split(s)
+    for i in range(0, len(parts), 2):
+        parts[i] = parts[i].replace("@", "@@")
+    return "".join(parts)
+
+
+def colorize(string, **kwargs):
+    """Wrapper for llnl.util.tty.color.colorize that automatically escapes `@`"""
+    string = auto_escape(string)
+    return llnl.util.tty.color.colorize(string, **kwargs)
+
+
+def cprint(fmt, *args, **kwargs):
+    """
+    Wrapper for llnl.util.tty.color.cprint that automatically escapes `@`
+    characters in the formatting string and arguments if they do not match
+    valid color codes.
+    """
+    fmt = auto_escape(fmt)
+    if args:
+        escaped_args = tuple(auto_escape(arg) for arg in args)
+        msg = fmt % escaped_args
+    else:
+        msg = fmt
+
+    llnl.util.tty.color.cprint(msg, **kwargs)
+
+
+def cwrite(fmt, *args, **kwargs):
+    """
+    Wrapper for llnl.util.tty.color.cwrite that automatically escapes `@`
+    characters in the formatting string and arguments if they do not match
+    valid color codes.
+    """
+    fmt = auto_escape(fmt)
+    if args:
+        escaped_args = tuple(auto_escape(arg) for arg in args)
+        msg = fmt % escaped_args
+    else:
+        msg = fmt
+
+    llnl.util.tty.color.cwrite(msg, **kwargs)
+
 
 def escape_str(s):
-    return s.replace("@@", "@").replace("@", "@@")
+    return cescape(str(s))
 
 
 def level_func(level):

--- a/lib/ramble/ramble/util/colors.py
+++ b/lib/ramble/ramble/util/colors.py
@@ -38,7 +38,6 @@ __all__ = [
     "nested_3",
     "nested_4",
     "title_color",
-    "plaintext",
 ]
 
 config_color = "@*Y"
@@ -64,9 +63,26 @@ def auto_escape(s):
     """Escapes `@` characters that are not part of valid color formats."""
     s = str(s)
     parts = _valid_color_re.split(s)
-    for i in range(0, len(parts), 2):
-        parts[i] = parts[i].replace("@", "@@")
-    return "".join(parts)
+
+    new_parts = []
+    for i, part in enumerate(parts):
+        if i % 2 == 0:
+            new_parts.append(part.replace("@", "@@"))
+        else:
+            # Heuristic: If it looks like a version separator (preceded by alnum or -_)
+            # and is not a braced color code or special escape, escape it.
+            if part in ["@@", "@."]:
+                new_parts.append(part)
+            elif "{" in part:
+                new_parts.append(part)
+            elif (
+                i > 0 and parts[i - 1] and (parts[i - 1][-1].isalnum() or parts[i - 1][-1] in "-_")
+            ):
+                new_parts.append(part.replace("@", "@@"))
+            else:
+                new_parts.append(part)
+
+    return "".join(new_parts)
 
 
 def colorize(string, **kwargs):
@@ -75,36 +91,22 @@ def colorize(string, **kwargs):
     return llnl.util.tty.color.colorize(string, **kwargs)
 
 
-def cprint(fmt, *args, **kwargs):
+def cprint(string, **kwargs):
     """
     Wrapper for llnl.util.tty.color.cprint that automatically escapes `@`
-    characters in the formatting string and arguments if they do not match
-    valid color codes.
+    characters in the string if they do not match valid color codes.
     """
-    fmt = auto_escape(fmt)
-    if args:
-        escaped_args = tuple(auto_escape(arg) for arg in args)
-        msg = fmt % escaped_args
-    else:
-        msg = fmt
-
-    llnl.util.tty.color.cprint(msg, **kwargs)
+    string = auto_escape(string)
+    llnl.util.tty.color.cprint(string, **kwargs)
 
 
-def cwrite(fmt, *args, **kwargs):
+def cwrite(string, **kwargs):
     """
     Wrapper for llnl.util.tty.color.cwrite that automatically escapes `@`
-    characters in the formatting string and arguments if they do not match
-    valid color codes.
+    characters in the string if they do not match valid color codes.
     """
-    fmt = auto_escape(fmt)
-    if args:
-        escaped_args = tuple(auto_escape(arg) for arg in args)
-        msg = fmt % escaped_args
-    else:
-        msg = fmt
-
-    llnl.util.tty.color.cwrite(msg, **kwargs)
+    string = auto_escape(string)
+    llnl.util.tty.color.cwrite(string, **kwargs)
 
 
 def escape_str(s):
@@ -164,8 +166,3 @@ def title_color(title: str, n_indent: int = 0):
         out_str = nested_4(f"{title}")
 
     return out_str
-
-
-def plaintext(s):
-    """Escapes `@` characters to print plaintext with cprint"""
-    return escape_str(s)

--- a/lib/ramble/ramble/util/logger.py
+++ b/lib/ramble/ramble/util/logger.py
@@ -10,8 +10,9 @@ from contextlib import contextmanager
 from pathlib import Path
 
 import llnl.util.tty as tty
-import llnl.util.tty.color
 import llnl.util.tty.log
+
+import ramble.util.colors as color
 
 
 class Logger:
@@ -130,11 +131,11 @@ class Logger:
 
     @contextmanager
     def configure_colors(self, **kwargs):
-        old_value = llnl.util.tty.color.get_color_when()
+        old_value = color.get_color_when()
         if "stream" in kwargs:
-            llnl.util.tty.color.set_color_when("never")
+            color.set_color_when("never")
         yield
-        llnl.util.tty.color.set_color_when(old_value)
+        color.set_color_when(old_value)
 
     def all_msg(self, *args, **kwargs):
         """Print a message to all logs

--- a/lib/ramble/ramble/util/spec_utils.py
+++ b/lib/ramble/ramble/util/spec_utils.py
@@ -9,7 +9,7 @@
 import copy
 from typing import Dict, List, Optional
 
-import ramble.util.colors as rucolor
+import ramble.util.colors as color
 
 
 def specs_conflict(new, existing, prefix="", skip_conflicting_when=False):
@@ -76,14 +76,14 @@ class SoftwareSpec:
         base_indent = " " * n_indent
         indentation = " " * (n_indent + 4)
         self_dict = self.to_dict()
-        color_name = rucolor.section_title(self.name)
+        color_name = color.section_title(self.name)
         output = f"{base_indent}{color_name}:\n"
         for key, val in self_dict.items():
-            output += f"{indentation}{rucolor.nested_1(key)}: {rucolor.plaintext(val)}\n"
+            output += f"{indentation}{color.nested_1(key)}: {val}\n"
         if self.when:
-            output += rucolor.nested_2(f"\n{indentation}When:\n")
+            output += color.nested_2(f"\n{indentation}When:\n")
             for condition in self.when:
-                output += f"{indentation}    {rucolor.plaintext(condition)}\n"
+                output += f"{indentation}    {condition}\n"
         return output
 
     def __str__(self):

--- a/lib/ramble/ramble/variants.py
+++ b/lib/ramble/ramble/variants.py
@@ -11,7 +11,7 @@ from enum import Enum
 from typing import Any, Callable, Optional, Union
 
 import ramble.error
-import ramble.util.colors as rucolor
+import ramble.util.colors as color
 from ramble.expander import Expander
 
 reserved_variants = {
@@ -422,7 +422,7 @@ class Variant:
         indentation = " " * n_indent
 
         if verbose:
-            out_str = rucolor.section_title(f"{indentation}{self.name}:\n")
+            out_str = color.section_title(f"{indentation}{self.name}:\n")
             attrs = [
                 ("Description", "description"),
                 ("Default", "default"),
@@ -432,7 +432,7 @@ class Variant:
                 if hasattr(self, attr_name):
                     value = getattr(self, attr_name, None)
                     if value is not None:
-                        out_str += f"{indentation}    {rucolor.nested_1(print_name)}: {value}\n"
+                        out_str += f"{indentation}    {color.nested_1(print_name)}: {value}\n"
         else:
             out_str = self.name
 

--- a/lib/ramble/ramble/workload.py
+++ b/lib/ramble/ramble/workload.py
@@ -8,7 +8,7 @@
 
 from typing import Dict, FrozenSet, List, Optional
 
-import ramble.util.colors as rucolor
+import ramble.util.colors as color
 from ramble.definitions.variables import EnvironmentVariable, Variable
 from ramble.util.format import when_order
 from ramble.util.logger import logger
@@ -84,28 +84,29 @@ class Workload:
 
         indentation = " " * n_indent
 
-        out_str = rucolor.section_title(f"{indentation}Workload: ")
+        out_str = color.section_title(f"{indentation}Workload: ")
         out_str += f"{self.name}\n"
         for attr in attrs:
-            out_str += rucolor.nested_1(f"{indentation}    {attr[0]}: ")
+            out_str += color.nested_1(f"{indentation}    {attr[0]}: ")
             attr_val = getattr(self, attr[1], [])
             # TODO: Remove this after adding 'when' to the loop in 'ramble info' that prints
             # workloads. Better to group workloads under 'when' than print 'when' for each workload
             if attr[0] == "When" and isinstance(attr_val, list):
-                out_str += rucolor.plaintext(f"{' AND '.join(attr_val)}\n")
+                out_str += f"{' AND '.join(color.plaintext(x) for x in attr_val)}\n"
             else:
-                out_str += rucolor.plaintext(f"{attr_val}\n")
+                out_str += f"{color.plaintext(attr_val)}\n"
 
         if self.variables:
-            out_str += rucolor.nested_1(f"{indentation}    Variables:\n")
+            out_str += color.nested_1(f"{indentation}    Variables:\n")
             for when_set, var_list in self.variables.items():
                 if when_set:
-                    out_str += rucolor.nested_2(f"{indentation}        When: ")
-                    out_str += rucolor.plaintext(
-                        f"{' AND '.join(sorted(when_set, key=when_order))}\n"
+                    out_str += color.nested_2(f"{indentation}        When: ")
+                    when_str = " AND ".join(
+                        color.plaintext(x) for x in sorted(when_set, key=when_order)
                     )
+                    out_str += f"{when_str}\n"
                 else:
-                    out_str += rucolor.nested_2(f"{indentation}        Unconditional\n")
+                    out_str += color.nested_2(f"{indentation}        Unconditional\n")
 
                 var_dict = {}
                 for var in var_list:
@@ -114,15 +115,16 @@ class Workload:
                     out_str += var_dict[var_name].as_str(n_indent=(n_indent + 12), verbose=verbose)
 
         if self.environment_variables:
-            out_str += rucolor.nested_1(f"{indentation}    Environment Variables:\n")
+            out_str += color.nested_1(f"{indentation}    Environment Variables:\n")
             for when_set, env_var_list in self.environment_variables.items():
                 if when_set:
-                    out_str += rucolor.nested_2(f"{indentation}        When: ")
-                    out_str += rucolor.plaintext(
-                        f"{' AND '.join(sorted(when_set, key=when_order))}\n"
+                    out_str += color.nested_2(f"{indentation}        When: ")
+                    when_str = " AND ".join(
+                        color.plaintext(x) for x in sorted(when_set, key=when_order)
                     )
+                    out_str += f"{when_str}\n"
                 else:
-                    out_str += rucolor.nested_2(f"{indentation}        Unconditional\n")
+                    out_str += color.nested_2(f"{indentation}        Unconditional\n")
 
                 env_var_dict = {}
                 for env_var in env_var_list:
@@ -256,16 +258,19 @@ class WorkloadGroup:
 
         """
         indentation = " " * n_indent
-        out_str = rucolor.section_title(f"{indentation}{self.name}\n")
+        out_str = color.section_title(f"{indentation}{self.name}\n")
         for when_set, workload_list in self.workloads.items():
             if when_set:
-                out_str += rucolor.nested_1(f"{indentation}    When: ")
-                out_str += rucolor.plaintext(f"{' AND '.join(sorted(when_set, key=when_order))}\n")
+                out_str += color.nested_1(f"{indentation}    When: ")
+                when_str = " AND ".join(
+                    color.plaintext(x) for x in sorted(when_set, key=when_order)
+                )
+                out_str += f"{when_str}\n"
             else:
-                out_str += rucolor.nested_1(f"{indentation}    Unconditional\n")
+                out_str += color.nested_1(f"{indentation}    Unconditional\n")
 
             for workload in workload_list:
-                out_str += rucolor.nested_2(f"{indentation}        {workload}\n")
+                out_str += color.nested_2(f"{indentation}        {workload}\n")
 
         return out_str
 

--- a/lib/ramble/ramble/workload.py
+++ b/lib/ramble/ramble/workload.py
@@ -92,18 +92,16 @@ class Workload:
             # TODO: Remove this after adding 'when' to the loop in 'ramble info' that prints
             # workloads. Better to group workloads under 'when' than print 'when' for each workload
             if attr[0] == "When" and isinstance(attr_val, list):
-                out_str += f"{' AND '.join(color.plaintext(x) for x in attr_val)}\n"
+                out_str += f"{' AND '.join(x for x in attr_val)}\n"
             else:
-                out_str += f"{color.plaintext(attr_val)}\n"
+                out_str += f"{attr_val}\n"
 
         if self.variables:
             out_str += color.nested_1(f"{indentation}    Variables:\n")
             for when_set, var_list in self.variables.items():
                 if when_set:
                     out_str += color.nested_2(f"{indentation}        When: ")
-                    when_str = " AND ".join(
-                        color.plaintext(x) for x in sorted(when_set, key=when_order)
-                    )
+                    when_str = " AND ".join(x for x in sorted(when_set, key=when_order))
                     out_str += f"{when_str}\n"
                 else:
                     out_str += color.nested_2(f"{indentation}        Unconditional\n")
@@ -119,9 +117,7 @@ class Workload:
             for when_set, env_var_list in self.environment_variables.items():
                 if when_set:
                     out_str += color.nested_2(f"{indentation}        When: ")
-                    when_str = " AND ".join(
-                        color.plaintext(x) for x in sorted(when_set, key=when_order)
-                    )
+                    when_str = " AND ".join(x for x in sorted(when_set, key=when_order))
                     out_str += f"{when_str}\n"
                 else:
                     out_str += color.nested_2(f"{indentation}        Unconditional\n")
@@ -262,9 +258,7 @@ class WorkloadGroup:
         for when_set, workload_list in self.workloads.items():
             if when_set:
                 out_str += color.nested_1(f"{indentation}    When: ")
-                when_str = " AND ".join(
-                    color.plaintext(x) for x in sorted(when_set, key=when_order)
-                )
+                when_str = " AND ".join(x for x in sorted(when_set, key=when_order))
                 out_str += f"{when_str}\n"
             else:
                 out_str += color.nested_1(f"{indentation}    Unconditional\n")

--- a/lib/ramble/ramble/workspace/shell.py
+++ b/lib/ramble/ramble/workspace/shell.py
@@ -7,9 +7,8 @@
 # except according to those terms.
 import os
 
-from llnl.util.tty.color import colorize
-
 import ramble.workspace
+from ramble.util.colors import colorize
 
 from spack.util.environment import EnvironmentModifications
 

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -32,7 +32,6 @@ import ramble.schema.applications
 import ramble.schema.merged
 import ramble.schema.workspace
 import ramble.software_environments
-import ramble.util.colors as rucolor
 import ramble.util.hashing
 import ramble.util.install_cache
 import ramble.util.lock as lk
@@ -1756,7 +1755,7 @@ ramble:
                         if exp["VARIANTS"]:
                             f.write("  Experiment variants:\n")
                             for variant in exp["VARIANTS"]:
-                                f.write(f"  - {rucolor.plaintext(variant)}\n")
+                                f.write(f"  - {variant}\n")
 
                         if exp["SUCCESS_CRITERIA"]:
                             f.write("  Success criteria summary:\n")

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -813,9 +813,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         for var, val in print_vars.items():
             expansion_var = self.expander.expansion_str(var)
             expanded = self.expander.expand_var(expansion_var)
-            color.cprint(
-                rucolor.plaintext(f"{indent}  {var} = {val} ==> {expanded}")
-            )
+            color.cprint(f"{indent}  {var} = {val} ==> {expanded}")
 
     def build_used_variables(self, workspace):
         """Build a set of all used variables


### PR DESCRIPTION
This merge updates the logic used for escaping strings prior to printing out colored output. `@` symbols need to be escaped when they are to be printed as is, by converting them to `@@` entries instead. The color utility is updated to provide wrappers that can only escape strings that are not used for coloring directly (since color markers also include `@`).