### PR TITLE
add version 2025 to lammps to strongly imply support 

### DIFF
--- a/var/ramble/repos/builtin/applications/lammps/application.py
+++ b/var/ramble/repos/builtin/applications/lammps/application.py
@@ -76,6 +76,7 @@ class Lammps(ExecutableApplication):
         workload_group="all_workloads",
     )
 
+    version("20250722", "Version 20250722 of LAMMPS")
     version("20220623.4", "Version 20220623.4 of LAMMPS", preferred=True)
 
     with when("package_manager_family=spack"):


### PR DESCRIPTION
I manually verified the foms. It seems like anything >=2022 uses the same consistent format

<=2021 likely needs different foms