### PR TITLE
Add `fast` and `perf` options explicitly to unit-test cmd

### DIFF
--- a/lib/ramble/ramble/cmd/unit_test.py
+++ b/lib/ramble/ramble/cmd/unit_test.py
@@ -56,6 +56,18 @@ def setup_parser(subparser):
         dest="repo_path",
         help="run tests under the given object repo root (used for testing external object repo)",
     )
+    subparser.add_argument(
+        "--perf",
+        action="store_true",
+        default=False,
+        help="run only performance tests",
+    )
+    subparser.add_argument(
+        "--fast",
+        action="store_true",
+        default=False,
+        help="run only fast tests (skip slow tests)",
+    )
 
     # extra ramble arguments to list tests
     list_group = subparser.add_argument_group("listing tests")
@@ -186,6 +198,10 @@ def add_back_pytest_args(args, unknown_args):
         result += ["--ignore-glob", "lib/ramble/ramble/test/*"]
     elif args.repo_path:
         result += ["--repo-path", args.repo_path]
+    if args.perf:
+        result += ["--perf"]
+    if args.fast:
+        result += ["--fast"]
     result += unknown_args or []
     result += args.pytest_args or []
     if args.expression:

--- a/lib/ramble/ramble/test/cmd/unit_test.py
+++ b/lib/ramble/ramble/test/cmd/unit_test.py
@@ -87,3 +87,9 @@ def test_external_repo_valid(tmpdir):
     )
     assert result.returncode == 0
     assert "1 passed" in result.stdout
+
+
+@pytest.mark.parametrize("flag", ["--perf", "--fast"])
+def test_flags_accepted(flag):
+    output = ramble_test(flag, "--list")
+    assert "ramble/test/cmd/unit_test.py" in output

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -613,7 +613,7 @@ _ramble_style() {
 _ramble_unit_test() {
     if $list_options
     then
-        RAMBLE_COMPREPLY="-h --help -H --pytest-help --lib --obj -r --repo-path -l --list -L --list-long -N --list-names -s -k --showlocals"
+        RAMBLE_COMPREPLY="-h --help -H --pytest-help --lib --obj -r --repo-path --perf --fast -l --list -L --list-long -N --list-names -s -k --showlocals"
     else
         _unit_tests
     fi


### PR DESCRIPTION
This allows the cli help message to document these options.