### PR TITLE
DRY include/ignore files in pr builds

### DIFF
--- a/share/ramble/cloud-build/terraform/triggers/codecov.tf
+++ b/share/ramble/cloud-build/terraform/triggers/codecov.tf
@@ -20,19 +20,16 @@ resource "google_cloudbuild_trigger" "codecov_pr" {
     }
   }
 
-  ignored_files = [
-    "lib/ramble/docs/**"
-  ]
+  ignored_files = local.docs_files
 
-  included_files = [
-    "lib/ramble/**",
-    "var/ramble/repos/**",
-    "share/ramble/cloud-build/**",
-    "share/ramble/qa/**",
-    "pyproject.toml",
-    "requirements-dev.txt",
-    "requirements.txt"
-  ]
+  included_files = concat(
+    local.core_source_files,
+    local.dependency_and_config_files,
+    [
+      "share/ramble/cloud-build/**",
+      "share/ramble/qa/**"
+    ]
+  )
 
   filename = "share/ramble/cloud-build/ramble-pr-unit-tests.yaml"
 

--- a/share/ramble/cloud-build/terraform/triggers/locals.tf
+++ b/share/ramble/cloud-build/terraform/triggers/locals.tf
@@ -20,4 +20,21 @@ locals {
     "debian"     = "apt"
     "rockylinux" = "yum"
   }
+
+  docs_files = [
+    "lib/ramble/docs/**"
+  ]
+
+  core_source_files = [
+    "bin/**",
+    "lib/ramble/**",
+    "var/ramble/repos/**",
+    "conftest.py"
+  ]
+
+  dependency_and_config_files = [
+    "requirements.txt",
+    "requirements-dev.txt",
+    "pyproject.toml"
+  ]
 }

--- a/share/ramble/cloud-build/terraform/triggers/pr_style.tf
+++ b/share/ramble/cloud-build/terraform/triggers/pr_style.tf
@@ -15,6 +15,16 @@ resource "google_cloudbuild_trigger" "pr_style" {
     }
   }
 
+  ignored_files = local.docs_files
+
+  included_files = concat(
+    local.core_source_files,
+    local.dependency_and_config_files,
+    [
+      "share/ramble/cloud-build/**"
+    ]
+  )
+
   include_build_logs = "INCLUDE_BUILD_LOGS_WITH_STATUS"
 
   filename = "share/ramble/cloud-build/ramble-pr-style.yaml"

--- a/share/ramble/cloud-build/terraform/triggers/pr_unit_tests.tf
+++ b/share/ramble/cloud-build/terraform/triggers/pr_unit_tests.tf
@@ -13,16 +13,15 @@ resource "google_cloudbuild_trigger" "pr_unit_tests" {
     }
   }
 
-  ignored_files = [
-    "lib/ramble/docs/**"
-  ]
+  ignored_files = local.docs_files
 
-  included_files = [
-    "lib/ramble/**",
-    "var/ramble/repos/**",
-    "share/ramble/cloud-build/**",
-    "conftest.py"
-  ]
+  included_files = concat(
+    local.core_source_files,
+    local.dependency_and_config_files,
+    [
+      "share/ramble/cloud-build/**"
+    ]
+  )
 
   include_build_logs = "INCLUDE_BUILD_LOGS_WITH_STATUS"
 


### PR DESCRIPTION
Besides avoiding duplication, also add in more correct changed files setup for unit-test and style check triggers.