### PR TITLE
Add pinned requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ e.g.
 
     pip install -r requirements-dev.txt
 
+Ramble's CI tests use a pinned set of dependencies. These can be installed
+using:
+
+    pip install -r requirements-pinned.txt
 
 Contributing to Ramble is relatively easy.  Just send us a
 [pull request](https://help.github.com/articles/using-pull-requests/).

--- a/lib/ramble/ramble/cmd/style.py
+++ b/lib/ramble/ramble/cmd/style.py
@@ -43,7 +43,7 @@ exclude_directories = [ramble.paths.external_path]
 max_line_length = 99
 
 # The black version used by the PR style test
-_BLACK_GOLDEN_VERSION = "26.3.1"
+_BLACK_GOLDEN_VERSION = "25.12.0"
 
 common_object_exemptions = {
     # Exempt lines with urls and descriptions from overlong line errors.

--- a/lib/ramble/ramble/main.py
+++ b/lib/ramble/ramble/main.py
@@ -240,12 +240,14 @@ class RambleArgumentParser(argparse.ArgumentParser):
         add_group(self._optionals)
 
         # epilog
-        formatter.add_text(f"""{section_descriptions['help']}:
+        formatter.add_text(
+            f"""{section_descriptions['help']}:
   ramble help --all       list all commands and options
   ramble help <command>   help on a specific command
   ramble help --spec      help on the application specification syntax
   ramble docs             open https://ramble.readthedocs.io/ in a browser
-""")
+"""
+        )
 
         # determine help from format above
         return formatter.format_help()

--- a/lib/ramble/ramble/test/cmd/config.py
+++ b/lib/ramble/ramble/test/cmd/config.py
@@ -57,22 +57,29 @@ def test_get_config_scope_merged(mock_low_high_config):
     fs.mkdirp(high_path)
 
     with open(os.path.join(low_path, "repos.yaml"), "w") as f:
-        f.write("""\
+        f.write(
+            """\
 repos:
 - repo3
-""")
+"""
+        )
 
     with open(os.path.join(high_path, "repos.yaml"), "w") as f:
-        f.write("""\
+        f.write(
+            """\
 repos:
 - repo1
 - repo2
-""")
+"""
+        )
 
-    assert config("get", "repos").strip() == """repos:
+    assert (
+        config("get", "repos").strip()
+        == """repos:
 - repo1
 - repo2
 - repo3"""
+    )
 
 
 def test_merged_variables_section(mock_low_high_config):
@@ -83,20 +90,27 @@ def test_merged_variables_section(mock_low_high_config):
     fs.mkdirp(high_path)
 
     with open(os.path.join(low_path, "variables.yaml"), "w") as f:
-        f.write("""\
+        f.write(
+            """\
 variables:
   foo: 'bar'
-""")
+"""
+        )
 
     with open(os.path.join(high_path, "variables.yaml"), "w") as f:
-        f.write("""\
+        f.write(
+            """\
 variables:
   bar: 'baz'
-""")
+"""
+        )
 
-    assert config("get", "variables").strip() == """variables:
+    assert (
+        config("get", "variables").strip()
+        == """variables:
   bar: baz
   foo: bar"""
+    )
 
 
 def test_merged_env_vars_section(mock_low_high_config):
@@ -107,26 +121,33 @@ def test_merged_env_vars_section(mock_low_high_config):
     fs.mkdirp(high_path)
 
     with open(os.path.join(low_path, "env_vars.yaml"), "w") as f:
-        f.write("""\
+        f.write(
+            """\
 env_vars:
   set:
     FOO: bar
-""")
+"""
+        )
 
     with open(os.path.join(high_path, "env_vars.yaml"), "w") as f:
-        f.write("""\
+        f.write(
+            """\
 env_vars:
   append:
     vars:
       FOO: baz
-""")
+"""
+        )
 
-    assert config("get", "env_vars").strip() == """env_vars:
+    assert (
+        config("get", "env_vars").strip()
+        == """env_vars:
   append:
     vars:
       FOO: baz
   set:
     FOO: bar"""
+    )
 
 
 @pytest.mark.parametrize("section_key", ["software"])
@@ -138,29 +159,36 @@ def test_merged_software_section(mock_low_high_config, section_key):
     fs.mkdirp(high_path)
 
     with open(os.path.join(low_path, f"{section_key}.yaml"), "w") as f:
-        f.write(f"""\
+        f.write(
+            f"""\
 {section_key}:
   packages:
     gcc:
       pkg_spec: gcc@4.8.5
-""")
+"""
+        )
 
     with open(os.path.join(high_path, f"{section_key}.yaml"), "w") as f:
-        f.write(f"""\
+        f.write(
+            f"""\
 {section_key}:
   packages:
     zlib:
       pkg_spec: zlib
       compiler: gcc
-""")
+"""
+        )
 
-    assert config("get", section_key).strip() == f"""{section_key}:
+    assert (
+        config("get", section_key).strip()
+        == f"""{section_key}:
   packages:
     zlib:
       pkg_spec: zlib
       compiler: gcc
     gcc:
       pkg_spec: gcc@4.8.5"""
+    )
 
 
 def test_merged_success_criteria_section(mock_low_high_config):
@@ -171,24 +199,30 @@ def test_merged_success_criteria_section(mock_low_high_config):
     fs.mkdirp(high_path)
 
     with open(os.path.join(low_path, "success_criteria.yaml"), "w") as f:
-        f.write("""\
+        f.write(
+            """\
 success_criteria:
   - name: done
     mode: string
     match: "DONE"
     file: "{log_file}"
-""")
+"""
+        )
 
     with open(os.path.join(high_path, "success_criteria.yaml"), "w") as f:
-        f.write("""\
+        f.write(
+            """\
 success_criteria:
   - name: complete
     mode: string
     match: "COMPLETE"
     file: "{log_file}"
-""")
+"""
+        )
 
-    assert config("get", "success_criteria").strip() == """success_criteria:
+    assert (
+        config("get", "success_criteria").strip()
+        == """success_criteria:
 - name: complete
   mode: string
   match: COMPLETE
@@ -197,6 +231,7 @@ success_criteria:
   mode: string
   match: DONE
   file: '{log_file}'"""
+    )
 
 
 def test_merged_applications_section(mock_low_high_config):
@@ -207,7 +242,8 @@ def test_merged_applications_section(mock_low_high_config):
     fs.mkdirp(high_path)
 
     with open(os.path.join(low_path, "applications.yaml"), "w") as f:
-        f.write("""\
+        f.write(
+            """\
 applications:
   foo:
     workloads:
@@ -216,10 +252,12 @@ applications:
           test:
             variables:
               my_var: value
-""")
+"""
+        )
 
     with open(os.path.join(high_path, "applications.yaml"), "w") as f:
-        f.write("""\
+        f.write(
+            """\
 applications:
   foo:
     workloads:
@@ -240,9 +278,12 @@ applications:
           single:
             variables:
               n_ranks: 1
-""")
+"""
+        )
 
-    assert config("get", "applications").strip() == """applications:
+    assert (
+        config("get", "applications").strip()
+        == """applications:
   foo:
     workloads:
       bar:
@@ -265,6 +306,7 @@ applications:
           single:
             variables:
               n_ranks: 1"""
+    )
 
 
 def test_config_edit():
@@ -334,9 +376,12 @@ def test_config_add(mutable_empty_config):
     config("add", "config:dirty:true")
     output = config("get", "config")
 
-    assert output == """config:
+    assert (
+        output
+        == """config:
   dirty: true
 """
+    )
 
 
 def test_config_add_list(mutable_empty_config):
@@ -345,12 +390,15 @@ def test_config_add_list(mutable_empty_config):
     config("add", "config:template_dirs:test3")
     output = config("get", "config")
 
-    assert output == """config:
+    assert (
+        output
+        == """config:
   template_dirs:
   - test3
   - test2
   - test1
 """
+    )
 
 
 def test_config_add_override(mutable_empty_config):
@@ -358,19 +406,25 @@ def test_config_add_override(mutable_empty_config):
     config("add", "config:template_dirs:[test2]")
     output = config("get", "config")
 
-    assert output == """config:
+    assert (
+        output
+        == """config:
   template_dirs:
   - test2
   - test1
 """
+    )
 
     config("add", "config::template_dirs:[test2]")
     output = config("get", "config")
 
-    assert output == """config:
+    assert (
+        output
+        == """config:
   template_dirs:
   - test2
 """
+    )
 
 
 def test_config_add_override_leaf(mutable_empty_config):
@@ -378,19 +432,25 @@ def test_config_add_override_leaf(mutable_empty_config):
     config("add", "config:template_dirs:[test2]")
     output = config("get", "config")
 
-    assert output == """config:
+    assert (
+        output
+        == """config:
   template_dirs:
   - test2
   - test1
 """
+    )
 
     config("add", "config:template_dirs::[test2]")
     output = config("get", "config")
 
-    assert output == """config:
+    assert (
+        output
+        == """config:
   'template_dirs:':
   - test2
 """
+    )
 
 
 def test_config_add_update_dict(mutable_empty_config):
@@ -420,10 +480,13 @@ def test_config_add_ordered_dict(mutable_empty_config):
     config("add", "config:second:/path/to/second")
     output = config("get", "config")
 
-    assert output == """config:
+    assert (
+        output
+        == """config:
   first: /path/to/first
   second: /path/to/second
 """
+    )
 
 
 def test_config_add_from_file(mutable_empty_config, tmpdir):
@@ -437,9 +500,12 @@ def test_config_add_from_file(mutable_empty_config, tmpdir):
     config("add", "-f", file)
     output = config("get", "config")
 
-    assert output == """config:
+    assert (
+        output
+        == """config:
   dirty: true
 """
+    )
 
 
 def test_config_add_from_file_multiple(mutable_empty_config, tmpdir):
@@ -454,10 +520,13 @@ def test_config_add_from_file_multiple(mutable_empty_config, tmpdir):
     config("add", "-f", file)
     output = config("get", "config")
 
-    assert output == """config:
+    assert (
+        output
+        == """config:
   dirty: true
   template_dirs: [test1]
 """
+    )
 
 
 def test_config_add_override_from_file(mutable_empty_config, tmpdir):
@@ -472,9 +541,12 @@ def test_config_add_override_from_file(mutable_empty_config, tmpdir):
     config("add", "-f", file)
     output = config("get", "config")
 
-    assert output == """config:
+    assert (
+        output
+        == """config:
   template_dirs: [test2]
 """
+    )
 
 
 def test_config_add_override_leaf_from_file(mutable_empty_config, tmpdir):
@@ -489,9 +561,12 @@ def test_config_add_override_leaf_from_file(mutable_empty_config, tmpdir):
     config("add", "-f", file)
     output = config("get", "config")
 
-    assert output == """config:
+    assert (
+        output
+        == """config:
   'template_dirs:': [test2]
 """
+    )
 
 
 def test_config_add_invalid_file_fails(tmpdir):
@@ -515,8 +590,11 @@ def test_config_remove_value(mutable_empty_config):
     config("remove", "config:dirty:true")
     output = config("get", "config")
 
-    assert output == """config: {}
+    assert (
+        output
+        == """config: {}
 """
+    )
 
 
 def test_config_remove_alias_rm(mutable_empty_config):
@@ -524,8 +602,11 @@ def test_config_remove_alias_rm(mutable_empty_config):
     config("rm", "config:dirty:true")
     output = config("get", "config")
 
-    assert output == """config: {}
+    assert (
+        output
+        == """config: {}
 """
+    )
 
 
 def test_config_remove_dict(mutable_empty_config):
@@ -533,8 +614,11 @@ def test_config_remove_dict(mutable_empty_config):
     config("rm", "config:dirty")
     output = config("get", "config")
 
-    assert output == """config: {}
+    assert (
+        output
+        == """config: {}
 """
+    )
 
 
 def test_remove_from_list(mutable_empty_config):
@@ -544,11 +628,14 @@ def test_remove_from_list(mutable_empty_config):
     config("remove", "config:template_dirs:test2")
     output = config("get", "config")
 
-    assert output == """config:
+    assert (
+        output
+        == """config:
   template_dirs:
   - test3
   - test1
 """
+    )
 
 
 def test_remove_list(mutable_empty_config):
@@ -558,11 +645,14 @@ def test_remove_list(mutable_empty_config):
     config("remove", "config:template_dirs:[test2]")
     output = config("get", "config")
 
-    assert output == """config:
+    assert (
+        output
+        == """config:
   template_dirs:
   - test3
   - test1
 """
+    )
 
 
 def test_config_add_to_workspace(mutable_empty_config, mutable_mock_workspace_path):

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -1982,7 +1982,8 @@ config:
     test_var: '1'
 """
 
-    test_config = """
+    test_config = (
+        """
 ramble:
   variables:
     mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
@@ -2007,7 +2008,9 @@ ramble:
   software:
     packages: {}
     environments: {}
-""" % inc_file
+"""
+        % inc_file
+    )
 
     with open(inc_file, "w+") as f:
         f.write(test_include)

--- a/lib/ramble/ramble/test/cmd/workspace_concretize.py
+++ b/lib/ramble/ramble/test/cmd/workspace_concretize.py
@@ -60,8 +60,10 @@ def test_workspace_concretize_additive(workspace_name):
     modifiers_path = os.path.join(ws.config_dir, "modifiers.yaml")
 
     with open(modifiers_path, "w+") as f:
-        f.write("""modifiers:
-- name: intel-aps""")
+        f.write(
+            """modifiers:
+- name: intel-aps"""
+        )
 
     workspace("concretize", "-q", global_args=global_args)
 

--- a/lib/ramble/ramble/test/end_to_end/configvar_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/configvar_dry_run.py
@@ -66,7 +66,9 @@ ramble:
         packages:
         - openfoam
         - intel
-""".format(*test_scopes, var_name=var_name1)
+""".format(
+        *test_scopes, var_name=var_name1
+    )
 
     config = ramble.main.RambleCommand("config")
 

--- a/lib/ramble/ramble/test/end_to_end/object_precedence.py
+++ b/lib/ramble/ramble/test/end_to_end/object_precedence.py
@@ -67,8 +67,10 @@ def test_object_precedence_variables(workspace_name, test_args, disabled_value, 
         assert disabled_value in f.read()
 
     with open(variants_file, "w+") as f:
-        f.write("""variants:
-  set_precedence_var: True""")
+        f.write(
+            """variants:
+  set_precedence_var: True"""
+        )
 
     workspace("setup", "--dry-run", global_args=global_args)
 

--- a/lib/ramble/ramble/test/end_to_end/perf_tests/large_template.py
+++ b/lib/ramble/ramble/test/end_to_end/perf_tests/large_template.py
@@ -31,7 +31,8 @@ def test_large_template_expansion(
 
     app_dir = repo_dir.mkdir("applications").mkdir("template")
     with open(os.path.join(str(app_dir), "application.py"), "w") as f:
-        f.write("""
+        f.write(
+            """
 from ramble.appkit import *
 
 class Template(ExecutableApplication):
@@ -44,7 +45,8 @@ class Template(ExecutableApplication):
     register_template(name="expansion_test_path",
                       src_path="{src_script_path}",
                       dest_path="{experiment_run_dir}/expansion_script.sh")
-""")
+"""
+        )
 
     repo = ramble.repository.Repo(
         str(repo_dir), object_type=ramble.repository.ObjectTypes.applications

--- a/lib/ramble/ramble/test/end_to_end/shell_wrappers.py
+++ b/lib/ramble/ramble/test/end_to_end/shell_wrappers.py
@@ -36,10 +36,12 @@ def test_shell_wrapper_workspace_activate_missing(shell, tmpdir):
     test_script_path = str(tmpdir.join("test_missing.sh"))
 
     with open(test_script_path, "w") as f:
-        f.write(f"""
+        f.write(
+            f"""
 source "{setup_env}"
 ramble workspace activate non_existent_workspace
-""")
+"""
+        )
 
     cmd = [shell, test_script_path]
     process = subprocess.run(

--- a/lib/ramble/ramble/test/end_to_end/software_spec_injection.py
+++ b/lib/ramble/ramble/test/end_to_end/software_spec_injection.py
@@ -35,8 +35,10 @@ def test_software_spec_injection_works(mock_modifiers, workspace_name):
         ws.write()
 
         with open(os.path.join(ws.config_dir, "variants.yaml"), "w+") as f:
-            f.write("""variants:
-  implicit_compiler: True""")
+            f.write(
+                """variants:
+  implicit_compiler: True"""
+            )
 
         workspace(
             "manage",
@@ -95,8 +97,10 @@ def test_existing_software_spec_does_not_inject(mock_modifiers, workspace_name):
         ws.write()
 
         with open(os.path.join(ws.config_dir, "variants.yaml"), "w+") as f:
-            f.write("""variants:
-  implicit_compiler: True""")
+            f.write(
+                """variants:
+  implicit_compiler: True"""
+            )
 
         workspace(
             "manage",
@@ -156,8 +160,10 @@ def test_software_spec_injection_missing_compiler_errors(mock_modifiers, workspa
         ws.write()
 
         with open(os.path.join(ws.config_dir, "variants.yaml"), "w+") as f:
-            f.write("""variants:
-  missing_compiler: True""")
+            f.write(
+                """variants:
+  missing_compiler: True"""
+            )
 
         workspace(
             "manage",
@@ -210,8 +216,10 @@ def test_software_spec_compiler_injection_works(mock_applications, mock_modifier
         ws.write()
 
         with open(os.path.join(ws.config_dir, "variants.yaml"), "w+") as f:
-            f.write("""variants:
-  injected_compiler: True""")
+            f.write(
+                """variants:
+  injected_compiler: True"""
+            )
 
         workspace(
             "manage",

--- a/lib/ramble/ramble/test/modifier_functionality/executable_modifier_usage_filters.py
+++ b/lib/ramble/ramble/test/modifier_functionality/executable_modifier_usage_filters.py
@@ -71,8 +71,10 @@ def test_executable_modifier_usage_filters(
         )
 
         with open(os.path.join(ws.config_dir, "variants.yaml"), "w+") as f:
-            f.write(f"""variants:
-  usage_filter_type: {filter_type}""")
+            f.write(
+                f"""variants:
+  usage_filter_type: {filter_type}"""
+            )
 
         ws._re_read()
 
@@ -151,8 +153,10 @@ def test_executable_modifier_usage_filters_broken_errors(
         )
 
         with open(os.path.join(ws.config_dir, "variants.yaml"), "w+") as f:
-            f.write("""variants:
-  usage_filter_type: broken""")
+            f.write(
+                """variants:
+  usage_filter_type: broken"""
+            )
 
         ws._re_read()
 

--- a/lib/ramble/ramble/test/repository.py
+++ b/lib/ramble/ramble/test/repository.py
@@ -18,10 +18,12 @@ def extra_repo(tmpdir_factory, request):
     repo_dir.ensure(request.param, dir=True)
 
     with open(str(repo_dir.join("repo.yaml")), "w") as f:
-        f.write("""
+        f.write(
+            """
 repo:
   namespace: extra_test_repo
-""")
+"""
+        )
         if request.param != "applications":
             f.write(f"  subdirectory: '{request.param}'")
     return (

--- a/lib/ramble/ramble/test/variant.py
+++ b/lib/ramble/ramble/test/variant.py
@@ -331,9 +331,11 @@ def test_variant_nesting_works(workspace_name, test_value):
         ws.write()
 
         with open(os.path.join(ws.config_dir, "variants.yaml"), "w+") as f:
-            f.write(f"""variants:
+            f.write(
+                f"""variants:
   iterative_variant: {test_value}
-  iterative_variant2: {test_value}""")
+  iterative_variant2: {test_value}"""
+            )
         workspace(
             "manage",
             "experiments",

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -592,7 +592,9 @@ class Workspace:
     def _template_execute_script(self):
         shell = ramble.config.get("config:shell")
         shell_path = os.path.join("/bin/", shell)
-        script = f"#!{shell_path}\n" + """\
+        script = (
+            f"#!{shell_path}\n"
+            + """\
 # This is a template execution script for
 # running the execute pipeline.
 #
@@ -614,6 +616,7 @@ cd "{experiment_run_dir}"
 
 {command}
 """
+        )
 
         return script
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,10 +2,8 @@
 pytest
 pytest-benchmark
 flake8
-black==26.3.1;python_version>="3.10"
-black;python_version<"3.10"
-coverage>=7.10;python_version>="3.9"
-coverage;python_version<"3.9"
+black
+coverage
 pre-commit
 pytest-xdist
 pytest-clarity

--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -1,0 +1,8 @@
+-r requirements-dev.txt
+flake8==7.3.0
+black==25.12.0
+isort==7.0.0
+mypy==1.20.1
+coverage==7.13.5
+codecov-cli==10.4.0
+line_profiler==5.0.2

--- a/share/ramble/cloud-build/Dockerfile-apt
+++ b/share/ramble/cloud-build/Dockerfile-apt
@@ -14,11 +14,11 @@ RUN cd /opt && \
     spack install --deprecated py-pip ^python@${PYTHON_VER} && \
     spack clean -a
 RUN echo ". /opt/spack/share/spack/setup-env.sh\n spack load py-pip ^python@${PYTHON_VER}\n export SPACK_PYTHON=`which python3`" > /etc/profile.d/ramble.sh
-COPY requirements.txt requirements-dev.txt /opt/
+COPY requirements.txt requirements-dev.txt requirements-pinned.txt /opt/
 RUN cd /opt &&  \
     . spack/share/spack/setup-env.sh && \
     spack load py-pip ^python@${PYTHON_VER} && \
-    python -m pip install --no-cache-dir -r /opt/requirements-dev.txt
+    python -m pip install --no-cache-dir -r /opt/requirements-pinned.txt
 COPY share/ramble/cloud-build/container_test.sh /container_test.sh
 RUN chmod a+x /container_test.sh
 FROM ${BASE_IMG}:${BASE_VER}

--- a/share/ramble/cloud-build/Dockerfile-yum
+++ b/share/ramble/cloud-build/Dockerfile-yum
@@ -15,11 +15,11 @@ RUN cd /opt && \
     spack install --deprecated py-pip ^python@${PYTHON_VER} && \
     spack clean -a
 RUN echo -e ". /opt/spack/share/spack/setup-env.sh\n spack load py-pip ^python@${PYTHON_VER}\n export SPACK_PYTHON=`which python3`" > /etc/profile.d/ramble.sh
-COPY requirements.txt requirements-dev.txt /opt/
+COPY requirements.txt requirements-dev.txt requirements-pinned.txt /opt/
 RUN cd /opt &&  \
     . spack/share/spack/setup-env.sh && \
     spack load py-pip ^python@${PYTHON_VER} && \
-    python -m pip install --no-cache-dir -r /opt/requirements-dev.txt
+    python -m pip install --no-cache-dir -r /opt/requirements-pinned.txt
 COPY share/ramble/cloud-build/container_test.sh /container_test.sh
 RUN chmod a+x /container_test.sh
 FROM ${BASE_IMG}:${BASE_VER}

--- a/share/ramble/cloud-build/container_test.sh
+++ b/share/ramble/cloud-build/container_test.sh
@@ -20,7 +20,7 @@ git checkout "$BRANCH"
 . /opt/spack/share/spack/setup-env.sh
 spack load py-pip
 
-python -m pip install -r /workspace/requirements-dev.txt
+python -m pip install -r /workspace/requirements-pinned.txt
 
 cat > /load_test_env.sh <<'EOF'
 #!/bin/bash

--- a/share/ramble/cloud-build/ramble-perf-tests.yaml
+++ b/share/ramble/cloud-build/ramble-perf-tests.yaml
@@ -35,7 +35,7 @@ steps:
 
         spack load py-pip ^python
 
-        pip install -r /workspace/requirements-dev.txt
+        pip install -r /workspace/requirements-pinned.txt
 
         export SPACK_PYTHON=$(which python3)
 

--- a/share/ramble/cloud-build/ramble-pr-docs.yaml
+++ b/share/ramble/cloud-build/ramble-pr-docs.yaml
@@ -39,7 +39,7 @@ steps:
 
         spack load py-pip ^python
 
-        pip install -r /workspace/requirements-dev.txt
+        pip install -r /workspace/requirements-pinned.txt
 
         export SPACK_PYTHON=`which python3`
 

--- a/share/ramble/cloud-build/ramble-pr-software-conflicts.yaml
+++ b/share/ramble/cloud-build/ramble-pr-software-conflicts.yaml
@@ -38,7 +38,7 @@ steps:
 
         spack load py-pip ^python
 
-        pip install -r /workspace/requirements-dev.txt
+        pip install -r /workspace/requirements-pinned.txt
 
         export SPACK_PYTHON=`which python3`
 

--- a/share/ramble/cloud-build/ramble-pr-style.yaml
+++ b/share/ramble/cloud-build/ramble-pr-style.yaml
@@ -38,7 +38,7 @@ steps:
 
         spack load py-pip ^python
 
-        pip install -r /workspace/requirements-dev.txt
+        pip install -r /workspace/requirements-pinned.txt
 
         export SPACK_PYTHON=`which python3`
 

--- a/share/ramble/cloud-build/ramble-pr-unit-tests.yaml
+++ b/share/ramble/cloud-build/ramble-pr-unit-tests.yaml
@@ -38,7 +38,7 @@ steps:
 
         spack load py-pip ^python
 
-        pip install -r /workspace/requirements-dev.txt
+        pip install -r /workspace/requirements-pinned.txt
 
         export SPACK_PYTHON=`which python3`
 

--- a/share/ramble/cloud-build/terraform/triggers/locals.tf
+++ b/share/ramble/cloud-build/terraform/triggers/locals.tf
@@ -35,6 +35,7 @@ locals {
   dependency_and_config_files = [
     "requirements.txt",
     "requirements-dev.txt",
+    "requirements-pinned.txt",
     "pyproject.toml"
   ]
 }

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-1.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-1.yaml
@@ -23,7 +23,7 @@ steps:
 
         spack load py-pip ^python
 
-        pip install -r /workspace/requirements-dev.txt
+        pip install -r /workspace/requirements-pinned.txt
 
         export SPACK_PYTHON=`which python3`
 

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-10.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-10.yaml
@@ -23,7 +23,7 @@ steps:
 
         spack load py-pip ^python
 
-        pip install -r /workspace/requirements-dev.txt
+        pip install -r /workspace/requirements-pinned.txt
 
         export SPACK_PYTHON=`which python3`
 

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-11.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-11.yaml
@@ -23,7 +23,7 @@ steps:
 
         spack load py-pip ^python
 
-        pip install -r /workspace/requirements-dev.txt
+        pip install -r /workspace/requirements-pinned.txt
 
         export SPACK_PYTHON=`which python3`
 

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-2.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-2.yaml
@@ -23,7 +23,7 @@ steps:
 
         spack load py-pip ^python
 
-        pip install -r /workspace/requirements-dev.txt
+        pip install -r /workspace/requirements-pinned.txt
 
         export SPACK_PYTHON=`which python3`
 

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-3.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-3.yaml
@@ -23,7 +23,7 @@ steps:
 
         spack load py-pip ^python
 
-        pip install -r /workspace/requirements-dev.txt
+        pip install -r /workspace/requirements-pinned.txt
 
         export SPACK_PYTHON=`which python3`
 

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-4.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-4.yaml
@@ -23,7 +23,7 @@ steps:
 
         spack load py-pip ^python
 
-        pip install -r /workspace/requirements-dev.txt
+        pip install -r /workspace/requirements-pinned.txt
 
         export SPACK_PYTHON=`which python3`
 

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-5.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-5.yaml
@@ -23,7 +23,7 @@ steps:
 
         spack load py-pip ^python
 
-        pip install -r /workspace/requirements-dev.txt
+        pip install -r /workspace/requirements-pinned.txt
 
         export SPACK_PYTHON=`which python3`
 

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-6.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-6.yaml
@@ -23,7 +23,7 @@ steps:
 
         spack load py-pip ^python
 
-        pip install -r /workspace/requirements-dev.txt
+        pip install -r /workspace/requirements-pinned.txt
 
         export SPACK_PYTHON=`which python3`
 

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-7.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-7.yaml
@@ -23,7 +23,7 @@ steps:
 
         spack load py-pip ^python
 
-        pip install -r /workspace/requirements-dev.txt
+        pip install -r /workspace/requirements-pinned.txt
 
         export SPACK_PYTHON=`which python3`
 

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-8.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-8.yaml
@@ -23,7 +23,7 @@ steps:
 
         spack load py-pip ^python
 
-        pip install -r /workspace/requirements-dev.txt
+        pip install -r /workspace/requirements-pinned.txt
 
         export SPACK_PYTHON=`which python3`
 

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-9.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-9.yaml
@@ -23,7 +23,7 @@ steps:
 
         spack load py-pip ^python
 
-        pip install -r /workspace/requirements-dev.txt
+        pip install -r /workspace/requirements-pinned.txt
 
         export SPACK_PYTHON=`which python3`
 

--- a/var/ramble/repos/builtin/applications/architecture-check/application.py
+++ b/var/ramble/repos/builtin/applications/architecture-check/application.py
@@ -20,33 +20,39 @@ class ArchitectureCheck(ExecutableApplication):
 
     executable(
         "spack_test",
-        template=["""which spack &> /dev/null
+        template=[
+            """which spack &> /dev/null
 if [ $? == 0 ]; then
     echo "Spack tuple: `spack arch`" >> {log_file}
 fi
-"""],
+"""
+        ],
         redirect="",
         output_capture="",
     )
 
     executable(
         "gcc_version",
-        template=[r"""which gcc &> /dev/null
+        template=[
+            r"""which gcc &> /dev/null
 if [ $? == 0 ]; then
     echo "Gcc version: `gcc --version | grep "[0-9]*\.[0-9]*\.[0-9]*"`" >> {log_file}
 fi
-"""],
+"""
+        ],
         redirect="",
         output_capture="",
     )
 
     executable(
         "gcc_test",
-        template=["""which gcc &> /dev/null
+        template=[
+            """which gcc &> /dev/null
 if [ $? == 0 ]; then
     echo "Gcc arch: `gcc -march=native -Q --help=target | grep "march=  "`" >> {log_file}
 fi
-"""],
+"""
+        ],
         redirect="",
         output_capture="",
     )

--- a/var/ramble/repos/builtin/applications/intel-hpl/application.py
+++ b/var/ramble/repos/builtin/applications/intel-hpl/application.py
@@ -53,13 +53,15 @@ class IntelHpl(HplBase):
     )
     executable(
         "prepare",
-        template=[r"""
+        template=[
+            r"""
 hpl_bench_dir="{intel-oneapi-mkl_path}/mkl/latest/benchmarks/mp_linpack"
 if [ ! -d ${hpl_bench_dir} ]; then
     hpl_bench_dir="{intel-oneapi-mkl_path}/mkl/latest/share/mkl/benchmarks/mp_linpack"
 fi
 hpl_run="${hpl_bench_dir}/runme_intel64_prv"
-    """.strip()],
+    """.strip()
+        ],
         mpi=False,
         redirect="",
         output_capture="",

--- a/var/ramble/repos/builtin/modifiers/install-ramble/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/install-ramble/modifier.py
@@ -60,7 +60,7 @@ if [ ! -d {ramble_venv_path} ]; then
   . {ramble_venv_path}/bin/activate
   pip install --upgrade pip
   pip install -r {ramble_install_dir}/requirements.txt
-  pip install -r {ramble_install_dir}/requirements-dev.txt
+  pip install -r {ramble_install_dir}/requirements-pinned.txt
 fi
 """
 

--- a/var/ramble/repos/builtin/modifiers/lscpu/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/lscpu/modifier.py
@@ -109,7 +109,8 @@ class Lscpu(BasicModifier):
             shell,
             "gcc -march=native -Q --help=target | grep -- '-march=  ' | cut -f3",
         )
-        return [f"""
+        return [
+            f"""
 if which spack > /dev/null; then
     spack_arch={spack_arch}
     echo "Spack detected arch=$spack_arch" >> {{lscpu_log}}
@@ -118,7 +119,8 @@ fi
 if which gcc > /dev/null; then
     gcc_arch={gcc_arch}
     echo "GCC detected arch=$gcc_arch" >> {{lscpu_log}}
-fi\n"""]
+fi\n"""
+        ]
 
     figure_of_merit(
         "spack_arch",

--- a/var/ramble/repos/builtin/modifiers/tunables/test/tunables.py
+++ b/var/ramble/repos/builtin/modifiers/tunables/test/tunables.py
@@ -62,7 +62,8 @@ ramble:
             assert "grep -i HugePages_Total /proc/meminfo" in content
 
         with open(os.path.join(run_dir, "tunables.log"), "w+") as f:
-            f.write("""
+            f.write(
+                """
 nodeset-1: fom:address-space-randomization:2
 nodeset-0: fom:address-space-randomization:2
 nodeset-0: fom:smt-active:1
@@ -71,7 +72,8 @@ nodeset-0: fom:thp-enabled:always
 nodeset-1: fom:thp-enabled:madvise
 nodeset-1: fom:hugepage-size:    2048 kB
 nodeset-0: fom:hugepage-size:    2048 kB
-""")
+"""
+            )
         workspace("analyze", global_args=["-w", ws_name])
         with open(os.path.join(ws.root, "results.latest.txt")) as f:
             content = f.read()

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/test/spack_runner.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/test/spack_runner.py
@@ -344,7 +344,9 @@ compilers::
     modules: []
     environment: {}
     extra_rpaths: []
-""".replace("tmpdir_path", os.path.join(os.getcwd(), "bin"))
+""".replace(
+            "tmpdir_path", os.path.join(os.getcwd(), "bin")
+        )
 
         packages_config = f"""
 packages:


### PR DESCRIPTION
This merge adds a pinned version of the development packages that handle our style CI tests. The motivation is to give a stable set of packages when performing the CI tests, and to make it easy for users to replicate the environment the CI uses.

References to installation of requirements-dev are updated to use the pinned version in the CI tests, and the changes for the updated black version are applied as well.