### PR TITLE
Add `ruff check` into `ramble style`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,7 +268,7 @@ Using `-k` is particularly useful for running only newly added tests.
 
 ## Running Style Checks
 
-Ramble uses `isort`, `black`, `flake8`, and `mypy` to enforce a consistent code style and type safety. You can check and fix style issues using the `ramble style` command.
+Ramble uses `isort`, `black`, `flake8`, `mypy`, and `ruff` to enforce a consistent code style and type safety. You can check and fix style issues using the `ramble style` command.
 
 *   **Checking for Style Errors:** To check for any style violations in the files you've changed in your current branch:
     ```bash

--- a/lib/ramble/ramble/cmd/style.py
+++ b/lib/ramble/ramble/cmd/style.py
@@ -127,7 +127,7 @@ pattern_exemptions = {
 }
 
 # Tools run in the given order
-tool_names = ["isort", "black", "flake8", "mypy"]
+tool_names = ["isort", "black", "flake8", "mypy", "ruff"]
 
 tools = {}
 
@@ -563,6 +563,31 @@ def run_mypy(mypy_cmd, file_list, args):
 
     print_output(output, args)
     print_tool_result("mypy", returncode)
+    return returncode
+
+
+@tool("ruff")
+def run_ruff(ruff_cmd, file_list, args):
+    # Even though Ruff hasn't reached v1 yet, it has been effective in catching
+    # issues like unused imports that flake8 misses.
+    del file_list
+    if args.repo_path is not None:
+        print("Skipping ruff for external repository.")
+        return 0
+    # ruff check always applies to all relevant files.
+    print_tool_header("ruff", [])
+
+    config_file = os.path.join(ramble.paths.prefix, "pyproject.toml")
+    ruff_args = ["check", "--config", config_file]
+
+    if args.fix:
+        ruff_args.append("--fix")
+
+    output = ruff_cmd(*ruff_args, fail_on_error=False, output=str, error=str)
+    returncode = ruff_cmd.returncode
+
+    print_output(output, args)
+    print_tool_result("ruff", returncode)
     return returncode
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,8 +168,6 @@ module = [
 ]
 check_untyped_defs = true
 
-# TODO: Add ruff into `ramble style` once it reaches v1.
-# For now, the ruff check can be invoked manually with `ruff check`.
 [tool.ruff]
 extend-include = ["bin/ramble"]
 extend-exclude = [
@@ -179,7 +177,7 @@ extend-exclude = [
 ]
 
 [tool.ruff.lint]
-preview = true
+preview = false
 # B905 requires Python 3.9 or up.
 ignore = ["B905"]
 extend-select = ["B", "C4", "F401"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,3 +11,4 @@ line_profiler
 isort
 codecov-cli
 mypy
+ruff

--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -6,3 +6,4 @@ mypy==1.20.1;python_version>="3.9"
 coverage==7.13.5;python_version>="3.9"
 codecov-cli==11.2.5;python_version>="3.9"
 line_profiler==5.0.2;python_version>="3.9"
+ruff==0.15.12


### PR DESCRIPTION
Even though `ruff` is not at v1 yet, it has proven to be quite effective in catching genuine issues that are missed by `flake8`. It's also quite performant and does not add much to the total runtime of style-check.