### PR TITLE
Fix up some ruff reported issues

### DIFF
--- a/lib/ramble/ramble/cmd/clean.py
+++ b/lib/ramble/ramble/cmd/clean.py
@@ -11,7 +11,7 @@ import argparse
 import os
 import shutil
 
-import llnl.util.tty as tty
+from llnl.util import tty
 
 import ramble.caches
 import ramble.reports

--- a/lib/ramble/ramble/cmd/commands.py
+++ b/lib/ramble/ramble/cmd/commands.py
@@ -205,7 +205,7 @@ def rst_index(out):
     sections = index["long"]
 
     dmax = max(len(section_descriptions.get(s, s)) for s in sections) + 2
-    cmax = max(len(c) for _, c in sections.items()) + 60
+    cmax = max(len(c) for c in sections.values()) + 60
 
     row = f"{'=' * dmax}  {'=' * cmax}\n"
     line = "%%-%ds  %%s\n" % dmax

--- a/lib/ramble/ramble/cmd/common/info.py
+++ b/lib/ramble/ramble/cmd/common/info.py
@@ -11,9 +11,9 @@ import fnmatch
 
 from llnl.util.tty.colify import colified
 
-import ramble.cmd.common.arguments as arguments
 import ramble.repository
 import ramble.util.colors as color
+from ramble.cmd.common import arguments
 from ramble.definitions.variables import Variable
 from ramble.util.logger import logger
 

--- a/lib/ramble/ramble/cmd/common/list.py
+++ b/lib/ramble/ramble/cmd/common/list.py
@@ -14,8 +14,8 @@ import sys
 
 from llnl.util.tty.colify import colify
 
-import ramble.cmd.common.arguments as arguments
 import ramble.repository
+from ramble.cmd.common import arguments
 from ramble.util import object_utils
 from ramble.util.logger import logger
 

--- a/lib/ramble/ramble/cmd/config.py
+++ b/lib/ramble/ramble/cmd/config.py
@@ -12,7 +12,7 @@ import shutil
 from typing import List
 
 import llnl.util.filesystem as fs
-import llnl.util.tty as tty
+from llnl.util import tty
 
 import ramble.cmd.common.arguments
 import ramble.config

--- a/lib/ramble/ramble/cmd/data.py
+++ b/lib/ramble/ramble/cmd/data.py
@@ -17,7 +17,6 @@ subcommands = [
 
 def data_create_db_setup_parser(subparser):
     """create the database"""
-    pass
 
 
 def data_create_db(args):

--- a/lib/ramble/ramble/cmd/deployment.py
+++ b/lib/ramble/ramble/cmd/deployment.py
@@ -11,7 +11,6 @@ import os
 import llnl.util.filesystem as fs
 
 import ramble.cmd
-import ramble.cmd.common.arguments as arguments
 import ramble.config
 import ramble.fetch_strategy
 import ramble.filters
@@ -19,6 +18,7 @@ import ramble.pipeline
 import ramble.repository
 import ramble.stage
 import ramble.util.path
+from ramble.cmd.common import arguments
 from ramble.main import RambleCommand
 from ramble.util.logger import logger
 

--- a/lib/ramble/ramble/cmd/mirror.py
+++ b/lib/ramble/ramble/cmd/mirror.py
@@ -5,9 +5,9 @@
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
-import ramble.cmd.common.arguments as arguments
 import ramble.config
 import ramble.mirror
+from ramble.cmd.common import arguments
 from ramble.util.logger import logger
 
 import spack.util.url as url_util

--- a/lib/ramble/ramble/cmd/on.py
+++ b/lib/ramble/ramble/cmd/on.py
@@ -6,10 +6,10 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-import ramble.cmd.common.arguments as arguments
 import ramble.config
 import ramble.filters
 import ramble.pipeline
+from ramble.cmd.common import arguments
 
 description = '"And now\'s the time, the time is now" (execute workspace experiments)'
 section = "workspaces"

--- a/lib/ramble/ramble/cmd/python.py
+++ b/lib/ramble/ramble/cmd/python.py
@@ -13,7 +13,7 @@ import platform
 import runpy
 import sys
 
-import llnl.util.tty as tty
+from llnl.util import tty
 
 import ramble
 

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -14,11 +14,10 @@ import tempfile
 from collections import defaultdict
 from typing import Callable, Dict
 
-import llnl.util.tty as tty
+from llnl.util import tty
 from llnl.util.tty.colify import colified, colify
 
 import ramble.cmd
-import ramble.cmd.common.arguments as arguments
 import ramble.config
 import ramble.expander
 import ramble.filters
@@ -27,11 +26,12 @@ import ramble.software_environments
 import ramble.util.colors as color
 import ramble.workspace
 import ramble.workspace.shell
+from ramble.cmd.common import arguments
 from ramble.namespace import namespace
 from ramble.util.logger import logger
 
 import spack.util.environment
-import spack.util.string as string
+from spack.util import string
 from spack.util.editor import editor
 
 description = "manage experiment workspaces"
@@ -991,7 +991,6 @@ def workspace_info(args):
 
 def workspace_list_setup_parser(subparser):
     """list available workspaces"""
-    pass
 
 
 def workspace_list(args):

--- a/lib/ramble/ramble/config.py
+++ b/lib/ramble/ramble/config.py
@@ -42,7 +42,7 @@ import sys
 from contextlib import contextmanager
 from typing import Any, Dict, List
 
-import ruamel.yaml as yaml
+from ruamel import yaml
 from ruamel.yaml.error import MarkedYAMLError
 
 import llnl.util.lang
@@ -1230,7 +1230,7 @@ def default_list_scope():
 
     Commands that list configuration list *all* scopes (merged) by default.
     """
-    return None
+    return
 
 
 def _update_in_memory(data, section):

--- a/lib/ramble/ramble/definitions/versions.py
+++ b/lib/ramble/ramble/definitions/versions.py
@@ -108,7 +108,6 @@ class ObjectVersion:
     def evaluate_conflicts(self, variant):
         """Error if this version conflicts with a variant that is used"""
         # TODO(dapomeroy): Implement logic to allow conflicts to be defined
-        pass
 
     def satisfies(self, variant):
         """Determine if an experiment's variant satisfies this version

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -365,7 +365,7 @@ class ExperimentSet:
         # TODO: Exploit the relationship between base and repeated experiments,
         # to save up redundant works.
         # For instance, caching may be enabled for expanders across these experiments.
-        for n in range(0, repeats.n_repeats + 1):
+        for n in range(repeats.n_repeats + 1):
             cur_repeats = ramble.repeats.Repeats()
             if repeats.is_repeat_base:
                 if n == 0:
@@ -655,7 +655,6 @@ class ExperimentSet:
                         raise RambleVariableDefinitionError(
                             f"In experiment {final_exp_namespace}: {e}"
                         ) from None
-                    pass
 
             workload_names.add(app_inst.expander.workload_name)
 

--- a/lib/ramble/ramble/fetch_strategy.py
+++ b/lib/ramble/ramble/fetch_strategy.py
@@ -36,7 +36,7 @@ import sys
 import urllib.parse
 from typing import List, Optional
 
-import llnl.util.tty as tty
+from llnl.util import tty
 from llnl.util.filesystem import (
     get_single_file,
     mkdirp,
@@ -50,10 +50,9 @@ import ramble.config
 import ramble.util.web as web_util
 from ramble.util.logger import logger
 
-import spack.util.crypto as crypto
-import spack.util.pattern as pattern
 import spack.util.url as url_util
 import spack.version
+from spack.util import crypto, pattern
 from spack.util.compression import decompressor_for, extension
 from spack.util.executable import CommandNotFoundError, which
 from spack.version import ver

--- a/lib/ramble/ramble/language/language_helpers.py
+++ b/lib/ramble/ramble/language/language_helpers.py
@@ -223,7 +223,7 @@ def expand_patterns(merged_types: list, multiple_pattern_match: Union[list, dict
             and isinstance(multiple_pattern_match, dict)
             and isinstance(next(iter(multiple_pattern_match)), frozenset)
         ):
-            for _, pattern_list in multiple_pattern_match.items():
+            for pattern_list in multiple_pattern_match.values():
                 matched_inputs = fnmatch.filter(pattern_list, input)
                 if matched_inputs:
                     expanded = True

--- a/lib/ramble/ramble/main.py
+++ b/lib/ramble/ramble/main.py
@@ -28,8 +28,8 @@ import jsonschema
 import ruamel
 
 import llnl.util.lang
-import llnl.util.tty as tty
 import llnl.util.tty.colify
+from llnl.util import tty
 from llnl.util.tty.log import log_output
 
 import ramble.cmd
@@ -713,7 +713,7 @@ class RambleCommand:
         self.returncode = None
         self.error = None
 
-        prepend = kwargs["global_args"] if "global_args" in kwargs else []
+        prepend = kwargs.get("global_args", [])
 
         args, unknown = self.parser.parse_known_args(prepend + [self.command_name] + list(argv))
 

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -17,7 +17,7 @@ from enum import Enum
 import py.path
 
 import llnl.util.filesystem as fs
-import llnl.util.tty as tty
+from llnl.util import tty
 
 import ramble.config
 import ramble.expander

--- a/lib/ramble/ramble/renderer.py
+++ b/lib/ramble/ramble/renderer.py
@@ -260,7 +260,7 @@ class Renderer:
 
             elif var in defined_zips:
                 zip_len = defined_zips[var]["length"]
-                idx_vector = list(range(0, zip_len))
+                idx_vector = list(range(zip_len))
 
                 matrix_size = matrix_size * zip_len
                 vectors.append(idx_vector)
@@ -402,7 +402,7 @@ class Renderer:
 
             # Iterate over the vector length, and set the value in the
             # object dict to the index value.
-            for i in range(0, max_vector_size):
+            for i in range(max_vector_size):
                 obj_vars = {}
                 for var, val in vector_vars.items():
                     if len(val) > i:

--- a/lib/ramble/ramble/repository.py
+++ b/lib/ramble/ramble/repository.py
@@ -24,7 +24,7 @@ import types
 from enum import Enum
 from typing import Mapping
 
-import ruamel.yaml as yaml
+from ruamel import yaml
 
 import llnl.util.filesystem as fs
 import llnl.util.lang

--- a/lib/ramble/ramble/stage.py
+++ b/lib/ramble/ramble/stage.py
@@ -33,8 +33,8 @@ from ramble.util.logger import logger
 
 import spack.config
 import spack.util.path as sup
-import spack.util.pattern as pattern
 import spack.util.url as url_util
+from spack.util import pattern
 from spack.util.crypto import bit_length, prefix_bits
 
 # The well-known stage source subdirectory name.

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -1520,7 +1520,7 @@ licenses:
 
     # Create more templates, and test files to archive
     new_templates = []
-    for i in range(0, 5):
+    for i in range(5):
         new_template = os.path.join(ws1.config_dir, f"test_template.{i}")
         new_templates.append(new_template)
         f = open(new_template, "w+")
@@ -1541,7 +1541,7 @@ licenses:
 
     # Create files that match archive pattern
     new_files = []
-    for i in range(0, 5):
+    for i in range(5):
         new_name = f"archive_test.{i}"
         new_file = os.path.join(experiment_dir, new_name)
 
@@ -1564,7 +1564,7 @@ licenses:
         assert os.path.exists(archived_path)
 
     # Check for archive pattern files
-    for i in range(0, 5):
+    for i in range(5):
         archived_path = os.path.join(ws1.latest_archive_path, f"test_pattern.{i}")
         assert os.path.isfile(archived_path)
         with open(archived_path) as f:
@@ -1623,7 +1623,7 @@ licenses:
 
     # Create more templates
     new_templates = []
-    for i in range(0, 5):
+    for i in range(5):
         new_template = os.path.join(ws1.config_dir, f"test_template.{i}")
         new_templates.append(new_template)
         f = open(new_template, "w+")
@@ -1677,7 +1677,7 @@ ramble:
 
     # Create more temlates
     new_templates = []
-    for i in range(0, 5):
+    for i in range(5):
         new_template = os.path.join(ws1.config_dir, f"test_template.{i}")
         new_templates.append(new_template)
         f = open(new_template, "w+")
@@ -1694,7 +1694,7 @@ ramble:
 
     # Create files that match archive pattern
     new_files = []
-    for i in range(0, 5):
+    for i in range(5):
         new_name = f"archive_test.{i}"
         new_file = os.path.join(experiment_dir, new_name)
 
@@ -1750,7 +1750,7 @@ ramble:
 
     # Create more templates
     new_templates = []
-    for i in range(0, 5):
+    for i in range(5):
         new_template = os.path.join(ws1.config_dir, f"test_template.{i}")
         new_templates.append(new_template)
         f = open(new_template, "w+")
@@ -1767,7 +1767,7 @@ ramble:
 
     # Create files that match archive pattern
     new_files = []
-    for i in range(0, 5):
+    for i in range(5):
         new_name = f"archive_test.{i}"
         new_file = os.path.join(experiment_dir, new_name)
 
@@ -1829,7 +1829,7 @@ ramble:
 
     # Create more templates
     new_templates = []
-    for i in range(0, 5):
+    for i in range(5):
         new_template = os.path.join(ws1.config_dir, f"test_template.{i}")
         new_templates.append(new_template)
         f = open(new_template, "w+")
@@ -1846,7 +1846,7 @@ ramble:
 
     # Create files that match archive pattern
     new_files = []
-    for i in range(0, 5):
+    for i in range(5):
         new_name = f"archive_test.{i}"
         new_file = os.path.join(experiment_dir, new_name)
 
@@ -2285,7 +2285,7 @@ software:
 def write_variables_config_file(file_path, levels, value):
     with open(file_path, "w+") as f:
         f.write("variables:\n")
-        for i in range(0, levels):
+        for i in range(levels):
             f.write(f"  scope{i}: {value}\n")
 
 

--- a/lib/ramble/ramble/test/end_to_end/analyze_fom_output.py
+++ b/lib/ramble/ramble/test/end_to_end/analyze_fom_output.py
@@ -11,7 +11,7 @@ import os
 
 import pytest
 
-import llnl.util.tty as tty
+from llnl.util import tty
 
 import ramble.workspace
 from ramble.main import RambleCommand

--- a/lib/ramble/ramble/test/expander.py
+++ b/lib/ramble/ramble/test/expander.py
@@ -174,7 +174,7 @@ def test_expansions(input, output, no_expand_vars, passes):
     expander = ramble.expander.Expander(expansion_vars, None, no_expand_vars=no_expand_vars)
 
     step_input = input
-    for _ in range(0, passes):
+    for _ in range(passes):
         step_input = expander.expand_var(step_input)
     final_output = step_input
 
@@ -236,7 +236,7 @@ def test_typed_expansions(input, output, no_expand_vars, passes):
     expander = ramble.expander.Expander(expansion_vars, None, no_expand_vars=no_expand_vars)
 
     step_input = input
-    for _ in range(0, passes):
+    for _ in range(passes):
         step_input = expander.expand_var(step_input, typed=True)
     final_output = step_input
 

--- a/lib/ramble/ramble/test/modifier_functionality/mock_env_var_modifiers.py
+++ b/lib/ramble/ramble/test/modifier_functionality/mock_env_var_modifiers.py
@@ -10,10 +10,10 @@ import os
 
 import pytest
 
-import ramble.test.modifier_functionality.modifier_helpers as modifier_helpers
 import ramble.workspace
 from ramble.main import RambleCommand
 from ramble.test.dry_run_helpers import SCOPES, dry_run_config
+from ramble.test.modifier_functionality import modifier_helpers
 
 workspace = RambleCommand("workspace")
 

--- a/lib/ramble/ramble/test/modifier_functionality/mock_layered_modifications.py
+++ b/lib/ramble/ramble/test/modifier_functionality/mock_layered_modifications.py
@@ -8,10 +8,10 @@
 
 import os
 
-import ramble.test.modifier_functionality.modifier_helpers as modifier_helpers
 import ramble.workspace
 from ramble.main import RambleCommand
 from ramble.test.dry_run_helpers import SCOPES, dry_run_config
+from ramble.test.modifier_functionality import modifier_helpers
 
 workspace = RambleCommand("workspace")
 

--- a/lib/ramble/ramble/test/modifier_functionality/mock_modifier_dry_run.py
+++ b/lib/ramble/ramble/test/modifier_functionality/mock_modifier_dry_run.py
@@ -10,11 +10,11 @@ import os
 
 import pytest
 
-import ramble.test.modifier_functionality.modifier_helpers as modifier_helpers
 import ramble.workspace
 from ramble.error import DirectiveError, InvalidModeError
 from ramble.main import RambleCommand
 from ramble.test.dry_run_helpers import SCOPES, dry_run_config
+from ramble.test.modifier_functionality import modifier_helpers
 
 workspace = RambleCommand("workspace")
 

--- a/lib/ramble/ramble/test/modifier_functionality/mock_modifier_phases.py
+++ b/lib/ramble/ramble/test/modifier_functionality/mock_modifier_phases.py
@@ -12,10 +12,10 @@ import re
 
 import pytest
 
-import ramble.test.modifier_functionality.modifier_helpers as modifier_helpers
 import ramble.workspace
 from ramble.main import RambleCommand
 from ramble.test.dry_run_helpers import SCOPES, dry_run_config, search_files_for_string
+from ramble.test.modifier_functionality import modifier_helpers
 
 workspace = RambleCommand("workspace")
 

--- a/lib/ramble/ramble/test/modifier_functionality/mock_modifier_spack_configs.py
+++ b/lib/ramble/ramble/test/modifier_functionality/mock_modifier_spack_configs.py
@@ -10,10 +10,10 @@ import os
 
 import pytest
 
-import ramble.test.modifier_functionality.modifier_helpers as modifier_helpers
 import ramble.workspace
 from ramble.main import RambleCommand
 from ramble.test.dry_run_helpers import SCOPES, dry_run_config
+from ramble.test.modifier_functionality import modifier_helpers
 
 workspace = RambleCommand("workspace")
 

--- a/lib/ramble/ramble/test/modifier_functionality/mock_repeated_modifications.py
+++ b/lib/ramble/ramble/test/modifier_functionality/mock_repeated_modifications.py
@@ -8,10 +8,10 @@
 
 import os
 
-import ramble.test.modifier_functionality.modifier_helpers as modifier_helpers
 import ramble.workspace
 from ramble.main import RambleCommand
 from ramble.test.dry_run_helpers import SCOPES, dry_run_config
+from ramble.test.modifier_functionality import modifier_helpers
 
 workspace = RambleCommand("workspace")
 

--- a/lib/ramble/ramble/test/modifier_functionality/mock_spack_modifier.py
+++ b/lib/ramble/ramble/test/modifier_functionality/mock_spack_modifier.py
@@ -11,10 +11,10 @@ import os
 
 import pytest
 
-import ramble.test.modifier_functionality.modifier_helpers as modifier_helpers
 import ramble.workspace
 from ramble.main import RambleCommand
 from ramble.test.dry_run_helpers import SCOPES, dry_run_config, search_files_for_string
+from ramble.test.modifier_functionality import modifier_helpers
 
 workspace = RambleCommand("workspace")
 

--- a/lib/ramble/ramble/test/modifier_functionality/modifier_conflicts.py
+++ b/lib/ramble/ramble/test/modifier_functionality/modifier_conflicts.py
@@ -36,7 +36,7 @@ def test_name_modifier_conflict(mutable_mock_workspace_path, mock_modifiers, wor
 
     define_experiments(global_args)
 
-    for _ in range(0, 2):
+    for _ in range(2):
         workspace(
             "manage",
             "modifiers",
@@ -59,7 +59,7 @@ def test_name_mode_modifier_conflict(mutable_mock_workspace_path, mock_modifiers
 
     define_experiments(global_args)
 
-    for _ in range(0, 2):
+    for _ in range(2):
         workspace(
             "manage",
             "modifiers",
@@ -84,7 +84,7 @@ def test_name_executables_modifier_conflict(
 
     define_experiments(global_args)
 
-    for _ in range(0, 2):
+    for _ in range(2):
         workspace(
             "manage",
             "modifiers",
@@ -111,7 +111,7 @@ def test_name_mode_executables_modifier_conflict(
 
     define_experiments(global_args)
 
-    for _ in range(0, 2):
+    for _ in range(2):
         workspace(
             "manage",
             "modifiers",

--- a/lib/ramble/ramble/test/modifier_functionality/modifier_prepare_analysis.py
+++ b/lib/ramble/ramble/test/modifier_functionality/modifier_prepare_analysis.py
@@ -11,10 +11,10 @@ import re
 
 import pytest
 
-import ramble.test.modifier_functionality.modifier_helpers as modifier_helpers
 import ramble.workspace
 from ramble.main import RambleCommand
 from ramble.test.dry_run_helpers import SCOPES, dry_run_config
+from ramble.test.modifier_functionality import modifier_helpers
 
 config = RambleCommand("config")
 workspace = RambleCommand("workspace")

--- a/lib/ramble/ramble/test/modifier_functionality/multi_modifier_dry_run.py
+++ b/lib/ramble/ramble/test/modifier_functionality/multi_modifier_dry_run.py
@@ -10,10 +10,10 @@ import os
 
 import pytest
 
-import ramble.test.modifier_functionality.modifier_helpers as modifier_helpers
 import ramble.workspace
 from ramble.main import RambleCommand
 from ramble.test.dry_run_helpers import SCOPES, dry_run_config
+from ramble.test.modifier_functionality import modifier_helpers
 
 workspace = RambleCommand("workspace")
 

--- a/lib/ramble/ramble/test/modifier_functionality/single_modifier_dry_run.py
+++ b/lib/ramble/ramble/test/modifier_functionality/single_modifier_dry_run.py
@@ -10,10 +10,10 @@ import os
 
 import pytest
 
-import ramble.test.modifier_functionality.modifier_helpers as modifier_helpers
 import ramble.workspace
 from ramble.main import RambleCommand
 from ramble.test.dry_run_helpers import SCOPES, dry_run_config
+from ramble.test.modifier_functionality import modifier_helpers
 
 workspace = RambleCommand("workspace")
 

--- a/lib/ramble/ramble/test/util/yaml_generation.py
+++ b/lib/ramble/ramble/test/util/yaml_generation.py
@@ -7,7 +7,7 @@
 # except according to those terms.
 
 import pytest
-import ruamel.yaml as yaml
+from ruamel import yaml
 
 import ramble.expander
 import ramble.util.yaml_generation

--- a/lib/ramble/ramble/uploader.py
+++ b/lib/ramble/ramble/uploader.py
@@ -90,7 +90,6 @@ class Uploader:
             raise ValueError(f"{self.__class__} requires {uri} argument.")
         if not data:
             raise ValueError(f"{self.__class__} requires %{data} argument.")
-        pass
 
     def chunked_upload(self, table_id, data, uri=None):
         """Abstract method for chunked uploads. Must be implemented by subclasses."""

--- a/lib/ramble/ramble/util/command_runner.py
+++ b/lib/ramble/ramble/util/command_runner.py
@@ -176,7 +176,6 @@ class CommandRunner:
             if not allow_failure:
                 logger.error(e)
                 error = True
-            pass
         self.elapsed_time = time.time() - start_time
 
         if error:

--- a/lib/ramble/ramble/util/logger.py
+++ b/lib/ramble/ramble/util/logger.py
@@ -9,8 +9,8 @@
 from contextlib import contextmanager
 from pathlib import Path
 
-import llnl.util.tty as tty
 import llnl.util.tty.log
+from llnl.util import tty
 
 import ramble.util.colors as color
 

--- a/lib/ramble/ramble/util/yaml_generation.py
+++ b/lib/ramble/ramble/util/yaml_generation.py
@@ -25,7 +25,7 @@ Would translate to `foo.bar.baz = 1.0` in Ramble syntax.
 
 from typing import Any, Dict, Union
 
-import ruamel.yaml as yaml
+from ruamel import yaml
 
 from ramble.util.logger import logger
 

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -18,8 +18,8 @@ from collections import defaultdict
 from typing import Optional, Set
 
 import llnl.util.filesystem as fs
-import llnl.util.tty as tty
-import llnl.util.tty.log as log
+from llnl.util import tty
+from llnl.util.tty import log
 
 import ramble.config
 import ramble.context
@@ -522,7 +522,7 @@ class Workspace:
         """Reinitialize the workspace object if it has been written (this
         may not be true if the workspace was just created in this running
         instance of ramble)."""
-        for _, section in self.config_sections.items():
+        for section in self.config_sections.values():
             if not os.path.exists(section["filename"]):
                 return
 
@@ -1169,7 +1169,7 @@ ramble:
                 clear (bool): Whether to clear previous comments or not
                 start_char (str): Character to begin the comment with
             """
-            import ruamel.yaml as yaml
+            from ruamel import yaml
 
             key_comment = base.ca.items.setdefault(key, [None, [], None, None])
 
@@ -1199,7 +1199,7 @@ ramble:
 
             return base
 
-        import ruamel.yaml as yaml
+        from ruamel import yaml
 
         edited = False
 
@@ -1218,7 +1218,6 @@ ramble:
                 # we still want to allow adding the experiment to the config.
                 # Full validation will happen during concretization/setup.
                 logger.debug(f"Version initialization failed for {application}: {e}")
-                pass
         elif hasattr(app_inst, "preferred_version"):
             try:
                 app_inst.set_version(version=app_inst.preferred_version, description=application)
@@ -1227,7 +1226,6 @@ ramble:
                 # If version validation fails, we still want to allow adding the experiment.
                 # Full validation will happen during concretization/setup.
                 logger.debug(f"Version initialization failed for {application}: {e}")
-                pass
 
         app_inst.variables = {}
         app_inst.expander = ramble.expander.Expander({}, None)
@@ -1273,7 +1271,7 @@ ramble:
 
         # Unpack all workload names from `when` sets
         all_workload_names = set()
-        for _, workloads in app_inst.workloads.items():
+        for workloads in app_inst.workloads.values():
             for workload in workloads:
                 all_workload_names.add(workload)
 
@@ -1328,7 +1326,6 @@ ramble:
                 # Workload may not be defined for the active 'when' conditions.
                 # Skip MPI requirement checks for now as full validation occurs later.
                 logger.debug(f"Skipping MPI requirement check for workload {workload_name}: {e}")
-                pass
             if workload_name not in workloads_dict:
                 workloads_dict[workload_name] = syaml.syaml_dict()
                 workloads_dict[workload_name][namespace.experiment] = syaml.syaml_dict()
@@ -2262,7 +2259,7 @@ ramble:
         """
         mod_list = []
         base_section = self._get_scope_section("workspace")
-        ws_mods = base_section[namespace.modifiers] if namespace.modifiers in base_section else []
+        ws_mods = base_section.get(namespace.modifiers, [])
 
         # Add workspace modifiers
         for mod in ws_mods:

--- a/var/ramble/repos/builtin.mock/applications/file-open/application.py
+++ b/var/ramble/repos/builtin.mock/applications/file-open/application.py
@@ -8,7 +8,7 @@
 
 import os
 
-import ruamel.yaml as yaml
+from ruamel import yaml
 
 from ramble.appkit import *
 

--- a/var/ramble/repos/builtin.mock/workflow_managers/info/workflow_manager.py
+++ b/var/ramble/repos/builtin.mock/workflow_managers/info/workflow_manager.py
@@ -143,4 +143,4 @@ class Info(WorkflowManagerBase):
 
     def get_status(self, workspace):
         """Return status of a given job"""
-        return None
+        return

--- a/var/ramble/repos/builtin.mock/workflow_managers/when-workflow-manager/workflow_manager.py
+++ b/var/ramble/repos/builtin.mock/workflow_managers/when-workflow-manager/workflow_manager.py
@@ -81,4 +81,4 @@ class WhenWorkflowManager(WorkflowManagerBase):
 
     def get_status(self, workspace):
         """Return status of a given job"""
-        return None
+        return

--- a/var/ramble/repos/builtin.mock/workflow_managers/wm-with-foms/workflow_manager.py
+++ b/var/ramble/repos/builtin.mock/workflow_managers/wm-with-foms/workflow_manager.py
@@ -35,4 +35,4 @@ class WmWithFoms(WorkflowManagerBase):
 
     def get_status(self, workspace):
         """Return status of a given job"""
-        return None
+        return

--- a/var/ramble/repos/builtin/applications/intel-mlc/application.py
+++ b/var/ramble/repos/builtin/applications/intel-mlc/application.py
@@ -184,7 +184,7 @@ class IntelMlc(ExecutableApplication):
             )
 
         threads = []
-        for i in range(0, n_threads):
+        for i in range(n_threads):
             threads.append(str(i))
         return threads
 
@@ -197,7 +197,7 @@ class IntelMlc(ExecutableApplication):
         threads = []
         cur_indices = []
         numa_index = 0
-        for _ in range(0, spread_divisions):
+        for _ in range(spread_divisions):
             cur_indices.append(numa_index)
             numa_index += max_thread // spread_divisions
 

--- a/var/ramble/repos/builtin/applications/maxtext/application.py
+++ b/var/ramble/repos/builtin/applications/maxtext/application.py
@@ -10,11 +10,11 @@ import glob
 import json
 import os
 
-import ruamel.yaml as yaml
+from ruamel import yaml
 
-import ramble.util.stats as stats
 from ramble.appkit import *
 from ramble.expander import Expander
+from ramble.util import stats
 
 from spack.util.path import canonicalize_path
 
@@ -339,7 +339,7 @@ class Maxtext(ExecutableApplication):
                         self.expander.expansion_str(var_name)
                     )
                 elif isinstance(var_val, list):
-                    for i in range(0, len(var_val)):
+                    for i in range(len(var_val)):
                         var_val[i] = self.expander.expand_var(
                             var_val[i], typed=True
                         )
@@ -437,7 +437,7 @@ class Maxtext(ExecutableApplication):
                 if current_step not in aggregated_metrics:
                     aggregated_metrics[current_step] = {}
 
-                for metric in expected_metrics.keys():
+                for metric in expected_metrics:
                     if metric not in aggregated_metrics[current_step]:
                         aggregated_metrics[current_step][metric] = [
                             line_dict[metric]

--- a/var/ramble/repos/builtin/applications/namd/application.py
+++ b/var/ramble/repos/builtin/applications/namd/application.py
@@ -403,7 +403,7 @@ class Namd(ExecutableApplication):
 
         if os.path.isfile(log_path):
             with open(log_path) as f:
-                for line in f.readlines():
+                for line in f:
                     match = ns_regex.match(line)
                     if match:
                         dpns = float(match.group("days_per_ns"))

--- a/var/ramble/repos/builtin/applications/osu-micro-benchmarks/application.py
+++ b/var/ramble/repos/builtin/applications/osu-micro-benchmarks/application.py
@@ -238,7 +238,7 @@ class OsuMicroBenchmarks(ExecutableApplication):
 
         compiled = re.compile(regex)
 
-        for grp_name, _ in compiled.groupindex.items():
+        for grp_name in compiled.groupindex:
             if grp_name in self.group_mapping:
                 self.figure_of_merit(
                     self.group_mapping[grp_name]["name"],
@@ -258,7 +258,7 @@ class OsuMicroBenchmarks(ExecutableApplication):
         log_file = self.expander.expand_var_name("log_file")
         if os.path.isfile(log_file):
             with open(log_file) as f:
-                for line in f.readlines():
+                for line in f:
                     for test_fom_type in self.fom_types:
                         if self.fom_regex_headers[test_fom_type].match(line):
                             fom_type = test_fom_type

--- a/var/ramble/repos/builtin/applications/py-cosmoflow/application.py
+++ b/var/ramble/repos/builtin/applications/py-cosmoflow/application.py
@@ -8,7 +8,7 @@
 
 import os
 
-import ruamel.yaml as yaml
+from ruamel import yaml
 
 import ramble.util.yaml_generation
 from ramble.appkit import *
@@ -341,7 +341,7 @@ class PyCosmoflow(ExecutableApplication):
                         self.expander.expansion_str(var_name)
                     )
                 elif isinstance(var_val, list):
-                    for i in range(0, len(var_val)):
+                    for i in range(len(var_val)):
                         var_val[i] = self.expander.expand_var(
                             var_val[i], typed=True
                         )

--- a/var/ramble/repos/builtin/applications/py-nemo/application.py
+++ b/var/ramble/repos/builtin/applications/py-nemo/application.py
@@ -9,7 +9,7 @@
 
 import os
 
-import ruamel.yaml as yaml
+from ruamel import yaml
 
 import ramble.util.yaml_generation
 from ramble.appkit import *
@@ -335,7 +335,7 @@ class PyNemo(BasePyNemo):
                         self.expander.expansion_str(var_name)
                     )
                 elif isinstance(var_val, list):
-                    for i in range(0, len(var_val)):
+                    for i in range(len(var_val)):
                         var_val[i] = self.expander.expand_var(
                             var_val[i], typed=True
                         )

--- a/var/ramble/repos/builtin/applications/wrf/application.py
+++ b/var/ramble/repos/builtin/applications/wrf/application.py
@@ -450,7 +450,7 @@ class Wrf(ExecutableApplication):
             sum_time = 0.0
             count = 0
             with open(out_file) as f:
-                for line in f.readlines():
+                for line in f:
                     m = timing_regex.match(line)
                     if m:
                         time = float(m.group("main_time"))

--- a/var/ramble/repos/builtin/applications/wrfv3/application.py
+++ b/var/ramble/repos/builtin/applications/wrfv3/application.py
@@ -191,7 +191,7 @@ class Wrfv3(ExecutableApplication):
             count = 0
             for out_file in file_list:
                 with open(out_file) as f:
-                    for line in f.readlines():
+                    for line in f:
                         m = timing_regex.match(line)
                         if m:
                             time = float(m.group("main_time"))

--- a/var/ramble/repos/builtin/applications/wrfv4/application.py
+++ b/var/ramble/repos/builtin/applications/wrfv4/application.py
@@ -359,7 +359,7 @@ class Wrfv4(ExecutableApplication):
             sum_time = 0.0
             count = 0
             with open(out_file) as f:
-                for line in f.readlines():
+                for line in f:
                     m = timing_regex.match(line)
                     if m:
                         time = float(m.group("main_time"))

--- a/var/ramble/repos/builtin/base_applications/openfoam/base_application.py
+++ b/var/ramble/repos/builtin/base_applications/openfoam/base_application.py
@@ -480,7 +480,7 @@ class Openfoam(ExecutableApplication):
             exec_times = []
             exec_regex = re.compile(self.simple_foam_exec_regex)
             with open(sf_log) as f:
-                for line in f.readlines():
+                for line in f:
                     m = exec_regex.match(line)
                     if m:
                         exec_times.append(float(m.group("foam_time")))
@@ -492,7 +492,7 @@ class Openfoam(ExecutableApplication):
             # Drop first time, to avoid init time
             if len(exec_times) > 1:
                 timestep_times = []
-                for i in range(0, len(exec_times) - 1):
+                for i in range(len(exec_times) - 1):
                     timestep_times.append(exec_times[i + 1] - exec_times[i])
 
                 # Compute statistics from other times

--- a/var/ramble/repos/builtin/base_applications/py-nemo/base_application.py
+++ b/var/ramble/repos/builtin/base_applications/py-nemo/base_application.py
@@ -342,7 +342,7 @@ class PyNemo(ExecutableApplication):
                 )
 
             with open(processed_log) as f:
-                for line in f.readlines():
+                for line in f:
                     m = final_regex.match(line)
 
                     if m:

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -21,7 +21,7 @@ from html import escape
 from typing import Dict, List
 
 import llnl.util.filesystem as fs
-import llnl.util.tty.color as color
+from llnl.util.tty import color
 
 import ramble.config
 import ramble.expander
@@ -1934,8 +1934,8 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             if workload
             else self.get_all_workloads()
         )
-        for workload in workloads:
-            for input_file in workload.inputs:
+        for wl in workloads:
+            for input_file in wl.inputs:
                 inputs_found = 0
                 active_inputs = 0
                 input_conf = {}
@@ -1948,7 +1948,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
                 if not inputs_found:
                     logger.die(
-                        f"Workload {workload.name} references a non-existent input file "
+                        f"Workload {wl.name} references a non-existent input file "
                         f"{input_file}.\n"
                         f"Make sure this input file is defined before using it in a workload."
                     )
@@ -1977,7 +1977,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
                 file_name = file_name.replace(f".{fetcher.extension}", "")
 
-                namespace = f"{self.name}.{workload.name}"
+                namespace = f"{self.name}.{wl.name}"
 
                 inputs[file_name] = {
                     "fetcher": fetcher,
@@ -2526,7 +2526,6 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         This function can be overridden at the application level to perform
         application specific processing of the output.
         """
-        pass
 
     def extract_inmem_foms(self, inmem_fom_defs, fom_values):
         """Extract in-memory FOMs"""
@@ -2651,7 +2650,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
                         # Iterate over contexts and add matched contexts to active_contexts
                         for context, foms in file_conf["contexts"].items():
-                            if not context == _NULL_CONTEXT:
+                            if context != _NULL_CONTEXT:
                                 context_conf = f_defs[context]["definition"]
                                 if (
                                     context_conf.get("pre_filter", "")
@@ -2716,10 +2715,9 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                                         if fom_conf["contexts"]:
                                             for _ in fom_conf["contexts"]:
                                                 context_name = (
-                                                    active_contexts[context]
-                                                    if context
-                                                    in active_contexts
-                                                    else _NULL_CONTEXT
+                                                    active_contexts.get(
+                                                        context, _NULL_CONTEXT
+                                                    )
                                                 )
                                                 fom_contexts.append(
                                                     context_name

--- a/var/ramble/repos/builtin/base_classes/disabled-modifier/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/disabled-modifier/base_class.py
@@ -34,4 +34,3 @@ class DisabledModifier(ModifierBase):
 
     def define_variable(self, var_name, var_value):
         """Given this modifier is disabled, never define variables in it"""
-        pass

--- a/var/ramble/repos/builtin/base_classes/modifier-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/modifier-base/base_class.py
@@ -348,7 +348,6 @@ class ModifierBase(ObjectMixin, metaclass=ModifierMeta):
         This can be used to define things like n_ranks and have it influence
         the name of the resulting experiment.
         """
-        pass
 
     def modded_variables(self, app, extra_vars=None):
         mods = {}
@@ -575,7 +574,7 @@ class ModifierBase(ObjectMixin, metaclass=ModifierMeta):
             (Any) Artifact inventory for this modifier
         """
 
-        return None
+        return
 
     def _prepare_analysis(self, workspace):
         """Hook to perform analysis that a modifier defines.
@@ -583,4 +582,3 @@ class ModifierBase(ObjectMixin, metaclass=ModifierMeta):
         This function allows modifier definitions to inject their own
         processing to output files, before FOMs are extracted.
         """
-        pass

--- a/var/ramble/repos/builtin/base_classes/object-mixin/test/object-mixin.py
+++ b/var/ramble/repos/builtin/base_classes/object-mixin/test/object-mixin.py
@@ -5,7 +5,7 @@
 # <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
-import unittest.mock as mock
+from unittest import mock
 
 import pytest
 

--- a/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
@@ -211,8 +211,6 @@ class PackageManagerBase(ObjectMixin, metaclass=PackageManagerMeta):
             require_exist (bool): Whether to require environment hashes exist or not.
         """
 
-        pass
-
     def define_missing_packages(self, workspace):
         """Injection of missing packages that are auto-injected by objects
 

--- a/var/ramble/repos/builtin/modifiers/exit-code/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/exit-code/modifier.py
@@ -154,7 +154,7 @@ class ExitCode(BasicModifier):
 
         if os.path.exists(log_file):
             with open(log_file) as f:
-                for line in f.readlines():
+                for line in f:
                     m = exit_regex.match(line)
 
                     if m:

--- a/var/ramble/repos/builtin/modifiers/gcp-metadata/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/gcp-metadata/modifier.py
@@ -156,7 +156,7 @@ class GcpMetadata(BasicModifier):
         file_name = os.path.join(exp_run_dir, "gcp-metadata.id.log")
         if os.path.isfile(file_name):
             with open(file_name) as f:
-                for cur_id in f.readlines():
+                for cur_id in f:
                     cur_id = cur_id.split(":")[-1].strip()
                     if cur_id.isnumeric():
                         ids.add(cur_id)
@@ -202,7 +202,7 @@ class GcpMetadata(BasicModifier):
         all_hosts = set()
 
         with open(log_path) as f:
-            for raw_host in f.readlines():
+            for raw_host in f:
                 physical_host = raw_host[1:].strip()
                 logger.debug(f"  Host line: {physical_host}")
                 all_hosts.add(physical_host)

--- a/var/ramble/repos/builtin/modifiers/tuned-adm/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/tuned-adm/modifier.py
@@ -59,7 +59,7 @@ class TunedAdm(BasicModifier):
         profiles = set()
         with open(read_profile_path) as f:
 
-            for line in f.readlines():
+            for line in f:
                 if "active profile:" in line:
                     profiles.add(line.split(":")[-1].strip())
             profiles_str = ",".join(profiles)

--- a/var/ramble/repos/builtin/package_managers/pip/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/pip/package_manager.py
@@ -187,7 +187,6 @@ class Pip(PackageManagerBase):
         except RunnerError as e:
             if self.environment_required:
                 logger.die(e)
-            pass
 
     register_phase(
         "define_package_paths",
@@ -308,12 +307,12 @@ class PipSoftwareInfo(ramble.software_info.SoftwareInfo):
         """
 
         if not in_str:
-            return None
+            return
 
         parts = in_str.replace("\n", "").split("==")
 
         if len(parts) <= 1:
-            return None
+            return
 
         self.version = parts[1]
 

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
@@ -159,7 +159,7 @@ class SpackLightweight(PackageManagerBase):
             )
 
         for config_dict in package_manager_config_dicts:
-            for _, config in config_dict.items():
+            for config in config_dict.values():
                 keep_config = app_inst.expander.satisfies(
                     config["when"], variant_set=self.experiment_variants()
                 )
@@ -377,7 +377,6 @@ class SpackLightweight(PackageManagerBase):
         except RunnerError as e:
             if self.environment_required:
                 logger.die(e)
-            pass
 
     register_phase("push_to_spack_cache", pipeline="pushtocache", run_after=[])
 
@@ -423,7 +422,6 @@ class SpackLightweight(PackageManagerBase):
         except RunnerError as e:
             if self.environment_required:
                 logger.die(e)
-            pass
 
     @PackageManagerBase.workspace_cache
     def get_version(self, workspace=None):
@@ -508,7 +506,6 @@ class SpackLightweight(PackageManagerBase):
         except RunnerError as e:
             if self.environment_required:
                 logger.die(e)
-            pass
 
     register_builtin(
         "spack_source", required=True, depends_on=["builtin::env_vars"]
@@ -1028,7 +1025,7 @@ class SpackRunner(CommandRunner):
                 "Environment runner has no path configured"
             )
 
-        if self.active and self.env_key in self.spack.default_env.keys():
+        if self.active and self.env_key in self.spack.default_env:
             del self.spack.default_env[self.env_key]
             del self.installer.default_env[self.env_key]
             del self.concretizer.default_env[self.env_key]

--- a/var/ramble/repos/builtin/package_managers/user-managed/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/user-managed/package_manager.py
@@ -62,7 +62,7 @@ class UserManaged(PackageManagerBase):
             package_objects = app_inst.objects()
 
         for _, obj in package_objects:
-            for pkgname in obj.required_packages.keys():
+            for pkgname in obj.required_packages:
                 app_inst.keywords.update_keys(
                     {
                         f"{pkgname}_path": {

--- a/var/ramble/repos/builtin/workflow_managers/gke-mpi/workflow_manager.py
+++ b/var/ramble/repos/builtin/workflow_managers/gke-mpi/workflow_manager.py
@@ -187,4 +187,4 @@ class GkeMpi(WorkflowManagerBase):
 
     def get_status(self, workspace):
         """Return status of a given job"""
-        return None
+        return

--- a/var/ramble/repos/builtin/workflow_managers/google-batch/workflow_manager.py
+++ b/var/ramble/repos/builtin/workflow_managers/google-batch/workflow_manager.py
@@ -8,7 +8,7 @@
 
 import os
 
-import ruamel.yaml as yaml
+from ruamel import yaml
 
 from ramble.experiment_result import ExperimentStatus
 from ramble.util import shell_utils

--- a/var/ramble/repos/builtin/workflow_managers/user-managed/workflow_manager.py
+++ b/var/ramble/repos/builtin/workflow_managers/user-managed/workflow_manager.py
@@ -40,4 +40,4 @@ class UserManaged(WorkflowManagerBase):
 
     def get_status(self, workspace):
         """Return status of a given job"""
-        return None
+        return


### PR DESCRIPTION
These are issues that get reported when using its `preview=true` rules:

* Use more readable import statement
* Remove unnecessary `range` lower bound
* Remove unnecessary `pass`
* Prefer `key in dict` instead of `key in dict.keys()`
* No unnecessary `return None`
* Fix up a variable redefinition
* Prefer file object iteration
* Simplify membership checking with `get`