### PR TITLE
Restructure PR unit tests to fail-fast

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -53,6 +53,12 @@ def pytest_addoption(parser):
         help='runs only "fast" unit tests, instead of the whole suite',
     )
     group.addoption(
+        "--slow",
+        action="store_true",
+        default=False,
+        help='runs only "slow" unit tests, instead of the whole suite',
+    )
+    group.addoption(
         "--repo-path",
         default=None,
         help="runs only tests under the given Ramble object repo path",
@@ -120,15 +126,23 @@ def pytest_collection_modifyitems(config, items):
             if "perf" in item.keywords:
                 item.add_marker(skip_perf)
 
-    if not config.getoption("--fast"):
-        # --fast not given, run all the tests
-        return
-
     slow_tests = ["db", "network", "maybeslow", "long"]
-    skip_as_slow = pytest.mark.skip(reason="skipped slow test [--fast command line option given]")
-    for item in items:
-        if any(x in item.keywords for x in slow_tests):
-            item.add_marker(skip_as_slow)
+
+    if config.getoption("--fast"):
+        skip_as_slow = pytest.mark.skip(
+            reason="skipped slow test [--fast command line option given]"
+        )
+        for item in items:
+            if any(x in item.keywords for x in slow_tests):
+                item.add_marker(skip_as_slow)
+
+    if config.getoption("--slow"):
+        skip_as_fast = pytest.mark.skip(
+            reason="skipped fast test [--slow command line option given]"
+        )
+        for item in items:
+            if not any(x in item.keywords for x in slow_tests):
+                item.add_marker(skip_as_fast)
 
 
 #

--- a/lib/ramble/ramble/cmd/unit_test.py
+++ b/lib/ramble/ramble/cmd/unit_test.py
@@ -62,11 +62,18 @@ def setup_parser(subparser):
         default=False,
         help="run only performance tests",
     )
-    subparser.add_argument(
+    speed = subparser.add_mutually_exclusive_group()
+    speed.add_argument(
         "--fast",
         action="store_true",
         default=False,
         help="run only fast tests (skip slow tests)",
+    )
+    speed.add_argument(
+        "--slow",
+        action="store_true",
+        default=False,
+        help="run only slow tests (skip fast tests)",
     )
 
     # extra ramble arguments to list tests
@@ -202,6 +209,8 @@ def add_back_pytest_args(args, unknown_args):
         result += ["--perf"]
     if args.fast:
         result += ["--fast"]
+    if args.slow:
+        result += ["--slow"]
     result += unknown_args or []
     result += args.pytest_args or []
     if args.expression:

--- a/lib/ramble/ramble/test/cmd/unit_test.py
+++ b/lib/ramble/ramble/test/cmd/unit_test.py
@@ -94,3 +94,8 @@ def test_external_repo_valid(tmpdir):
 def test_flags_accepted(flag):
     output = ramble_test(flag, "--list")
     assert "ramble/test/cmd/unit_test.py" in output
+
+
+def test_slow_flag():
+    output = ramble_test("--slow", "--list")
+    assert "test_slow_flag" not in output

--- a/share/ramble/qa/run-unit-tests
+++ b/share/ramble/qa/run-unit-tests
@@ -65,12 +65,23 @@ fi
 #-----------------------------------------------------------
 
 if [[ "$LONG" == "true" ]]; then
-  ${UNIT_TEST_COVERAGE_PREFIX} $(which ramble) unit-test ${PYTEST_ADDOPTS} -x --verbose
-else
+  echo "Running fast unit tests..."
   ${UNIT_TEST_COVERAGE_PREFIX} $(which ramble) unit-test ${PYTEST_ADDOPTS} -x --verbose --fast
-fi
-if [ $? != 0 ]; then
+  if [ $? != 0 ]; then
     ERROR=1
+  else
+    echo "Running slow unit tests..."
+    ${UNIT_TEST_COVERAGE_PREFIX} $(which ramble) unit-test ${PYTEST_ADDOPTS} -x --verbose --slow
+    if [ $? != 0 ]; then
+      ERROR=1
+    fi
+  fi
+else
+  echo "Running fast unit tests..."
+  ${UNIT_TEST_COVERAGE_PREFIX} $(which ramble) unit-test ${PYTEST_ADDOPTS} -x --verbose --fast
+  if [ $? != 0 ]; then
+    ERROR=1
+  fi
 fi
 
 if [[ "$UNIT_TEST_COVERAGE" == "true" ]]; then

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -613,7 +613,7 @@ _ramble_style() {
 _ramble_unit_test() {
     if $list_options
     then
-        RAMBLE_COMPREPLY="-h --help -H --pytest-help --lib --obj -r --repo-path --perf --fast -l --list -L --list-long -N --list-names -s -k --showlocals"
+        RAMBLE_COMPREPLY="-h --help -H --pytest-help --lib --obj -r --repo-path --perf --fast --slow -l --list -L --list-long -N --list-names -s -k --showlocals"
     else
         _unit_tests
     fi


### PR DESCRIPTION
Run fast unit tests first, and only continue with slower tests after the fast ones pass.