### PR TITLE
Warn for duplicate YAML blocks

### DIFF
--- a/lib/ramble/docs/conf.py
+++ b/lib/ramble/docs/conf.py
@@ -231,6 +231,7 @@ nitpick_ignore = [
     ("py:class", "spack.util.environment.EnvironmentModifications"),
     ("py:class", "spack.util.executable.Executable"),
     ("py:class", "spack.util.pattern.Composite"),
+    ("py:class", "spack.util.spack_yaml.OrderedLineLoader"),
     ("py:class", "ramble.keywords.type"),
     ("py:class", "ramble.keywords.level"),
     ("py:class", "ramble.cmd.common.info.formats"),

--- a/lib/ramble/ramble/cmd/config.py
+++ b/lib/ramble/ramble/cmd/config.py
@@ -325,7 +325,7 @@ def config_update(args) -> None:
     for scope in updates:
         cfg_file = ramble.config.config.get_config_filename(scope.name, args.section)
         with open(cfg_file) as f:
-            data = syaml.load_config(f) or {}
+            data = ramble.config.load_config(f) or {}
             data = data.pop(args.section, {})
         update_fn(data)
 

--- a/lib/ramble/ramble/config.py
+++ b/lib/ramble/ramble/config.py
@@ -126,11 +126,13 @@ all_schemas = copy.deepcopy(section_schemas)
 all_schemas.update(dict.fromkeys(ramble.schema.workspace.keys, ramble.schema.workspace.schema))
 
 
-class RambleLineLoader(syaml.OrderedLineLoader):
+class _RambleLineLoader(syaml.OrderedLineLoader):
     def construct_mapping(self, node, maptyp, deep=False):
-        import builtins
+        from builtins import set
 
-        seen_keys = builtins.set()
+        import llnl.util.tty as tty
+
+        seen_keys = set()
         for key_node, _ in node.value:
             key = self.construct_object(key_node, deep=True)
 
@@ -151,8 +153,6 @@ class RambleLineLoader(syaml.OrderedLineLoader):
 
             if is_hashable:
                 if key in seen_keys:
-                    import llnl.util.tty as tty
-
                     filename = node.start_mark.name
                     line = key_node.start_mark.line + 1
                     tty.warn(
@@ -166,7 +166,7 @@ class RambleLineLoader(syaml.OrderedLineLoader):
 
 def load_config(*args, **kwargs):
     """Load YAML using Ramble's custom Loader that warns on duplicate keys."""
-    kwargs["Loader"] = RambleLineLoader
+    kwargs["Loader"] = _RambleLineLoader
     return syaml.load(*args, **kwargs)
 
 

--- a/lib/ramble/ramble/config.py
+++ b/lib/ramble/ramble/config.py
@@ -125,6 +125,51 @@ section_schemas: Dict[str, Dict[str, Any]] = {
 all_schemas = copy.deepcopy(section_schemas)
 all_schemas.update(dict.fromkeys(ramble.schema.workspace.keys, ramble.schema.workspace.schema))
 
+
+class RambleLineLoader(syaml.OrderedLineLoader):
+    def construct_mapping(self, node, maptyp, deep=False):
+        import builtins
+
+        seen_keys = builtins.set()
+        for key_node, _ in node.value:
+            key = self.construct_object(key_node, deep=True)
+
+            # Check if key is hashable; convert lists to tuples
+            try:
+                hash(key)
+                is_hashable = True
+            except TypeError:
+                if isinstance(key, list):
+                    try:
+                        key = tuple(key)
+                        hash(key)
+                        is_hashable = True
+                    except TypeError:
+                        is_hashable = False
+                else:
+                    is_hashable = False
+
+            if is_hashable:
+                if key in seen_keys:
+                    import llnl.util.tty as tty
+
+                    filename = node.start_mark.name
+                    line = key_node.start_mark.line + 1
+                    tty.warn(
+                        f'Duplicate key "{key}" detected in {filename} at line {line}. '
+                        "This will overwrite the previous value."
+                    )
+                seen_keys.add(key)
+
+        super().construct_mapping(node, maptyp, deep=deep)
+
+
+def load_config(*args, **kwargs):
+    """Load YAML using Ramble's custom Loader that warns on duplicate keys."""
+    kwargs["Loader"] = RambleLineLoader
+    return syaml.load(*args, **kwargs)
+
+
 #: Builtin paths to configuration files in ramble
 configuration_paths = (
     # Default configuration scope is the lowest-level scope. These are
@@ -926,14 +971,14 @@ def add(fullpath, scope=None):
             existing = get_valid_type(path)
 
             # construct value from this point down
-            value = syaml.load_config(components[-1])
+            value = load_config(components[-1])
             for component in reversed(components[idx + 1 : -1]):
                 value = {component: value}
             break
 
     if has_existing_value:
         path, _, value = fullpath.rpartition(":")
-        value = syaml.load_config(value)
+        value = load_config(value)
         existing = get(path, scope=scope)
 
     # append values to lists
@@ -1033,7 +1078,7 @@ def read_config_file(filename, schema=None):
     try:
         logger.debug(f"Reading config file {filename}")
         with open(filename) as f:
-            data = syaml.load_config(f)
+            data = load_config(f)
 
         if data:
             if not schema:

--- a/lib/ramble/ramble/test/config.py
+++ b/lib/ramble/ramble/test/config.py
@@ -65,51 +65,57 @@ ramble:
 
 
 def test_unhashable_yaml_keys_coverage():
-    import ramble.config
     import io
+
     from ruamel.yaml.nodes import MappingNode
-    
+
+    import ramble.config
+
     loader = ramble.config._RambleLineLoader(io.StringIO())
-    
+
     # Mock construct_object to return custom keys dynamically with caching
     mock_keys = []
+
     def mock_construct_object(node, deep=False):
         if node not in loader.constructed_objects:
             loader.constructed_objects[node] = mock_keys.pop(0)
         return loader.constructed_objects[node]
+
     loader.construct_object = mock_construct_object
-    
+
     class MockMap(dict):
         def _yaml_set_kv_line_col(self, *args, **kwargs):
             pass
-            
+
         def __setitem__(self, key, value):
             pass
-            
+
     from ruamel.yaml.nodes import ScalarNode
-    
+
     # Mock node having a start_mark for constructor warnings
     class MockMark:
         name = "test"
         line = 0
         column = 0
-        
-    dummy = ScalarNode(tag='tag:yaml.org,2002:str', value='dummy')
+
+    dummy = ScalarNode(tag="tag:yaml.org,2002:str", value="dummy")
     dummy.start_mark = MockMark()
-    node = MappingNode(tag='tag:yaml.org,2002:map', value=[(dummy, dummy)])
+    node = MappingNode(tag="tag:yaml.org,2002:map", value=[(dummy, dummy)])
     node.start_mark = MockMark()
-    
-    # 1. Key is a list containing unhashable dicts (exercising the inner nested try-except TypeError block)
+
+    # 1. Key is a list containing unhashable dicts
+    # (exercising the inner nested try-except TypeError block)
     mock_keys.append([{"a": 1}])
     loader.construct_mapping(node, MockMap())
-    
+
     # 2. Key is a mapping (exercising the outer else block)
-    dummy2 = ScalarNode(tag='tag:yaml.org,2002:str', value='dummy2')
+    dummy2 = ScalarNode(tag="tag:yaml.org,2002:str", value="dummy2")
     dummy2.start_mark = MockMark()
-    node2 = MappingNode(tag='tag:yaml.org,2002:map', value=[(dummy2, dummy2)])
+    node2 = MappingNode(tag="tag:yaml.org,2002:map", value=[(dummy2, dummy2)])
     node2.start_mark = MockMark()
-    
+
     mock_keys.append({"a": 1})
     import ruamel.yaml.constructor
+
     with pytest.raises(ruamel.yaml.constructor.ConstructorError, match="found unhashable key"):
         loader.construct_mapping(node2, MockMap())

--- a/lib/ramble/ramble/test/config.py
+++ b/lib/ramble/ramble/test/config.py
@@ -46,3 +46,19 @@ def test_default_configs_no_conflict(default_config):
 def test_process_config_path_error(config, expected_error):
     with pytest.raises(ramble.config.ConfigError, match=expected_error):
         ramble.config.process_config_path(config)
+
+
+def test_duplicate_key_warning(capsys):
+    yaml_content = """
+ramble:
+  config:
+    upload:
+      type: BigQuery
+      uri: some.uri
+  config:
+    n_repeats: 2
+"""
+    data = ramble.config.load_config(yaml_content)
+    captured = capsys.readouterr()
+    assert 'Duplicate key "config" detected' in captured.err
+    assert data["ramble"]["config"]["n_repeats"] == 2

--- a/lib/ramble/ramble/test/config.py
+++ b/lib/ramble/ramble/test/config.py
@@ -62,3 +62,54 @@ ramble:
     captured = capsys.readouterr()
     assert 'Duplicate key "config" detected' in captured.err
     assert data["ramble"]["config"]["n_repeats"] == 2
+
+
+def test_unhashable_yaml_keys_coverage():
+    import ramble.config
+    import io
+    from ruamel.yaml.nodes import MappingNode
+    
+    loader = ramble.config._RambleLineLoader(io.StringIO())
+    
+    # Mock construct_object to return custom keys dynamically with caching
+    mock_keys = []
+    def mock_construct_object(node, deep=False):
+        if node not in loader.constructed_objects:
+            loader.constructed_objects[node] = mock_keys.pop(0)
+        return loader.constructed_objects[node]
+    loader.construct_object = mock_construct_object
+    
+    class MockMap(dict):
+        def _yaml_set_kv_line_col(self, *args, **kwargs):
+            pass
+            
+        def __setitem__(self, key, value):
+            pass
+            
+    from ruamel.yaml.nodes import ScalarNode
+    
+    # Mock node having a start_mark for constructor warnings
+    class MockMark:
+        name = "test"
+        line = 0
+        column = 0
+        
+    dummy = ScalarNode(tag='tag:yaml.org,2002:str', value='dummy')
+    dummy.start_mark = MockMark()
+    node = MappingNode(tag='tag:yaml.org,2002:map', value=[(dummy, dummy)])
+    node.start_mark = MockMark()
+    
+    # 1. Key is a list containing unhashable dicts (exercising the inner nested try-except TypeError block)
+    mock_keys.append([{"a": 1}])
+    loader.construct_mapping(node, MockMap())
+    
+    # 2. Key is a mapping (exercising the outer else block)
+    dummy2 = ScalarNode(tag='tag:yaml.org,2002:str', value='dummy2')
+    dummy2.start_mark = MockMark()
+    node2 = MappingNode(tag='tag:yaml.org,2002:map', value=[(dummy2, dummy2)])
+    node2.start_mark = MockMark()
+    
+    mock_keys.append({"a": 1})
+    import ruamel.yaml.constructor
+    with pytest.raises(ruamel.yaml.constructor.ConstructorError, match="found unhashable key"):
+        loader.construct_mapping(node2, MockMap())

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -2729,7 +2729,7 @@ def _equiv_dict(first, second):
 
 def _read_yaml(str_or_file, schema):
     """Read YAML from a file for round-trip parsing."""
-    data = syaml.load_config(str_or_file)
+    data = ramble.config.load_config(str_or_file)
     filename = getattr(str_or_file, "name", None)
     default_data = ramble.config.validate(data, schema, filename)
     return (data, default_data)


### PR DESCRIPTION
This can cause some fairly subtle odd behavior since the duplication can hide things you think you asked for

Gemini is confident this is a low overhead change and should help users avoid confusing issues

Produces a warning like:

```
==> Warning: Duplicate key "config" detected in ./my_workspace/configs/ramble.yaml at line 25. This will overwrite the previous value.
```