### PR TITLE
Re-enable ramle to detect duplicate named experiments [AI]

### DIFF
--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -53,6 +53,7 @@ class ExperimentSet:
         self.chained_experiments = {}
         self.chained_order = []
         self._workspace = workspace
+        self.rendered_experiments = set()
         self._context = {}
         self._filtered_experiments_cache = {}
 
@@ -601,7 +602,6 @@ class ExperimentSet:
         render_group.used_variables = used_variables.copy()
 
         workload_names = set()
-        rendered_experiments = set()
         rendered_instances = []
 
         render_list = renderer.render_objects(render_group, exclude_where=exclude_where)
@@ -634,7 +634,7 @@ class ExperimentSet:
         for app_inst, final_exp_namespace, is_base_experiment in all_processed_experiments:
             logger.debug(f"   Final name: {final_exp_namespace}")
 
-            if final_exp_namespace in rendered_experiments:
+            if final_exp_namespace in self.rendered_experiments:
                 left_vars = self.experiments[final_exp_namespace].variables
                 right_vars = app_inst.variables
                 lkeys = set(left_vars.keys())
@@ -690,7 +690,7 @@ class ExperimentSet:
                 len(self.experiments) + len(self.chained_experiments) + 1,
             )
             app_inst.set_success_list(final_context.success_criteria)
-            rendered_experiments.add(final_exp_namespace)
+            self.rendered_experiments.add(final_exp_namespace)
             rendered_instances.append(app_inst)
             if not chained:
                 self.experiments[final_exp_namespace] = app_inst


### PR DESCRIPTION
Defining an exp with the same name now gives:

==> Warning: Two experiments are defined with the name hostname.local.test-0-1
==> Warning: Variables unique to previously defined experiment:
==> Warning:   - experiment_index
==> Warning:   - indm1
==> Warning: Variables unique to newly defined experiment:
==> Warning:   - indp1
==> Warning: Variable differences between experiment definitions:
==> Warning:   - experiment_template_name: {'previous': 'test-{indm1}-{node_index}', 'new': 'test-{node_index}-{indp1}'}
==> Warning:   - workflow_pragmas: {'previous': '#SBATCH --exclusive\n#SBATCH --ntasks-per-node 1\n#SBATCH -J hostname_local_test-0-1\n#SBATCH -N 2\n#SBATCH -e /Users/robertbird/ramble/var/ramble/workspaces/unique/experiments/hostname/local/test-0-1/slurm-%j.err\n#SBATCH -o /Users/robertbird/ramble/var/ramble/workspaces/unique/experiments/hostname/local/test-0-1/slurm-%j.out\n#SBATCH -w partition-0,partition-1', 'new': '#SBATCH --exclusive\n#SBATCH --ntasks-per-node 1\n#SBATCH -J hostname_local_test-0-1\n#SBATCH -N 2\n#SBATCH -e /Users/robertbird/ramble/var/ramble/workspaces/unique/experiments/hostname/local/test-0-1/slurm-%j.err\n#SBATCH -o /Users/robertbird/ramble/var/ramble/workspaces/unique/experiments/hostname/local/test-0-1/slurm-%j.out\n#SBATCH -w partition-1,partition-0'}
==> Warning:   - extra_sbatch_headers: {'previous': '#SBATCH -w {node_prefix}{indm1},{node_prefix}{node_index}', 'new': '#SBATCH -w {node_prefix}{indp1},{node_prefix}{node_index}'}
==> Warning:   - node_index: {'previous': 1, 'new': 0}
==> Error: Experiment hostname.local.test-0-1 is not unique.