### PR TITLE
make none verbose prints unique since we don't have the when to differentiate 

### DIFF
--- a/lib/ramble/ramble/cmd/common/info.py
+++ b/lib/ramble/ramble/cmd/common/info.py
@@ -183,6 +183,7 @@ def _unpack_when_set_if_needed(internal_attr: dict):
 
 def _print_nonverbose_list_attr(internal_attr, pattern="*", format=supported_formats.text):
     to_print = fnmatch.filter(map(str, internal_attr), pattern)
+    to_print = list(dict.fromkeys(to_print))
     if format == supported_formats.lists:
         color.cprint(f"    {list(to_print)}")
     elif format == supported_formats.text:


### PR DESCRIPTION
Example before:

```
object_environment_variables:
    IRDMA_TRANSPARENT_UD_QD_OVERRIDE  I_MPI_ADJUST_IBCAST     I_MPI_ADJUST_BCAST
    I_MPI_ADJUST_ALLTOALL             I_MPI_ADJUST_BARRIER    I_MPI_ADJUST_IBCAST
    I_MPI_ADJUST_ALLTOALL             I_MPI_ADJUST_REDUCE     I_MPI_ADJUST_BARRIER
    I_MPI_ADJUST_IALLTOALL            I_MPI_ADJUST_ALLTOALL   I_MPI_ADJUST_REDUCE
    I_MPI_ADJUST_ALLREDUCE            I_MPI_ADJUST_IALLTOALL  FI_TCP_IFACE
    I_MPI_ADJUST_BCAST                I_MPI_ADJUST_ALLREDUCE  I_MPI_ADJUST_ALLTOALL
    I_MPI_ADJUST_IBCAST               I_MPI_ADJUST_BCAST      I_MPI_ADJUST_IALLTOALL
    I_MPI_ADJUST_BARRIER              I_MPI_ADJUST_IBCAST     I_MPI_ADJUST_ALLREDUCE
    I_MPI_ADJUST_REDUCE               I_MPI_ADJUST_BARRIER    I_MPI_ADJUST_BCAST
    FI_TCP_IFACE                      I_MPI_ADJUST_REDUCE     I_MPI_ADJUST_IBCAST
    I_MPI_ADJUST_ALLTOALL             FI_TCP_IFACE            I_MPI_ADJUST_BARRIER
    I_MPI_ADJUST_IALLTOALL            I_MPI_ADJUST_ALLTOALL   I_MPI_ADJUST_REDUCE
    I_MPI_ADJUST_ALLREDUCE            I_MPI_ADJUST_IALLTOALL  FI_TCP_IFACE
    I_MPI_ADJUST_BCAST                I_MPI_ADJUST_ALLREDUCE
```
(each repeat is from a different when)

After:
```
object_environment_variables:
    IRDMA_TRANSPARENT_UD_QD_OVERRIDE  I_MPI_ADJUST_ALLREDUCE  I_MPI_ADJUST_BARRIER
    I_MPI_ADJUST_ALLTOALL             I_MPI_ADJUST_BCAST      I_MPI_ADJUST_REDUCE
    I_MPI_ADJUST_IALLTOALL            I_MPI_ADJUST_IBCAST     FI_TCP_IFACE
```