### PR TITLE
Enhance line-profile for phase functions

### DIFF
--- a/lib/ramble/ramble/cmd/common/arguments.py
+++ b/lib/ramble/ramble/cmd/common/arguments.py
@@ -163,6 +163,17 @@ def profile_phases():
 
 
 @arg
+def profile_phase_output():
+    return Args(
+        "--profile-phase-output",
+        default=None,
+        dest="profile_phase_output",
+        help="file path to save the phase line_profiler output",
+        required=False,
+    )
+
+
+@arg
 def where():
     return Args(
         "--where",

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -494,14 +494,9 @@ def workspace_run_pipeline(args, pipeline):
             except ValueError as e:
                 logger.debug(f"Failed to disable line_profiler: {e}")
             if profile_phase_output:
-                try:
-                    with open(profile_phase_output, "w", encoding="utf-8") as f:
-                        profiler.print_stats(stream=f, stripzeros=True)
-                    logger.msg(f"Phase profile stats written to {profile_phase_output}")
-                except Exception as e:
-                    logger.error(
-                        f"Failed to write phase profile stats to {profile_phase_output}: {e}"
-                    )
+                with open(profile_phase_output, "w", encoding="utf-8") as f:
+                    profiler.print_stats(stream=f, stripzeros=True)
+                logger.msg(f"Phase profile stats written to {profile_phase_output}")
             else:
                 profiler.print_stats(stripzeros=True)
 

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -472,6 +472,7 @@ def workspace_concretize(args):
 
 def workspace_run_pipeline(args, pipeline):
     profile_phases = getattr(args, "profile_phases", None)
+    profile_phase_output = getattr(args, "profile_phase_output", None)
     if profile_phases:
         import line_profiler
 
@@ -488,8 +489,21 @@ def workspace_run_pipeline(args, pipeline):
             pipeline.run()
     finally:
         if profile_phases:
-            profiler.disable()
-            profiler.print_stats()
+            try:
+                profiler.disable()
+            except ValueError as e:
+                logger.debug(f"Failed to disable line_profiler: {e}")
+            if profile_phase_output:
+                try:
+                    with open(profile_phase_output, "w", encoding="utf-8") as f:
+                        profiler.print_stats(stream=f, stripzeros=True)
+                    logger.msg(f"Phase profile stats written to {profile_phase_output}")
+                except Exception as e:
+                    logger.error(
+                        f"Failed to write phase profile stats to {profile_phase_output}: {e}"
+                    )
+            else:
+                profiler.print_stats(stripzeros=True)
 
 
 def workspace_setup_setup_parser(subparser):
@@ -512,6 +526,7 @@ def workspace_setup_setup_parser(subparser):
             "exclude_where",
             "filter_tags",
             "profile_phases",
+            "profile_phase_output",
         ],
     )
 
@@ -595,6 +610,7 @@ def workspace_analyze_setup_parser(subparser):
             "exclude_where",
             "filter_tags",
             "profile_phases",
+            "profile_phase_output",
         ],
     )
 
@@ -670,7 +686,8 @@ def workspace_push_to_cache_setup_parser(subparser):
     )
 
     arguments.add_common_arguments(
-        subparser, ["where", "exclude_where", "filter_tags", "profile_phases"]
+        subparser,
+        ["where", "exclude_where", "filter_tags", "profile_phases", "profile_phase_output"],
     )
 
 
@@ -1233,7 +1250,14 @@ def workspace_archive_setup_parser(subparser):
 
     arguments.add_common_arguments(
         subparser,
-        ["phases", "include_phase_dependencies", "where", "exclude_where", "profile_phases"],
+        [
+            "phases",
+            "include_phase_dependencies",
+            "where",
+            "exclude_where",
+            "profile_phases",
+            "profile_phase_output",
+        ],
     )
 
 
@@ -1282,7 +1306,14 @@ def workspace_mirror_setup_parser(subparser):
 
     arguments.add_common_arguments(
         subparser,
-        ["phases", "include_phase_dependencies", "where", "exclude_where", "profile_phases"],
+        [
+            "phases",
+            "include_phase_dependencies",
+            "where",
+            "exclude_where",
+            "profile_phases",
+            "profile_phase_output",
+        ],
     )
 
 

--- a/lib/ramble/ramble/test/end_to_end/phase_profiling.py
+++ b/lib/ramble/ramble/test/end_to_end/phase_profiling.py
@@ -62,9 +62,23 @@ ramble:
     with open(profile_output) as f:
         content = f.read()
 
-    assert "Function: ApplicationBase._make_experiments" in content
-    assert "Function: ApplicationBase._define_commands" in content
-    assert "Function: TestMod.test_builtin" in content
+    # These assertions try to be compatible with older versions of line-profiler,
+    # which don't prefix function names with class names in the output.
+    assert (
+        "Function: ApplicationBase._make_experiments" in content
+        or "Function: _make_experiments" in content
+    )
+    assert (
+        "Function: ApplicationBase._define_commands" in content
+        or "Function: _define_commands" in content
+    )
+    assert "Function: TestMod.test_builtin" in content or "Function: test_builtin" in content
 
-    assert "Function: ApplicationBase._mirror_inputs" not in content
-    assert "Function: ApplicationBase.validate_experiment" not in content
+    assert (
+        "Function: ApplicationBase._mirror_inputs" not in content
+        and "Function: _mirror_inputs" not in content
+    )
+    assert (
+        "Function: ApplicationBase.validate_experiment" not in content
+        and "Function: validate_experiment" not in content
+    )

--- a/lib/ramble/ramble/test/end_to_end/phase_profiling.py
+++ b/lib/ramble/ramble/test/end_to_end/phase_profiling.py
@@ -1,0 +1,70 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+from ramble.main import RambleCommand
+
+pytestmark = pytest.mark.usefixtures(
+    "mutable_config",
+    "mutable_mock_workspace_path",
+    "mutable_mock_apps_repo",
+    "mutable_mock_mods_repo",
+    "workspace_deactivate",
+)
+
+workspace = RambleCommand("workspace")
+
+
+@pytest.mark.maybeslow
+def test_workspace_setup_phase_profiling(tmpdir, make_workspace_from_config):
+    test_config = """
+ramble:
+  modifiers:
+    - name: test-mod
+      mode: test
+  variables:
+    processes_per_node: 1
+    mpi_command: ''
+    batch_submit: '{execute_experiment}'
+    modeless_required_var: 'dummy'
+  applications:
+    basic:
+      workloads:
+        test_wl:
+          experiments:
+            test_exp:
+              variables: {}
+"""
+    _, ws_name = make_workspace_from_config(test_config)
+
+    profile_output = os.path.join(str(tmpdir), "profile_output.txt")
+
+    workspace(
+        "setup",
+        "--phases",
+        "make_experiments",
+        "--profile-phase",
+        "make_experiments",
+        "--profile-phase-output",
+        profile_output,
+        global_args=["-w", ws_name],
+    )
+
+    assert os.path.exists(profile_output)
+    with open(profile_output) as f:
+        content = f.read()
+
+    assert "Function: ApplicationBase._make_experiments" in content
+    assert "Function: ApplicationBase._define_commands" in content
+    assert "Function: TestMod.test_builtin" in content
+
+    assert "Function: ApplicationBase._mirror_inputs" not in content
+    assert "Function: ApplicationBase.validate_experiment" not in content

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -638,7 +638,7 @@ _ramble_workspace_activate() {
 }
 
 _ramble_workspace_archive() {
-    RAMBLE_COMPREPLY="-h --help --tar-archive -t --prefix -p --upload-url -u --include-secrets --archive-pattern --phases --include-phase-dependencies --where --exclude-where --profile-phase"
+    RAMBLE_COMPREPLY="-h --help --tar-archive -t --prefix -p --upload-url -u --include-secrets --archive-pattern --phases --include-phase-dependencies --where --exclude-where --profile-phase --profile-phase-output"
 }
 
 _ramble_workspace_deactivate() {
@@ -663,15 +663,15 @@ _ramble_workspace_config() {
 }
 
 _ramble_workspace_setup() {
-    RAMBLE_COMPREPLY="-h --help --dry-run --phases --include-phase-dependencies --where --exclude-where --filter-tags --profile-phase"
+    RAMBLE_COMPREPLY="-h --help --dry-run --phases --include-phase-dependencies --where --exclude-where --filter-tags --profile-phase --profile-phase-output"
 }
 
 _ramble_workspace_analyze() {
-    RAMBLE_COMPREPLY="-h --help -f --formats -u --upload -p --print-results --fom-origin-types -s --summary-only --phases --include-phase-dependencies --where --exclude-where --filter-tags --profile-phase"
+    RAMBLE_COMPREPLY="-h --help -f --formats -u --upload -p --print-results --fom-origin-types -s --summary-only --phases --include-phase-dependencies --where --exclude-where --filter-tags --profile-phase --profile-phase-output"
 }
 
 _ramble_workspace_push_to_cache() {
-    RAMBLE_COMPREPLY="-h --help --dry-run -d --where --exclude-where --filter-tags --profile-phase"
+    RAMBLE_COMPREPLY="-h --help --dry-run -d --where --exclude-where --filter-tags --profile-phase --profile-phase-output"
 }
 
 _ramble_workspace_info() {
@@ -688,7 +688,7 @@ _ramble_workspace_edit() {
 }
 
 _ramble_workspace_mirror() {
-    RAMBLE_COMPREPLY="-h --help -d --dry-run --phases --include-phase-dependencies --where --exclude-where --profile-phase"
+    RAMBLE_COMPREPLY="-h --help -d --dry-run --phases --include-phase-dependencies --where --exclude-where --profile-phase --profile-phase-output"
 }
 
 _ramble_workspace_experiment_logs() {

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -125,6 +125,32 @@ def _get_phase_func_wrapper(workspace, phase_func, phase_name):
     profiler, profile_phases = workspace.profile_config
     if phase_name not in profile_phases:
         return phase_func
+
+    # In addition to the phase function, also instrument methods of all associated objects.
+    import inspect
+
+    obj = getattr(phase_func, "__self__", None)
+    if obj:
+        objects_to_register = [obj]
+        if hasattr(obj, "objects"):
+            try:
+                for _, assoc_obj in obj.objects(yield_all=False):
+                    if assoc_obj and assoc_obj not in objects_to_register:
+                        objects_to_register.append(assoc_obj)
+            except (AttributeError, TypeError):
+                pass
+
+        for target_obj in objects_to_register:
+            for _, member in inspect.getmembers(
+                target_obj, predicate=inspect.ismethod
+            ):
+                try:
+                    func_to_profile = getattr(member, "__func__", member)
+                    if inspect.isfunction(func_to_profile):
+                        profiler.add_function(func_to_profile)
+                except (TypeError, ValueError, AttributeError):
+                    pass
+
     return profiler(phase_func)
 
 

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -132,24 +132,20 @@ def _get_phase_func_wrapper(workspace, phase_func, phase_name):
     obj = getattr(phase_func, "__self__", None)
     if obj:
         objects_to_register = [obj]
-        if hasattr(obj, "objects"):
-            try:
-                for _, assoc_obj in obj.objects(yield_all=False):
-                    if assoc_obj and assoc_obj not in objects_to_register:
-                        objects_to_register.append(assoc_obj)
-            except (AttributeError, TypeError):
-                pass
+        if getattr(obj, "origin_type", None) == "application" and hasattr(
+            obj, "objects"
+        ):
+            for _, assoc_obj in obj.objects(yield_all=False):
+                if assoc_obj and assoc_obj not in objects_to_register:
+                    objects_to_register.append(assoc_obj)
 
         for target_obj in objects_to_register:
             for _, member in inspect.getmembers(
                 target_obj, predicate=inspect.ismethod
             ):
-                try:
-                    func_to_profile = getattr(member, "__func__", member)
-                    if inspect.isfunction(func_to_profile):
-                        profiler.add_function(func_to_profile)
-                except (TypeError, ValueError, AttributeError):
-                    pass
+                func_to_profile = getattr(member, "__func__", member)
+                if inspect.isfunction(func_to_profile):
+                    profiler.add_function(func_to_profile)
 
     return profiler(phase_func)
 


### PR DESCRIPTION
Specifically, instrument methods of associated objects of the app instantce, beyond just the phase function itself. This helps with further drilling down based on the generated profiling.

Also add in an option to allow the profiling output to be piped into a file instead of just the console.

Example invocation:

```
ramble workspace setup --profile-phase make_experiments --profile-phase-output make_experiments_phase_profile.txt
```