### PR TITLE
drop optional None foms

### DIFF
--- a/lib/ramble/ramble/test/experiment_result.py
+++ b/lib/ramble/ramble/test/experiment_result.py
@@ -194,3 +194,130 @@ def test_get_newest_experiment_file_inner_file_not_found(tmpdir, monkeypatch):
     newest_file, max_mtime = get_newest_experiment_file(str(experiment_dir))
     assert newest_file is None
     assert max_mtime is None
+
+
+def test_extract_inmem_foms_skips_none(mutable_mock_apps_repo):
+    """Test that _extract_inmem_foms skips FOMs with None value"""
+    app_inst = mutable_mock_apps_repo.get("basic")
+
+    # Set up _fom_map to return None for a key
+    app_inst._fom_map = {"test_key": None}
+
+    inmem_defs = {
+        "test_context": {
+            "foms": {
+                "test_fom": {
+                    "fom_name_expanded": "test_fom",
+                    "fom_map_key": "test_key",
+                    "units_expanded": "s",
+                    "origin": "test",
+                    "origin_type": "test",
+                    "fom_type": "test",
+                }
+            }
+        }
+    }
+
+    fom_values = {}
+    app_inst._extract_inmem_foms(inmem_defs, fom_values)
+
+    # Assert that test_fom is NOT in fom_values
+    assert "test_context" not in fom_values or "test_fom" not in fom_values["test_context"]
+
+
+def test_analyze_experiments_skips_none_fom(mutable_mock_apps_repo, monkeypatch, tmpdir):
+    """Test that _analyze_experiments skips FOMs when value group is None"""
+    app_inst = mutable_mock_apps_repo.get("basic")
+
+    # Create a temp file to analyze
+    log_file = tmpdir.join("test.out")
+    log_file.write("Match line but optional group is empty: Value=\nValid Value=42\n")
+
+    import re
+
+    # Mock analysis_dicts
+    def mock_analysis_dicts(criteria_list):
+        files = {
+            str(log_file): {
+                "success_criteria": [],
+                "contexts": {"null": ["test_fom", "valid_fom"]},
+            }
+        }
+        f_defs = {
+            "null": {
+                "foms": {
+                    "test_fom": {
+                        "regex": re.compile(r"Value=(?P<val>\d*)"),  # Optional digits
+                        "group": "val",
+                        "fom_name_expanded": "test_fom",
+                        "units": "",
+                        "origin": "test",
+                        "origin_type": "test",
+                        "fom_type": "test",
+                        "contexts": [],
+                        "units_expanded": None,
+                        "origin_type_expanded": "test",
+                        "fom_type_expanded": "test",
+                    },
+                    "valid_fom": {
+                        "regex": re.compile(r"Valid Value=(?P<val>\d+)"),
+                        "group": "val",
+                        "fom_name_expanded": "valid_fom",
+                        "units": "",
+                        "origin": "test",
+                        "origin_type": "test",
+                        "fom_type": "test",
+                        "contexts": [],
+                        "units_expanded": None,
+                        "origin_type_expanded": "test",
+                        "fom_type_expanded": "test",
+                    },
+                }
+            }
+        }
+        inmem_defs = {}
+        return files, f_defs, inmem_defs
+
+    monkeypatch.setattr(app_inst, "_analysis_dicts", mock_analysis_dicts)
+
+    # Mock other dependencies of _analyze_experiments
+    monkeypatch.setattr(app_inst.result, "read_cache", lambda *args: False)
+    monkeypatch.setattr(app_inst, "get_status", lambda: None)
+    monkeypatch.setattr(app_inst, "set_status", lambda status: None)
+    monkeypatch.setattr(app_inst.result, "finalize", lambda workspace: None)
+
+    from unittest.mock import MagicMock
+
+    app_inst._exp_lock = MagicMock()
+
+    class MockExpander:
+        def expand_var(self, val, extra_vars=None):
+            return val
+
+    app_inst.expander = MockExpander()
+
+    class MockCriteriaList:
+        def all_criteria(self):
+            return []
+
+        def passed(self):
+            return True
+
+    criteria_list = MockCriteriaList()
+
+    # Call the method
+    app_inst._analyze_experiments(criteria_list)
+
+    # Verify that the FOM was not added to app_inst.result.contexts
+    fom_found = False
+    valid_fom_found = False
+    for context in app_inst.result.contexts:
+        if context["name"] == "null":
+            for fom in context["foms"]:
+                if fom["name"] == "test_fom":
+                    fom_found = True
+                if fom["name"] == "valid_fom":
+                    valid_fom_found = True
+
+    assert not fom_found
+    assert valid_fom_found

--- a/lib/ramble/ramble/test/uploader.py
+++ b/lib/ramble/ramble/test/uploader.py
@@ -363,3 +363,27 @@ def test_sqlite_uploader_chunked_upload_errors(tmpdir, mock_results_with_metadat
         uploader.chunked_upload(exp_table_id, bad_exps_to_insert, uri)
         captured = capsys.readouterr()
         assert "Could not find a valid schema" in captured.err
+
+
+def test_fom_validation_fails_with_none():
+    """Test that FOM validation fails when value is None"""
+    import jsonschema
+
+    from ramble.schema.fom import fom_schema, fom_schema_version
+    from ramble.uploader import validate_data
+
+    bad_fom = {
+        "name": "test_fom",
+        "value": None,  # This should be a string according to schema
+        "unit": "s",
+        "origin": "test",
+        "origin_type": "test",
+        "context": "test",
+        "experiment_id": 1,
+        "experiment_name": "test_exp",
+    }
+
+    schema = fom_schema[fom_schema_version]
+
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        validate_data(bad_fom, schema)

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -2522,6 +2522,8 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                 if fom_map_key not in self._fom_map:
                     continue
                 fom_value = self._fom_map.get(fom_map_key)
+                if fom_value is None:
+                    continue
                 expanded_fom_value = self.expander.expand_var(fom_value)
                 fom_values[context][fom_name] = {
                     "value": expanded_fom_value,
@@ -2708,6 +2710,8 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                                             fom_val = fom_match.group(
                                                 fom_conf["group"]
                                             )
+                                            if fom_val is None:
+                                                continue
                                             if (
                                                 fom_conf["units_expanded"]
                                                 is not None


### PR DESCRIPTION
If a fom group is optional now, its value is propagated as `None`. This semantic is different from if a fom is not found (where it is not listed), so this PR aligns the two semantics 