### PR TITLE
Adjust execution times of perf tests

### DIFF
--- a/lib/ramble/ramble/test/end_to_end/perf_tests/analyze_perf.py
+++ b/lib/ramble/ramble/test/end_to_end/perf_tests/analyze_perf.py
@@ -44,8 +44,8 @@ def test_analyze_large_file(workspace_name, ramble_benchmark):
     workspace("setup", "--dry-run", global_args=global_args)
     out_file = os.path.join(ws.experiment_dir, "sleep", "rand_sleep", "generated", "generated.out")
     with open(out_file, "w") as f:
-        # Write 10 million lines to simulate a large output file
-        for _ in range(10_000):
+        # Write 1 million lines to simulate a large output file
+        for _ in range(1_000):
             f.write("no match\n" * 1_000)
         f.write("Sleep for 10 seconds\n")
 

--- a/lib/ramble/ramble/test/end_to_end/perf_tests/large_template.py
+++ b/lib/ramble/ramble/test/end_to_end/perf_tests/large_template.py
@@ -54,7 +54,7 @@ class Template(ExecutableApplication):
     mutable_mock_apps_repo.put_first(repo)
 
     # Create a large template with math and non-math statements
-    n_lines = 10000
+    n_lines = 20000
     template_lines = []
     for i in range(n_lines):
         if i % 3 == 0:

--- a/lib/ramble/ramble/test/end_to_end/perf_tests/many_experiments.py
+++ b/lib/ramble/ramble/test/end_to_end/perf_tests/many_experiments.py
@@ -38,7 +38,7 @@ def test_many_experiments(workspace_name, ramble_benchmark):
         "-v",
         "n_ranks='{n_nodes}*{processes_per_node}'",
         "-v",
-        "n_nodes=[1,2,4,8,16,32,64,128,256]",
+        "n_nodes=[1,2,4,8,16]",
         "-v",
         "var1=[1,2,3,4,5,6,7,8,9,10]",
         "-v",
@@ -52,4 +52,4 @@ def test_many_experiments(workspace_name, ramble_benchmark):
 
     output = ramble_benchmark(workspace, "info", global_args=global_args)
 
-    assert "Experiment 8100" in output
+    assert "Experiment 5000" in output

--- a/lib/ramble/ramble/test/end_to_end/perf_tests/many_objects_defaults.py
+++ b/lib/ramble/ramble/test/end_to_end/perf_tests/many_objects_defaults.py
@@ -38,12 +38,12 @@ def test_many_objects_defaults(make_workspace_from_config, ramble_benchmark):
     modifier_list_yaml = "\n".join([f"    - name: {m}" for m in modifiers])
     modifier_section = f"  modifiers:\n{modifier_list_yaml}"
 
-    # Create 1000 experiments (10 x 100 matrix)
+    # Create 200 experiments (10 x 20 matrix)
     # Each experiment has 9 modifiers.
     # Each experiment will have ~171 default variables.
-    # Total variable objects = 1000 * 171 = 171,000.
+    # Total variable objects = 200 * 171 = 34,200.
 
-    matrix_var_list = ", ".join([f"'{i}'" for i in range(100)])
+    matrix_var_list = ", ".join([f"'{i}'" for i in range(20)])
 
     test_config = f"""\
 ramble:
@@ -74,21 +74,20 @@ ramble:
     ramble_benchmark(workspace, "setup", "--dry-run", global_args=["-w", ws_name])
 
     # Verify that the correct number of experiments were created
-    # 10 n_nodes * 100 matrix_var = 1000 experiments
     application_dir = os.path.join(ws.experiment_dir, "hostname", "local")
     experiments = [
         d for d in os.listdir(application_dir) if os.path.isdir(os.path.join(application_dir, d))
     ]
-    assert len(experiments) == 1000
+    assert len(experiments) == 200
 
     # Verify that at least one experiment was created
     exp_dir = os.path.join(ws.experiment_dir, "hostname", "local", "exp_1_0")
     assert os.path.isdir(exp_dir)
 
     # Verify that a middle experiment was created
-    exp_dir = os.path.join(ws.experiment_dir, "hostname", "local", "exp_256_50")
+    exp_dir = os.path.join(ws.experiment_dir, "hostname", "local", "exp_256_10")
     assert os.path.isdir(exp_dir)
 
     # Verify that the last experiment was created
-    exp_dir = os.path.join(ws.experiment_dir, "hostname", "local", "exp_512_99")
+    exp_dir = os.path.join(ws.experiment_dir, "hostname", "local", "exp_512_19")
     assert os.path.isdir(exp_dir)


### PR DESCRIPTION
Since we use pytest-benchmark (which runs multiple iterations to get more reliable statistics) to run individual perf tests, and that each perf test is run serially, a slow test can make the perf test PR builds take a long time. Adjust some slower tests so that they finish a bit faster, while they can still reliably detect regressions. Also increase the run time of one faster test, to make its result more reliable.

The downside is that the historical perf data are invalidated, but given we only recently started collecting the data, this is probably OK.