### PR TITLE
Add experiment inventory to pipeline logs

### DIFF
--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -162,6 +162,7 @@ class Pipeline:
                 logger.all_msg(f"    log file: {exp_log_path}")
 
             with logger.add_log_context(exp_log_path):
+                logger.msg(f"Experiment inventory:\n{sjson.dump(app_inst.hash_inventory)}")
                 phase_list = list(app_inst.get_pipeline_phases(self.name, self.filters.phases))
 
                 disable_progress = (


### PR DESCRIPTION
This merge adds printing of the full experiment inventory to each pipeline log, to help enhance the debuggability of the pipeline logs.