### PR TITLE
Add directives for editing or patching files [AI]

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -531,7 +531,7 @@ def mock_directive_bundle():
     return MockBundle()
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def clear_directive_functions():
     """Clear all overridden directive functions for subsequent tests."""
     yield
@@ -539,7 +539,9 @@ def clear_directive_functions():
     # Make sure any directive functions overridden by tests are cleared before
     # proceeding with subsequent tests that may depend on the original
     # functions.
-    ramble.directives.DirectiveMeta._directives_to_be_executed = []
+    import ramble.language.language_base
+
+    ramble.language.language_base.DirectiveMeta._directives_to_be_executed = []
 
 
 @pytest.fixture

--- a/lib/ramble/docs/workspace.rst
+++ b/lib/ramble/docs/workspace.rst
@@ -107,6 +107,8 @@ Ramble creates workspaces using the following structure by default:
     |   | - ramble.yaml
     |   | - execute_experiment.tpl
     |   | - auxiliary_software_files/
+    | - shared/
+    |   | - utilities/
     | - experiments/
     | - inputs/
     | - logs/
@@ -116,6 +118,7 @@ Ramble creates workspaces using the following structure by default:
 This various parts of this directory structure are defined as:
   * ``configs/``: Contain configuration for the workspace
   * ``configs/auxiliary_software_files``: Contain files used by the package managers
+  * ``shared/utilities``: Contain ramble-generated workspace utilities
   * ``experiments/``: Contain experiments define by the workspace configuration
   * ``inputs``: Contain the inputs experiments in this workspace require
   * ``logs``: Contain some logging output from ramble

--- a/lib/ramble/ramble/language/language_base.py
+++ b/lib/ramble/ramble/language/language_base.py
@@ -147,13 +147,30 @@ class DirectiveMeta(abc.ABCMeta):
         if valid_module:
             # Ensure the presence of the dictionaries associated
             # with the directives
-            for d, t in DirectiveMeta._directive_init_values.items():
+            # We use type(cls) to get the metaclass, and iterate its MRO to
+            # collect all init values and directive attributes.
+            all_init_values = {}
+            all_directive_names = set()
+            all_directive_functions = {}
+            all_directive_classes = {}
+
+            for base_meta in reversed(type(cls).__mro__):
+                if hasattr(base_meta, "_directive_init_values"):
+                    all_init_values.update(base_meta._directive_init_values)
+                if hasattr(base_meta, "_directive_names"):
+                    all_directive_names |= base_meta._directive_names
+                if hasattr(base_meta, "_directive_functions"):
+                    all_directive_functions.update(base_meta._directive_functions)
+                if hasattr(base_meta, "_directive_classes"):
+                    all_directive_classes.update(base_meta._directive_classes)
+
+            for d, t in all_init_values.items():
                 setattr(cls, d, copy.deepcopy(t))
 
             directive_attrs = {
-                "_directive_functions": {},
-                "_directive_classes": {},
-                "_directive_names": DirectiveMeta._directive_names.copy(),
+                "_directive_functions": all_directive_functions,
+                "_directive_classes": all_directive_classes,
+                "_directive_names": all_directive_names | DirectiveMeta._directive_names.copy(),
             }
 
             for attr, val in directive_attrs.items():
@@ -236,9 +253,9 @@ class DirectiveMeta(abc.ABCMeta):
 
         # Add the dictionary names if not already there
         dicts_set = set(dicts)
-        DirectiveMeta._directive_names |= dicts_set
+        cls._directive_names |= dicts_set
         for attr_name in dicts_set:
-            DirectiveMeta._directive_init_values[attr_name] = init_value
+            cls._directive_init_values[attr_name] = init_value
 
         # This decorator just returns the directive functions
         def _decorator(decorated_function):
@@ -336,8 +353,8 @@ class DirectiveMeta(abc.ABCMeta):
                 # that we can nest directives
                 return result
 
-            DirectiveMeta._directive_classes[decorated_function.__name__] = cls
-            DirectiveMeta._directive_functions[decorated_function.__name__] = decorated_function
+            cls._directive_classes[decorated_function.__name__] = cls
+            cls._directive_functions[decorated_function.__name__] = decorated_function
 
             return _wrapper
 

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -40,6 +40,7 @@ inherit from the SharedMeta class.
 class SharedMeta(ramble.language.language_base.DirectiveMeta):
     _directive_names = set()
     _directives_to_be_executed = []
+    _directive_init_values = {"custom_edit_functions": {}}
 
 
 shared_directive = SharedMeta.directive
@@ -85,6 +86,202 @@ def _add_specs(
 def _add_list_attributes(obj, attr_name, values):
     base_list = getattr(obj, attr_name, [])
     setattr(obj, attr_name, sorted(set(base_list + list(values))))
+
+
+@shared_directive("executables")
+def edit_file(
+    name,
+    file_path,
+    match=None,
+    replace=None,
+    append=None,
+    prepend=None,
+    function=None,
+    fail_on_error=True,
+    when=None,
+    **kwargs,
+):
+    """Adds an edit_file executable to this object
+
+    Defines a new executable that uses Ramble's helper script to edit a file.
+
+    Required Args:
+        name (str): Name of the executable
+        file_path (str): Path to the file to edit
+
+    Optional Args:
+        match (str): Regex pattern to match
+        replace (str): Replacement string
+        append (str): String to append to the end of the file
+        prepend (str): String to prepend to the beginning of the file
+        function (callable): A Python function to be used for editing the file.
+                             The function must accept a single string argument
+                             (the file content) and return a string (the modified
+                             content). It must be a named top-level function.
+                             Note: any imports or global variables used by the
+                             function must be defined within the function body
+                             itself, as only the function's source code is
+                             serialized.
+        fail_on_error (bool): If true, the experiment fails if the edit fails.
+                              Defaults to True.
+        when (list | None): List of when conditions to apply to directive
+    """
+
+    def _execute_edit_file(obj):
+        import inspect
+        import shlex
+
+        from ramble.util.executable import CommandExecutable
+        from ramble.util.file_editor import get_file_editor_exec_path
+
+        origin_str = f"{getattr(obj, 'origin_type', 'object')} '{obj.name}'"
+
+        if bool(match) != (replace is not None):
+            raise ramble.language.language_helpers.DirectiveError(
+                f"Directive '{name}' in {origin_str} requires both 'match' and 'replace' "
+                "to be specified together."
+            )
+
+        if not any([match, append, prepend, function]):
+            raise ramble.language.language_helpers.DirectiveError(
+                f"Directive '{name}' in {origin_str} requires at least one action "
+                "(match/replace, append, prepend, or function) to be specified."
+            )
+
+        script_path = get_file_editor_exec_path()
+        template = [f'python "{script_path}" ' f"--mode regex --file {shlex.quote(file_path)}"]
+        if match:
+            template[0] += f" --match {shlex.quote(match)}"
+        if replace is not None:
+            template[0] += f" --replace {shlex.quote(replace)}"
+        if append:
+            template[0] += f" --append {shlex.quote(append)}"
+        if prepend:
+            template[0] += f" --prepend {shlex.quote(prepend)}"
+        if function:
+            import textwrap
+
+            if not inspect.isfunction(function) or function.__name__ == "<lambda>":
+                raise ramble.language.language_helpers.DirectiveError(
+                    f"Directive '{name}' in {origin_str} requires a named top-level "
+                    "function, not a lambda or a method."
+                )
+
+            sig = inspect.signature(function)
+            if len(sig.parameters) != 1 or "self" in sig.parameters:
+                raise ramble.language.language_helpers.DirectiveError(
+                    f"Directive '{name}' in {origin_str} requires a function that "
+                    "accepts exactly one argument (the file content), and does "
+                    "not have a 'self' parameter."
+                )
+
+            # Use a unique name for the function in the helper script to avoid collisions
+            unique_func_name = f"custom_edit_{name}_{function.__name__}"
+            template[0] += (
+                f" --function {unique_func_name} "
+                f"--import-module {{experiment_run_dir}}/utilities/"
+                f"{ramble.util.file_editor.CUSTOM_EDIT_FUNCTIONS_NAME}"
+            )
+
+            try:
+                import ast
+
+                raw_source = textwrap.dedent(inspect.getsource(function))
+                parsed_ast = ast.parse(raw_source)
+                has_value_return = any(
+                    isinstance(node, ast.Return) and node.value is not None
+                    for node in ast.walk(parsed_ast)
+                )
+                if not has_value_return:
+                    raise ramble.language.language_helpers.DirectiveError(
+                        f"Directive '{name}' in {origin_str} requires the function "
+                        f"'{function.__name__}' to return a value."
+                    )
+
+                # Wrap the original function to give it a unique name and avoid collisions
+                # while also ensuring it's defined in the script's scope.
+                # We use a nested definition to avoid name conflicts with the original name
+                # if multiple directives use different functions with same original name.
+                wrapper = [
+                    f"def {unique_func_name}(content):",
+                    textwrap.indent(raw_source, "    "),
+                    f"    return {function.__name__}(content)",
+                ]
+                obj.custom_edit_functions[name] = "\n".join(wrapper)
+            except (OSError, TypeError):
+                raise ramble.language.language_helpers.DirectiveError(
+                    f"Directive '{name}' in {origin_str} could not retrieve source "
+                    f"for function '{function.__name__}'."
+                ) from None
+
+        if not fail_on_error:
+            template[0] += " || true"
+
+        when_list = ramble.language.language_helpers.build_when_list(when, obj, name, "edit_file")
+        when_set = frozenset(when_list)
+
+        if not hasattr(obj, "executables"):
+            obj.executables = {}
+
+        if when_set not in obj.executables:
+            obj.executables[when_set] = {}
+
+        obj.executables[when_set][name] = CommandExecutable(name=name, template=template, **kwargs)
+
+    return _execute_edit_file
+
+
+@shared_directive("executables")
+def patch_file(
+    name,
+    file_path,
+    patch_file,
+    fail_on_error=True,
+    when=None,
+    **kwargs,
+):
+    """Adds a patch_file executable to this object
+
+    Defines a new executable that uses Ramble's helper script to apply a patch.
+
+    Required Args:
+        name (str): Name of the executable
+        file_path (str): Path to the file to patch
+        patch_file (str): Path to the patch file
+
+    Optional Args:
+        fail_on_error (bool): If true, the experiment fails if the patch fails.
+                              Defaults to True.
+        when (list | None): List of when conditions to apply to directive
+    """
+
+    def _execute_patch_file(obj):
+        import shlex
+
+        from ramble.util.executable import CommandExecutable
+        from ramble.util.file_editor import get_file_editor_exec_path
+
+        script_path = get_file_editor_exec_path()
+        template = [
+            f'python "{script_path}" '
+            f"--mode patch --file {shlex.quote(file_path)} --patch-file {shlex.quote(patch_file)}"
+        ]
+
+        if not fail_on_error:
+            template[0] += " || true"
+
+        when_list = ramble.language.language_helpers.build_when_list(when, obj, name, "patch_file")
+        when_set = frozenset(when_list)
+
+        if not hasattr(obj, "executables"):
+            obj.executables = {}
+
+        if when_set not in obj.executables:
+            obj.executables[when_set] = {}
+
+        obj.executables[when_set][name] = CommandExecutable(name=name, template=template, **kwargs)
+
+    return _execute_patch_file
 
 
 @shared_directive("archive_patterns")

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -517,7 +517,46 @@ class SetupPipeline(Pipeline):
 
     def _prepare(self):
         super()._prepare()
-        experiment_file = open(self.workspace.all_experiments_path, "w+")
+
+        # Ensure workspace utilities are written before execution scripts are built
+        if hasattr(self.workspace, "write_utilities"):
+            self.workspace.write_utilities()
+
+        # Write custom edit functions to each experiment's run directory
+        import llnl.util.filesystem as fs
+
+        import ramble.util.file_editor
+
+        for _, app_inst, _ in self._experiment_set.filtered_experiments(self.filters):
+            custom_functions = []
+            if hasattr(app_inst, "custom_edit_functions"):
+                for func_source in app_inst.custom_edit_functions.values():
+                    if func_source not in custom_functions:
+                        custom_functions.append(func_source)
+
+            if custom_functions:
+                exp_run_dir = app_inst.expander.experiment_run_dir
+                fs.mkdirp(os.path.join(exp_run_dir, "utilities"))
+                script_path = os.path.join(
+                    exp_run_dir, "utilities", ramble.util.file_editor.CUSTOM_EDIT_FUNCTIONS_NAME
+                )
+                # Ensure the module has the required imports
+                copyright_header = (
+                    "# Copyright 2022-2026 The Ramble Authors\n"
+                    "#\n"
+                    "# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or\n"
+                    "# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license\n"
+                    "# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your\n"
+                    "# option. This file may not be copied, modified, or distributed\n"
+                    "# except according to those terms.\n\n"
+                )
+                module_content = (
+                    copyright_header + "import re\nimport os\n\n" + "\n\n".join(custom_functions)
+                )
+                with open(script_path, "w+", encoding="utf-8") as f:
+                    f.write(module_content)
+
+        experiment_file = open(self.workspace.all_experiments_path, "w+", encoding="utf-8")
         shell = ramble.config.get("config:shell")
         shell_path = os.path.join("/bin/", shell)
         experiment_file.write(f"#!{shell_path}\n")

--- a/lib/ramble/ramble/schema/config.py
+++ b/lib/ramble/ramble/schema/config.py
@@ -198,6 +198,8 @@ properties["config"]["enable_strict_versions"] = {"type": "boolean", "default": 
 
 properties["config"]["overwrite_inventories"] = {"type": "boolean", "default": False}
 
+properties["config"]["generate_file_editing_scripts"] = {"type": "boolean", "default": True}
+
 properties["config"]["stage_method"] = {
     "type": "string",
     "enum": ["cp", "rsync", "symbolic_link", "hard_link"],

--- a/lib/ramble/ramble/test/application_language.py
+++ b/lib/ramble/ramble/test/application_language.py
@@ -265,6 +265,85 @@ def test_executable_directive(app_class):
 
 
 @pytest.mark.parametrize("app_class", app_types)
+def test_edit_file_directive(app_class):
+    import shlex
+
+    app_inst = app_class("/not/a/path")
+    app_inst.edit_file(
+        "edit_test",
+        file_path="/path/to/test.txt",
+        match="match_str",
+        replace="replace_str",
+        append="append_str",
+        prepend="prepend_str",
+        fail_on_error=True,
+    )
+
+    assert hasattr(app_inst, "executables")
+    assert "edit_test" in app_inst.executables[_FS]
+
+    exe_obj = app_inst.executables[_FS]["edit_test"]
+    assert exe_obj.name == "edit_test"
+    template_str = exe_obj.template[0]
+
+    assert "python" in template_str
+    assert "_ramble_file_editor.py" in template_str
+    assert "--mode regex" in template_str
+    assert f"--file {shlex.quote('/path/to/test.txt')}" in template_str
+    assert f"--match {shlex.quote('match_str')}" in template_str
+    assert f"--replace {shlex.quote('replace_str')}" in template_str
+    assert f"--append {shlex.quote('append_str')}" in template_str
+    assert f"--prepend {shlex.quote('prepend_str')}" in template_str
+    assert "|| true" not in template_str
+
+    app_inst.edit_file(
+        "edit_test_fail",
+        file_path="/path/to/test.txt",
+        match="match_str",
+        replace="replace_str",
+        fail_on_error=False,
+    )
+    exe_obj2 = app_inst.executables[_FS]["edit_test_fail"]
+    assert "|| true" in exe_obj2.template[0]
+
+
+@pytest.mark.parametrize("app_class", app_types)
+def test_patch_file_directive(app_class):
+    import shlex
+
+    app_inst = app_class("/not/a/path")
+    app_inst.patch_file(
+        "patch_test",
+        file_path="/path/to/test.txt",
+        patch_file="/path/to/patch.patch",
+        fail_on_error=True,
+    )
+
+    assert hasattr(app_inst, "executables")
+    assert "patch_test" in app_inst.executables[_FS]
+
+    exe_obj = app_inst.executables[_FS]["patch_test"]
+    assert exe_obj.name == "patch_test"
+    template_str = exe_obj.template[0]
+
+    assert "python" in template_str
+    assert "_ramble_file_editor.py" in template_str
+    assert "--mode patch" in template_str
+    assert f"--file {shlex.quote('/path/to/test.txt')}" in template_str
+    assert f"--patch-file {shlex.quote('/path/to/patch.patch')}" in template_str
+    assert "|| true" not in template_str
+
+    app_inst.patch_file(
+        "patch_test_fail",
+        file_path="/path/to/test.txt",
+        patch_file="/path/to/patch.patch",
+        fail_on_error=False,
+    )
+    exe_obj2 = app_inst.executables[_FS]["patch_test_fail"]
+    assert "|| true" in exe_obj2.template[0]
+
+
+@pytest.mark.parametrize("app_class", app_types)
 def test_figure_of_merit_directive(app_class):
     test_defs = {}
 

--- a/lib/ramble/ramble/test/edit_file_validation.py
+++ b/lib/ramble/ramble/test/edit_file_validation.py
@@ -1,0 +1,217 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import pytest
+
+import ramble.language.language_helpers
+from ramble.language.shared_language import edit_file
+
+
+class MockApp:
+    def __init__(self):
+        self.name = "mock_app"
+        self.origin_type = "application"
+        self.executables = {}
+        self.custom_edit_functions = {}
+
+
+@pytest.fixture
+def mock_app():
+    return MockApp()
+
+
+def test_edit_file_valid_function(mock_app):
+    def my_custom_edit(content):
+        return content.replace("a", "b")
+
+    # The directive is usually used as a decorator on the class,
+    # but here we call the returned function directly.
+    edit_func = edit_file("my_edit", "/path/f", function=my_custom_edit)
+    edit_func(mock_app)
+
+    assert "my_edit" in mock_app.custom_edit_functions
+    source = mock_app.custom_edit_functions["my_edit"]
+    assert "def custom_edit_my_edit_my_custom_edit(content):" in source
+    assert "return my_custom_edit(content)" in source
+
+    template = mock_app.executables[frozenset()]["my_edit"].template[0]
+    assert "--function custom_edit_my_edit_my_custom_edit" in template
+
+
+def test_edit_file_invalid_lambda(mock_app):
+    with pytest.raises(
+        ramble.language.language_helpers.DirectiveError,
+        match="Directive 'my_edit' in application 'mock_app' requires a named top-level "
+        "function, not a lambda or a method",
+    ):
+        edit_func = edit_file("my_edit", "/path/f", function=lambda c: c)
+        edit_func(mock_app)
+
+
+def test_edit_file_invalid_method(mock_app):
+    class SomeClass:
+        def my_method(self, content):
+            return content
+
+    with pytest.raises(
+        ramble.language.language_helpers.DirectiveError,
+        match="Directive 'my_edit' in application 'mock_app' requires a named top-level "
+        "function, not a lambda or a method",
+    ):
+        edit_func = edit_file("my_edit", "/path/f", function=SomeClass().my_method)
+        edit_func(mock_app)
+
+
+def test_edit_file_invalid_signature(mock_app):
+    def too_many_args(content, extra):
+        return content
+
+    with pytest.raises(
+        ramble.language.language_helpers.DirectiveError,
+        match="Directive 'my_edit' in application 'mock_app' requires a function that "
+        "accepts exactly one argument",
+    ):
+        edit_func = edit_file("my_edit", "/path/f", function=too_many_args)
+        edit_func(mock_app)
+
+
+def test_edit_file_missing_return(mock_app):
+    def no_return(content):
+        print(content)
+
+    with pytest.raises(
+        ramble.language.language_helpers.DirectiveError,
+        match="Directive 'my_edit' in application 'mock_app' requires the function "
+        "'no_return' to return a value",
+    ):
+        edit_func = edit_file("my_edit", "/path/f", function=no_return)
+        edit_func(mock_app)
+
+
+def test_edit_file_collision_avoidance(mock_app):
+    def edit(content):
+        return content + "1"
+
+    def another_edit(content):
+        return content + "2"
+
+    edit_func1 = edit_file("e1", "/path/f1", function=edit)
+    edit_func1(mock_app)
+
+    edit_func2 = edit_file("e2", "/path/f2", function=another_edit)
+    edit_func2(mock_app)
+
+    assert "e1" in mock_app.custom_edit_functions
+    assert "e2" in mock_app.custom_edit_functions
+
+    source1 = mock_app.custom_edit_functions["e1"]
+    source2 = mock_app.custom_edit_functions["e2"]
+
+    assert "def custom_edit_e1_edit(content):" in source1
+    assert "def custom_edit_e2_another_edit(content):" in source2
+
+    template1 = mock_app.executables[frozenset()]["e1"].template[0]
+    template2 = mock_app.executables[frozenset()]["e2"].template[0]
+
+    assert "--function custom_edit_e1_edit" in template1
+    assert "--function custom_edit_e2_another_edit" in template2
+
+
+def test_write_utilities(tmpdir):
+    import os
+
+    from ramble.workspace import workspace
+
+    ws_root = str(tmpdir.mkdir("ws"))
+    ws = workspace.Workspace(ws_root, True)
+
+    ws.write_utilities()
+
+    shared_util_dir = os.path.join(ws_root, "shared", "utilities")
+    assert os.path.exists(shared_util_dir)
+
+    # Base script
+    assert os.path.exists(os.path.join(shared_util_dir, "_ramble_file_editor.py"))
+
+
+def test_edit_file_missing_replace(mock_app):
+    with pytest.raises(
+        ramble.language.language_helpers.DirectiveError,
+        match="requires both 'match' and 'replace' to be specified together",
+    ):
+        edit_func = edit_file("my_edit", "/path/f", match="foo")
+        edit_func(mock_app)
+
+
+def test_edit_file_missing_match(mock_app):
+    with pytest.raises(
+        ramble.language.language_helpers.DirectiveError,
+        match="requires both 'match' and 'replace' to be specified together",
+    ):
+        edit_func = edit_file("my_edit", "/path/f", replace="foo")
+        edit_func(mock_app)
+
+
+def test_edit_file_no_actions(mock_app):
+    with pytest.raises(
+        ramble.language.language_helpers.DirectiveError,
+        match="requires at least one action \\(match/replace, append, "
+        "prepend, or function\\) to be specified",
+    ):
+        edit_func = edit_file("my_edit", "/path/f")
+        edit_func(mock_app)
+
+
+def test_edit_file_unretrievable_source(mock_app):
+    # Dynamically created function has no source code file
+    d = {}
+    exec("def dynamic_func(content):\n    return content", d)
+    dynamic_func = d["dynamic_func"]
+
+    with pytest.raises(
+        ramble.language.language_helpers.DirectiveError,
+        match="could not retrieve source for function",
+    ):
+        edit_func = edit_file("my_edit", "/path/f", function=dynamic_func)
+        edit_func(mock_app)
+
+
+def test_patch_file_directive():
+    from ramble.language.shared_language import patch_file
+
+    # Create an app without executables to cover that branch
+    class EmptyApp:
+        def __init__(self):
+            self.name = "empty_app"
+
+    app = EmptyApp()
+    patch_func = patch_file("my_patch", "/path/f", "/path/to/patch")
+    patch_func(app)
+
+    # Adding a second one to hit the line where executables dict exists
+    patch_func2 = patch_file("my_patch2", "/path/f2", "/path/to/patch2")
+    patch_func2(app)
+
+    when_set = frozenset()
+    assert "my_patch" in app.executables[when_set]
+    assert "my_patch2" in app.executables[when_set]
+    template = app.executables[when_set]["my_patch"].template[0]
+    assert "--mode patch" in template
+
+
+def test_edit_file_directive_empty_app():
+    # Same for edit_file
+    class EmptyApp:
+        def __init__(self):
+            self.name = "empty_app"
+            self.custom_edit_functions = {}
+
+    app = EmptyApp()
+    edit_func = edit_file("my_edit", "/path/f", match="a", replace="b")
+    edit_func(app)
+    assert "my_edit" in app.executables[frozenset()]

--- a/lib/ramble/ramble/test/end_to_end/experiment_excludes.py
+++ b/lib/ramble/ramble/test/end_to_end/experiment_excludes.py
@@ -237,9 +237,21 @@ compilers:
                 assert "unset TEST_VAR" in data
 
                 # Test the expected portions of the execution command exist
-                assert "sed -i -e 's/ start_hour.*/ start_hour" in data
-                assert "sed -i -e 's/ restart .*/ restart" in data
+                expected_editor = '_ramble_file_editor.py" --mode regex --file namelist.input'
+                expected_fix_hour = (
+                    expected_editor
+                    + " --match ' start_hour.*' --replace"
+                    + " ' start_hour                          = 23,'"
+                )
+                expected_fix_restart = (
+                    expected_editor
+                    + " --match ' restart .*' --replace"
+                    + " ' restart                             = .true.,'"
+                )
+                assert expected_fix_hour in data
+                assert expected_fix_restart in data
                 assert "mpirun" in data
+
                 assert "wrf.exe" in data
 
                 # Test the run script has a reference to the experiment log file
@@ -254,9 +266,21 @@ compilers:
                 assert "unset TEST_VAR" in data
 
                 # Test the expected portions of the execution command exist
-                assert "sed -i -e 's/ start_hour.*/ start_hour" in data
-                assert "sed -i -e 's/ restart .*/ restart" in data
+                expected_editor = '_ramble_file_editor.py" --mode regex --file namelist.input'
+                expected_fix_hour = (
+                    expected_editor
+                    + " --match ' start_hour.*' --replace"
+                    + " ' start_hour                          = 23,'"
+                )
+                expected_fix_restart = (
+                    expected_editor
+                    + " --match ' restart .*' --replace"
+                    + " ' restart                             = .true.,'"
+                )
+                assert expected_fix_hour in data
+                assert expected_fix_restart in data
                 assert "mpirun" in data
+
                 assert "wrf.exe" in data
 
                 # Test the run script has a reference to the experiment log file

--- a/lib/ramble/ramble/test/end_to_end/explicit_zips.py
+++ b/lib/ramble/ramble/test/end_to_end/explicit_zips.py
@@ -206,9 +206,21 @@ licenses:
                 assert "unset TEST_VAR" in data
 
                 # Test the expected portions of the execution command exist
-                assert "sed -i -e 's/ start_hour.*/ start_hour" in data
-                assert "sed -i -e 's/ restart .*/ restart" in data
+                expected_editor = '_ramble_file_editor.py" --mode regex --file namelist.input'
+                expected_fix_hour = (
+                    expected_editor
+                    + " --match ' start_hour.*' --replace"
+                    + " ' start_hour                          = 23,'"
+                )
+                expected_fix_restart = (
+                    expected_editor
+                    + " --match ' restart .*' --replace"
+                    + " ' restart                             = .true.,'"
+                )
+                assert expected_fix_hour in data
+                assert expected_fix_restart in data
                 assert "mpirun" in data
+
                 assert "wrf.exe" in data
 
                 # Test the run script has a reference to the experiment log file
@@ -223,9 +235,21 @@ licenses:
                 assert "unset TEST_VAR" in data
 
                 # Test the expected portions of the execution command exist
-                assert "sed -i -e 's/ start_hour.*/ start_hour" in data
-                assert "sed -i -e 's/ restart .*/ restart" in data
+                expected_editor = '_ramble_file_editor.py" --mode regex --file namelist.input'
+                expected_fix_hour = (
+                    expected_editor
+                    + " --match ' start_hour.*' --replace"
+                    + " ' start_hour                          = 23,'"
+                )
+                expected_fix_restart = (
+                    expected_editor
+                    + " --match ' restart .*' --replace"
+                    + " ' restart                             = .true.,'"
+                )
+                assert expected_fix_hour in data
+                assert expected_fix_restart in data
                 assert "mpirun" in data
+
                 assert "wrf.exe" in data
 
                 # Test the run script has a reference to the experiment log file

--- a/lib/ramble/ramble/test/end_to_end/wrfv4_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/wrfv4_dry_run.py
@@ -220,8 +220,20 @@ compilers:
                 assert "unset TEST_VAR" in data
 
                 # Test the expected portions of the execution command exist
-                assert "sed -i -e 's/ start_hour.*/ start_hour" in data
-                assert "sed -i -e 's/ restart .*/ restart" in data
+                expected_editor = '_ramble_file_editor.py" --mode regex --file namelist.input'
+                expected_fix_hour = (
+                    expected_editor
+                    + " --match ' start_hour.*' --replace"
+                    + " ' start_hour                          = 23,'"
+                )
+                expected_fix_restart = (
+                    expected_editor
+                    + " --match ' restart .*' --replace"
+                    + " ' restart                             = .true.,'"
+                )
+                assert expected_fix_hour in data
+                assert expected_fix_restart in data
+
                 assert re.search("\nmpirun", data)
                 assert "wrf.exe" in data
 
@@ -248,8 +260,20 @@ compilers:
                 assert "unset TEST_VAR" in data
 
                 # Test the expected portions of the execution command exist
-                assert "sed -i -e 's/ start_hour.*/ start_hour" in data
-                assert "sed -i -e 's/ restart .*/ restart" in data
+                expected_editor = '_ramble_file_editor.py" --mode regex --file namelist.input'
+                expected_fix_hour = (
+                    expected_editor
+                    + " --match ' start_hour.*' --replace"
+                    + " ' start_hour                          = 23,'"
+                )
+                expected_fix_restart = (
+                    expected_editor
+                    + " --match ' restart .*' --replace"
+                    + " ' restart                             = .true.,'"
+                )
+                assert expected_fix_hour in data
+                assert expected_fix_restart in data
+
                 assert "mpirun" in data
                 assert "wrf.exe" in data
 
@@ -454,8 +478,20 @@ licenses:
                 assert "unset TEST_VAR" in data
 
                 # Test the expected portions of the execution command exist
-                assert "sed -i -e 's/ start_hour.*/ start_hour" in data
-                assert "sed -i -e 's/ restart .*/ restart" in data
+                expected_editor = '_ramble_file_editor.py" --mode regex --file namelist.input'
+                expected_fix_hour = (
+                    expected_editor
+                    + " --match ' start_hour.*' --replace"
+                    + " ' start_hour                          = 23,'"
+                )
+                expected_fix_restart = (
+                    expected_editor
+                    + " --match ' restart .*' --replace"
+                    + " ' restart                             = .true.,'"
+                )
+                assert expected_fix_hour in data
+                assert expected_fix_restart in data
+
                 assert "mpirun" in data
                 assert "wrf.exe" in data
 
@@ -481,8 +517,20 @@ licenses:
                 assert "unset TEST_VAR" in data
 
                 # Test the expected portions of the execution command exist
-                assert "sed -i -e 's/ start_hour.*/ start_hour" in data
-                assert "sed -i -e 's/ restart .*/ restart" in data
+                expected_editor = '_ramble_file_editor.py" --mode regex --file namelist.input'
+                expected_fix_hour = (
+                    expected_editor
+                    + " --match ' start_hour.*' --replace"
+                    + " ' start_hour                          = 23,'"
+                )
+                expected_fix_restart = (
+                    expected_editor
+                    + " --match ' restart .*' --replace"
+                    + " ' restart                             = .true.,'"
+                )
+                assert expected_fix_hour in data
+                assert expected_fix_restart in data
+
                 assert "mpirun" in data
                 assert "wrf.exe" in data
 

--- a/lib/ramble/ramble/util/file_editor.py
+++ b/lib/ramble/ramble/util/file_editor.py
@@ -1,0 +1,128 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+
+def get_file_editor_exec_path():
+    """Returns the path to the file editor script to use"""
+    return f"{{workspace_shared}}/utilities/{HELPER_SCRIPT_NAME}"
+
+
+def get_file_editor_script():
+    """Returns the content of the standalone file editor script"""
+
+    return r"""# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+
+import re
+import os
+import argparse
+import sys
+import shutil
+
+def edit_file(args):
+    if not os.path.exists(args.file):
+        content = ""
+    else:
+        # Use newline='' to preserve original line endings across platforms
+        with open(args.file, 'r', newline='', encoding='utf-8') as f:
+            content = f.read()
+
+    def unescape(s):
+        if s is None:
+            return None
+        return s.encode('utf-8').decode('unicode_escape')
+
+    new_content = content
+    if args.mode == 'regex':
+        if args.function:
+            func = None
+            if args.import_module:
+                import importlib.util
+                if not os.path.exists(args.import_module):
+                    print(f"Error: Module file {args.import_module} not found.")
+                    return 1
+                spec = importlib.util.spec_from_file_location(
+                    "custom_functions", args.import_module
+                )
+                custom_module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(custom_module)
+                func = getattr(custom_module, args.function, None)
+            else:
+                func = globals().get(args.function)
+
+            if func:
+                new_content = func(content)
+                if not isinstance(new_content, str):
+                    print(
+                        f"Error: Function {args.function} must return a string, "
+                        f"not {type(new_content).__name__}"
+                    )
+                    return 1
+            else:
+                print(f"Error: Function {args.function} not found.")
+                return 1
+
+        if args.match and args.replace is not None:
+
+            new_content = re.sub(args.match, unescape(args.replace), new_content)
+        if args.append:
+            new_content = new_content + unescape(args.append)
+        if args.prepend:
+            new_content = unescape(args.prepend) + new_content
+    elif args.mode == 'patch':
+        if not shutil.which('patch'):
+            print("Error: 'patch' utility not found.")
+            print("On Windows, please ensure a tool providing 'patch' "
+                  "(e.g., Git Bash, MSYS2, Cygwin) is installed and in your PATH.")
+            return 1
+
+        import subprocess
+        try:
+            subprocess.run(['patch', args.file, args.patch_file], check=True)
+            return 0
+        except Exception as e:
+            print(f"Error applying patch: {e}")
+            return 1
+
+    needs_write = new_content != content or not os.path.exists(args.file)
+    if needs_write:
+        # Ensure the directory exists
+        os.makedirs(os.path.dirname(os.path.abspath(args.file)), exist_ok=True)
+        with open(args.file, 'w', newline='', encoding='utf-8') as f:
+            f.write(new_content)
+
+    return 0
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Ramble File Editor')
+    parser.add_argument('--mode', choices=['regex', 'patch'], required=True)
+    parser.add_argument('--file', required=True)
+    parser.add_argument('--match', help='Regex pattern to match')
+    parser.add_argument('--replace', help='Replacement string')
+    parser.add_argument('--append', help='String to append')
+    parser.add_argument('--prepend', help='String to prepend')
+    parser.add_argument('--patch-file', help='Path to patch file')
+    parser.add_argument('--function', help='Name of custom function to execute')
+    parser.add_argument(
+        '--import-module',
+        help='Path to python module containing custom functions'
+    )
+
+    args = parser.parse_args()
+    sys.exit(edit_file(args))
+"""
+
+
+HELPER_SCRIPT_NAME = "_ramble_file_editor.py"
+CUSTOM_EDIT_FUNCTIONS_NAME = "custom_edit_functions.py"

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -529,8 +529,15 @@ class Workspace:
             if not os.path.exists(section["filename"]):
                 return
 
+        was_active = _active_workspace == self
+        if was_active:
+            deactivate_config_scope(self)
+
         self.clear()
         self._read()
+
+        if was_active:
+            prepare_config_scope(self)
 
     def _read(self):
         # Create the workspace config section
@@ -761,6 +768,8 @@ ramble:
             fs.mkdirp(self.path)
             fs.mkdirp(self.config_dir)
             fs.mkdirp(self.auxiliary_software_dir)
+            fs.mkdirp(self.shared_dir)
+            fs.mkdirp(self.shared_utilities_dir)
             fs.mkdirp(self.log_dir)
             fs.mkdirp(self.experiment_dir)
 
@@ -783,6 +792,10 @@ ramble:
 
             self.write_templates()
 
+            self.write_utilities()
+
+            self.write_auxiliary_software_files()
+
             self.write_metadata()
 
     def write_config(self, section, force=False):
@@ -802,8 +815,31 @@ ramble:
 
         for name, conf in self._templates.items():
             template_path = self.template_path(name)
-            with open(template_path, "w+") as f:
+            with open(template_path, "w+", encoding="utf-8") as f:
                 f.write(conf["contents"])
+
+    def write_utilities(self):
+        """Write workspace utilities out to the shared directory"""
+        import ramble.util.file_editor
+
+        if ramble.config.get("config:generate_file_editing_scripts", True):
+            fs.mkdirp(self.shared_utilities_dir)
+
+            # Write to base shared utilities directory
+            base_script_content = ramble.util.file_editor.get_file_editor_script()
+            base_script_path = os.path.join(
+                self.shared_utilities_dir, ramble.util.file_editor.HELPER_SCRIPT_NAME
+            )
+            with open(base_script_path, "w+", encoding="utf-8") as f:
+                f.write(base_script_content)
+
+    def write_auxiliary_software_files(self):
+        """Write all auxiliary software files out to workspace"""
+
+        for name, contents in self._auxiliary_software_files.items():
+            aux_path = os.path.join(self.auxiliary_software_dir, name)
+            with open(aux_path, "w+", encoding="utf-8") as f:
+                f.write(contents)
 
     def update_metadata(self, key, value):
         """Set the metadata key value
@@ -2132,6 +2168,11 @@ ramble:
         return os.path.join(self.config_dir, AUXILIARY_SOFTWARE_DIR_NAME)
 
     @property
+    def shared_utilities_dir(self):
+        """Path to the Ramble shared utilities directory"""
+        return os.path.join(self.shared_dir, "utilities")
+
+    @property
     def config_file_path(self):
         """Path to the configuration file directory"""
         return os.path.join(self.config_dir, CONFIG_FILE_NAME)
@@ -2176,7 +2217,7 @@ ramble:
         yield from self._templates.items()
 
     def all_auxiliary_software_files(self):
-        """Iterator over each file in $workspace/configs/auxiliary_software_files"""
+        """Iterator over each auxiliary software file"""
         yield from self._auxiliary_software_files.items()
 
     @classmethod

--- a/var/ramble/repos/builtin/applications/elk/application.py
+++ b/var/ramble/repos/builtin/applications/elk/application.py
@@ -44,10 +44,11 @@ class Elk(ExecutableApplication):
         src="{input_path}/elk.in",
         dst="{experiment_run_dir}/.",
     )
-    executable(
+    edit_file(
         "update_input",
-        "sed -i 's|../../../species/|{examples}/species/|g' elk.in",
-        use_mpi=False,
+        file_path="elk.in",
+        match=r"\.\./\.\./\.\./species/",
+        replace="{examples}/species/",
     )
 
     workload(

--- a/var/ramble/repos/builtin/applications/intel-hpcg/application.py
+++ b/var/ramble/repos/builtin/applications/intel-hpcg/application.py
@@ -45,18 +45,28 @@ class IntelHpcg(HpcgBase, IntelMklBenchmarksBase):
     executable(
         "move-log", "mv n[0-9]*-[0-9]*p-[0-9]*t*.txt {out_file}", use_mpi=False
     )
-    executable(
-        "reformat-output",  # Removes spaces to match OSS HPCG formatting
-        template=[
-            "sed -i 's/ Final Summary ::/Final Summary::/g' {out_file}",
-            "sed -i 's/    HPCG 2.4 Rating/HPCG 2.4 Rating/g' {out_file}",
-        ],
-        use_mpi=False,
+    edit_file(
+        "reformat-summary",
+        file_path="{out_file}",
+        match=" Final Summary ::",
+        replace="Final Summary::",
+    )
+    edit_file(
+        "reformat-rating",
+        file_path="{out_file}",
+        match="    HPCG 2.4 Rating",
+        replace="HPCG 2.4 Rating",
     )
 
     workload(
         "standard",
-        executables=["set_vars", "execute", "move-log", "reformat-output"],
+        executables=[
+            "set_vars",
+            "execute",
+            "move-log",
+            "reformat-summary",
+            "reformat-rating",
+        ],
     )
 
     workload_group("all_workloads", workloads=["standard"], mode="append")

--- a/var/ramble/repos/builtin/applications/lammps/application.py
+++ b/var/ramble/repos/builtin/applications/lammps/application.py
@@ -141,42 +141,74 @@ class Lammps(ExecutableApplication):
         src="{input_path}",
         dst="{experiment_run_dir}/input.txt",
     )
-    executable(
-        "configure-reaxff",
-        template=[
-            "sed -i -e 's/x index .*/x index {x}/g' -i input.txt",
-            "sed -i -e 's/y index .*/y index {y}/g' -i input.txt",
-            "sed -i -e 's/z index .*/z index {z}/g' -i input.txt",
-            "sed -i -e 's/y index .*/y index {timesteps}/g' -i input.txt",
-        ],
-        use_mpi=False,
+    edit_file(
+        "configure-reaxff-x",
+        file_path="input.txt",
+        match=r"x index .*",
+        replace="x index {x}",
+    )
+    edit_file(
+        "configure-reaxff-y",
+        file_path="input.txt",
+        match=r"y index .*",
+        replace="y index {y}",
+    )
+    edit_file(
+        "configure-reaxff-z",
+        file_path="input.txt",
+        match=r"z index .*",
+        replace="z index {z}",
+    )
+    edit_file(
+        "configure-reaxff-timesteps",
+        file_path="input.txt",
+        match=r"y index .*",
+        replace="y index {timesteps}",
     )
 
-    executable(
-        "configure-size-scale",
-        template=[
-            "sed -i -e 's/xx equal .*/xx equal {xx}/g' -i input.txt",
-            "sed -i -e 's/yy equal .*/yy equal {yy}/g' -i input.txt",
-            "sed -i -e 's/zz equal .*/zz equal {zz}/g' -i input.txt",
-        ],
-        use_mpi=False,
+    edit_file(
+        "configure-size-scale-xx",
+        file_path="input.txt",
+        match=r"xx equal .*",
+        replace="xx equal {xx}",
     )
-    executable(
+    edit_file(
+        "configure-size-scale-yy",
+        file_path="input.txt",
+        match=r"yy equal .*",
+        replace="yy equal {yy}",
+    )
+    edit_file(
+        "configure-size-scale-zz",
+        file_path="input.txt",
+        match=r"zz equal .*",
+        replace="zz equal {zz}",
+    )
+
+    edit_file(
         "configure-run-timesteps",
-        template=[
-            "sed 's/run.*[0-9]+/run\t\t{timesteps}/g' -i input.txt",
-        ],
-        use_mpi=False,
+        file_path="input.txt",
+        match=r"run.*[0-9]+",
+        replace="run\t\t{timesteps}",
     )
 
-    executable(
-        "configure-timestep-variables",
-        template=[
-            "sed 's/t index .*[0-9]+/t index {main_timesteps}/g' -i input.txt",
-            "sed 's/w index .*[0-9]+/t index {warmup_timesteps}/g' -i input.txt",
-            "sed 's/m index .*[0-9]+/t index {timestep_multiplier}/g' -i input.txt",
-        ],
-        use_mpi=False,
+    edit_file(
+        "configure-timestep-variables-main",
+        file_path="input.txt",
+        match=r"t index .*[0-9]+",
+        replace="t index {main_timesteps}",
+    )
+    edit_file(
+        "configure-timestep-variables-warmup",
+        file_path="input.txt",
+        match=r"w index .*[0-9]+",
+        replace="t index {warmup_timesteps}",
+    )
+    edit_file(
+        "configure-timestep-variables-multiplier",
+        file_path="input.txt",
+        match=r"m index .*[0-9]+",
+        replace="t index {timestep_multiplier}",
     )
 
     exec_path = os.path.join("{lammps_path}", "bin", "lmp")
@@ -187,22 +219,18 @@ class Lammps(ExecutableApplication):
         use_mpi=True,
     )
 
-    executable(
+    edit_file(
         "set-data-path",
-        template=[
-            r"sed 's|data\.|"
-            + os.path.join("{lammps-stage}", "bench", "data.")
-            + "|g' -i input.txt"
-        ],
-        use_mpi=False,
+        file_path="input.txt",
+        match=r"data\.",
+        replace=os.path.join("{lammps-stage}", "bench", "data."),
     )
 
-    executable(
+    edit_file(
         "change-root",
-        template=[
-            "sed 's|${root}|{lammps-stage}" + os.path.sep + "|g' -i input.txt"
-        ],
-        use_mpi=False,
+        file_path="input.txt",
+        match=r"\$\{root\}",
+        replace="{lammps-stage}" + os.path.sep,
     )
 
     stage_files(
@@ -231,7 +259,9 @@ class Lammps(ExecutableApplication):
         "lj",
         executables=[
             "stage-input",
-            "configure-size-scale",
+            "configure-size-scale-xx",
+            "configure-size-scale-yy",
+            "configure-size-scale-zz",
             "configure-run-timesteps",
             "execute",
         ],
@@ -265,7 +295,9 @@ class Lammps(ExecutableApplication):
         "eam",
         executables=[
             "stage-input",
-            "configure-size-scale",
+            "configure-size-scale-xx",
+            "configure-size-scale-yy",
+            "configure-size-scale-zz",
             "configure-run-timesteps",
             "execute",
         ],
@@ -347,8 +379,12 @@ class Lammps(ExecutableApplication):
         executables=[
             "stage-input",
             "change-root",
-            "configure-size-scale",
-            "configure-timestep-variables",
+            "configure-size-scale-xx",
+            "configure-size-scale-yy",
+            "configure-size-scale-zz",
+            "configure-timestep-variables-main",
+            "configure-timestep-variables-warmup",
+            "configure-timestep-variables-multiplier",
             "execute",
         ],
         input="lammps-stage",
@@ -392,8 +428,12 @@ class Lammps(ExecutableApplication):
         executables=[
             "stage-input",
             "change-root",
-            "configure-size-scale",
-            "configure-timestep-variables",
+            "configure-size-scale-xx",
+            "configure-size-scale-yy",
+            "configure-size-scale-zz",
+            "configure-timestep-variables-main",
+            "configure-timestep-variables-warmup",
+            "configure-timestep-variables-multiplier",
             "execute",
         ],
         input="lammps-stage",
@@ -437,8 +477,12 @@ class Lammps(ExecutableApplication):
         executables=[
             "stage-input",
             "change-root",
-            "configure-size-scale",
-            "configure-timestep-variables",
+            "configure-size-scale-xx",
+            "configure-size-scale-yy",
+            "configure-size-scale-zz",
+            "configure-timestep-variables-main",
+            "configure-timestep-variables-warmup",
+            "configure-timestep-variables-multiplier",
             "execute",
         ],
         input="lammps-stage",
@@ -482,7 +526,9 @@ class Lammps(ExecutableApplication):
         executables=[
             "stage-input",
             "change-root",
-            "configure-timestep-variables",
+            "configure-timestep-variables-main",
+            "configure-timestep-variables-warmup",
+            "configure-timestep-variables-multiplier",
             "execute",
         ],
         input="lammps-stage",
@@ -511,8 +557,12 @@ class Lammps(ExecutableApplication):
         executables=[
             "stage-input",
             "change-root",
-            "configure-size-scale",
-            "configure-timestep-variables",
+            "configure-size-scale-xx",
+            "configure-size-scale-yy",
+            "configure-size-scale-zz",
+            "configure-timestep-variables-main",
+            "configure-timestep-variables-warmup",
+            "configure-timestep-variables-multiplier",
             "execute",
         ],
         input="lammps-stage",
@@ -556,7 +606,9 @@ class Lammps(ExecutableApplication):
         executables=[
             "stage-input",
             "change-root",
-            "configure-timestep-variables",
+            "configure-timestep-variables-main",
+            "configure-timestep-variables-warmup",
+            "configure-timestep-variables-multiplier",
             "execute",
         ],
         input="lammps-stage",
@@ -585,8 +637,12 @@ class Lammps(ExecutableApplication):
         executables=[
             "stage-input",
             "change-root",
-            "configure-size-scale",
-            "configure-timestep-variables",
+            "configure-size-scale-xx",
+            "configure-size-scale-yy",
+            "configure-size-scale-zz",
+            "configure-timestep-variables-main",
+            "configure-timestep-variables-warmup",
+            "configure-timestep-variables-multiplier",
             "execute",
         ],
         input="lammps-stage",
@@ -630,8 +686,12 @@ class Lammps(ExecutableApplication):
         executables=[
             "stage-input",
             "change-root",
-            "configure-size-scale",
-            "configure-timestep-variables",
+            "configure-size-scale-xx",
+            "configure-size-scale-yy",
+            "configure-size-scale-zz",
+            "configure-timestep-variables-main",
+            "configure-timestep-variables-warmup",
+            "configure-timestep-variables-multiplier",
             "execute",
         ],
         input="lammps-stage",
@@ -675,7 +735,9 @@ class Lammps(ExecutableApplication):
         executables=[
             "stage-input",
             "change-root",
-            "configure-timestep-variables",
+            "configure-timestep-variables-main",
+            "configure-timestep-variables-warmup",
+            "configure-timestep-variables-multiplier",
             "execute",
         ],
         input="lammps-stage",
@@ -704,7 +766,10 @@ class Lammps(ExecutableApplication):
         executables=[
             "stage-contents",
             "stage-input-file",
-            "configure-reaxff",
+            "configure-reaxff-x",
+            "configure-reaxff-y",
+            "configure-reaxff-z",
+            "configure-reaxff-timesteps",
             "execute",
         ],
         inputs=["lammps-stage"],

--- a/var/ramble/repos/builtin/applications/orca/application.py
+++ b/var/ramble/repos/builtin/applications/orca/application.py
@@ -53,10 +53,11 @@ class Orca(ExecutableApplication):
     # The only way to configure total ranks launched is by changing the PAL nprocs keyword
     # in the main input file.
     scratch_in_path = os.path.join("{scratch_dir}", "{main_input_file}")
-    executable(
+    edit_file(
         "configure_nprocs",
-        f"sed -i 's/nprocs.*/nprocs {{n_ranks}}/' {scratch_in_path}",
-        use_mpi=False,
+        file_path=scratch_in_path,
+        match=r"nprocs.*",
+        replace="nprocs {n_ranks}",
     )
 
     # orca requires the full path when running in parallel

--- a/var/ramble/repos/builtin/applications/wrf/application.py
+++ b/var/ramble/repos/builtin/applications/wrf/application.py
@@ -146,35 +146,33 @@ class Wrf(ExecutableApplication):
             output_capture=OUTPUT_CAPTURE.ALL,
         )
 
-        executable(
-            "fix_12km",
-            template=[
-                "sed -i -e 's/ start_hour.*/ start_hour                          = 23,/g' namelist.input",
-                "sed -i -e 's/ restart .*/ restart                             = .true.,/g' namelist.input",
-            ],
-            use_mpi=False,
-            output_capture=OUTPUT_CAPTURE.ALL,
+        edit_file(
+            "fix_12km_start_hour",
+            file_path="namelist.input",
+            match=r" start_hour.*",
+            replace=" start_hour                          = 23,",
         )
 
-        executable(
+        edit_file(
+            "fix_12km_restart",
+            file_path="namelist.input",
+            match=r" restart .*",
+            replace=" restart                             = .true.,",
+        )
+
+        edit_file(
             "define_nproc_x",
-            template=[
-                "awk '/e_sn.*=/ {print $0 RS \" nproc_x                            = {nproc_x},\"} !/e_sn.*=/ {print $0}' namelist.input > {experiment_run_dir}/temp_namelist.input",
-                "mv {experiment_run_dir}/temp_namelist.input {experiment_run_dir}/namelist.input",
-            ],
-            redirect="",
-            output_capture="",
+            file_path="namelist.input",
+            match=r"(e_sn.*=.*)",
+            replace=r"\g<1>\n nproc_x                            = {nproc_x},",
             when="+wrf_explicit_x",
         )
 
-        executable(
+        edit_file(
             "define_nproc_y",
-            template=[
-                "awk '/e_sn.*=/ {print $0 RS \" nproc_y                            = {nproc_y},\"} !/e_sn.*=/ {print $0}' namelist.input > {experiment_run_dir}/temp_namelist.input",
-                "mv {experiment_run_dir}/temp_namelist.input {experiment_run_dir}/namelist.input",
-            ],
-            redirect="",
-            output_capture="",
+            file_path="namelist.input",
+            match=r"(e_sn.*=.*)",
+            replace=r"\g<1>\n nproc_y                            = {nproc_y},",
             when="+wrf_explicit_y",
         )
 
@@ -212,7 +210,8 @@ class Wrf(ExecutableApplication):
                 "cleanup",
                 "define_nproc_y",
                 "define_nproc_x",
-                "fix_12km",
+                "fix_12km_start_hour",
+                "fix_12km_restart",
                 "execute",
                 "copy-logs",
                 "post-exec-clean",

--- a/var/ramble/repos/builtin/applications/wrfv4/application.py
+++ b/var/ramble/repos/builtin/applications/wrfv4/application.py
@@ -113,35 +113,33 @@ class Wrfv4(ExecutableApplication):
         output_capture=OUTPUT_CAPTURE.ALL,
     )
 
-    executable(
-        "fix_12km",
-        template=[
-            "sed -i -e 's/ start_hour.*/ start_hour                          = 23,/g' namelist.input",
-            "sed -i -e 's/ restart .*/ restart                             = .true.,/g' namelist.input",
-        ],
-        use_mpi=False,
-        output_capture=OUTPUT_CAPTURE.ALL,
+    edit_file(
+        "fix_12km_start_hour",
+        file_path="namelist.input",
+        match=r" start_hour.*",
+        replace=" start_hour                          = 23,",
     )
 
-    executable(
+    edit_file(
+        "fix_12km_restart",
+        file_path="namelist.input",
+        match=r" restart .*",
+        replace=" restart                             = .true.,",
+    )
+
+    edit_file(
         "define_nproc_x",
-        template=[
-            "awk '/e_sn.*=/ {print $0 RS \" nproc_x                            = {nproc_x},\"} !/e_sn.*=/ {print $0}' namelist.input > {experiment_run_dir}/temp_namelist.input",
-            "mv {experiment_run_dir}/temp_namelist.input {experiment_run_dir}/namelist.input",
-        ],
-        redirect="",
-        output_capture="",
+        file_path="namelist.input",
+        match=r"(e_sn.*=.*)",
+        replace=r"\g<1>\n nproc_x                            = {nproc_x},",
         when="+wrf_explicit_x",
     )
 
-    executable(
+    edit_file(
         "define_nproc_y",
-        template=[
-            "awk '/e_sn.*=/ {print $0 RS \" nproc_y                            = {nproc_y},\"} !/e_sn.*=/ {print $0}' namelist.input > {experiment_run_dir}/temp_namelist.input",
-            "mv {experiment_run_dir}/temp_namelist.input {experiment_run_dir}/namelist.input",
-        ],
-        redirect="",
-        output_capture="",
+        file_path="namelist.input",
+        match=r"(e_sn.*=.*)",
+        replace=r"\g<1>\n nproc_y                            = {nproc_y},",
         when="+wrf_explicit_y",
     )
 
@@ -196,7 +194,8 @@ class Wrfv4(ExecutableApplication):
             "cleanup",
             "define_nproc_y",
             "define_nproc_x",
-            "fix_12km",
+            "fix_12km_start_hour",
+            "fix_12km_restart",
             "execute",
             "copy-logs",
             "post-exec-clean",


### PR DESCRIPTION
This merge adds two new directives, one for performing portable editing of a file, and another for patching files. This allows ramble objects to define manipulations on files in the experiments using a portable syntax that can be applied across operating systems.

Additionally, the edit directive allows users to define a python function to edit the resulting file which will then be executed as part of the experiment.