### PR TITLE
Group and pin requirements by Python version [AI]

### DIFF
--- a/lib/ramble/docs/conf.py
+++ b/lib/ramble/docs/conf.py
@@ -424,3 +424,12 @@ intersphinx_mapping = {
 copybutton_exclude = ".gp, .go"
 # Escape hatch for turning off the copy button.
 copybutton_selector = "div:not(.hide-copy) > div.highlight > pre"
+
+# sphinx.ext.linkcheck
+linkcheck_ignore = [
+    r"^https://$",  # Ignore the bare https:// used as an example
+    r"http://www.example.com/.*",  # Ignore example URLs
+    r"https://github.com/project/repo.git",  # Ignore example URLs
+    r"https://jay.grs.rwth-aachen.de/hg/lwm2",  # Ignore problematic URL
+    r"https://www.intel.com/.*",  # Intel site often returns 403 to linkcheck
+]

--- a/lib/ramble/docs/dev_guides/1_basic_application_definition_tutorial.rst
+++ b/lib/ramble/docs/dev_guides/1_basic_application_definition_tutorial.rst
@@ -451,6 +451,7 @@ some file in the experiment directory. We will use the following definition to
 track whatever the output from the experiment is as the possible hostname:
 
 .. code-block:: python
+
     figure_of_merit(
       "possible hostname",
       fom_regex=r"(?P<hostname>\S+)",
@@ -562,6 +563,7 @@ To begin with, delete the tutorial workspace, and recreate it using:
   $ ramble workspace deactivate
   $ rm -rf tutorial-workspace
   $ ramble workspace create -d tutorial-workspace -a
+
 Now, we can add an experiment to exercise the local workload using:
 
 .. code-block:: console

--- a/lib/ramble/docs/dev_guides/application_dev_guide.rst
+++ b/lib/ramble/docs/dev_guides/application_dev_guide.rst
@@ -125,7 +125,7 @@ The HPL application definition file is named ``application.py`` and is stored
 within a directory named ``hpl``. Within the ``application.py`` file, a python
 class is defined with a similar name to the application directory. Ramble's
 application definition naming syntax follows
-`Spack's package naming rules <https://spack.readthedocs.io/en/latest/packaging_guide.html#naming-directory-structure>`_.
+`Spack's package naming rules <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#package-names-and-the-package-directory>`_.
 
 ^^^^^^^^^^^^
 Base Classes
@@ -330,7 +330,7 @@ Ramble allows objects to be defined with multiple versions, and then to use
 :ref:`conditional logic<application-dev-conditional-logic>` to set other
 directives based on the version. The ``version`` directive 
 (:py:meth:`ramble.language.shared_language.version`) is used to set a version,
- and ``when`` conditions can be described using the following syntax:
+and ``when`` conditions can be described using the following syntax:
 
 * ``application_version@<version_number>`` Apply to only a specific version.
 * ``application_version@:<version_number>`` Apply to a range up to and including

--- a/lib/ramble/docs/dev_guides/modifier_dev_guide.rst
+++ b/lib/ramble/docs/dev_guides/modifier_dev_guide.rst
@@ -84,7 +84,7 @@ The lscpu modifier definition file is named ``modifier.py`` and is stored
 within a directory named ``lscpu``. Within the ``modifier.py`` file, a python
 class is defined with a similar name to the modifier directory. Ramble's
 modifier definition naming syntax follows
-`Spack's package naming rules <https://spack.readthedocs.io/en/latest/packaging_guide.html#naming-directory-structure>`_.
+`Spack's package naming rules <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#package-names-and-the-package-directory>`_.
 
 ^^^^^^^^^^^^
 Base Classes

--- a/lib/ramble/docs/dev_guides/package_manager_dev_guide.rst
+++ b/lib/ramble/docs/dev_guides/package_manager_dev_guide.rst
@@ -72,7 +72,7 @@ and is stored within a directory named ``spack``. Witihn the
 ``package_manager.py`` file, a python class is defined with a similar name to
 the package manager directory.  Ramble's package manager definition naming
 syntax follows
-`Spack's package naming rules <https://spack.readthedocs.io/en/latest/packaging_guide.html#naming-directory-structure>`_.
+`Spack's package naming rules <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#package-names-and-the-package-directory>`_.
 
 When creating a new package manager, it is recommended that a ``runner`` class
 is created to encapsulate executing commands under the specific package

--- a/lib/ramble/docs/package_managers.rst
+++ b/lib/ramble/docs/package_managers.rst
@@ -136,7 +136,7 @@ mirror software source.
 
 The use of this package manager requires an external installation of Spack. For
 instructions on installing Spack, see
-`Spack's documentation <https://github.com/spack/spack#-spack>`_.
+`Spack's documentation <https://spack.readthedocs.io/en/latest/getting_started.html>`_.
 
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -159,7 +159,7 @@ mirror software source.
 
 The use of this package manager requires an external installation of Spack. For
 instructions on installing Spack, see
-`Spack's documentation <https://github.com/spack/spack#-spack>`_.
+`Spack's documentation <https://spack.readthedocs.io/en/latest/getting_started.html>`_.
 
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/lib/ramble/docs/requirements.txt
+++ b/lib/ramble/docs/requirements.txt
@@ -1,8 +1,19 @@
 -r ../../../requirements.txt
-sphinx
-docutils
-sphinx_rtd_theme
-sphinxcontrib-programoutput
-sphinxcontrib-jquery
-sphinx-copybutton
-pytest
+
+# Python >= 3.10
+docutils==0.20.1; python_version >= "3.10"
+pytest==8.2.2; python_version >= "3.10"
+sphinx==7.3.7; python_version >= "3.10"
+sphinx-copybutton==0.5.2; python_version >= "3.10"
+sphinx_rtd_theme==2.0.0; python_version >= "3.10"
+sphinxcontrib-jquery==4.1; python_version >= "3.10"
+sphinxcontrib-programoutput==0.17; python_version >= "3.10"
+
+# Python < 3.10
+docutils; python_version < "3.10"
+pytest; python_version < "3.10"
+sphinx; python_version < "3.10"
+sphinx-copybutton; python_version < "3.10"
+sphinx_rtd_theme; python_version < "3.10"
+sphinxcontrib-jquery; python_version < "3.10"
+sphinxcontrib-programoutput; python_version < "3.10"

--- a/lib/ramble/docs/tutorials/Workspace_config_command.rst
+++ b/lib/ramble/docs/tutorials/Workspace_config_command.rst
@@ -33,9 +33,9 @@ around configuring a workspace. Configuring experiments within a workspace will
 not be covered in this tutorial, however we will use pre-configured workspaces
 to illustrate the utility of the ``workspace config`` command.
 
----------------------
+------------------------
 Create Complex Workspace
----------------------
+------------------------
 
 To begin, we will construct a complex workspace to serve as an example of
 something we want to share with other users. Before configuring the workspace,

--- a/lib/ramble/docs/tutorials/shared/gromacs_vector_workspace.rst
+++ b/lib/ramble/docs/tutorials/shared/gromacs_vector_workspace.rst
@@ -69,8 +69,8 @@ the ``package_manager`` variant will change this behavior.
    :language: YAML
 
 Note that specifying compilers that Spack doesn't have installed may take a while.
-To see available compilers, use ``spack compilers`` or see `Spack documentation
-<https://spack.readthedocs.io/en/latest/getting_started.html#spack-compilers>`_
+To see available compilers, use ``spack compilers`` or see `Spack's documentation
+<https://spack.readthedocs.io/en/latest/configuring_compilers.html>`_
 for more information.
 
 The second file you should edit is the ``execute_experiment.tpl`` template file.

--- a/lib/ramble/docs/tutorials/shared/gromacs_workspace.rst
+++ b/lib/ramble/docs/tutorials/shared/gromacs_workspace.rst
@@ -80,7 +80,7 @@ the ``package_manager`` variant will change this behavior.
 
 Note that specifying compilers that Spack doesn't have installed may take a while.
 To see available compilers, use ``spack compilers`` or see `Spack's documentation
-<https://spack.readthedocs.io/en/latest/getting_started.html#spack-compilers>`_
+<https://spack.readthedocs.io/en/latest/configuring_compilers.html>`_
 for more information.
 
 The second file you should edit is the ``execute_experiment.tpl`` template file.

--- a/lib/ramble/ramble/fetch_strategy.py
+++ b/lib/ramble/ramble/fetch_strategy.py
@@ -988,7 +988,7 @@ class GitFetchStrategy(VCSFetchStrategy):
     def protocol_supports_shallow_clone(self):
         """Shallow clone operations (--depth #) are not supported by the basic
         HTTP protocol or by no-protocol file specifications.
-        Use (e.g.) https:// or file:// instead."""
+        Use (e.g.) `https://` or `file://` instead."""
         return not (self.url.startswith("http://") or self.url.startswith("/"))
 
     def __str__(self):

--- a/lib/ramble/ramble/language/application_language.py
+++ b/lib/ramble/ramble/language/application_language.py
@@ -148,23 +148,21 @@ def executable(name, template, when=None, **kwargs):
 
     Executables may or may not use MPI.
 
-    Required Args:
+    Args:
         name (str): Name of the executable
         template (list[str] | str): The template command this executable should generate from
-
-    Optional Args:
-        use_mpi or mpi (bool): determines if this executable should be
-                        wrapped with an `mpirun` like command or not.
-
+        use_mpi (bool): Determines if this executable should be
+            wrapped with an `mpirun` like command or not. (Alternative: mpi)
         variables (dict): Dictionary of variable definitions to use for this
-                          executable only
+            executable only
         redirect (str): Optional, sets the path for outputs to be written to.
-                             defaults to {log_file}
+            Defaults to {log_file}
         output_capture (str): Optional, Declare which output (stdout, stderr,
-                              both) to capture. Defaults to stdout
+            both) to capture. Defaults to stdout
         run_in_background (bool): Optional, Declare if the command should
-                                     run in the background. Defaults to False
+            run in the background. Defaults to False
         when (list | None): List of when conditions to apply to directive
+
     """
 
     def _execute_executable(app):
@@ -199,16 +197,18 @@ def input_file(
     fetched from.
 
     Args:
+        name (str): Name of the input file
         url (str): Path to the input file / archive
         description (str): Description of this input file
         target_dir (str): Optional, the directory where the archive will be
-                               expanded. Defaults to the '{workload_input_dir}'
-                               + os.sep + '{input_name}'
+            expanded. Defaults to the '{workload_input_dir}'
+            + os.sep + '{input_name}'
         sha256 (str): Optional, the expected sha256 checksum for the input file
-        extension (str): Optiona, the extension to use for the input, if it isn't part of the
-                              file name.
+        extension (str): Optional, the extension to use for the input, if it
+            isn't part of the file name.
         expand (bool): Optional. Whether the input should be expanded or not. Defaults to True
         when (list | None): List of when conditions to apply to directive
+
     """
 
     def _execute_input_file(app):

--- a/lib/ramble/ramble/language/workflow_manager_language.py
+++ b/lib/ramble/ramble/language/workflow_manager_language.py
@@ -31,6 +31,7 @@ def workflow_manager_variable(
     **kwargs,
 ):
     """Define a variable for this wm
+
     Args:
         name: Name of variable
         default: Default value if the variable is not defined
@@ -40,7 +41,6 @@ def workflow_manager_variable(
         track_used (bool): True if the variable should be tracked as used,
                            False if not. Can help with allowing lists without vectorizing
         when (list | None): List of when conditions to apply to directive
-
     """
 
     def _define_wm_variable(wm):

--- a/lib/ramble/ramble/reports.py
+++ b/lib/ramble/ramble/reports.py
@@ -182,24 +182,27 @@ def filter_exp_results(experiments: list):
 def generate_result_index(experiments: list, all_vars=False, where_query=None):
     """Creates an index from the results in the list of experiments
 
-    Index format is:
-    {
-        "applications": {
-            application_name: {
-                workload: {
+    Index format is::
+
+        {
+            "applications": {
+                application_name: {
+                    workload: {
+                        "Contexts": set(),
+                        "FOMs": set(),
+                        "Template Variables": set(),
+                    }
+                }
+            },
+            "modifiers": {
+                modifier_name: {
                     "Contexts": set(),
                     "FOMs": set(),
-                    "Template Variables": set(),
                 }
-            }
+            },
+            (all other object types)
         }
-        "modifiers": {
-            modifier_name: {
-                "Contexts": set(),
-                "FOMs": set(),
-            }
-        (all other object types)
-    }
+
     """
     result_index: Dict[str, dict] = {}
     for obj_name in OBJECT_NAMES.values():

--- a/lib/ramble/ramble/test/end_to_end/setup_analyze.py
+++ b/lib/ramble/ramble/test/end_to_end/setup_analyze.py
@@ -33,23 +33,21 @@ ws_cmd = RambleCommand("workspace")
 
 
 def test_setup_analyze(test_case_path, workspace_name):
-    """test_setup_analyze tests ramble objects that contain a `test_cases` directory.
+    """test_setup_analyze tests ramble objects that contain a ``test_cases`` directory.
 
-    Specifically, it assumes the following structure for the `test_cases` directory:
+    Specifically, it assumes the following structure for the ``test_cases`` directory::
 
-    ```
-    test_cases/
-    └── test_scenario_1 (can have multiple scenarios)
-        ├── artifacts
-        │   └── <application-name>__<workload_name>__<experiment_name>
-        │       └── <experiment_name>.out (can have other artifacts)
-        ├── expected_analyze.out
-        ├── setup.yaml (contains workspace commands for setting up the ramble config)
-        └── configs (either this or the setup.yaml must be present)
-            └── ramble.yaml (can contain more config files)
-    ```
+        test_cases/
+        └── test_scenario_1 (can have multiple scenarios)
+            ├── artifacts
+            │   └── <application-name>__<workload_name>__<experiment_name>
+            │       └── <experiment_name>.out (can have other artifacts)
+            ├── expected_analyze.out
+            ├── setup.yaml (contains workspace commands for setting up the ramble config)
+            └── configs (either this or the setup.yaml must be present)
+                └── ramble.yaml (can contain more config files)
 
-    When writing a Ramble object, if a `test_cases` directory is included, then
+    When writing a Ramble object, if a ``test_cases`` directory is included, then
     the test case will be run to verify the output of analyze.
 
     There is an example in the osu-micro-benchmarks application directory.

--- a/lib/ramble/ramble/variants.py
+++ b/lib/ramble/ramble/variants.py
@@ -332,10 +332,12 @@ class VariantSet:
         The set of variant definitions will be used to determine if a when
         clause is valid or not.
 
-        Returns:
-            set: A set consisting of strings with the variant definitions
+        Args:
             expander (ramble.expander.Expander): Expander to use when expanding
                                                  variant definitions
+
+        Returns:
+            set: A set consisting of strings with the variant definitions
         """
         if self._set_cache is not None:
             return self._expanded_set(expander)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,14 +1,32 @@
 -r requirements.txt
-pytest
-flake8
-black==26.3.1;python_version>="3.10"
-black;python_version<"3.10"
-coverage>=7.10;python_version>="3.9"
-coverage;python_version<"3.9"
-pre-commit
-pytest-xdist
-pytest-clarity
-line_profiler
-isort
-codecov-cli
-mypy
+
+# Python >= 3.10
+black==26.3.1; python_version >= "3.10"
+codecov-cli==0.6.0; python_version >= "3.10"
+coverage==7.10.0; python_version >= "3.10"
+flake8==7.1.0; python_version >= "3.10"
+isort==5.13.2; python_version >= "3.10"
+line_profiler==4.1.3; python_version >= "3.10"
+mypy==1.10.0; python_version >= "3.10"
+pre-commit==3.6.2; python_version >= "3.10"
+pytest==8.2.2; python_version >= "3.10"
+pytest-clarity==1.0.1; python_version >= "3.10"
+pytest-xdist==3.6.1; python_version >= "3.10"
+
+# Python < 3.10
+black; python_version < "3.10"
+codecov-cli; python_version < "3.10"
+flake8; python_version < "3.10"
+isort; python_version < "3.10"
+line_profiler; python_version < "3.10"
+mypy; python_version < "3.10"
+pre-commit; python_version < "3.10"
+pytest; python_version < "3.10"
+pytest-clarity; python_version < "3.10"
+pytest-xdist; python_version < "3.10"
+
+# Python == 3.9
+coverage>=7.10; python_version == "3.9"
+
+# Python < 3.9
+coverage; python_version < "3.9"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,33 @@
-google-cloud-storage # for gcs fetch test
-google-api-core # for gcs fetch error .execptions
-graphlib-backport;python_version<"3.9"
-urllib3==1.26.18;python_version<="3.6"
-protobuf;python_version>"3.6"
-protobuf==3.19.4;python_version<="3.6"
-pyarrow==3.0.0;python_version<="3.6"
-google-cloud-bigquery
-tqdm
-deprecation
-pandas
-matplotlib
-setuptools
-scipy
-types-PyYAML
+# Python >= 3.10
+deprecation==2.1.0; python_version >= "3.10"
+google-api-core==2.19.1; python_version >= "3.10" # for gcs fetch error .execptions
+google-cloud-bigquery==3.25.0; python_version >= "3.10"
+google-cloud-storage==2.18.2; python_version >= "3.10" # for gcs fetch test
+matplotlib==3.9.0; python_version >= "3.10"
+pandas==2.2.3; python_version >= "3.10"
+protobuf==5.27.1; python_version >= "3.10"
+scipy==1.14.1; python_version >= "3.10"
+setuptools==70.0.0; python_version >= "3.10"
+tqdm==4.66.4; python_version >= "3.10"
+types-PyYAML==6.0.12.20240311; python_version >= "3.10"
+
+# Python < 3.10
+deprecation; python_version < "3.10"
+google-api-core; python_version < "3.10" # for gcs fetch error .execptions
+google-cloud-bigquery; python_version < "3.10"
+google-cloud-storage; python_version < "3.10" # for gcs fetch test
+matplotlib; python_version < "3.10"
+pandas; python_version < "3.10"
+protobuf; python_version > "3.6" and python_version < "3.10"
+scipy; python_version < "3.10"
+setuptools; python_version < "3.10"
+tqdm; python_version < "3.10"
+types-PyYAML; python_version < "3.10"
+
+# Python < 3.9
+graphlib-backport; python_version < "3.9"
+
+# Python <= 3.6
+protobuf==3.19.4; python_version <= "3.6"
+pyarrow==3.0.0; python_version <= "3.6"
+urllib3==1.26.18; python_version <= "3.6"

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/test/spack_lightweight.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/test/spack_lightweight.py
@@ -100,11 +100,9 @@ def test_spack_auxiliary_files(request):
     with open(
         os.path.join(ws.auxiliary_software_dir, "packages.yaml"), "w+"
     ) as f:
-        f.write(
-            """packages:
+        f.write("""packages:
   all:
-    target: ['{opt_target}']"""
-        )
+    target: ['{opt_target}']""")
 
     ws._re_read()
 


### PR DESCRIPTION
Organizes dependencies into blocks based on their target Python versions, adding pinned requirements for Python >= 3.10 and leaving older constraints intact.