### PR TITLE
warn for duplicate yaml blocks

### DIFF
--- a/lib/ramble/ramble/config.py
+++ b/lib/ramble/ramble/config.py
@@ -89,6 +89,37 @@ import spack.platforms
 import spack.util.spack_yaml as syaml
 from spack.util.cpus import cpus_available
 
+
+# Monkeypatch to detect duplicate keys in parsed YAML files
+def _patch_spack_yaml_duplicate_keys():
+    def custom_construct_mapping(self, node, maptyp, deep=False):
+        import builtins
+
+        seen_keys = builtins.set()
+        for key_node, _ in node.value:
+            key = self.construct_object(key_node, deep=True)
+            if not isinstance(key, collections.abc.Hashable):
+                if isinstance(key, list):
+                    key = tuple(key)
+
+            if key in seen_keys:
+                import llnl.util.tty as tty
+
+                filename = node.start_mark.name
+                line = key_node.start_mark.line + 1
+                tty.warn(
+                    f'Duplicate key "{key}" detected in {filename} at line {line}. '
+                    "This will overwrite the previous value."
+                )
+            seen_keys.add(key)
+
+        super(syaml.OrderedLineLoader, self).construct_mapping(node, maptyp, deep=deep)
+
+    syaml.OrderedLineLoader.construct_mapping = custom_construct_mapping
+
+
+_patch_spack_yaml_duplicate_keys()
+
 #: Dict from section names -> schema for that section
 section_schemas: Dict[str, Dict[str, Any]] = {
     "formatted_executables": ramble.schema.formatted_executables.schema,

--- a/lib/ramble/ramble/test/config.py
+++ b/lib/ramble/ramble/test/config.py
@@ -46,3 +46,21 @@ def test_default_configs_no_conflict(default_config):
 def test_process_config_path_error(config, expected_error):
     with pytest.raises(ramble.config.ConfigError, match=expected_error):
         ramble.config.process_config_path(config)
+
+
+def test_duplicate_key_warning(capsys):
+    import spack.util.spack_yaml as syaml
+
+    yaml_content = """
+ramble:
+  config:
+    upload:
+      type: BigQuery
+      uri: hpc-workload-performance.h4d_OpenMPI
+  config:
+    n_repeats: 2
+"""
+    data = syaml.load_config(yaml_content)
+    captured = capsys.readouterr()
+    assert 'Duplicate key "config" detected' in captured.err
+    assert data["ramble"]["config"]["n_repeats"] == 2


### PR DESCRIPTION
This can cause some fairly subtle odd behavior since the duplication can hide things you think you asked for 

There are many ways to achieve this, so marking as draft while we reach consensus (since it's heavily using older vendored code)

Another option is to wrap/side the calls to syaml.load and do something more like this:

```
+def load_config(*args, **kwargs):
+    """Load YAML using Ramble's custom Loader that warns on duplicate keys."""
+    kwargs["Loader"] = RambleLineLoader
+    return yaml.load(*args, **kwargs)
``` 