### PR TITLE
Fix up pinned deps

### DIFF
--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -1,8 +1,8 @@
 -r requirements-dev.txt
-flake8==7.3.0
-black==25.12.0
-isort==7.0.0
-mypy==1.20.1
-coverage==7.13.5
-codecov-cli==11.2.5
-line_profiler==5.0.2
+flake8==7.3.0;python_version>="3.9"
+black==25.12.0;python_version>="3.9"
+isort==7.0.0;python_version>="3.9"
+mypy==1.20.1;python_version>="3.9"
+coverage==7.13.5;python_version>="3.9"
+codecov-cli==11.2.5;python_version>="3.9"
+line_profiler==5.0.2;python_version>="3.9"

--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -4,5 +4,5 @@ black==25.12.0
 isort==7.0.0
 mypy==1.20.1
 coverage==7.13.5
-codecov-cli==10.4.0
+codecov-cli==11.2.5
 line_profiler==5.0.2


### PR DESCRIPTION
The pinned versions only work for Python 3.9 and up.

Additionally, the previous 10.4.0 version of codecov-cli has a dependency on a version of `test-results-parser`, which does not support py3.14 due to https://github.com/codecov/test-results-parser/pull/89.

A successful image-build run with python 3.7: https://console.cloud.google.com/cloud-build/builds/42b8071b-fcf7-4c4c-a099-efe5f88cb921?project=993292483723