### PR TITLE
Avoid showing duplicates for info output

### DIFF
--- a/lib/ramble/ramble/cmd/common/info.py
+++ b/lib/ramble/ramble/cmd/common/info.py
@@ -168,12 +168,15 @@ def _unpack_when_set_if_needed(internal_attr: dict):
             # unpack to a list of dicts so dicts with same keys don't overwrite
             unpacked_dict = []
             for inner_dict in internal_attr.values():
-                unpacked_dict.append(inner_dict)
+                if inner_dict not in unpacked_dict:
+                    unpacked_dict.append(inner_dict)
             return unpacked_dict
         elif isinstance(first_val, list):
             unpacked_list = []
             for inner_list in internal_attr.values():
-                unpacked_list.extend(inner_list)
+                for item in inner_list:
+                    if item not in unpacked_list:
+                        unpacked_list.append(item)
             return unpacked_list
         else:
             return internal_attr[first_key]
@@ -336,7 +339,9 @@ def print_single_attribute(obj, attr, verbose=False, pattern="*", format=support
         # Otherwise, print it as a raw string.
         if isinstance(to_print, list):
             if internal_attr and isinstance(next(iter(internal_attr)), dict):
-                to_print = [key for attr_dict in internal_attr for key in attr_dict]
+                to_print = list(
+                    dict.fromkeys(key for attr_dict in internal_attr for key in attr_dict)
+                )
             _print_nonverbose_list_attr(to_print, pattern=pattern, format=format)
         else:
             color.cprint(f"    {to_print}\n")


### PR DESCRIPTION
```
$ ramble info gromacs | grep -i validators -A 7
validators:
    validate_values_for_verbose_obj_gromacs
    validate_values_for_notunepme_obj_gromacs
    validate_values_for_dlb_obj_gromacs
    validate_values_for_size_obj_gromacs
    validate_values_for_type_obj_gromacs

workloads:
```