### PR TITLE
make workspace dir an array

### DIFF
--- a/etc/ramble/defaults/config.yaml
+++ b/etc/ramble/defaults/config.yaml
@@ -21,7 +21,8 @@ config:
   checksum: true
   shell: bash
   input_cache: $ramble/var/ramble/cache
-  workspace_dirs: $ramble/var/ramble/workspaces
+  workspace_dirs:
+    - $ramble/var/ramble/workspaces
   report_dirs: ~/.ramble/reports
   include_phase_dependencies: false
   resolve_variables_in_subprocesses: false

--- a/lib/ramble/ramble/config.py
+++ b/lib/ramble/ramble/config.py
@@ -154,7 +154,7 @@ config_defaults = {
         "spack": {"flags": {"install": "--reuse", "concretize": "--reuse"}},
         "pip": {"install": {"flags": []}},
         "input_cache": "$ramble/var/ramble/cache",
-        "workspace_dirs": "$ramble/var/ramble/workspaces",
+        "workspace_dirs": ["$ramble/var/ramble/workspaces"],
         "upload": {"push_failed": True},
         "report_dirs": "~/.ramble/reports",
         "enable_strict_versions": True,

--- a/lib/ramble/ramble/schema/config.py
+++ b/lib/ramble/ramble/schema/config.py
@@ -155,7 +155,7 @@ properties["config"]["input_cache"] = {"type": "string", "default": "$ramble/var
 properties["config"]["workspace_dirs"] = {
     "type": ["string", "array"],
     "items": {"type": "string"},
-    "default": "$ramble/var/ramble/workspaces",
+    "default": ["$ramble/var/ramble/workspaces"],
 }
 
 properties["config"]["report_dirs"] = {

--- a/lib/ramble/ramble/schema/config.py
+++ b/lib/ramble/ramble/schema/config.py
@@ -153,7 +153,8 @@ properties["config"]["pip"] = {
 properties["config"]["input_cache"] = {"type": "string", "default": "$ramble/var/ramble/cache"}
 
 properties["config"]["workspace_dirs"] = {
-    "type": "string",
+    "type": ["string", "array"],
+    "items": {"type": "string"},
     "default": "$ramble/var/ramble/workspaces",
 }
 

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -138,6 +138,7 @@ def test_workspace_activate_fails(mutable_mock_workspace_path):
 
 
 def test_workspace_activate_prompt(workspace_name):
+    ramble.workspace.deactivate()
     ws = ramble.workspace.create(workspace_name)
     ws.write()
 

--- a/lib/ramble/ramble/test/workspace.py
+++ b/lib/ramble/ramble/test/workspace.py
@@ -12,6 +12,7 @@ import shutil
 
 import pytest
 
+import ramble
 from ramble.workspace import TEMPLATE_EXTENSION, workspace
 
 # everything here uses the mock_workspace_path
@@ -136,3 +137,31 @@ def test_get_workspace():
             workspace.deactivate()
         if os.path.exists(ws_root):
             shutil.rmtree(ws_root)
+
+
+def test_all_workspace_names_multiple_dirs(tmpdir, monkeypatch):
+    dir1 = tmpdir.mkdir("dir1")
+    dir2 = tmpdir.mkdir("dir2")
+
+    orig_get = ramble.config.get
+
+    def mock_get(path, default=None, scope=None):
+        if path == "config:workspace_dirs":
+            return [str(dir1), str(dir2)]
+        return orig_get(path, default=default, scope=scope)
+
+    monkeypatch.setattr(ramble.config, "get", mock_get)
+
+    ws1_root = os.path.join(str(dir1), "ws1")
+    ws2_root = os.path.join(str(dir2), "ws2")
+
+    ws1 = workspace.Workspace(ws1_root, True)
+    ws1.write()
+
+    ws2 = workspace.Workspace(ws2_root, True)
+    ws2.write()
+
+    names = workspace.all_workspace_names()
+
+    assert "ws1" in names
+    assert "ws2" in names

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -204,12 +204,8 @@ def all_workspace_names():
 
         candidates = sorted(os.listdir(wspath))
         for candidate in candidates:
-            configured = True
             cand_root = os.path.join(wspath, candidate)
-            yaml_path = os.path.join(cand_root, WORKSPACE_CONFIG_PATH, CONFIG_FILE_NAME)
-            if not os.path.exists(yaml_path):
-                configured = False
-            if valid_workspace_name(candidate) and configured:
+            if valid_workspace_name(candidate) and is_workspace_dir(cand_root):
                 names.append(candidate)
     return sorted(list(set(names)))
 
@@ -239,7 +235,7 @@ def _root(name):
     wspaths = get_workspace_path()
     for wspath in wspaths:
         cand_root = os.path.join(wspath, name)
-        if os.path.exists(os.path.join(cand_root, WORKSPACE_CONFIG_PATH, CONFIG_FILE_NAME)):
+        if is_workspace_dir(cand_root):
             return cand_root
     return os.path.join(wspaths[0], name)
 

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -207,7 +207,7 @@ def all_workspace_names():
             cand_root = os.path.join(wspath, candidate)
             if valid_workspace_name(candidate) and is_workspace_dir(cand_root):
                 names.append(candidate)
-    return sorted(list(set(names)))
+    return sorted(set(names))
 
 
 def active_workspace():

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -196,22 +196,22 @@ def deactivate_config_scope(workspace):
 
 def all_workspace_names():
     """List the names of workspaces that currently exist."""
-    # just return empty if the workspace path does not exist.  A read-only
-    # operation like list should not try to create a directory.
-    wspath = get_workspace_path()
-    if not os.path.exists(wspath):
-        return []
-
-    candidates = sorted(os.listdir(wspath))
+    wspaths = get_workspace_path()
     names = []
-    for candidate in candidates:
-        configured = True
-        yaml_path = os.path.join(_root(candidate), WORKSPACE_CONFIG_PATH, CONFIG_FILE_NAME)
-        if not os.path.exists(yaml_path):
-            configured = False
-        if valid_workspace_name(candidate) and configured:
-            names.append(candidate)
-    return names
+    for wspath in wspaths:
+        if not os.path.exists(wspath):
+            continue
+
+        candidates = sorted(os.listdir(wspath))
+        for candidate in candidates:
+            configured = True
+            cand_root = os.path.join(wspath, candidate)
+            yaml_path = os.path.join(cand_root, WORKSPACE_CONFIG_PATH, CONFIG_FILE_NAME)
+            if not os.path.exists(yaml_path):
+                configured = False
+            if valid_workspace_name(candidate) and configured:
+                names.append(candidate)
+    return sorted(list(set(names)))
 
 
 def active_workspace():
@@ -226,14 +226,22 @@ def get_workspace_path():
         # command above should have worked, so if it doesn't, error out:
         logger.die("No config:workspace_dirs setting found in configuration!")
 
-    wspath = ramble.util.path.canonicalize_path(str(path_in_config))
-    return wspath
+    if isinstance(path_in_config, str):
+        paths = [path_in_config]
+    else:
+        paths = path_in_config
+
+    return [ramble.util.path.canonicalize_path(str(p)) for p in paths]
 
 
 def _root(name):
     """Non-validating version of root(), to be used internally."""
-    wspath = get_workspace_path()
-    return os.path.join(wspath, name)
+    wspaths = get_workspace_path()
+    for wspath in wspaths:
+        cand_root = os.path.join(wspath, name)
+        if os.path.exists(os.path.join(cand_root, WORKSPACE_CONFIG_PATH, CONFIG_FILE_NAME)):
+            return cand_root
+    return os.path.join(wspaths[0], name)
 
 
 def root(name):
@@ -2060,8 +2068,8 @@ ramble:
     @property
     def internal(self):
         """Whether this workspace is managed by Ramble."""
-        wspath = get_workspace_path()
-        return self.path.startswith(wspath)
+        wspaths = get_workspace_path()
+        return any(self.path.startswith(wspath) for wspath in wspaths)
 
     @property
     def name(self):

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -202,7 +202,7 @@ def all_workspace_names():
         if not os.path.exists(wspath):
             continue
 
-        candidates = sorted(os.listdir(wspath))
+        candidates = os.listdir(wspath)
         for candidate in candidates:
             cand_root = os.path.join(wspath, candidate)
             if valid_workspace_name(candidate) and is_workspace_dir(cand_root):

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/test/spack_lightweight.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/test/spack_lightweight.py
@@ -100,11 +100,9 @@ def test_spack_auxiliary_files(request):
     with open(
         os.path.join(ws.auxiliary_software_dir, "packages.yaml"), "w+"
     ) as f:
-        f.write(
-            """packages:
+        f.write("""packages:
   all:
-    target: ['{opt_target}']"""
-        )
+    target: ['{opt_target}']""")
 
     ws._re_read()
 

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/test/spack_runner.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/test/spack_runner.py
@@ -344,9 +344,7 @@ compilers::
     modules: []
     environment: {}
     extra_rpaths: []
-""".replace(
-            "tmpdir_path", os.path.join(os.getcwd(), "bin")
-        )
+""".replace("tmpdir_path", os.path.join(os.getcwd(), "bin"))
 
         packages_config = f"""
 packages:


### PR DESCRIPTION
I wanted to beef up workspace dir support so we can normalize having multiple directory 

To add a directory: ramble config add config:workspace_dirs:/path/to/new/dir
To remove a directory: ramble config remove config:workspace_dirs:/path/to/dir

User added and file order gives precedence for any colliding names