### PR TITLE
Avoid unnecessary test file copying

### DIFF
--- a/lib/ramble/ramble/cmd/unit_test.py
+++ b/lib/ramble/ramble/cmd/unit_test.py
@@ -225,12 +225,13 @@ def unit_test(parser, args, unknown_args):
                     return os.path.join(os.getcwd(), filename)
                 return None
 
-            copied_conftest_path = _ensure_path_in_cwd("conftest.py")
-            copied_ini_path = _ensure_path_in_cwd("pytest.ini")
-            # This specific test should be run against custom repos, so copy it over.
-            copied_test_path = _ensure_path_in_cwd(
-                "setup_analyze.py", src_root=os.path.join(ramble.paths.test_path, "end_to_end")
-            )
+            if args.repo_path is not None:
+                copied_conftest_path = _ensure_path_in_cwd("conftest.py")
+                copied_ini_path = _ensure_path_in_cwd("pytest.ini")
+                # This specific test should be run against custom repos, so copy it over.
+                copied_test_path = _ensure_path_in_cwd(
+                    "setup_analyze.py", src_root=os.path.join(ramble.paths.test_path, "end_to_end")
+                )
 
             if args.list:
                 do_list(args, pytest_args)

--- a/lib/ramble/ramble/test/cmd/unit_test.py
+++ b/lib/ramble/ramble/test/cmd/unit_test.py
@@ -6,8 +6,12 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+import os
+import subprocess
+
 import pytest
 
+import ramble.paths
 from ramble import main
 
 pytestmark = pytest.mark.maybeslow
@@ -63,6 +67,23 @@ def test_list_only_objects():
     assert "lib/ramble/ramble/test" not in output
 
 
-def test_external_repo():
+def test_external_repo_invalid():
     with pytest.raises(FileNotFoundError):
         ramble_test("--repo-path", "non-existent-path")
+
+
+def test_external_repo_valid(tmpdir):
+    test_dir = tmpdir.mkdir("test")
+    test_file = test_dir.join("test_dummy.py")
+    test_file.write("def test_dummy():\n    assert True\n")
+
+    # Need to launch a new process due to how setup_analyze.py is handled differently
+    # for Ramble repo and external repos.
+    ramble_bin = os.path.join(ramble.paths.ramble_root, "bin", "ramble")
+    result = subprocess.run(
+        [ramble_bin, "unit-test", "--repo-path", str(tmpdir), "-k", "test_dummy"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "1 passed" in result.stdout


### PR DESCRIPTION
The file copy is only needed when specifying `--repo-path` for unit testing custom object repos.