### PR TITLE
Improve defining directive methods

### DIFF
--- a/lib/ramble/ramble/language/language_base.py
+++ b/lib/ramble/ramble/language/language_base.py
@@ -21,6 +21,7 @@ import llnl.util.lang
 
 import ramble.language.language_helpers
 from ramble.error import DirectiveError
+from ramble.util import directives
 from ramble.util.logger import logger
 
 __all__ = ["DirectiveMeta", "DirectiveError"]
@@ -173,6 +174,8 @@ class DirectiveMeta(abc.ABCMeta):
             # Ignore any directives executed *within* top-level
             # directives by clearing out the queue they're appended to
             DirectiveMeta._directives_to_be_executed = []
+
+            directives.define_directive_methods_on_class(cls)
 
         super().__init__(name, bases, attr_dict)
 

--- a/lib/ramble/ramble/util/class_attributes.py
+++ b/lib/ramble/ramble/util/class_attributes.py
@@ -17,10 +17,9 @@ def convert_class_attributes(obj):
     """
 
     if hasattr(obj, "_directive_names"):
-        dir_set = dir(obj)
         var_set = vars(obj)
         for attr in obj._directive_names:
-            if attr in dir_set and attr not in var_set:
+            if attr not in var_set and hasattr(obj, attr):
                 val = getattr(obj, attr)
                 if hasattr(val, "copy"):
                     inst_val = val.copy()

--- a/lib/ramble/ramble/util/directives.py
+++ b/lib/ramble/ramble/util/directives.py
@@ -7,56 +7,32 @@
 # except according to those terms.
 
 
-def define_directive_methods(obj_inst):
-    """Create class methods that execute directives
+def define_directive_methods_on_class(cls):
+    """Create class methods that execute directives on the class.
 
-    Wrap each directive, and inject it into this class instance as a class
-    method.
-
-    This allows: `self.<directive_name>(<directive_args>)` to be called. As in::
-
-        self.archive_pattern('*.log')
-
-    Which can be called within `def __init__(self, file_path)` instead of
-    having to call `archive_pattern()` at the class definition level.
-
-    This function requires the object instance to have internal attributes:
-
-    - `_directive_classes` - Dictionary mapping a directive to the class the
-      directive is defined for
-    - `_directive_functions` - Dictionary mapping a directive to the decorated function
-      that defines the directive
-    - `_language_classes` - A list of classes that language features should be "imported" from
-
-    Both `_directive_classes` and `_directive_functions` are defined for all
-    classes that use the DirectiveMeta meta-class.
-
-    The `_language_classes` attribute is defined in ApplicationBase and ModifierBase.
+    Wrap each directive, and inject it into this class as a method.
     """
-    if not hasattr(obj_inst, "_directive_classes") or not hasattr(
-        obj_inst, "_directive_functions"
-    ):
+    if not hasattr(cls, "_directive_classes") or not hasattr(cls, "_directive_functions"):
         return
 
-    for directive, directive_class in obj_inst._directive_classes.items():
+    for directive, directive_class in cls._directive_classes.items():
         is_valid_lang = False
-        if hasattr(obj_inst, "_language_classes"):
-            for lang_class in obj_inst._language_classes:
+        if hasattr(cls, "_language_classes"):
+            for lang_class in cls._language_classes:
                 if directive_class is lang_class:
                     is_valid_lang = True
 
-        if not hasattr(obj_inst, directive) and is_valid_lang:
-            setattr(obj_inst, directive, wrap_named_directive(obj_inst, directive))
+        if not hasattr(cls, directive) and is_valid_lang:
+            setattr(cls, directive, wrap_named_directive_class_level(directive))
 
 
-def wrap_named_directive(obj_inst, name):
-    """Wrap a directive to simplify execution
+def wrap_named_directive_class_level(name):
+    """Wrap a directive to simplify execution at the class level
 
-    Create a wrapper method that executes a directive, to inject the
-    `(self)` argument to simplify use of directives as class methods
+    Create a bound-like method that executes a directive on the instance
     """
 
-    def _execute_directive(*args, directive_name=name, **kwargs):
-        obj_inst._directive_functions[directive_name](*args, **kwargs)(obj_inst)
+    def _execute_directive(self, *args, directive_name=name, **kwargs):
+        self._directive_functions[directive_name](*args, **kwargs)(self)
 
     return _execute_directive

--- a/lib/ramble/ramble/util/directives.py
+++ b/lib/ramble/ramble/util/directives.py
@@ -8,21 +8,16 @@
 
 
 def define_directive_methods_on_class(cls):
-    """Create class methods that execute directives on the class.
+    """Create methods that execute directives on the class.
 
     Wrap each directive, and inject it into this class as a method.
     """
     if not hasattr(cls, "_directive_classes") or not hasattr(cls, "_directive_functions"):
         return
 
+    lang_classes = getattr(cls, "_language_classes", [])
     for directive, directive_class in cls._directive_classes.items():
-        is_valid_lang = False
-        if hasattr(cls, "_language_classes"):
-            for lang_class in cls._language_classes:
-                if directive_class is lang_class:
-                    is_valid_lang = True
-
-        if not hasattr(cls, directive) and is_valid_lang:
+        if directive_class in lang_classes and not hasattr(cls, directive):
             setattr(cls, directive, wrap_named_directive_class_level(directive))
 
 

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -235,8 +235,6 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
         self.result = ExperimentResult(self)
 
-        ramble.util.directives.define_directive_methods(self)
-
     @property
     def experiment_lock(self):
         """Create a lock for the experiment directory, and return it"""

--- a/var/ramble/repos/builtin/base_classes/modifier-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/modifier-base/base_class.py
@@ -77,8 +77,6 @@ class ModifierBase(ObjectMixin, metaclass=ModifierMeta):
             self._mod_prefix_builtin + f"{self.name}{NS_SEPARATOR}"
         )
 
-        ramble.util.directives.define_directive_methods(self)
-
     def copy(self):
         """Deep copy a modifier instance"""
         new_copy = super().copy()

--- a/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
@@ -79,8 +79,6 @@ class PackageManagerBase(ObjectMixin, metaclass=PackageManagerMeta):
 
         self._allow_unprefixed_specs = True
 
-        ramble.util.directives.define_directive_methods(self)
-
         self.object_variants.default_variant(
             self.origin_type,
             default=self.name,

--- a/var/ramble/repos/builtin/base_classes/platform-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/platform-base/base_class.py
@@ -107,8 +107,6 @@ class PlatformBase(ObjectMixin, metaclass=PlatformMeta):
 
         self._file_path = file_path
 
-        ramble.util.directives.define_directive_methods(self)
-
         self.object_variants.default_variant(
             self.origin_type,
             default=self.name,

--- a/var/ramble/repos/builtin/base_classes/system-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/system-base/base_class.py
@@ -77,8 +77,6 @@ class SystemBase(ObjectMixin, metaclass=SystemMeta):
 
         self._file_path = file_path
 
-        ramble.util.directives.define_directive_methods(self)
-
         self.object_variants.default_variant(
             self.origin_type,
             default=self.name,

--- a/var/ramble/repos/builtin/base_classes/workflow-manager-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/workflow-manager-base/base_class.py
@@ -77,8 +77,6 @@ class WorkflowManagerBase(ObjectMixin, metaclass=WorkflowManagerMeta):
 
         self._file_path = file_path
 
-        ramble.util.directives.define_directive_methods(self)
-
         self.object_variants.default_variant(
             self.origin_type,
             default=self.name,


### PR DESCRIPTION
A couple improvements:

* Improve on the `convert_class_attributes` to avoid calling `dir()`
* Define directives at the class level instead of per-instance. This makes it cleaner to not needing each object to call the define directive method separately. It also brings some small performance improvement for not needing to define the directives for each instance.