### PR TITLE
Convert Ramble's default for Spack to --fresh

### DIFF
--- a/etc/ramble/defaults/config.yaml
+++ b/etc/ramble/defaults/config.yaml
@@ -28,9 +28,9 @@ config:
   stage_method: cp
   spack:
     install:
-      flags: --reuse
+      flags: --fresh
     concretize:
-      flags: --reuse
+      flags: --fresh
     buildcache:
       flags: ''
     env_create:

--- a/lib/ramble/docs/configuration_files.rst
+++ b/lib/ramble/docs/configuration_files.rst
@@ -179,9 +179,9 @@ The current default configuration is as follows:
       shell: 'bash'
       spack:
         install:
-          flags: '--reuse'
+          flags: '--fresh'
         concretize:
-          flags: '--reuse'
+          flags: '--fresh'
         buildcache:
           flags: ''
         env_create:

--- a/lib/ramble/ramble/config.py
+++ b/lib/ramble/ramble/config.py
@@ -151,7 +151,7 @@ config_defaults = {
         "concretizer": "clingo",
         "license_dir": spack.paths.default_license_dir,
         "shell": "bash",
-        "spack": {"flags": {"install": "--reuse", "concretize": "--reuse"}},
+        "spack": {"install": {"flags": "--fresh"}, "concretize": {"flags": "--fresh"}},
         "pip": {"install": {"flags": []}},
         "input_cache": "$ramble/var/ramble/cache",
         "workspace_dirs": "$ramble/var/ramble/workspaces",

--- a/lib/ramble/ramble/schema/config.py
+++ b/lib/ramble/ramble/schema/config.py
@@ -25,7 +25,7 @@ properties["config"]["shell"] = {"type": "string", "enum": ["sh", "bash", "csh",
 
 properties["config"]["spack"] = {
     "type": "object",
-    "default": {"install": {"flags": "--reuse"}, "concretize": {"flags": "--reuse"}},
+    "default": {"install": {"flags": "--fresh"}, "concretize": {"flags": "--fresh"}},
     "properties": {
         "global": {
             "type": "object",
@@ -36,13 +36,13 @@ properties["config"]["spack"] = {
         "install": {
             "type": "object",
             "default": {
-                "flags": "--reuse",
+                "flags": "--fresh",
                 "prefix": "",
             },
             "properties": {
                 "flags": {
                     "type": "string",
-                    "default": "--reuse",
+                    "default": "--fresh",
                 },
                 "prefix": {"type": "string", "default": ""},
             },
@@ -51,13 +51,13 @@ properties["config"]["spack"] = {
         "concretize": {
             "type": "object",
             "default": {
-                "flags": "--reuse",
+                "flags": "--fresh",
                 "prefix": "",
             },
             "properties": {
                 "flags": {
                     "type": "string",
-                    "default": "--reuse",
+                    "default": "--fresh",
                 },
                 "prefix": {"type": "string", "default": ""},
             },

--- a/lib/ramble/ramble/test/data/config/config.yaml
+++ b/lib/ramble/ramble/test/data/config/config.yaml
@@ -3,9 +3,9 @@ config:
     overwrite_inventories: false
     spack:
       install:
-        flags: --reuse
+        flags: --fresh
       concretize:
-        flags: --reuse
+        flags: --fresh
       env_view:
         link_type: symlink
     include:

--- a/lib/ramble/ramble/test/modifier_functionality/mock_spack_modifier.py
+++ b/lib/ramble/ramble/test/modifier_functionality/mock_spack_modifier.py
@@ -55,7 +55,7 @@ def test_gromacs_dry_run_mock_spack_mod(
         workspace("setup", "--dry-run", global_args=["-D", ws1.root])
         out_files = glob.glob(os.path.join(ws1.log_dir, "**", "*.out"), recursive=True)
 
-        expected_str = "with args: ['--reuse', 'mod_compiler@1.1 target=x86_64']"
+        expected_str = "with args: ['--fresh', 'mod_compiler@1.1 target=x86_64']"
 
         assert search_files_for_string(out_files, expected_str)
 

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/test/spack_runner.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/test/spack_runner.py
@@ -214,7 +214,7 @@ def test_default_concretize_flags(tmpdir, capsys, request):
         sr.concretize()
         captured = capsys.readouterr()
         assert "spack concretize" in captured.out
-        assert "with args: ['--reuse']" in captured.out
+        assert "with args: ['--fresh']" in captured.out
     except RunnerError as e:
         pytest.skip("%s" % e)
 
@@ -344,9 +344,7 @@ compilers::
     modules: []
     environment: {}
     extra_rpaths: []
-""".replace(
-            "tmpdir_path", os.path.join(os.getcwd(), "bin")
-        )
+""".replace("tmpdir_path", os.path.join(os.getcwd(), "bin"))
 
         packages_config = f"""
 packages:


### PR DESCRIPTION
Previously, Ramble's Spack default was to use --reuse. We are updating this to --fresh. The main difference for Ramble's usage is to allow concretization in Spack to create new packages. The --reuse default causes packages that are already installed to be selected if they are viable for nodes in the spec, while --fresh forces reconcretizing these nodes. Installation will still skip rebuilding if a package matching what is requested exists already.