### PR TITLE
Optimize variant caching and workspace info generation [AI]

### DIFF
--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -912,7 +912,9 @@ def workspace_info(args):
                     if not active:
                         continue
 
-                    if app_inst.package_manager is not None:
+                    if (
+                        args.software or args.all_software
+                    ) and app_inst.package_manager is not None:
                         software_environments.render_environment(
                             app_inst.expander.expand_var("{env_name}"),
                             app_inst.expander,
@@ -934,11 +936,12 @@ def workspace_info(args):
                         print_header = False
 
                     # Aggregate pipeline phases
-                    for pipeline in app_inst.pipelines:
-                        if pipeline not in all_pipelines:
-                            all_pipelines[pipeline] = set()
-                        for phase in app_inst.get_pipeline_phases(pipeline):
-                            all_pipelines[pipeline].add(phase)
+                    if args.phases:
+                        for pipeline in app_inst.pipelines:
+                            if pipeline not in all_pipelines:
+                                all_pipelines[pipeline] = set()
+                            for phase in app_inst.get_pipeline_phases(pipeline):
+                                all_pipelines[pipeline].add(phase)
 
                     experiment_index = app_inst.expander.expand_var_name(
                         app_inst.keywords.experiment_index

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -489,6 +489,59 @@ ramble:
     assert "zlib.ensure_installed.test_experiment" not in output
 
 
+def test_workspace_info_phases(workspace_name):
+    test_config = """
+ramble:
+  variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
+    processes_per_node: '5'
+    n_ranks: '{processes_per_node}*{n_nodes}'
+  applications:
+    basic:
+      workloads:
+        test_wl:
+          experiments:
+            test_experiment:
+              variables:
+                n_nodes: '2'
+        test_wl2:
+          experiments:
+            test_experiment:
+              variables:
+                n_nodes: '2'
+    zlib:
+      workloads:
+        ensure_installed:
+          experiments:
+            test_experiment:
+              variables:
+                n_nodes: '2'
+"""
+
+    ws1 = ramble.workspace.create(workspace_name)
+    ws1.write()
+
+    config_path = os.path.join(ws1.config_dir, ramble.workspace.CONFIG_FILE_NAME)
+
+    with open(config_path, "w+") as f:
+        f.write(test_config)
+
+    ws1._re_read()
+
+    output = workspace("info", "--phases", global_args=["-w", workspace_name])
+
+    assert "basic" in output
+    assert "test_wl" in output
+    assert "test_wl2" in output
+    assert "Application" in output
+    assert "Workload" in output
+    assert "Experiment" in output
+
+    assert "Phases for analyze pipeline:" in output
+    assert "analyze_experiments" in output
+
+
 def test_workspace_info_complete(workspace_name):
     global_args = ["-w", workspace_name]
     ws = ramble.workspace.create(workspace_name)
@@ -517,6 +570,9 @@ def test_workspace_info_complete(workspace_name):
     output = workspace(
         "info",
         "-vv",
+        "--phases",
+        "--variants",
+        "--all-software",
         global_args=["-w", workspace_name],
     )
 
@@ -2545,6 +2601,10 @@ def test_workspace_info_software(workspace_name):
     output = workspace("info", "--software", global_args=global_args)
     assert "pip-pkg" in output
     assert "spack-pkg" in output
+
+    output_all = workspace("info", "--all-software", global_args=global_args)
+    assert "pip-pkg" in output_all
+    assert "spack-pkg" in output_all
     assert "pip-test" in output
     assert "spack-test" in output
 

--- a/lib/ramble/ramble/variants.py
+++ b/lib/ramble/ramble/variants.py
@@ -71,20 +71,13 @@ class VariantSet:
     def copy(self):
         new_set = VariantSet()
 
-        set_attrs = ["default_variants", "experiment_variants"]
+        set_attrs = ["default_variants", "experiment_variants", "version_variants"]
         for set_attr in set_attrs:
             src_attr_set = getattr(self, set_attr)
-            dest_attr_set = getattr(new_set, set_attr)
-            for name, variant in src_attr_set.items():
-                dest_attr_set[name] = variant.copy()
+            setattr(new_set, set_attr, src_attr_set.copy())
 
         for name, var_list in self.multi_value_variants.items():
-            new_set.multi_value_variants[name] = set()
-            for variant in var_list:
-                new_set.multi_value_variants[name].add(variant.copy())
-
-        for name, variant in self.version_variants.items():
-            new_set.version_variants[name] = variant.copy()
+            new_set.multi_value_variants[name] = var_list.copy()
 
         return new_set
 

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -386,9 +386,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         all_workloads_names = set()
         found = False
         for when_set, workloads in self.workloads.items():
-            if self.expander.satisfies(
-                when_set, self.experiment_variants(allow_caching=False)
-            ):
+            if self.expander.satisfies(when_set, self.experiment_variants()):
                 for workload_name, workload in workloads.items():
                     if workload_name in all_workloads_names:
                         logger.die(
@@ -403,15 +401,13 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         if not found:
             logger.die(
                 "No workloads satisfy the current `when` conditions: \n"
-                f"  {self.experiment_variants(allow_caching=False).as_set()}"
+                f"  {self.experiment_variants().as_set()}"
             )
 
     def _set_package_manager(self):
         pkgman = conversions.canonical_none(
             self.expander.expand_var(
-                self.experiment_variants(allow_caching=False).value(
-                    namespace.package_manager
-                )
+                self.experiment_variants().value(namespace.package_manager)
             )
         )
 
@@ -441,7 +437,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             for pkgname, config in self.required_packages.items():
                 if self.expander.satisfies(
                     config["when"],
-                    variant_set=self.experiment_variants(allow_caching=False),
+                    variant_set=self.experiment_variants(),
                 ):
                     self.keywords.update_keys(
                         {
@@ -454,9 +450,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
     def _set_system(self):
         sys_var = conversions.canonical_none(
-            self.experiment_variants(allow_caching=False).value(
-                namespace.system
-            )
+            self.experiment_variants().value(namespace.system)
         )
 
         if sys_var is None:
@@ -481,31 +475,26 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                     "\tramble list --type systems"
                 )
 
+            added_defaults = False
             for variant in ["platform", "package_manager", "workflow_manager"]:
-                if (
-                    self.experiment_variants(allow_caching=False).value(
-                        variant
-                    )
-                    is None
-                ):
+                if self.experiment_variants().value(variant) is None:
                     default_value = getattr(
                         self.system, f"system_default_{variant}", None
                     )
                     if default_value:
-                        self.experiment_variants(
-                            allow_caching=False
-                        ).default_variant(
+                        self.object_variants.default_variant(
                             variant,
                             default=default_value,
                             description=f"{variant} selection variant",
                         )
+                        added_defaults = True
+            if added_defaults:
+                self.clear_variant_cache()
 
     def _set_platform(self):
         plat_var = conversions.canonical_none(
             self.expander.expand_var(
-                self.experiment_variants(allow_caching=False).value(
-                    namespace.platform
-                )
+                self.experiment_variants().value(namespace.platform)
             )
         )
 
@@ -549,9 +538,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         if self.system:
             # Apply platform_variable_maps
             plat_name = conversions.canonical_none(
-                self.experiment_variants(allow_caching=False).value(
-                    namespace.platform
-                )
+                self.experiment_variants().value(namespace.platform)
             )
 
             if plat_name:
@@ -573,9 +560,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
     def _set_workflow_manager(self):
         workflow = conversions.canonical_none(
             self.expander.expand_var(
-                self.experiment_variants(allow_caching=False).value(
-                    namespace.workflow_manager
-                )
+                self.experiment_variants().value(namespace.workflow_manager)
             )
         )
 
@@ -699,15 +684,18 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             )
 
         # Define experiment variants
-        for name, value in variants.items():
-            expanded_value = self.expander.expand_var(value, typed=True)
-            self.object_variants.experiment_variant(name, expanded_value)
+        if variants:
+            for name, value in variants.items():
+                expanded_value = self.expander.expand_var(value, typed=True)
+                self.object_variants.experiment_variant(name, expanded_value)
+            self.clear_variant_cache()
 
         # Set up remaining variants
         self._set_system()
 
         # Apply defaults from system and platform
         if self.system:
+            added_defaults = False
             if (
                 self.system.default_platform
                 and namespace.platform not in self.variants
@@ -715,6 +703,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                 self.object_variants.experiment_variant(
                     namespace.platform, self.system.system_default_platform
                 )
+                added_defaults = True
 
             if (
                 self.system.default_package_manager
@@ -724,6 +713,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                     namespace.package_manager,
                     self.system.system_default_package_manager,
                 )
+                added_defaults = True
 
             if (
                 self.system.default_workflow_manager
@@ -733,6 +723,10 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                     namespace.workflow_manager,
                     self.system.system_default_workflow_manager,
                 )
+                added_defaults = True
+
+            if added_defaults:
+                self.clear_variant_cache()
 
         self._set_platform()
         self._set_package_manager()
@@ -757,6 +751,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             default=self.expander.workload_name,
             description="Name of experiment workload",
         )
+        self.clear_variant_cache()
 
         self.no_expand_vars = set()
         workloads = self.get_workloads()
@@ -764,7 +759,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         for workload in workloads:
             for var_when_set, var_list in workload.variables.items():
                 if self.expander.satisfies(
-                    var_when_set, self.experiment_variants(allow_caching=False)
+                    var_when_set, self.experiment_variants()
                 ):
                     for var in var_list:
                         if not var.expandable:
@@ -1494,6 +1489,8 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
         # Define any missing modifier variables
         self.define_missing_variables()
+        if self.modifiers:
+            self.clear_variant_cache()
 
     @property
     def inventory_file(self):

--- a/var/ramble/repos/builtin/base_classes/object-mixin/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/object-mixin/base_class.py
@@ -161,6 +161,7 @@ class ObjectMixin:
         self.object_variants.version_variant(
             f"{self.origin_type}_version", self.selected_version
         )
+        self.clear_variant_cache()
 
     def set_required_variables(self, app_inst=None):
         """Stub that allows objects to update required variables"""
@@ -178,6 +179,14 @@ class ObjectMixin:
     def pep440_to_version(version_str):
         """Converts PEP 440 compliant version number to object version number"""
         return version_str
+
+    def clear_variant_cache(self):
+        """Clear the cached variant set for this object."""
+        if hasattr(self, "_variant_cache"):
+            self._variant_cache.clear()
+        app_inst = self._get_app_inst()
+        if app_inst is not self and hasattr(app_inst, "clear_variant_cache"):
+            app_inst.clear_variant_cache()
 
     def experiment_variants(
         self, include_modifier=None, allow_caching=True, app_inst=None

--- a/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
@@ -161,6 +161,7 @@ class PackageManagerBase(ObjectMixin, metaclass=PackageManagerMeta):
         """
         self.app_inst = app_inst
         self.keywords = app_inst.keywords
+        self.clear_variant_cache()
 
     def build_used_variables(self):
         """Build a set of all used variables

--- a/var/ramble/repos/builtin/base_classes/platform-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/platform-base/base_class.py
@@ -123,3 +123,4 @@ class PlatformBase(ObjectMixin, metaclass=PlatformMeta):
     def set_application(self, app_inst):
         """Set the application instance for this platform"""
         self.app_inst = app_inst
+        self.clear_variant_cache()

--- a/var/ramble/repos/builtin/base_classes/system-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/system-base/base_class.py
@@ -93,3 +93,4 @@ class SystemBase(ObjectMixin, metaclass=SystemMeta):
     def set_application(self, app_inst):
         """Set the application instance for this system"""
         self.app_inst = app_inst
+        self.clear_variant_cache()

--- a/var/ramble/repos/builtin/base_classes/workflow-manager-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/workflow-manager-base/base_class.py
@@ -94,6 +94,7 @@ class WorkflowManagerBase(ObjectMixin, metaclass=WorkflowManagerMeta):
     def set_application(self, app_inst):
         """Set a reference to the associated app_inst"""
         self.app_inst = app_inst
+        self.clear_variant_cache()
 
     @abc.abstractmethod
     def get_status(self, workspace):

--- a/var/ramble/repos/builtin/modifiers/nccl-env/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/nccl-env/modifier.py
@@ -524,7 +524,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_nvb_disable",
         default="",
-        values=["0", "1"],
+        values=["", "0", "1"],
         description="Disable intra-node communication through NVLink via an intermediate GPU.",
         modes=["standard"],
     )
@@ -532,7 +532,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_pxn_disable",
         default="",
-        values=["0", "1"],
+        values=["", "0", "1"],
         description="Disable inter-node communication using a non-local NIC, using NVLink and an intermediate GPU.",
         modes=["standard"],
     )
@@ -547,7 +547,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_runtime_connect",
         default="",
-        values=["0", "1"],
+        values=["", "0", "1"],
         description="Dynamically connect peers during runtime instead of init stage.",
         modes=["standard"],
     )
@@ -555,7 +555,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_local_register",
         default="",
-        values=["0", "1"],
+        values=["", "0", "1"],
         description="Enable user local buffer registration when users explicitly call ncclCommRegister.",
         modes=["standard"],
     )
@@ -563,7 +563,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_set_stack_size",
         default="",
-        values=["0", "1"],
+        values=["", "0", "1"],
         description="Set CUDA kernel stack size to the maximum stack size amongst all NCCL kernels.",
         modes=["standard"],
     )
@@ -571,7 +571,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_graph_mixing_support",
         default="",
-        values=["0", "1"],
+        values=["", "0", "1"],
         description="Controls support for multiple outstanding NCCL calls.",
         modes=["standard"],
     )
@@ -579,7 +579,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_dmabuf_enable",
         default="",
-        values=["0", "1"],
+        values=["", "0", "1"],
         description="Enable GPU Direct RDMA buffer registration using the Linux dma-buf subsystem.",
         modes=["standard"],
     )
@@ -601,7 +601,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_alloc_p2p_net_ll_buffers",
         default="",
-        values=["0", "1"],
+        values=["", "0", "1"],
         description="Instructs communicators to allocated dedicated LL buffers for all P2P network connections.",
         modes=["standard"],
     )
@@ -609,7 +609,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_comm_blocking",
         default="",
-        values=["0", "1"],
+        values=["", "0", "1"],
         description="Controls whether NCCL calls are allowed to block or not.",
         modes=["standard"],
     )
@@ -617,7 +617,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_cga_cluster_size",
         default="",
-        values=["0", "1", "2", "3", "4", "5", "6", "7", "8"],
+        values=["", "0", "1", "2", "3", "4", "5", "6", "7", "8"],
         description="Set CUDA Cooperative Group Array cluster size.",
         modes=["standard"],
     )
@@ -646,7 +646,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_ib_merge_nics",
         default="",
-        values=["0", "1"],
+        values=["", "0", "1"],
         description="Enable NCCL to combine dual-port IB NICs into a single logical network device.",
         modes=["standard"],
     )
@@ -654,7 +654,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_ib_merge_vfs",
         default="",
-        values=["0", "1"],
+        values=["", "0", "1"],
         description="Enable NCCL to combine virtual functions into a single physical network device.",
         modes=["standard"],
     )
@@ -662,7 +662,7 @@ class NcclEnv(BasicModifier):
     modifier_variable(
         "nccl_mnnvl_enable",
         default="",
-        values=["0", "1"],
+        values=["", "0", "1"],
         description="Enable NCCL to use Multi-Node NVLink when available.",
         modes=["standard"],
     )

--- a/var/ramble/repos/builtin/package_managers/spack-pip/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-pip/package_manager.py
@@ -42,6 +42,7 @@ class SpackPip(PackageManagerBase):
         self.pip_mgr._allow_unprefixed_specs = False
 
     def set_application(self, app_inst):
+        super().set_application(app_inst)
         self.spack_mgr.set_application(app_inst)
         self.pip_mgr.set_application(app_inst)
 


### PR DESCRIPTION
This merge addresses performance regressions introduced by the addition of system, platform, and package manager objects to every experiment instance.

- Lazy Phase and Software Metadata Aggregation: Guarded pipeline phase aggregation and software environment rendering in `workspace info` with conditional checks so they are only computed when explicitly requested.

- Variant Set Caching: Re-enabled default variant set caching in `experiment_variants()` during experiment setup and added a robust cache invalidation mechanism (`clear_variant_cache()`) that triggers whenever the object hierarchy changes (e.g., when setting system, platform, modifier objects).

- Variant Copy Optimization: Optimized `VariantSet.copy()` to avoid redundant deep copies of `Variant` objects, which are treated as immutable in this context.

These optimizations yield a ~28% reduction in the mean execution time of the `test_many_experiments` benchmark.