### PR TITLE
Add a permission block for the spelling check workflow

### DIFF
--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -1,5 +1,8 @@
 name: ramble spelling
 
+permissions:
+  contents: read
+
 on:
   pull_request:
    types:


### PR DESCRIPTION
This is to close out https://github.com/GoogleCloudPlatform/ramble/security/code-scanning/21.