### PR TITLE
Handle impossible when conditions in application definitions [AI]

### DIFF
--- a/lib/ramble/ramble/error.py
+++ b/lib/ramble/ramble/error.py
@@ -95,6 +95,10 @@ class RambleError(Exception):
         return type(self), (self.message, self.long_message)
 
 
+class DirectiveError(RambleError):
+    """This is raised when something is wrong with a language directive."""
+
+
 class SpecError(RambleError):
     """Superclass for all errors that occur while constructing specs."""
 

--- a/lib/ramble/ramble/language/application_language.py
+++ b/lib/ramble/ramble/language/application_language.py
@@ -10,7 +10,7 @@ import ramble.definitions.variables
 import ramble.language.language_helpers
 import ramble.language.shared_language
 import ramble.workload
-from ramble.language.language_base import DirectiveError
+from ramble.error import DirectiveError
 
 """This package contains directives that can be used within an application.
 
@@ -125,16 +125,27 @@ def workload_group(name, workloads=None, mode=None, when=None, **kwargs):
             )
 
         # Apply any existing variables in the group to the workload
-        for workload in workloads:
-            for when_set in app.workloads:
-                if workload in app.workloads[when_set]:
-                    if name in app.workload_group_vars:
-                        for var in app.workload_group_vars[name]:
-                            app.workloads[when_set][workload].add_variable(var)
+        if name in app.workload_group_vars:
+            for var in app.workload_group_vars[name]:
+                var_when_frozenset = frozenset(var.when)
+                for workload in workloads:
+                    for when_set in app.workloads:
+                        if workload in app.workloads[when_set]:
+                            if ramble.language.language_helpers.are_when_compatible(
+                                when_set, var_when_frozenset
+                            ):
+                                app.workloads[when_set][workload].add_variable(var)
 
-                    if name in app.workload_group_env_vars:
-                        for env_var in app.workload_group_env_vars[name]:
-                            app.workloads[when_set][workload].add_environment_variable(env_var)
+        if name in app.workload_group_env_vars:
+            for env_var in app.workload_group_env_vars[name]:
+                env_var_when_frozenset = frozenset(env_var.when)
+                for workload in workloads:
+                    for when_set in app.workloads:
+                        if workload in app.workloads[when_set]:
+                            if ramble.language.language_helpers.are_when_compatible(
+                                when_set, env_var_when_frozenset
+                            ):
+                                app.workloads[when_set][workload].add_environment_variable(env_var)
 
     return _execute_workload_groups
 
@@ -318,17 +329,21 @@ def workload_variable(
                     when=when_list,
                     **kwargs,
                 )
+                workload_var_when_frozenset = frozenset(workload_var.when)
                 for when_set, app_workloads in app.workloads.items():
                     if wl_name in app_workloads:
-                        app.workloads[when_set][wl_name].add_variable(workload_var.copy())
-                        if validation:
-                            ramble.language.language_helpers.add_variable_validator(
-                                app, name, values, when_list, wl_name=wl_name
-                            )
-                        if env_var is not None:
-                            app.workloads[when_set][wl_name].add_environment_variable(
-                                env_var.copy()
-                            )
+                        if ramble.language.language_helpers.are_when_compatible(
+                            when_set, workload_var_when_frozenset
+                        ):
+                            app.workloads[when_set][wl_name].add_variable(workload_var.copy())
+                            if validation:
+                                ramble.language.language_helpers.add_variable_validator(
+                                    app, name, values, when_list, wl_name=wl_name
+                                )
+                            if env_var is not None:
+                                app.workloads[when_set][wl_name].add_environment_variable(
+                                    env_var.copy()
+                                )
             return
 
         # Handle the remainder of the workload_variable directive, if
@@ -343,16 +358,22 @@ def workload_variable(
             **kwargs,
         )
 
+        workload_var_when_frozenset = frozenset(workload_var.when)
         for when_set, app_workloads in app.workloads.items():
             for wl_name in all_workloads:
                 if wl_name in app_workloads:
-                    app.workloads[when_set][wl_name].add_variable(workload_var.copy())
-                    if validation:
-                        ramble.language.language_helpers.add_variable_validator(
-                            app, name, values, when_list, wl_name=wl_name
-                        )
-                    if env_var:
-                        app.workloads[when_set][wl_name].add_environment_variable(env_var.copy())
+                    if ramble.language.language_helpers.are_when_compatible(
+                        when_set, workload_var_when_frozenset
+                    ):
+                        app.workloads[when_set][wl_name].add_variable(workload_var.copy())
+                        if validation:
+                            ramble.language.language_helpers.add_variable_validator(
+                                app, name, values, when_list, wl_name=wl_name
+                            )
+                        if env_var:
+                            app.workloads[when_set][wl_name].add_environment_variable(
+                                env_var.copy()
+                            )
 
         if workload_group is not None:
             workload_group_inst = app.workload_groups[workload_group]
@@ -369,28 +390,35 @@ def workload_variable(
 
             for when_set, app_workloads in app.workloads.items():
                 for (
-                    wl_group_when_list,
+                    wl_group_when_set,
                     workload_group_list,
                 ) in workload_group_inst.workloads.items():
+                    # Apply the variable
+                    # Add wl group 'when' to variable to defer satisfies evaluation
+                    workload_var_copy = workload_var.copy()
+                    workload_var_copy.when += wl_group_when_set
+                    var_when_frozenset = frozenset(workload_var_copy.when)
+
+                    if env_var:
+                        env_var_copy = env_var.copy()
+                        env_var_copy.when += wl_group_when_set
+                    else:
+                        env_var_copy = None
+
                     for wl_name in workload_group_list:
                         if wl_name in app_workloads:
-                            # Apply the variable
-                            # Add wl group 'when' to variable to defer satisfies evaluation
-                            workload_var_copy = workload_var.copy()
-                            workload_var_copy.when += wl_group_when_list
-
-                            app.workloads[when_set][wl_name].add_variable(workload_var_copy)
-                            if validation:
-                                ramble.language.language_helpers.add_variable_validator(
-                                    app, name, values, when_list, wl_name=wl_name
-                                )
-                            if env_var:
-                                env_var_copy = env_var.copy()
-                                env_var_copy.when += wl_group_when_list
-
-                                app.workloads[when_set][wl_name].add_environment_variable(
-                                    env_var_copy
-                                )
+                            if ramble.language.language_helpers.are_when_compatible(
+                                when_set, var_when_frozenset
+                            ):
+                                app.workloads[when_set][wl_name].add_variable(workload_var_copy)
+                                if validation:
+                                    ramble.language.language_helpers.add_variable_validator(
+                                        app, name, values, when_list, wl_name=wl_name
+                                    )
+                                if env_var_copy:
+                                    app.workloads[when_set][wl_name].add_environment_variable(
+                                        env_var_copy
+                                    )
 
         if not all_workloads and workload_group is None:
             raise DirectiveError("A workload or workload group is required")
@@ -446,7 +474,7 @@ def cleanup(
 
     def _define_cleanup(obj):
         if not pre and not post:
-            raise ramble.language.language_base.DirectiveError(
+            raise DirectiveError(
                 f"Cleanup directive '{name}' must set at least one of 'pre' or 'post' to True."
             )
         when_list = ramble.language.language_helpers.build_when_list(when, obj, name, "cleanup")

--- a/lib/ramble/ramble/language/language_base.py
+++ b/lib/ramble/ramble/language/language_base.py
@@ -18,13 +18,33 @@ from collections.abc import Sequence  # novm
 from typing import Any, Callable, Dict, List, Set
 
 import llnl.util.lang
-import llnl.util.tty as tty
 
 import ramble.error
 import ramble.language.language_helpers
 from ramble.error import DirectiveError
+from ramble.util.logger import logger
 
 __all__ = ["DirectiveMeta", "DirectiveError"]
+
+
+def _impossible_when_warning(directive_name, obj_type, obj_name, message, args, kwargs):
+    arg_lines = ["Directive Arguments:"] + [f" - {arg}" for arg in args] if args else []
+    kwarg_lines = (
+        ["Directive Keyword Arguments:"] + [f"  {k} = {v}" for k, v in kwargs.items()]
+        if kwargs
+        else []
+    )
+
+    parts = [
+        f'Directive "{directive_name}"'
+        f'{f" in {obj_type} {obj_name}" if obj_name and obj_type else ""} '
+        "has an impossible when condition:",
+        message,
+        *arg_lines,
+        *kwarg_lines,
+    ]
+
+    logger.warn("\n".join(parts))
 
 
 #: These are variant names used by ramble internally; applications can't use
@@ -50,7 +70,7 @@ def _push_to_context(when_condition: str) -> None:
         DirectiveMeta._when_constraints_from_context
     )
     if impossible:
-        tty.warn(f"Entering an impossible 'when' context: {message}")
+        logger.warn(f"Entering an impossible 'when' context: {message}")
 
 
 def _pop_from_context() -> str:
@@ -261,11 +281,21 @@ class DirectiveMeta(abc.ABCMeta):
                         kwargs["when"]
                     )
                     if impossible:
-                        tty.warn(
-                            f'Directive "{decorated_function.__name__}" has '
-                            f"an impossible when condition: {message}"
-                        )
-                        return lambda x: None
+
+                        def _warn_impossible(obj):
+                            obj_type = obj.origin_type if hasattr(obj, "origin_type") else ""
+                            obj_name = obj.name if hasattr(obj, "name") else ""
+                            _impossible_when_warning(
+                                decorated_function.__name__,
+                                obj_type,
+                                obj_name,
+                                message,
+                                args,
+                                kwargs,
+                            )
+
+                        DirectiveMeta._directives_to_be_executed.append(_warn_impossible)
+                        return _warn_impossible
 
                 # If any of the arguments are executors returned by a
                 # directive passed as an argument, don't execute them

--- a/lib/ramble/ramble/language/language_base.py
+++ b/lib/ramble/ramble/language/language_base.py
@@ -18,8 +18,11 @@ from collections.abc import Sequence  # novm
 from typing import Any, Callable, Dict, List, Set
 
 import llnl.util.lang
+import llnl.util.tty as tty
 
 import ramble.error
+import ramble.language.language_helpers
+from ramble.error import DirectiveError
 
 __all__ = ["DirectiveMeta", "DirectiveError"]
 
@@ -42,6 +45,12 @@ namespaces = [
 
 def _push_to_context(when_condition: str) -> None:
     DirectiveMeta._when_constraints_from_context.append(when_condition)
+
+    impossible, message = ramble.language.language_helpers.is_when_impossible(
+        DirectiveMeta._when_constraints_from_context
+    )
+    if impossible:
+        tty.warn(f"Entering an impossible 'when' context: {message}")
 
 
 def _pop_from_context() -> str:
@@ -247,6 +256,17 @@ class DirectiveMeta(abc.ABCMeta):
 
                     kwargs["when"] = when_constraints.copy()
 
+                if "when" in kwargs:
+                    impossible, message = ramble.language.language_helpers.is_when_impossible(
+                        kwargs["when"]
+                    )
+                    if impossible:
+                        tty.warn(
+                            f'Directive "{decorated_function.__name__}" has '
+                            f"an impossible when condition: {message}"
+                        )
+                        return lambda x: None
+
                 # If any of the arguments are executors returned by a
                 # directive passed as an argument, don't execute them
                 # lazily. Instead, let the called directive handle them.
@@ -290,7 +310,3 @@ class DirectiveMeta(abc.ABCMeta):
             return _wrapper
 
         return _decorator
-
-
-class DirectiveError(ramble.error.RambleError):
-    """This is raised when something is wrong with a language directive."""

--- a/lib/ramble/ramble/language/language_helpers.py
+++ b/lib/ramble/ramble/language/language_helpers.py
@@ -7,10 +7,11 @@
 # except according to those terms.
 
 import fnmatch
+import functools
 from collections import OrderedDict
 from typing import Any, List, Optional, Union
 
-from ramble.language.language_base import DirectiveError
+from ramble.error import DirectiveError
 
 
 def check_definition(
@@ -307,3 +308,100 @@ def build_when_list(
                 )
         when_list.extend(when_arg)
     return when_list
+
+
+@functools.lru_cache(maxsize=None)
+def _parse_when(w_set):
+    from ramble.util.format import when_order
+
+    variants = {}
+    versions = {}
+    for w_entry in sorted(w_set, key=when_order):
+        for w in w_entry.split():
+            if "=" in w:
+                name, val = w.split("=", 1)
+                if name in variants and variants[name] != val:
+                    return (
+                        None,
+                        None,
+                        f"variant '{name}' has conflicting values: '{variants[name]}' and '{val}'",
+                    )
+                variants[name] = val
+            elif w.startswith(("+", "~")):
+                name = w[1:]
+                val = "True" if w.startswith("+") else "False"
+                if name in variants and variants[name] != val:
+                    return (
+                        None,
+                        None,
+                        f"variant '{name}' has conflicting values: '{variants[name]}' and '{val}'",
+                    )
+                variants[name] = val
+            elif "@" in w:
+                name, ver = w.split("@", 1)
+                if name in versions and versions[name] != ver:
+                    return (
+                        None,
+                        None,
+                        f"version '{name}' has conflicting values: '{versions[name]}' and '{ver}'",
+                    )
+                versions[name] = ver
+    return variants, versions, None
+
+
+def are_when_compatible(when_set1, when_set2):
+    """Determine if two sets of when conditions are compatible
+
+    Args:
+        when_set1 (list): First set of when conditions
+        when_set2 (list): Second set of when conditions
+
+    Returns:
+        (bool): True if they are compatible, False otherwise
+    """
+    if not isinstance(when_set1, frozenset):
+        when_set1 = frozenset(when_set1)
+
+    if not isinstance(when_set2, frozenset):
+        when_set2 = frozenset(when_set2)
+
+    v1, ver1, _ = _parse_when(when_set1)
+    v2, ver2, _ = _parse_when(when_set2)
+
+    if v1 is None or v2 is None:
+        return False
+
+    for name in v1:
+        if name in v2:
+            if v1[name] != v2[name]:
+                return False
+
+    for name in ver1:
+        if name in ver2:
+            if ver1[name] != ver2[name]:
+                return False
+    return True
+
+
+def is_when_impossible(when_list):
+    """Determine if a single list of when conditions is self-contradictory
+
+    Args:
+        when_list (list): list of when conditions
+
+    Returns:
+        (bool, str): True and a message if it is impossible, False and None otherwise
+    """
+    if when_list is None:
+        return False, None
+
+    if isinstance(when_list, str):
+        when_list = [when_list]
+
+    if not isinstance(when_list, frozenset):
+        when_list = frozenset(when_list)
+
+    _, _, conflict = _parse_when(when_list)
+    if conflict:
+        return True, conflict
+    return False, None

--- a/lib/ramble/ramble/language/modifier_language.py
+++ b/lib/ramble/ramble/language/modifier_language.py
@@ -12,7 +12,7 @@ import ramble.definitions.requirements
 import ramble.language.language_helpers
 import ramble.language.shared_language
 from ramble.definitions.variables import EnvironmentVariableModifications, VariableModification
-from ramble.language.language_base import DirectiveError
+from ramble.error import DirectiveError
 
 
 class ModifierMeta(ramble.language.shared_language.SharedMeta):

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -936,12 +936,16 @@ def environment_variable(
                 workload, workloads, obj.workloads, "workload", "workloads", "environment_variable"
             )
 
+            env_var_when_frozenset = frozenset(workload_env_var.when)
             for when_set, app_workloads in obj.workloads.items():
                 for wl_name in all_workloads:
                     if wl_name in app_workloads:
-                        obj.workloads[when_set][wl_name].add_environment_variable(
-                            workload_env_var.copy()
-                        )
+                        if ramble.language.language_helpers.are_when_compatible(
+                            when_set, env_var_when_frozenset
+                        ):
+                            obj.workloads[when_set][wl_name].add_environment_variable(
+                                workload_env_var.copy()
+                            )
 
             if workload_group is not None:
                 workload_group_inst = obj.workload_groups[workload_group]
@@ -961,17 +965,20 @@ def environment_variable(
                     for wl_name in wl_group_workloads:
                         wl_group_when_map[wl_name].append(wl_group_when_set)
 
-                for when_set, app_workloads in obj.workloads.items():
-                    for app_wl_name in app_workloads:
-                        if app_wl_name in wl_group_when_map:
-                            # Add each variation of merged 'when' set for each workload
-                            for wl_group_when_set in wl_group_when_map[app_wl_name]:
-                                workload_env_var_copy = workload_env_var.copy()
-                                workload_env_var_copy.when.extend(wl_group_when_set)
+                for app_wl_name, wl_group_when_sets in wl_group_when_map.items():
+                    for wl_group_when_set in wl_group_when_sets:
+                        workload_env_var_copy = workload_env_var.copy()
+                        workload_env_var_copy.when.extend(wl_group_when_set)
+                        env_var_when_frozenset = frozenset(workload_env_var_copy.when)
 
-                                obj.workloads[when_set][app_wl_name].add_environment_variable(
-                                    workload_env_var_copy
-                                )
+                        for when_set, app_workloads in obj.workloads.items():
+                            if app_wl_name in app_workloads:
+                                if ramble.language.language_helpers.are_when_compatible(
+                                    when_set, env_var_when_frozenset
+                                ):
+                                    obj.workloads[when_set][app_wl_name].add_environment_variable(
+                                        workload_env_var_copy
+                                    )
         else:
             when_set = frozenset(when_list)
             if when_set not in obj.object_environment_variables:

--- a/lib/ramble/ramble/test/application_language.py
+++ b/lib/ramble/ramble/test/application_language.py
@@ -12,9 +12,8 @@ from typing import FrozenSet
 import deprecation
 import pytest
 
-from ramble import language
 from ramble.appkit import *  # noqa
-from ramble.language.language_base import DirectiveError
+from ramble.error import DirectiveError
 
 app_types = [
     ApplicationBase,  # noqa: F405
@@ -282,9 +281,7 @@ def test_figure_of_merit_directive(app_class):
 
 def test_figure_of_merit_directive_required_args():
     app_inst = ExecutableApplication("/not/a/path")  # noqa: F405
-    with pytest.raises(
-        language.language_base.DirectiveError, match="required for defining file-based FOM"
-    ):
+    with pytest.raises(DirectiveError, match="required for defining file-based FOM"):
         app_inst.figure_of_merit(
             "test_fom",
             units="s",

--- a/lib/ramble/ramble/test/impossible_when.py
+++ b/lib/ramble/ramble/test/impossible_when.py
@@ -1,0 +1,72 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.main import RambleCommand
+
+info = RambleCommand("info")
+
+
+def test_info_impossible_when(mock_applications):
+    out = info("-v", "impossible-when")
+
+    # Check that test_wl (ver1) does NOT contain ver2 variables
+    # We find the first occurrence of 'Workload: test_wl'
+
+    parts = out.split("Workload: test_wl")
+    assert len(parts) == 3  # 0: before, 1: ver1, 2: ver2
+
+    ver1_part = parts[1]
+    ver2_part = parts[2]
+
+    assert "When: workload_versions=ver1" in ver1_part
+    assert "test_variable" in ver1_part
+    assert "Default: Test" in ver1_part
+    assert "Default: 1" not in ver1_part  # This was the bug
+    assert "APP_ENV_VAR2" not in ver1_part  # This was also the bug
+
+    assert "When: workload_versions=ver2" in ver2_part
+    assert "test_variable" in ver2_part
+    assert "Default: 1" in ver2_part
+    assert "APP_ENV_VAR2" in ver2_part
+
+
+def test_info_version_impossible(mock_applications):
+    out = info("-v", "version-impossible")
+
+    parts = out.split("Workload: wl1")
+    assert len(parts) == 3
+
+    wl1_part = parts[1]
+    wl2_part = parts[2]
+
+    assert "When: @1.0" in wl1_part
+    assert "var1" in wl1_part
+    assert "var2" not in wl1_part
+
+    assert "When: @2.0" in wl2_part
+    assert "var2" in wl2_part
+    assert "var1" not in wl2_part
+
+
+def test_info_truly_impossible(mock_applications):
+    out = info("-v", "truly-impossible")
+
+    assert "Warning: Entering an impossible 'when' context" in out
+    assert 'Warning: Directive "workload_variable" has an impossible when condition' in out
+
+    assert "var1" not in out
+
+
+def test_info_value_conflict_impossible(mock_applications):
+    out = info("-v", "value-conflict-impossible")
+
+    assert (
+        "Warning: Entering an impossible 'when' context: variant 'v' "
+        "has conflicting values: '1' and 'True'" in out
+    )
+    assert "var1" not in out

--- a/lib/ramble/ramble/test/impossible_when.py
+++ b/lib/ramble/ramble/test/impossible_when.py
@@ -57,9 +57,11 @@ def test_info_truly_impossible(mock_applications):
     out = info("-v", "truly-impossible")
 
     assert "Warning: Entering an impossible 'when' context" in out
-    assert 'Warning: Directive "workload_variable" has an impossible when condition' in out
+    assert 'Warning: Directive "workload_variable"' in out
+    assert "has an impossible when condition" in out
 
-    assert "var1" not in out
+    parts = out.split("Workload: wl1")
+    assert "var1" not in parts[1]
 
 
 def test_info_value_conflict_impossible(mock_applications):
@@ -69,4 +71,6 @@ def test_info_value_conflict_impossible(mock_applications):
         "Warning: Entering an impossible 'when' context: variant 'v' "
         "has conflicting values: '1' and 'True'" in out
     )
-    assert "var1" not in out
+
+    parts = out.split("Workload: wl1")
+    assert "var1" not in parts[1]

--- a/lib/ramble/ramble/test/modifier_functionality/mock_modifier_dry_run.py
+++ b/lib/ramble/ramble/test/modifier_functionality/mock_modifier_dry_run.py
@@ -12,8 +12,7 @@ import pytest
 
 import ramble.test.modifier_functionality.modifier_helpers as modifier_helpers
 import ramble.workspace
-from ramble.error import InvalidModeError
-from ramble.language.language_base import DirectiveError
+from ramble.error import DirectiveError, InvalidModeError
 from ramble.main import RambleCommand
 from ramble.test.dry_run_helpers import SCOPES, dry_run_config
 

--- a/lib/ramble/ramble/test/modifier_language.py
+++ b/lib/ramble/ramble/test/modifier_language.py
@@ -13,7 +13,7 @@ import deprecation
 import pytest
 
 import ramble.language.language_helpers
-from ramble.language.language_base import DirectiveError
+from ramble.error import DirectiveError
 from ramble.modkit import *  # noqa
 
 mod_types = [ModifierBase, BasicModifier]  # noqa: F405

--- a/lib/ramble/ramble/test/version.py
+++ b/lib/ramble/ramble/test/version.py
@@ -14,8 +14,7 @@ import ramble.variants
 import ramble.workspace
 from ramble.appkit import ExecutableApplication
 from ramble.definitions.versions import ObjectVersion
-from ramble.error import ObjectValidationError
-from ramble.language.language_base import DirectiveError
+from ramble.error import DirectiveError, ObjectValidationError
 from ramble.main import RambleCommand
 
 pytestmark = pytest.mark.usefixtures(

--- a/var/ramble/repos/builtin.mock/applications/impossible-when/application.py
+++ b/var/ramble/repos/builtin.mock/applications/impossible-when/application.py
@@ -1,0 +1,88 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.appkit import *
+
+
+class ImpossibleWhen(ExecutableApplication):
+    name = "impossible-when"
+
+    executable("base_exec", "echo 'base'", use_mpi=False)
+    executable("test_exec", "echo '{test_variable}'", use_mpi=False)
+    executable("test_exec2", "echo 'Two'", use_mpi=False)
+
+    workload("base_wl", executable="base_exec")
+
+    workload("ver_wl1", executable="base_exec", when="@1.0")
+    workload("ver_wl1", executable="base_exec", when="@2.0")
+
+    variant(
+        "workload_versions",
+        default="ver1",
+        values=["ver1", "ver2"],
+        description="Register additional phase using when",
+    )
+
+    with when("workload_versions=ver1"):
+        workload(
+            "test_wl",
+            executables=["base_exec", "test_exec"],
+        )
+
+        workload_variable(
+            "test_variable",
+            default="Test",
+            description="Variable to print for testing",
+            workload="test_wl",
+        )
+
+        workload_variable(
+            "impossible_variable",
+            default="Foo",
+            description="This is an impossible variable definition",
+            workload="test_wl",
+            when="workload_versions=ver2",
+        )
+
+    workload(
+        "test_wl",
+        executables=["base_exec", "test_exec2"],
+        when="workload_versions=ver2",
+    )
+
+    environment_variable(
+        "APP_ENV_VAR2",
+        value="TEST_WL2_ENV_VAR",
+        description="Test app environment variable",
+        workload="test_wl",
+        when="workload_versions=ver2",
+    )
+
+    workload_variable(
+        "test_variable",
+        default="1",
+        description="Variable to print for testing",
+        workload="test_wl",
+        when="workload_versions=ver2",
+    )
+
+    workload_variable(
+        "var1",
+        default="val1",
+        description="var for 1.0",
+        workload="wl1",
+        when="@1.0",
+    )
+
+    workload_variable(
+        "var2",
+        default="val2",
+        description="var for 2.0",
+        workload="wl1",
+        when="@2.0",
+    )

--- a/var/ramble/repos/builtin.mock/applications/truly-impossible/application.py
+++ b/var/ramble/repos/builtin.mock/applications/truly-impossible/application.py
@@ -1,0 +1,26 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.appkit import *
+
+
+class TrulyImpossible(ExecutableApplication):
+    name = "truly-impossible"
+
+    executable("base_exec", "echo 'base'", use_mpi=False)
+
+    workload("wl1", executable="base_exec")
+
+    with when("v=1"):
+        with when("v=2"):
+            workload_variable(
+                "var1",
+                default="val1",
+                description="impossible var",
+                workload="wl1",
+            )

--- a/var/ramble/repos/builtin.mock/applications/value-conflict-impossible/application.py
+++ b/var/ramble/repos/builtin.mock/applications/value-conflict-impossible/application.py
@@ -1,0 +1,26 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.appkit import *
+
+
+class ValueConflictImpossible(ExecutableApplication):
+    name = "value-conflict-impossible"
+
+    executable("base_exec", "echo 'base'", use_mpi=False)
+
+    workload("wl1", executable="base_exec")
+
+    with when("v=1"):
+        with when("+v"):
+            workload_variable(
+                "var1",
+                default="val1",
+                description="impossible var",
+                workload="wl1",
+            )

--- a/var/ramble/repos/builtin.mock/applications/version-impossible/application.py
+++ b/var/ramble/repos/builtin.mock/applications/version-impossible/application.py
@@ -1,0 +1,34 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.appkit import *
+
+
+class VersionImpossible(ExecutableApplication):
+    name = "version-impossible"
+
+    executable("base_exec", "echo 'base'", use_mpi=False)
+
+    workload("wl1", executable="base_exec", when="@1.0")
+    workload("wl1", executable="base_exec", when="@2.0")
+
+    workload_variable(
+        "var1",
+        default="val1",
+        description="var for 1.0",
+        workload="wl1",
+        when="@1.0",
+    )
+
+    workload_variable(
+        "var2",
+        default="val2",
+        description="var for 2.0",
+        workload="wl1",
+        when="@2.0",
+    )


### PR DESCRIPTION
This merge adds logic to detect and handle impossible when conditions in Ramble application definitions. It includes:
- Logic to check if a 'when' condition is self-contradictory.
- Warnings when entering an impossible 'with when' context.
- Logic to skip directives with impossible 'when' conditions.
- Logic to only add variables/env vars to workloads if their 'when' conditions are compatible with the workload's 'when' condition.
- A new test file 'lib/ramble/ramble/test/impossible_when.py' to verify the fix.