### PR TITLE
Allow context derived columns in tables [AI]

### DIFF
--- a/lib/ramble/docs/configuration_files.rst
+++ b/lib/ramble/docs/configuration_files.rst
@@ -773,6 +773,7 @@ In the above, ``[optional table attributes]`` includes any of the following:
    - "list of expressions"
    - "to filter experiments"
    - "to build table from"
+   transpose: true # Optional: transpose the table before writing out
 
 The ``group_method`` can be selected from any `groupby method supported by
 Pandas dataframes
@@ -798,8 +799,40 @@ a context is not provided, Ramble will attempt to auto-detect the context.
 Similarly, if the origin type is not provided, Ramble will auto detect the
 origin type.
 
+Tables also support ``autocolumns``, which allow columns to be generated
+dynamically based on the contexts and figures of merit found in an experiment's
+results. The attributes for ``autocolumns`` are as follows:
+
+.. code-block:: yaml
+
+   autocolumns:
+   - name: "column name template"
+     context_name: "glob or regex for context definition name or instance name"
+     figure_of_merit: "glob or regex for figure of merit name"
+     figure_of_merit_origin_type: "Origin type to extract figure of merit from"
+     sort_by:
+     - "list of context variables"
+     - "to sort generated columns by"
+     where:
+     - "list of expressions"
+     - "to filter experiments"
+     - "when building this column"
+
+In an ``autocolumn``, ``name`` and ``figure_of_merit`` are required. If
+``context_name`` is omitted, Ramble will match figures of merit that are not
+within any specific context (the "null" context).
+
+The ``name`` template for an ``autocolumn`` can include any variables from the
+matched context, as well as the special variables ``{fom_name}`` and
+``{context_name}`` (the name of the specific context instance). If regular
+expressions are used for ``context_name`` or ``figure_of_merit``, any named
+capture groups will also be available as variables in the ``name`` template.
+
 Columns are built in YAML order. The ``expression`` attribute can be used to
 refer to values from other columns that are defined before the current column.
+Explicitly defined columns are always added to the table before any generated
+``autocolumns``. Within a set of generated columns from the same template, the
+``sort_by`` field determines their relative order.
 
 Both ``table_name_template`` and ``column_name_template`` can include Ramble
 variables, to automatically generate new tables and columns. As an example:

--- a/lib/ramble/docs/success_criteria.rst
+++ b/lib/ramble/docs/success_criteria.rst
@@ -120,7 +120,8 @@ Both ``fom_name`` and ``fom_context`` support
 
 When using the globbing functionality, all contexts that match the
 ``fom_context`` argument are searched. Within each context, all FOMs that match
-``fom_name`` are tested with ``formula``.
+``fom_name`` are tested with ``formula``. The success criteria will only pass
+if **all** matched figures of merit satisfy the formula.
 
 The ``formula`` attribute can access any variables defined within an
 experiment. Additionally, an extra ``value`` variable is defined, which takes

--- a/lib/ramble/ramble/results_table.py
+++ b/lib/ramble/ramble/results_table.py
@@ -12,6 +12,7 @@ import os
 from ramble.util.file_util import create_symlink
 from ramble.util.logger import logger
 from ramble.util.module_utils import import_pandas
+from ramble.util.naming import match_pattern
 
 
 class ResultsColumn:
@@ -36,7 +37,10 @@ class ResultsColumn:
         """
         # Extract column attributes
         for attr in self._column_attrs:
-            setattr(self, attr, str(conf_dict[attr]) if attr in conf_dict else None)
+            val = conf_dict.get(attr)
+            if val is not None:
+                val = str(val)
+            setattr(self, attr, val)
 
         if self.expression and self.figure_of_merit:
             logger.die(
@@ -52,6 +56,10 @@ class ResultsColumn:
         self.where = []
         if self._where_name in conf_dict:
             self.where.extend(conf_dict[self._where_name])
+
+        # Internal attributes for context columns
+        self._context_def_name = conf_dict.get("_context_def_name")
+        self._context_vars = conf_dict.get("_context_vars")
 
     def col_name(self, app_inst):
         """Expand this columns name based on the current experiment
@@ -101,20 +109,72 @@ class ResultsColumn:
 
             results = app_inst.result
             for context in results.contexts:
-                if context_name is None or context_name == context["name"]:
-                    for fom in context["foms"]:
-                        if fom["name"] == fom_name:
-                            keep = True
-                            if origin_type and origin_type != fom["origin_type"]:
-                                keep = False
+                if (context_name is None or context_name == context["name"]) and (
+                    self._context_def_name is None
+                    or self._context_def_name == context.get("context_def_name")
+                ):
+                    match_vars = True
+                    if self._context_vars is not None:
+                        # Ensure all original context vars match.
+                        # Regex groups in self._context_vars don't need to match
+                        # because they aren't in context.get('context_vars')
+                        c_vars = context.get("context_vars", {})
+                        for k, v in c_vars.items():
+                            if self._context_vars.get(k) != v:
+                                match_vars = False
+                                break
 
-                            if keep:
-                                if value is not None:
-                                    logger.warn(
-                                        "Non-unique values found " f"for column {self.name}"
-                                    )
-                                value = fom["value"]
+                    if match_vars:
+                        for fom in context["foms"]:
+                            if fom["name"] == fom_name:
+                                keep = True
+                                if origin_type and origin_type != fom["origin_type"]:
+                                    keep = False
+
+                                if keep:
+                                    if value is not None:
+                                        logger.warn(
+                                            "Non-unique values found " f"for column {self.name}"
+                                        )
+                                    value = fom["value"]
         return value
+
+
+class ResultsAutoColumn:
+    """Class representing a template for auto-generated columns"""
+
+    _where_name = "where"
+    _sort_by_name = "sort_by"
+    _column_attrs = [
+        "name",
+        "context_name",
+        "figure_of_merit",
+        "figure_of_merit_origin_type",
+    ]
+
+    def __init__(self, conf_dict):
+        """Construct an auto column from a configuration dict
+
+        Args:
+            conf_dict (dict): dictionary structured like the autocolumn schema
+        """
+        # Extract column attributes
+        for attr in self._column_attrs:
+            val = conf_dict.get(attr)
+            if val is not None:
+                val = str(val)
+            setattr(self, attr, val)
+
+        self.where = []
+        if self._where_name in conf_dict:
+            self.where.extend(conf_dict[self._where_name])
+
+        self.sort_by = []
+        if self._sort_by_name in conf_dict:
+            if isinstance(conf_dict[self._sort_by_name], list):
+                self.sort_by.extend(conf_dict[self._sort_by_name])
+            else:
+                self.sort_by.append(conf_dict[self._sort_by_name])
 
 
 class ResultsTable:
@@ -125,7 +185,9 @@ class ResultsTable:
     _group_by_name = "group_by"
     _sort_by_name = "sort_by"
     _columns_name = "columns"
+    _autocolumns_name = "autocolumns"
     _where_name = "where"
+    _transpose_name = "transpose"
 
     def __init__(self, conf_dict):
         """Constructor for a single table
@@ -158,11 +220,23 @@ class ResultsTable:
         if self._where_name in conf_dict:
             self.where.extend(conf_dict[self._where_name])
 
+        self.transpose = False
+        if self._transpose_name in conf_dict:
+            self.transpose = conf_dict[self._transpose_name]
+
         # Build table columns
         self.columns = []
         if self._columns_name in conf_dict:
             for column_config in conf_dict[self._columns_name]:
                 self.columns.append(ResultsColumn(column_config))
+
+        # Build table auto columns
+        self.autocolumns = []
+        if self._autocolumns_name in conf_dict:
+            for column_config in conf_dict[self._autocolumns_name]:
+                self.autocolumns.append(ResultsAutoColumn(column_config))
+
+        self.generated_columns = {}
 
     def render(self, app_inst):
         new_table = copy.deepcopy(self)
@@ -220,10 +294,118 @@ class ResultsTable:
         Args:
             app_inst: Instance of an application class to extract data from
         """
+
+        # Perform discovery for auto columns
+        manual_col_names = {c.col_name(app_inst) for c in self.columns}
+        for autocol_template in self.autocolumns:
+            action_column = True
+            for expression in autocol_template.where:
+                if not app_inst.expander.evaluate_predicate(expression):
+                    action_column = False
+
+            if not action_column:
+                continue
+
+            for context in app_inst.result.contexts:
+                # Try matching against context_def_name first (the type of context)
+                matched_ctx, ctx_groups = match_pattern(
+                    autocol_template.context_name, context.get("context_def_name", "")
+                )
+
+                # If no match, try matching against the instance name (the output name)
+                if not matched_ctx:
+                    matched_ctx, ctx_groups = match_pattern(
+                        autocol_template.context_name, context.get("name", "")
+                    )
+
+                if matched_ctx:
+                    context_vars = context.get("context_vars", {}).copy()
+                    context_vars.update(ctx_groups)
+
+                    for fom in context["foms"]:
+                        matched_fom, fom_groups = match_pattern(
+                            autocol_template.figure_of_merit, fom["name"]
+                        )
+                        if matched_fom:
+                            temp_vars = context_vars.copy()
+                            temp_vars.update(fom_groups)
+                            temp_vars["fom_name"] = fom["name"]
+                            temp_vars["context_name"] = context.get("name")
+
+                            col_name = app_inst.expander.expand_var(
+                                autocol_template.name, extra_vars=temp_vars
+                            )
+
+                            if (
+                                col_name not in manual_col_names
+                                and col_name not in self.generated_columns
+                            ):
+                                combined_vars = context.get("context_vars", {}).copy()
+                                combined_vars.update(ctx_groups)
+                                combined_vars.update(fom_groups)
+                                combined_vars["context_name"] = context.get("name")
+                                conf_dict = {
+                                    "name": col_name,
+                                    "figure_of_merit": fom["name"],
+                                    "figure_of_merit_context": context["name"],
+                                    "figure_of_merit_origin_type": (
+                                        autocol_template.figure_of_merit_origin_type
+                                    ),
+                                    "where": autocol_template.where,
+                                    "_context_def_name": context.get("context_def_name"),
+                                    "_context_vars": combined_vars,
+                                }
+                                col_obj = ResultsColumn(conf_dict)
+                                col_obj._template = autocol_template
+                                self.generated_columns[col_name] = col_obj
+
         column_values = {}
         remaining_columns = set(self._data.keys())
 
-        for column in self.columns:
+        # Combine manual and generated columns
+        all_columns = self.columns.copy()
+
+        # Group generated columns by template to apply variable-based sorting if specified
+        for autocol_template in self.autocolumns:
+            template_cols = [
+                col
+                for col in self.generated_columns.values()
+                if getattr(col, "_template", None) is autocol_template
+            ]
+
+            if autocol_template.sort_by:
+
+                def sort_key(col, template=autocol_template):
+                    key = []
+                    for var in template.sort_by:
+                        val = col._context_vars.get(var) if col._context_vars else None
+                        try:
+                            val = float(val) if val is not None else float("-inf")
+                        except (ValueError, TypeError):
+                            val = str(val) if val is not None else ""
+                        # Use a tuple of (type_flag, value) to prevent comparison errors
+                        # between strings and floats in Python 3
+                        type_flag = 0 if isinstance(val, (int, float)) else 1
+                        key.append((type_flag, val))
+                    return tuple(key)
+
+                template_cols.sort(key=sort_key)
+
+            all_columns.extend(template_cols)
+
+        # Re-order self._data to ensure columns appear in the correct sorted order
+        new_data = {}
+        for column in all_columns:
+            col_name = column.col_name(app_inst)
+            if col_name in self._data:
+                new_data[col_name] = self._data[col_name]
+
+        for k, v in self._data.items():
+            if k not in new_data:
+                new_data[k] = v
+        self._data = new_data
+
+        for column in all_columns:
             col_value = column.extract_value(app_inst, extra_vars=column_values)
 
             if col_value is None:
@@ -256,9 +438,16 @@ class ResultsTable:
             except ValueError:
                 pass
 
+        if self.transpose:
+            self._df = self._df.transpose()
+            # If transposed, the original columns become the index,
+            # and rows become columns.
+            # We might want to reset the index if we want it as a column,
+            # but usually transpose in CSV means just flipping it.
+
     def _group_dataframe(self):
         """Apply any grouping to this pandas dataframe"""
-        if self.group_by:
+        if self.group_by and not self.transpose:
             try:
                 grouped_df = self._df.groupby(*self.group_by, as_index=False)
 
@@ -269,7 +458,7 @@ class ResultsTable:
 
     def _sort_dataframe(self):
         """Apply any sorting to this pandas dataframe"""
-        if self.sort_by:
+        if self.sort_by and not self.transpose:
             try:
                 self._df = self._df.sort_values(by=self.sort_by)
             except KeyError:
@@ -292,7 +481,8 @@ class ResultsTable:
         latestname = self.name + inner_delim + "latest" + inner_delim + extension
         file_path = os.path.join(directory, filename)
         latest_path = os.path.join(directory, latestname)
-        self._df.to_csv(file_path, index=False)
+        # If transposed, we might want the index to be written as the first column
+        self._df.to_csv(file_path, index=self.transpose)
 
         create_symlink(file_path, latest_path)
         return file_path, latest_path

--- a/lib/ramble/ramble/schema/tables.py
+++ b/lib/ramble/ramble/schema/tables.py
@@ -24,6 +24,24 @@ column = {
     "additionalProperties": False,
 }
 
+autocolumn = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "context_name": {"type": "string"},
+        "figure_of_merit": {"type": "string"},
+        "figure_of_merit_origin_type": {"type": "string", "default": None},
+        "where": where_clause,
+        "sort_by": {
+            "type": ["string", "array"],
+            "items": {"type": "string"},
+            "default": None,
+        },
+    },
+    "required": ["name", "figure_of_merit"],
+    "additionalProperties": False,
+}
+
 # TODO: Make key a table attribute that has to be an expression
 properties = {
     "tables": {
@@ -34,6 +52,7 @@ properties = {
             "properties": {
                 "name": {"type": "string"},
                 "columns": {"type": "array", "items": column},
+                "autocolumns": {"type": "array", "items": autocolumn},
                 "group_method": {"type": "string", "default": "max"},
                 "group_by": {
                     "type": ["string", "array"],
@@ -45,9 +64,10 @@ properties = {
                     "items": {"type": "string"},
                     "default": None,
                 },
+                "transpose": {"type": "boolean", "default": False},
                 "where": where_clause,
             },
-            "required": ["name", "columns"],
+            "required": ["name"],
             "additionalProperties": False,
         },
     }

--- a/lib/ramble/ramble/success_criteria.py
+++ b/lib/ramble/ramble/success_criteria.py
@@ -189,11 +189,15 @@ class SuccessCriteria:
             comparison_tested = False
             result = True
 
-            contexts = fnmatch.filter(
-                fom_values.keys(), app_inst.expander.expand_var(self.fom_context)
-            )
+            fom_context_glob = app_inst.expander.expand_var(self.fom_context)
+            matching_keys = []
+            for k in fom_values.keys():
+                name = k[0] if isinstance(k, tuple) else k
+                if fnmatch.fnmatch(name, fom_context_glob):
+                    matching_keys.append(k)
+
             # If fom context doesn't exist, fail the comparison
-            if not contexts:
+            if not matching_keys:
                 logger.debug(
                     f'When checking success criteria "{self.name}" FOM '
                     f'context "{self.fom_context}" matches no contexts.'
@@ -202,16 +206,16 @@ class SuccessCriteria:
 
             fom_name_glob = app_inst.expander.expand_var(self.fom_name)
 
-            for context in contexts:
-                fom_names = fnmatch.filter(fom_values[context].keys(), fom_name_glob)
+            for context_key in matching_keys:
+                fom_names = fnmatch.filter(fom_values[context_key].keys(), fom_name_glob)
 
                 for fom_name in fom_names:
                     comparison_vars = {
-                        "value": fom_values[context][fom_name]["value"],
+                        "value": fom_values[context_key][fom_name]["value"],
                     }
 
                     comparison_tested = True
-                    result = app_inst.expander.evaluate_predicate(
+                    result = result and app_inst.expander.evaluate_predicate(
                         self.fom_formula, extra_vars=comparison_vars
                     )
 

--- a/lib/ramble/ramble/test/success_criteria.py
+++ b/lib/ramble/ramble/test/success_criteria.py
@@ -89,3 +89,88 @@ def test_criteria_list(tmpdir):
     remark_all([criteria for criteria, _ in criteria_list.all_criteria()], log_path)
 
     assert not criteria_list.passed()
+
+
+def test_success_criteria_globbing():
+    from unittest.mock import MagicMock
+
+    # Mock application instance and its expander
+    app_inst = MagicMock()
+
+    def expand_var(var, extra_vars=None):
+        res = var
+        if extra_vars:
+            for k, v in extra_vars.items():
+                res = res.replace(f"{{{k}}}", str(v))
+        return res
+
+    app_inst.expander.expand_var.side_effect = expand_var
+
+    def evaluate_predicate(expr, extra_vars=None):
+        expanded = expand_var(expr, extra_vars)
+        # Handle simple > comparison for test
+        if " > " in expanded:
+            parts = expanded.split(" > ")
+            return float(parts[0]) > float(parts[1])
+        return True
+
+    app_inst.expander.evaluate_predicate.side_effect = evaluate_predicate
+
+    # Mock fom_values
+    fom_values = {
+        ("ctx-1", "null"): {
+            "Bandwidth": {"value": 150},
+            "Latency": {"value": 10},
+        },
+        ("ctx-2", "null"): {
+            "Bandwidth": {"value": 250},
+            "Latency": {"value": 5},
+        },
+        ("other-ctx", "null"): {
+            "Bandwidth": {"value": 50},
+        },
+    }
+
+    # Test globbing on context
+    crit1 = ramble.success_criteria.SuccessCriteria(
+        name="check_bw",
+        mode="fom_comparison",
+        fom_context="ctx-*",
+        fom_name="Bandwidth",
+        formula="{value} > 100",
+    )
+
+    # Both ctx-1 and ctx-2 have BW > 100
+    assert crit1.passed(app_inst=app_inst, fom_values=fom_values)
+
+    # Test globbing on FOM name
+    crit2 = ramble.success_criteria.SuccessCriteria(
+        name="check_all_ctx1",
+        mode="fom_comparison",
+        fom_context="ctx-1",
+        fom_name="*",
+        formula="{value} > 5",
+    )
+    # Both Bandwidth (150) and Latency (10) in ctx-1 are > 5
+    assert crit2.passed(app_inst=app_inst, fom_values=fom_values)
+
+    # Test failing globbing
+    crit3 = ramble.success_criteria.SuccessCriteria(
+        name="check_all_bw",
+        mode="fom_comparison",
+        fom_context="*",
+        fom_name="Bandwidth",
+        formula="{value} > 100",
+    )
+    # other-ctx has Bandwidth = 50, which is not > 100
+    assert not crit3.passed(app_inst=app_inst, fom_values=fom_values)
+
+    # Test no matches
+    crit4 = ramble.success_criteria.SuccessCriteria(
+        name="no_match",
+        mode="fom_comparison",
+        fom_context="non-existent",
+        fom_name="*",
+        formula="{value} > 0",
+    )
+    assert not crit4.passed(app_inst=app_inst, fom_values=fom_values)

--- a/lib/ramble/ramble/test/test_context_columns.py
+++ b/lib/ramble/ramble/test/test_context_columns.py
@@ -1,0 +1,587 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ramble.results_table import ResultsTable
+
+
+class TestContextColumns(unittest.TestCase):
+    def test_context_column_discovery(self):
+        conf_dict = {
+            "name": "table",
+            "columns": [{"name": "Static", "expression": "const"}],
+            "autocolumns": [
+                {"name": "Latency {bytes}", "context_name": "latency-*", "figure_of_merit": "Avg"}
+            ],
+        }
+        table = ResultsTable(conf_dict)
+
+        app_inst = MagicMock()
+        app_inst.expander.evaluate_predicate.return_value = True
+
+        # Mock expander.expand_var to handle {bytes} and others
+        def side_effect(var, extra_vars=None):
+            if extra_vars:
+                # Basic template expansion for test
+                res = var
+                for k, v in extra_vars.items():
+                    res = res.replace(f"{{{k}}}", str(v))
+                return res
+            return var
+
+        app_inst.expander.expand_var.side_effect = side_effect
+
+        app_inst.result.contexts = [
+            {
+                "name": "latency-1",
+                "context_def_name": "latency-bytes",
+                "context_vars": {"bytes": "1"},
+                "foms": [{"name": "Avg", "value": 1.0, "origin_type": "application"}],
+            },
+            {
+                "name": "latency-2",
+                "context_def_name": "latency-bytes",
+                "context_vars": {"bytes": "2"},
+                "foms": [{"name": "Avg", "value": 2.0, "origin_type": "application"}],
+            },
+        ]
+
+        # Test row extraction and discovery
+        table.extract_row(app_inst)
+
+        self.assertEqual(table._num_rows, 1)
+        self.assertIn("Static", table._data)
+        self.assertIn("Latency 1", table._data)
+        self.assertIn("Latency 2", table._data)
+        self.assertEqual(table._data["Latency 1"], [1.0])
+        self.assertEqual(table._data["Latency 2"], [2.0])
+
+    def test_context_column_fom_globbing(self):
+        conf_dict = {
+            "name": "table",
+            "autocolumns": [
+                {"name": "{fom_name} {size}", "context_name": "ctx", "figure_of_merit": "*"}
+            ],
+        }
+        table = ResultsTable(conf_dict)
+
+        app_inst = MagicMock()
+        app_inst.expander.evaluate_predicate.return_value = True
+
+        def side_effect(var, extra_vars=None):
+            if extra_vars:
+                res = var
+                for k, v in extra_vars.items():
+                    res = res.replace(f"{{{k}}}", str(v))
+                return res
+            return var
+
+        app_inst.expander.expand_var.side_effect = side_effect
+
+        app_inst.result.contexts = [
+            {
+                "name": "formatted-ctx",
+                "context_def_name": "ctx",
+                "context_vars": {"size": "large"},
+                "foms": [
+                    {"name": "FOM1", "value": 10, "origin_type": "application"},
+                    {"name": "FOM2", "value": 20, "origin_type": "application"},
+                ],
+            }
+        ]
+
+        table.extract_row(app_inst)
+
+        self.assertIn("FOM1 large", table._data)
+        self.assertIn("FOM2 large", table._data)
+        self.assertEqual(table._data["FOM1 large"], [10])
+        self.assertEqual(table._data["FOM2 large"], [20])
+
+    def test_context_column_ambiguous_names(self):
+        # Test that contexts with same name but different metadata are handled correctly
+        conf_dict = {
+            "name": "table",
+            "autocolumns": [{"name": "Col {val}", "context_name": "ctx*", "figure_of_merit": "F"}],
+        }
+        table = ResultsTable(conf_dict)
+
+        app_inst = MagicMock()
+        app_inst.expander.evaluate_predicate.return_value = True
+
+        def side_effect(var, extra_vars=None):
+            if extra_vars:
+                res = var
+                for k, v in extra_vars.items():
+                    res = res.replace(f"{{{k}}}", str(v))
+                return res
+            return var
+
+        app_inst.expander.expand_var.side_effect = side_effect
+
+        app_inst.result.contexts = [
+            {
+                "name": "Ctx",
+                "context_def_name": "ctx1",
+                "context_vars": {"val": "1"},
+                "foms": [{"name": "F", "value": 100, "origin_type": "application"}],
+            },
+            {
+                "name": "Ctx",
+                "context_def_name": "ctx2",
+                "context_vars": {"val": "2"},
+                "foms": [{"name": "F", "value": 200, "origin_type": "application"}],
+            },
+        ]
+
+        table.extract_row(app_inst)
+
+        self.assertIn("Col 1", table._data)
+        self.assertIn("Col 2", table._data)
+        self.assertEqual(table._data["Col 1"], [100])
+        self.assertEqual(table._data["Col 2"], [200])
+
+    def test_context_column_sorting(self):
+        conf_dict = {
+            "name": "table",
+            "autocolumns": [
+                {
+                    "name": "BW {size}",
+                    "context_name": "bw-*",
+                    "figure_of_merit": "Bandwidth",
+                    "sort_by": ["size"],
+                }
+            ],
+        }
+        table = ResultsTable(conf_dict)
+
+        app_inst = MagicMock()
+        app_inst.expander.evaluate_predicate.return_value = True
+
+        def side_effect(var, extra_vars=None):
+            if extra_vars:
+                res = var
+                for k, v in extra_vars.items():
+                    res = res.replace(f"{{{k}}}", str(v))
+                return res
+            return var
+
+        app_inst.expander.expand_var.side_effect = side_effect
+
+        # Add rows in non-sorted order
+        app_inst.result.contexts = [
+            {
+                "name": "bw-1024",
+                "context_def_name": "bw-bytes",
+                "context_vars": {"size": "1024"},
+                "foms": [{"name": "Bandwidth", "value": 1000, "origin_type": "application"}],
+            },
+            {
+                "name": "bw-64",
+                "context_def_name": "bw-bytes",
+                "context_vars": {"size": "64"},
+                "foms": [{"name": "Bandwidth", "value": 50, "origin_type": "application"}],
+            },
+            {
+                "name": "bw-256",
+                "context_def_name": "bw-bytes",
+                "context_vars": {"size": "256"},
+                "foms": [{"name": "Bandwidth", "value": 200, "origin_type": "application"}],
+            },
+        ]
+
+        table.extract_row(app_inst)
+
+        # Columns should be sorted by size: 64, 256, 1024
+        col_names = list(table._data.keys())
+        expected_order = ["BW 64", "BW 256", "BW 1024"]
+        self.assertEqual(col_names, expected_order)
+
+    def test_context_column_manual_conflict(self):
+        conf_dict = {
+            "name": "table",
+            "columns": [{"name": "Conflict", "expression": "ManualValue"}],
+            "autocolumns": [
+                {"name": "Conflict", "context_name": "ctx", "figure_of_merit": "FomValue"}
+            ],
+        }
+        table = ResultsTable(conf_dict)
+
+        app_inst = MagicMock()
+        app_inst.expander.evaluate_predicate.return_value = True
+
+        def side_effect(var, extra_vars=None):
+            if var == "ManualValue":
+                return "Manual"
+            if extra_vars:
+                res = var
+                for k, v in extra_vars.items():
+                    res = res.replace(f"{{{k}}}", str(v))
+                return res
+            return var
+
+        app_inst.expander.expand_var.side_effect = side_effect
+
+        app_inst.result.contexts = [
+            {
+                "name": "ctx",
+                "context_def_name": "ctx",
+                "context_vars": {},
+                "foms": [{"name": "FomValue", "value": 100, "origin_type": "application"}],
+            }
+        ]
+
+        table.extract_row(app_inst)
+
+        # Manual column should win
+        self.assertIn("Conflict", table._data)
+        self.assertEqual(table._data["Conflict"], ["Manual"])
+
+    def test_context_column_where_clause(self):
+        conf_dict = {
+            "name": "table",
+            "autocolumns": [
+                {
+                    "name": "Incl {val}",
+                    "context_name": "ctx",
+                    "figure_of_merit": "F",
+                    "where": ["{n_nodes} > 1"],
+                }
+            ],
+        }
+        table = ResultsTable(conf_dict)
+
+        app_inst = MagicMock()
+
+        def side_effect(var, extra_vars=None):
+            res = var.replace("{n_nodes}", "2")
+            if extra_vars:
+                for k, v in extra_vars.items():
+                    res = res.replace(f"{{{k}}}", str(v))
+            return res
+
+        app_inst.expander.expand_var.side_effect = side_effect
+
+        def eval_predicate(expr):
+            # Simple eval for testing
+            if ">" in expr:
+                # Expand before eval
+                expanded = app_inst.expander.expand_var(expr)
+                parts = expanded.split(">")
+                return float(parts[0].strip()) > float(parts[1].strip())
+            return True
+
+        app_inst.expander.evaluate_predicate.side_effect = eval_predicate
+
+        app_inst.result.contexts = [
+            {
+                "name": "ctx",
+                "context_def_name": "ctx",
+                "context_vars": {"val": "15"},
+                "foms": [{"name": "F", "value": 150, "origin_type": "application"}],
+            },
+        ]
+
+        table.extract_row(app_inst)
+
+        self.assertIn("Incl 15", table._data)
+        self.assertEqual(table._data["Incl 15"], [150])
+
+        # Test with where clause failing
+        conf_dict["autocolumns"][0]["where"] = ["{n_nodes} > 4"]
+        table2 = ResultsTable(conf_dict)
+        table2.extract_row(app_inst)
+        self.assertEqual(table2._data, {})
+
+    def test_context_column_mixed_sorting(self):
+        conf_dict = {
+            "name": "table",
+            "autocolumns": [
+                {
+                    "name": "{a}-{b}",
+                    "context_name": "ctx",
+                    "figure_of_merit": "F",
+                    "sort_by": ["a", "b"],
+                }
+            ],
+        }
+        table = ResultsTable(conf_dict)
+
+        app_inst = MagicMock()
+        app_inst.expander.evaluate_predicate.return_value = True
+
+        def side_effect(var, extra_vars=None):
+            if extra_vars:
+                res = var
+                for k, v in extra_vars.items():
+                    res = res.replace(f"{{{k}}}", str(v))
+                return res
+            return var
+
+        app_inst.expander.expand_var.side_effect = side_effect
+
+        app_inst.result.contexts = [
+            {
+                "name": "c1",
+                "context_def_name": "ctx",
+                "context_vars": {"a": "10", "b": "z"},
+                "foms": [{"name": "F", "value": 1, "origin_type": "app"}],
+            },
+            {
+                "name": "c2",
+                "context_def_name": "ctx",
+                "context_vars": {"a": "2", "b": "a"},
+                "foms": [{"name": "F", "value": 2, "origin_type": "app"}],
+            },
+            {
+                "name": "c3",
+                "context_def_name": "ctx",
+                "context_vars": {"a": "10", "b": "m"},
+                "foms": [{"name": "F", "value": 3, "origin_type": "app"}],
+            },
+            {
+                "name": "c4",
+                "context_def_name": "ctx",
+                "context_vars": {"a": "not-a-number", "b": "x"},
+                "foms": [{"name": "F", "value": 4, "origin_type": "app"}],
+            },
+        ]
+
+        table.extract_row(app_inst)
+
+        col_names = list(table._data.keys())
+        # Expected order:
+        # a=2, b=a (numeric 2)
+        # a=10, b=m (numeric 10)
+        # a=10, b=z (numeric 10)
+        # a=not-a-number, b=x (string)
+        expected_order = ["2-a", "10-m", "10-z", "not-a-number-x"]
+        self.assertEqual(col_names, expected_order)
+
+    def test_autocolumn_regex_groups(self):
+        conf_dict = {
+            "name": "table",
+            "autocolumns": [
+                {
+                    "name": "{fom_name} ({size})",
+                    "context_name": "ctx-(?P<size>.*)",
+                    "figure_of_merit": "(?P<fom_name>.*)",
+                }
+            ],
+        }
+        table = ResultsTable(conf_dict)
+
+        app_inst = MagicMock()
+        app_inst.expander.evaluate_predicate.return_value = True
+
+        def side_effect(var, extra_vars=None):
+            if extra_vars:
+                res = var
+                for k, v in extra_vars.items():
+                    res = res.replace(f"{{{k}}}", str(v))
+                return res
+            return var
+
+        app_inst.expander.expand_var.side_effect = side_effect
+
+        app_inst.result.contexts = [
+            {
+                "name": "ctx-small",
+                "context_def_name": "ctx-64",
+                "context_vars": {},
+                "foms": [{"name": "BW", "value": 100, "origin_type": "app"}],
+            }
+        ]
+
+        table.extract_row(app_inst)
+
+        self.assertIn("BW (64)", table._data)
+        self.assertEqual(table._data["BW (64)"], [100])
+
+    def test_autocolumn_null_context(self):
+        conf_dict = {
+            "name": "table",
+            "autocolumns": [{"name": "{fom_name}", "figure_of_merit": "*"}],
+        }
+        table = ResultsTable(conf_dict)
+
+        app_inst = MagicMock()
+        app_inst.expander.evaluate_predicate.return_value = True
+        app_inst.expander.expand_var.side_effect = lambda x, extra_vars=None: (
+            extra_vars["fom_name"] if extra_vars and "fom_name" in extra_vars else x
+        )
+
+        app_inst.result.contexts = [
+            {
+                "name": "null",
+                "context_def_name": None,
+                "context_vars": {},
+                "foms": [{"name": "GlobalFOM", "value": 500, "origin_type": "app"}],
+            }
+        ]
+
+        table.extract_row(app_inst)
+
+        self.assertIn("GlobalFOM", table._data)
+        self.assertEqual(table._data["GlobalFOM"], [500])
+
+    def test_autocolumn_origin_filter(self):
+        conf_dict = {
+            "name": "table",
+            "autocolumns": [
+                {
+                    "name": "{fom_name}",
+                    "context_name": "ctx",
+                    "figure_of_merit": "*",
+                    "figure_of_merit_origin_type": "application",
+                }
+            ],
+        }
+        table = ResultsTable(conf_dict)
+
+        app_inst = MagicMock()
+        app_inst.expander.evaluate_predicate.return_value = True
+        app_inst.expander.expand_var.side_effect = lambda x, extra_vars=None: (
+            extra_vars["fom_name"] if extra_vars and "fom_name" in extra_vars else x
+        )
+
+        app_inst.result.contexts = [
+            {
+                "name": "ctx",
+                "context_def_name": "ctx",
+                "context_vars": {},
+                "foms": [
+                    {"name": "AppFOM", "value": 1, "origin_type": "application"},
+                    {"name": "SysFOM", "value": 2, "origin_type": "system"},
+                ],
+            }
+        ]
+
+        table.extract_row(app_inst)
+
+        self.assertIn("AppFOM", table._data)
+        self.assertNotIn("SysFOM", table._data)
+
+    def test_autocolumn_context_name_variable(self):
+        conf_dict = {
+            "name": "table",
+            "autocolumns": [
+                {
+                    "name": "{context_name} - {fom_name}",
+                    "context_name": "ctx*",
+                    "figure_of_merit": "*",
+                }
+            ],
+        }
+        table = ResultsTable(conf_dict)
+
+        app_inst = MagicMock()
+        app_inst.expander.evaluate_predicate.return_value = True
+
+        def side_effect(var, extra_vars=None):
+            if extra_vars:
+                res = var
+                for k, v in extra_vars.items():
+                    res = res.replace(f"{{{k}}}", str(v))
+                return res
+            return var
+
+        app_inst.expander.expand_var.side_effect = side_effect
+
+        app_inst.result.contexts = [
+            {
+                "name": "ctx-A",
+                "context_def_name": "ctx1",
+                "context_vars": {},
+                "foms": [{"name": "F1", "value": 1, "origin_type": "app"}],
+            },
+            {
+                "name": "ctx-B",
+                "context_def_name": "ctx2",
+                "context_vars": {},
+                "foms": [{"name": "F2", "value": 2, "origin_type": "app"}],
+            },
+        ]
+
+        table.extract_row(app_inst)
+
+        self.assertIn("ctx-A - F1", table._data)
+        self.assertIn("ctx-B - F2", table._data)
+        self.assertEqual(table._data["ctx-A - F1"], [1])
+        self.assertEqual(table._data["ctx-B - F2"], [2])
+
+    def test_autocolumn_match_instance_name_regex(self):
+        conf_dict = {
+            "name": "table",
+            "autocolumns": [
+                {
+                    "name": "Step {num} FOM",
+                    "context_name": "Step (?P<num>[0-9]+)",
+                    "figure_of_merit": "F1",
+                }
+            ],
+        }
+        table = ResultsTable(conf_dict)
+
+        app_inst = MagicMock()
+        app_inst.expander.evaluate_predicate.return_value = True
+
+        def side_effect(var, extra_vars=None):
+            if extra_vars:
+                res = var
+                for k, v in extra_vars.items():
+                    res = res.replace(f"{{{k}}}", str(v))
+                return res
+            return var
+
+        app_inst.expander.expand_var.side_effect = side_effect
+
+        app_inst.result.contexts = [
+            {
+                "name": "Step 123",
+                "context_def_name": "step_context",
+                "context_vars": {},
+                "foms": [{"name": "F1", "value": 99, "origin_type": "app"}],
+            }
+        ]
+
+        table.extract_row(app_inst)
+
+        self.assertIn("Step 123 FOM", table._data)
+        self.assertEqual(table._data["Step 123 FOM"], [99])
+
+    def test_table_transpose(self):
+        conf_dict = {
+            "name": "table",
+            "transpose": True,
+            "columns": [{"name": "Col1", "expression": "Val1"}],
+        }
+        table = ResultsTable(conf_dict)
+
+        app_inst = MagicMock()
+        app_inst.expander.evaluate_predicate.return_value = True
+        app_inst.expander.expand_var.side_effect = lambda x, extra_vars=None: x
+
+        table.extract_row(app_inst)
+
+        # Mock pandas to verify transpose was called
+        with patch("ramble.results_table.import_pandas") as mock_import:
+            pd = MagicMock()
+            mock_import.return_value = pd
+            df = MagicMock()
+            pd.DataFrame.return_value = df
+            df.columns = ["Col1"]
+
+            table._to_dataframe()
+
+            df.transpose.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lib/ramble/ramble/test/util/naming.py
+++ b/lib/ramble/ramble/test/util/naming.py
@@ -91,3 +91,25 @@ def test_validate_fully_qualified_module_name(mod_name, expect_error):
             naming.validate_fully_qualified_module_name(mod_name)
     else:
         naming.validate_fully_qualified_module_name(mod_name)
+
+
+@pytest.mark.parametrize(
+    "pattern,string,expected_match,expected_groups",
+    [
+        (None, "anything", True, {}),
+        ("Step *", "Step 123", True, {}),  # Glob
+        ("Step (?P<num>[0-9]+)", "Step 123", True, {"num": "123"}),  # Regex
+        ("foo.bar", "fooxbar", True, {}),  # Regex (. matches x)
+        ("foo.bar", "foo.bar", True, {}),  # Glob matches literally
+        ("^start.*", "start_here", True, {}),  # Regex with anchor
+        ("Step [0-9]+", "Step 123", True, {}),  # Regex with []
+        ("a|b", "a", True, {}),  # Regex with |
+        ("a|b", "c", False, {}),  # Regex mismatch
+        ("*.txt", "file.txt", True, {}),  # Glob
+        ("*.txt", "file.py", False, {}),  # Glob mismatch
+    ],
+)
+def test_match_pattern(pattern, string, expected_match, expected_groups):
+    match, groups = naming.match_pattern(pattern, string)
+    assert match == expected_match
+    assert groups == expected_groups

--- a/lib/ramble/ramble/util/naming.py
+++ b/lib/ramble/ramble/util/naming.py
@@ -7,6 +7,7 @@
 # except according to those terms.
 
 # Need this because of ramble.util.string
+import fnmatch
 import io
 import itertools
 import re
@@ -23,6 +24,7 @@ __all__ = [
     "validate_module_name",
     "possible_ramble_module_names",
     "simplify_name",
+    "match_pattern",
     "NamespaceTrie",
     "NS_SEPARATOR",
 ]
@@ -267,3 +269,49 @@ class NamespaceTrie:
         stream = io.StringIO()
         self._str_helper(stream)
         return stream.getvalue()
+
+
+def match_pattern(pattern, string):
+    """Match a string against a pattern (regex or glob)
+
+    Args:
+        pattern (str): pattern to match against
+        string (str): string to match
+
+    Returns:
+        (tuple): (bool: matched, dict: captured groups)
+    """
+    if pattern is None:
+        return True, {}
+
+    # If the pattern contains characters that strongly suggest a regex,
+    # try regex matching first.
+    # Common regex-only characters: (, ), [, ], ^, $, |
+    # Note: * and ? are common to both. . is also common but more regex-y.
+    is_regex = any(c in pattern for c in "()[]^$|") or "(?P<" in pattern
+
+    if is_regex:
+        try:
+            regex = re.compile(pattern)
+            match = regex.fullmatch(string)
+            if match:
+                return True, match.groupdict()
+            return False, {}
+        except re.error:
+            pass
+
+    # Try globbing
+    if fnmatch.fnmatch(string, pattern):
+        return True, {}
+
+    # Final attempt: try as regex even if it didn't look like one
+    if not is_regex:
+        try:
+            regex = re.compile(pattern)
+            match = regex.fullmatch(string)
+            if match:
+                return True, match.groupdict()
+        except re.error:
+            pass
+
+    return False, {}

--- a/table_context_columns.md
+++ b/table_context_columns.md
@@ -1,0 +1,128 @@
+# Design Document: Auto-generated Columns in Results Tables
+
+## Overview
+Results tables in Ramble provide a way to aggregate figures of merit (FOMs) across multiple experiments into a tabular format (e.g., CSV). Previously, columns had to be explicitly defined, which made it difficult to handle applications that produce a variable number of FOMs or FOMs within many dynamically named contexts.
+
+This feature introduces `autocolumns`, which allow results tables to define a template for columns that are generated dynamically based on the contexts found in an experiment's results.
+
+## Motivation
+Many HPC applications produce performance data in a structured way where the same metric is reported across different "contexts" (e.g., different message sizes, different iterations, or different components). 
+
+For example, a bandwidth test might report "Bandwidth" for several message sizes:
+- Context: `size=64`, FOM: `Bandwidth`
+- Context: `size=1024`, FOM: `Bandwidth`
+
+Defining a table with columns for each size would require knowing all sizes in advance and explicitly listing them in the configuration. `autocolumns` allow a single template to discover all such contexts and create corresponding columns.
+
+## Design
+
+### Configuration Schema
+The `tables` section of a Ramble configuration now supports an `autocolumns` list alongside the existing `columns` list. Tables also support a `transpose` option.
+
+```yaml
+tables:
+  - name: my_table
+    transpose: true
+    autocolumns:
+      - name: '{fom_name}'
+        figure_of_merit: '(?P<fom_name>.*)'
+        context_name: 'bw-*'
+        sort_by: ['size']
+        where: ['{n_nodes} > 1']
+```
+
+#### Fields:
+- `name` (required): A template for the column name. It can include variables from the context (e.g., `{size}`), `{fom_name}`, `{context_name}` (the name of the specific context instance), and any named groups from regular expression matching in `context_name` or `figure_of_merit`.
+- `context_name` (optional): A glob pattern or regular expression to match the `context_def_name` (the type of context) or the `name` (the specific instance name) of a context. If omitted, it matches the "null" context (FOMs without a context).
+- `figure_of_merit` (required): A glob pattern or regular expression to match the name of a FOM within a matched context.
+- `figure_of_merit_origin_type` (optional): Filter FOMs by their origin type (e.g., `application`).
+- `sort_by` (optional): A list of context variables to sort the generated columns by.
+- `where` (optional): A list of predicates that must evaluate to true for the column to be generated for a given experiment.
+
+Tables also support:
+- `transpose` (optional): If set to `true`, the table will be transposed before being written out.
+
+### Implementation Details
+
+#### Discovery Phase
+When extracting a row for a table (`ResultsTable.extract_row`), Ramble now performs a discovery phase for each `autocolumn` template:
+1. Iterate over all `autocolumns` in the table definition.
+2. Evaluate any `where` clauses against the current experiment.
+3. Iterate over all contexts reported in the application results, including the "null" context if `context_name` is omitted.
+4. Match the context's definition name against the template's `context_name` using globbing or regular expressions.
+5. If a match is found, iterate over all FOMs in that context.
+6. Match the FOM name against the template's `figure_of_merit` using globbing or regular expressions.
+7. For each match, generate a unique column name by expanding the `name` template with:
+    - Variables from the context.
+    - The `{fom_name}`.
+    - Any named groups captured by regular expressions in `context_name` or `figure_of_merit`.
+8. Create a new `ResultsColumn` object for this specific column if it hasn't been created already.
+
+#### Column Ordering and Sorting
+The order of columns in the resulting table is determined by:
+1. Explicitly defined `columns`.
+2. Generated `autocolumns`.
+
+Within a set of columns generated from the same template, the `sort_by` field determines their relative order. The sorting logic attempts to convert context variables to floats for numeric sorting, falling back to string sorting if conversion fails. This ensures that columns like "BW 64", "BW 256", and "BW 1024" appear in the expected numeric order.
+
+#### Conflicts
+If a generated column name conflicts with an explicitly defined column name, the explicitly defined column takes precedence.
+
+## Examples
+
+### Generating columns for different message sizes
+```yaml
+tables:
+  - name: bandwidth_summary
+    autocolumns:
+      - name: 'Latency {bytes}'
+        context_name: 'latency-bytes'
+        figure_of_merit: 'Avg'
+        sort_by: ['bytes']
+```
+If the results contain contexts named `latency-bytes` with variables `bytes=64` and `bytes=1024`, this will produce columns "Latency 64" and "Latency 1024".
+
+### Using regular expressions for multiple FOMs and named groups
+```yaml
+tables:
+  - name: all_metrics
+    autocolumns:
+      - name: '{fom_name} ({size})'
+        context_name: 'ctx-(?P<size>.*)'
+        figure_of_merit: '(?P<fom_name>.*)'
+```
+This will match any context starting with `ctx-`, capture the rest of the name into `{size}`, and match any FOM, capturing its name into `{fom_name}`.
+
+### Matching FOMs in the null context
+```yaml
+tables:
+  - name: base_metrics
+    autocolumns:
+      - name: '{fom_name}'
+        figure_of_merit: '*'
+```
+By omitting `context_name`, this template will match all FOMs that are not within any specific context.
+
+### Extracting all FOMs from all contexts
+```yaml
+tables:
+  - name: all_results
+    autocolumns:
+      - name: '{context_name} - {fom_name}'
+        context_name: '*'
+        figure_of_merit: '*'
+```
+This will generate a column for every single figure of merit in every single context found in the results.
+
+## Related Changes: Success Criteria Globbing
+In addition to tables, `success_criteria` of mode `fom_comparison` have been updated to support globbing for both `fom_context` and `fom_name`. This allows a single success criterion to be applied across multiple contexts or multiple FOMs.
+
+```yaml
+success_criteria:
+  - name: my_check
+    mode: fom_comparison
+    fom_context: 'bw-*'
+    fom_name: 'Bandwidth'
+    formula: '{value} > 100'
+```
+This criterion will pass only if *all* matched FOMs satisfy the formula.

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -2532,11 +2532,24 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         application specific processing of the output.
         """
 
-    def extract_inmem_foms(self, inmem_fom_defs, fom_values):
+    def extract_inmem_foms(
+        self, inmem_fom_defs, fom_values, context_metadata=None
+    ):
         """Extract in-memory FOMs"""
         for context, foms in inmem_fom_defs.items():
-            if context not in fom_values:
-                fom_values[context] = {}
+            context_key = context
+            if context_metadata is not None:
+                if isinstance(context, str):
+                    context_key = (context, context, frozenset())
+                    if context_key not in context_metadata:
+                        context_metadata[context_key] = {
+                            "name": context,
+                            "def_name": context,
+                            "vars": {},
+                        }
+
+            if context_key not in fom_values:
+                fom_values[context_key] = {}
             foms = inmem_fom_defs[context]["foms"]
             for fom in foms:
                 fom_conf = inmem_fom_defs[context]["foms"][fom]
@@ -2552,7 +2565,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                 if fom_value is None:
                     continue
                 expanded_fom_value = self.expander.expand_var(fom_value)
-                fom_values[context][fom_name] = {
+                fom_values[context_key][fom_name] = {
                     "value": expanded_fom_value,
                     "units": fom_conf["units_expanded"],
                     "origin": fom_conf["origin"],
@@ -2622,6 +2635,14 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         exp_lock = self.experiment_lock
 
         fom_values = {}
+        context_metadata = {}
+        null_key = (_NULL_CONTEXT, _NULL_CONTEXT, frozenset())
+        context_metadata[null_key] = {
+            "name": _NULL_CONTEXT,
+            "def_name": _NULL_CONTEXT,
+            "vars": {},
+        }
+
         # Iterate over files. We already know they exist
         with lk.ReadTransaction(exp_lock):
             for file, file_conf in files.items():
@@ -2677,10 +2698,22 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                                         f" Context match {context} -- {context_name}"
                                     )
 
-                                    active_contexts[context] = context_name
+                                    context_vars = context_match.groupdict()
+                                    context_key = (
+                                        context_name,
+                                        context,
+                                        frozenset(context_vars.items()),
+                                    )
 
-                                    if context_name not in fom_values:
-                                        fom_values[context_name] = {}
+                                    active_contexts[context] = context_key
+
+                                    if context_key not in fom_values:
+                                        fom_values[context_key] = {}
+                                        context_metadata[context_key] = {
+                                            "name": context_name,
+                                            "def_name": context,
+                                            "vars": context_vars,
+                                        }
 
                             for fom in foms:
                                 fom_conf = f_defs[context]["foms"][fom]
@@ -2719,16 +2752,17 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                                         # if a FOM has contexts, check if each is active
                                         if fom_conf["contexts"]:
                                             for _ in fom_conf["contexts"]:
-                                                context_name = (
-                                                    active_contexts.get(
-                                                        context, _NULL_CONTEXT
-                                                    )
+                                                context_key = (
+                                                    active_contexts[context]
+                                                    if context
+                                                    in active_contexts
+                                                    else null_key
                                                 )
                                                 fom_contexts.append(
-                                                    context_name
+                                                    context_key
                                                 )
                                         else:
-                                            fom_contexts.append(_NULL_CONTEXT)
+                                            fom_contexts.append(null_key)
 
                                         for fom_context in fom_contexts:
                                             if fom_context not in fom_values:
@@ -2763,7 +2797,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                                                     "fom_type"
                                                 ],
                                             }
-        self.extract_inmem_foms(inmem_defs, fom_values)
+        self.extract_inmem_foms(inmem_defs, fom_values, context_metadata)
 
         # Test all non-file based success criteria
         for criteria_obj, _ in criteria_list.all_criteria():
@@ -2800,7 +2834,6 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                 status = wm_status
 
         self.set_status(status)
-
         self.result.finalize(workspace)
 
         for criteria_obj, criteria_scope in criteria_list.all_criteria():
@@ -2817,11 +2850,14 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             else:
                 self.result.success_criteria[criteria_name] = "FAILED"
 
-        for context, fom_map in fom_values.items():
+        for context_key, fom_map in fom_values.items():
+            metadata = context_metadata[context_key]
             context_map = {
-                "name": context,
+                "name": metadata["name"],
                 "foms": [],
-                "display_name": _get_context_display_name(context),
+                "display_name": _get_context_display_name(metadata["name"]),
+                "context_def_name": metadata["def_name"],
+                "context_vars": metadata["vars"],
             }
 
             for fom_name, fom in fom_map.items():
@@ -2829,7 +2865,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                 fom_copy["name"] = fom_name
                 context_map["foms"].append(fom_copy)
 
-            if context == _NULL_CONTEXT:
+            if metadata["name"] == _NULL_CONTEXT:
                 self.result.contexts.insert(0, context_map)
             else:
                 self.result.contexts.append(context_map)


### PR DESCRIPTION
This merge enables the ability for results tables to define a mapping from a figure of merit context to a column name. Columns are then generated based on the context definition, allowing figures of merit to map to the context they were extracted from.