### PR TITLE
Use `pytest-benchmark` to get more reliable stats from perf tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -76,10 +76,15 @@ def pytest_runtest_makereport(item, call):
     res = outcome.get_result()
 
     if res.when == "call" and "perf" in item.keywords:
+        if hasattr(item, "benchmark_stats"):
+            duration = item.benchmark_stats.stats.median
+        else:
+            duration = res.duration
+
         metric = {
             "test_name": item.name,
             "test_id": item.nodeid,
-            "duration": res.duration,
+            "duration": duration,
             "outcome": res.outcome,
         }
         item.session.perf_metrics.append(metric)
@@ -129,6 +134,22 @@ def pytest_collection_modifyitems(config, items):
 #
 # These fixtures are applied to all tests
 #
+
+
+@pytest.fixture
+def ramble_benchmark(benchmark, request):
+    """A wrapper around pytest-benchmark that automatically exposes benchmark stats."""
+
+    def runner(*args, **kwargs):
+        if hasattr(request.node, "benchmark_stats"):
+            raise RuntimeError("ramble_benchmark can only be called at most once per test.")
+        result = benchmark(*args, **kwargs)
+        request.node.benchmark_stats = benchmark.stats
+        return result
+
+    return runner
+
+
 @pytest.fixture(scope="function", autouse=True)
 def no_chdir():
     """Ensure that no test changes Ramble's working directory.

--- a/lib/ramble/ramble/test/end_to_end/perf_tests/analyze_perf.py
+++ b/lib/ramble/ramble/test/end_to_end/perf_tests/analyze_perf.py
@@ -23,7 +23,7 @@ workspace = RambleCommand("workspace")
 
 @pytest.mark.perf
 @pytest.mark.maybeslow
-def test_analyze_large_file(workspace_name):
+def test_analyze_large_file(workspace_name, ramble_benchmark):
     global_args = ["-w", workspace_name]
     ws = ramble.workspace.create(workspace_name)
     workspace(
@@ -48,6 +48,8 @@ def test_analyze_large_file(workspace_name):
         for _ in range(10_000):
             f.write("no match\n" * 1_000)
         f.write("Sleep for 10 seconds\n")
-    output = workspace("analyze", "-p", global_args=global_args)
+
+    output = ramble_benchmark(workspace, "analyze", "-p", global_args=global_args)
+
     assert "Status = SUCCESS" in output
     assert "Sleep time = 10 s" in output

--- a/lib/ramble/ramble/test/end_to_end/perf_tests/analyze_perf.py
+++ b/lib/ramble/ramble/test/end_to_end/perf_tests/analyze_perf.py
@@ -49,7 +49,16 @@ def test_analyze_large_file(workspace_name, ramble_benchmark):
             f.write("no match\n" * 1_000)
         f.write("Sleep for 10 seconds\n")
 
-    output = ramble_benchmark(workspace, "analyze", "-p", global_args=global_args)
+    cache_file = os.path.join(
+        ws.experiment_dir, "sleep", "rand_sleep", "generated", "ramble_results_cache.json"
+    )
+
+    def run_analyze_no_cache():
+        if os.path.exists(cache_file):
+            os.remove(cache_file)
+        return workspace("analyze", "-p", global_args=global_args)
+
+    output = ramble_benchmark(run_analyze_no_cache)
 
     assert "Status = SUCCESS" in output
     assert "Sleep time = 10 s" in output

--- a/lib/ramble/ramble/test/end_to_end/perf_tests/large_template.py
+++ b/lib/ramble/ramble/test/end_to_end/perf_tests/large_template.py
@@ -21,7 +21,9 @@ workspace = RambleCommand("workspace")
 
 
 @pytest.mark.perf
-def test_large_template_expansion(make_workspace_from_config, mutable_mock_apps_repo, tmpdir):
+def test_large_template_expansion(
+    make_workspace_from_config, mutable_mock_apps_repo, tmpdir, ramble_benchmark
+):
     # Define a mock template app in a temporary repo
     repo_dir = tmpdir.mkdir("mock_repo")
     with open(os.path.join(str(repo_dir), "repo.yaml"), "w") as f:
@@ -91,7 +93,7 @@ ramble:
         f.write(template_content)
 
     # Run workspace setup to trigger template expansion
-    workspace("setup", "--dry-run", global_args=["-w", ws_name])
+    ramble_benchmark(workspace, "setup", "--dry-run", global_args=["-w", ws_name])
 
     # Verify the expanded file exists and has correct content
     run_dir = os.path.join(ws.experiment_dir, "template", "test_template", "test")

--- a/lib/ramble/ramble/test/end_to_end/perf_tests/many_experiments.py
+++ b/lib/ramble/ramble/test/end_to_end/perf_tests/many_experiments.py
@@ -22,7 +22,7 @@ workspace = RambleCommand("workspace")
 
 @pytest.mark.perf
 @pytest.mark.long
-def test_many_experiments(workspace_name):
+def test_many_experiments(workspace_name, ramble_benchmark):
     ws = ramble.workspace.create(workspace_name)
     ws.write()
     global_args = ["-w", workspace_name]
@@ -50,6 +50,6 @@ def test_many_experiments(workspace_name):
         global_args=global_args,
     )
 
-    output = workspace("info", global_args=global_args)
+    output = ramble_benchmark(workspace, "info", global_args=global_args)
 
     assert "Experiment 8100" in output

--- a/lib/ramble/ramble/test/end_to_end/perf_tests/many_objects_defaults.py
+++ b/lib/ramble/ramble/test/end_to_end/perf_tests/many_objects_defaults.py
@@ -18,7 +18,7 @@ workspace = RambleCommand("workspace")
 
 @pytest.mark.perf
 @pytest.mark.long
-def test_many_objects_defaults(make_workspace_from_config):
+def test_many_objects_defaults(make_workspace_from_config, ramble_benchmark):
     # This test is designed to stress the variable expansion and object creation
     # by using many modifiers, each with many default variables.
     # It aims to verify performance when a large number of objects are present.
@@ -71,7 +71,7 @@ ramble:
     ws, ws_name = make_workspace_from_config(test_config)
 
     # We only run setup --dry-run to trigger the expansion and object creation
-    workspace("setup", "--dry-run", global_args=["-w", ws_name])
+    ramble_benchmark(workspace, "setup", "--dry-run", global_args=["-w", ws_name])
 
     # Verify that the correct number of experiments were created
     # 10 n_nodes * 100 matrix_var = 1000 experiments

--- a/lib/ramble/ramble/test/end_to_end/perf_tests/matrix_filter_perf.py
+++ b/lib/ramble/ramble/test/end_to_end/perf_tests/matrix_filter_perf.py
@@ -19,7 +19,7 @@ workspace = RambleCommand("workspace")
 
 @pytest.mark.perf
 @pytest.mark.maybeslow
-def test_matrix_filter_perf(make_workspace_from_config):
+def test_matrix_filter_perf(make_workspace_from_config, ramble_benchmark):
     # Create a matrix of 10000 experiments, but exclude 9999 of them.
     # This test is to monitor the efficiency of the filtering.
     test_config = (
@@ -52,7 +52,7 @@ ramble:
     )
     ws, ws_name = make_workspace_from_config(test_config)
 
-    workspace("setup", "--dry-run", global_args=["-w", ws_name])
+    ramble_benchmark(workspace, "setup", "--dry-run", global_args=["-w", ws_name])
 
     exp_dir = os.path.join(ws.root, "experiments", "hostname", "local", "test_1_1")
     assert os.path.isdir(exp_dir)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 pytest
+pytest-benchmark
 flake8
 black==26.3.1;python_version>="3.10"
 black;python_version<"3.10"


### PR DESCRIPTION
* Create a fixture on top of `pytest-benchmark`, which allows to be applied specifically to the operation that's intended to be benchmarked
* The `pytest-benchmark` runs multiple rounds (min. of 5) of the benchmarked operation and get the stats out of the runs. We then report the median numbers.