### PR TITLE
Ensure base modifier classes have name attribute

### DIFF
--- a/lib/ramble/ramble/test/modifier_language.py
+++ b/lib/ramble/ramble/test/modifier_language.py
@@ -470,7 +470,7 @@ def test_modifier_variable_directive(mod_class):
         for when_set, var_list in mod_inst.object_variables.items():
             for var in var_list:
                 if var.name == test_def["name"]:
-                    mode_variant = f"mock-test-mod_mode={test_def['mode']}"
+                    mode_variant = f"{mod_inst.name}_mode={test_def['mode']}"
                     assert mode_variant in when_set
                     assert test_def["description"] == var.description
                     assert test_def["default"] == var.default
@@ -508,7 +508,7 @@ def test_merge_conditions_creates_when_list(mod_class):
     expected_modes = ["mode_0", "mode_1", "mode_2"]
     assert len(when_lists) == 3
     for i, mode_name in enumerate(expected_modes):
-        assert f"test-mod_mode={mode_name}" in when_lists[i]
+        assert f"{mod_inst.name}_mode={mode_name}" in when_lists[i]
         assert "test-mod_mode=mode_3" in when_lists[i]
 
 

--- a/var/ramble/repos/builtin/base_classes/basic-modifier/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/basic-modifier/base_class.py
@@ -17,4 +17,5 @@ class BasicModifier(ModifierBase):
     experiment definitions.
     """
 
+    name = "basic-modifier"
     modifier_class = "BasicModifier"

--- a/var/ramble/repos/builtin/base_classes/modifier-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/modifier-base/base_class.py
@@ -33,6 +33,7 @@ ObjectMixin = ramble.repository.get_base_class("object-mixin")
 
 
 class ModifierBase(ObjectMixin, metaclass=ModifierMeta):
+    name = "modifier-base"
     origin_type = "modifier"
     _builtin_name = NS_SEPARATOR.join(
         ("modifier_builtin", "{obj_name}", "{name}")

--- a/var/ramble/repos/builtin/base_classes/object-mixin/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/object-mixin/base_class.py
@@ -47,8 +47,9 @@ class ObjectMixin:
             if type(self) is ObjectMixin:
                 self._name = "object-mixin"
             else:
+                base_type = getattr(self, "origin_type", "base_class")
                 logger.warn(
-                    f"Application {self.__class__.__name__} is missing explicit name."
+                    f"{base_type} {self.__class__.__name__} is missing explicit name."
                 )
                 self._name = os.path.basename(os.path.dirname(self._file_path))
         return self._name


### PR DESCRIPTION
This merge adds a name attribute to the base modifier classes, to avoid warning prints when using modifiers.