### PR TITLE
Make slurm workflow manager call execute_experiment

### DIFF
--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -112,6 +112,15 @@ def _re_search(regex, s):
     return re.search(regex, s) is not None
 
 
+def _file_contains(file_path, pattern):
+    import os
+
+    if os.path.isfile(file_path):
+        with open(file_path, encoding="utf-8") as f:
+            return re.search(pattern, f.read(), re.MULTILINE) is not None
+    return False
+
+
 def _str_replace(s, *args, **kwargs):
     return str(s).replace(*args, **kwargs)
 
@@ -196,6 +205,7 @@ supported_scalar_function_pointers = {
     "simplify_str": naming.simplify_name,
     "join_str": _join_str,
     "re_search": _re_search,
+    "file_contains": _file_contains,
     "replace": _str_replace,
 }
 

--- a/lib/ramble/ramble/test/end_to_end/object_precedence.py
+++ b/lib/ramble/ramble/test/end_to_end/object_precedence.py
@@ -115,7 +115,7 @@ def test_object_precedence_ordering(
     workspace("setup", "--dry-run", global_args=["-D", ws.root])
 
     exec_file = os.path.join(
-        ws.experiment_dir, "basic", "test_wl2", "generated", "slurm_experiment_sbatch"
+        ws.experiment_dir, "basic", "test_wl2", "generated", "execute_experiment"
     )
     assert os.path.isfile(exec_file)
     with open(exec_file, encoding="utf-8") as f:

--- a/lib/ramble/ramble/test/end_to_end/phase_profiling.py
+++ b/lib/ramble/ramble/test/end_to_end/phase_profiling.py
@@ -78,7 +78,9 @@ ramble:
         "Function: ApplicationBase._mirror_inputs" not in content
         and "Function: _mirror_inputs" not in content
     )
-    assert (
-        "Function: ApplicationBase.validate_experiment" not in content
-        and "Function: validate_experiment" not in content
+    import re
+
+    assert not re.search(
+        r"application-base/base_class\.py\s+Function: (ApplicationBase\.)?validate_experiment\b",
+        content,
     )

--- a/lib/ramble/ramble/test/systems_and_platforms/system_platform_general.py
+++ b/lib/ramble/ramble/test/systems_and_platforms/system_platform_general.py
@@ -77,8 +77,15 @@ def test_system_platform_works(workspace_name, mock_platforms, mock_systems, ens
     with open(exec_file, encoding="utf-8") as f:
         data = f.read()
         assert "SBATCH" in data
+
+    payload_file = os.path.join(
+        ws.experiment_dir, "gromacs", "lignocellulose", "generated", "execute_experiment"
+    )
+    assert os.path.isfile(payload_file)
+    with open(payload_file, encoding="utf-8") as f:
+        payload_data = f.read()
         # Ensure cores_per_node=4 propagated, and srun is used from slurm
-        assert "srun -n 4" in data
+        assert "srun -n 4" in payload_data
     # Verify command variables were "defined"
     log_file = os.path.join(ws.log_dir, "setup.latest", "gromacs.lignocellulose.generated.out")
     expected = "max_nodes = 4 (dry-run) from 'sinfo -p " "mock-partition -O 'Nodes' | tail -n 1'"

--- a/lib/ramble/ramble/test/workflow_manager_functionality/workflow_manager.py
+++ b/lib/ramble/ramble/test/workflow_manager_functionality/workflow_manager.py
@@ -93,19 +93,14 @@ cd "{experiment_run_dir}"
         ws._re_read()
 
         with patch("ramble.util.logger.logger.warn") as mock_warn:
-            res = workspace("setup", "--dry-run", global_args=["-D", ws.root])
-            try:
-                # Assert logger.warn was called with the specific message
-                assert mock_warn.called
-                expected_msg = (
-                    "In experiment hostname.local.test_default:\n"
-                    "  `execute_experiment` contains `#SBATCH` directives, "
-                    "which will be ignored.\n"
-                    "  Custom headers should be added to `extra_sbatch_headers` "
-                    "in the workspace configuration instead."
-                )
-                mock_warn.assert_any_call(expected_msg)
-            except AssertionError as e:
-                print("WORKSPACE SETUP OUTPUT:")
-                print(res)
-                raise e
+            workspace("setup", "--dry-run", global_args=["-D", ws.root])
+            # Assert logger.warn was called with the specific message
+            assert mock_warn.called
+            expected_msg = (
+                "In experiment hostname.local.test_default:\n"
+                "  `execute_experiment` contains `#SBATCH` directives, "
+                "which will be ignored.\n"
+                "  Custom headers should be added to `extra_sbatch_headers` "
+                "in the workspace configuration instead."
+            )
+            mock_warn.assert_any_call(expected_msg)

--- a/lib/ramble/ramble/test/workflow_manager_functionality/workflow_manager.py
+++ b/lib/ramble/ramble/test/workflow_manager_functionality/workflow_manager.py
@@ -97,10 +97,11 @@ cd "{experiment_run_dir}"
             # Assert logger.warn was called with the specific message
             assert mock_warn.called
             expected_msg = (
-                "In experiment hostname.local.test_default:\n"
+                "Validator 'check_sbatch_in_execute_experiment' (defined in 'slurm') "
+                "fails with message: 'In experiment hostname.local.test_default:\n"
                 "  `execute_experiment` contains `#SBATCH` directives, "
                 "which will be ignored.\n"
                 "  Custom headers should be added to `extra_sbatch_headers` "
-                "in the workspace configuration instead."
+                "in the workspace configuration instead.'"
             )
             mock_warn.assert_any_call(expected_msg)

--- a/lib/ramble/ramble/test/workflow_manager_functionality/workflow_manager.py
+++ b/lib/ramble/ramble/test/workflow_manager_functionality/workflow_manager.py
@@ -52,3 +52,60 @@ ramble:
                 "If this file is not the same as the above path, it is unlikely that this script"
                 in content
             )
+
+
+def test_workflow_manager_sbatch_warning(workspace_name):
+    from unittest.mock import patch
+
+    test_config = """
+ramble:
+  variants:
+    workflow_manager: slurm
+  variables:
+    processes_per_node: 1
+    n_nodes: 1
+    mpi_command: ""
+    batch_submit: ""
+  applications:
+    hostname:
+      workloads:
+        local:
+          experiments:
+            test_default: {}
+"""
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+        config_path = os.path.join(ws.config_dir, ramble.workspace.CONFIG_FILE_NAME)
+        with open(config_path, "w+", encoding="utf-8") as f:
+            f.write(test_config)
+
+        # Overwrite execute_experiment.tpl to contain #SBATCH
+        tpl_path = os.path.join(ws.config_dir, "execute_experiment.tpl")
+        with open(tpl_path, "w+", encoding="utf-8") as f:
+            f.write(
+                """{workflow_banner}
+#SBATCH --custom-header
+cd "{experiment_run_dir}"
+{command}
+"""
+            )
+
+        ws._re_read()
+
+        with patch("ramble.util.logger.logger.warn") as mock_warn:
+            res = workspace("setup", "--dry-run", global_args=["-D", ws.root])
+            try:
+                # Assert logger.warn was called with the specific message
+                assert mock_warn.called
+                expected_msg = (
+                    "In experiment hostname.local.test_default:\n"
+                    "  `execute_experiment` contains `#SBATCH` directives, "
+                    "which will be ignored.\n"
+                    "  Custom headers should be added to `extra_sbatch_headers` "
+                    "in the workspace configuration instead."
+                )
+                mock_warn.assert_any_call(expected_msg)
+            except AssertionError as e:
+                print("WORKSPACE SETUP OUTPUT:")
+                print(res)
+                raise e

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -3006,15 +3006,18 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                 )
                 fs.mkdirp(os.path.dirname(expand_path))
 
+                rendered_content = self.expander.expand_var(
+                    template_conf["contents"], extra_vars=exec_vars
+                )
+
                 with open(expand_path, "w+", encoding="utf-8") as f:
-                    f.write(
-                        self.expander.expand_var(
-                            template_conf["contents"], extra_vars=exec_vars
-                        )
-                    )
+                    f.write(rendered_content)
                 os.chmod(expand_path, _DEFAULT_CONTENT_PERM)
 
             self._render_object_templates(exec_vars)
+
+            if self.workflow_manager:
+                self.workflow_manager.validate_experiment()
 
             experiment_script = workspace.experiments_script
             experiment_script.write(

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -3016,9 +3016,6 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
 
             self._render_object_templates(exec_vars)
 
-            if self.workflow_manager:
-                self.workflow_manager.validate_experiment()
-
             experiment_script = workspace.experiments_script
             experiment_script.write(
                 self.expander.expand_var("{batch_submit}\n")

--- a/var/ramble/repos/builtin/base_classes/workflow-manager-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/workflow-manager-base/base_class.py
@@ -123,7 +123,3 @@ class WorkflowManagerBase(ObjectMixin, metaclass=WorkflowManagerMeta):
     def template_render_vars(self):
         """Define variables to be used in template rendering"""
         return {}
-
-    def validate_experiment(self):
-        """Validate experiment files after creation"""
-        pass

--- a/var/ramble/repos/builtin/base_classes/workflow-manager-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/workflow-manager-base/base_class.py
@@ -123,3 +123,7 @@ class WorkflowManagerBase(ObjectMixin, metaclass=WorkflowManagerMeta):
     def template_render_vars(self):
         """Define variables to be used in template rendering"""
         return {}
+
+    def validate_experiment(self):
+        """Validate experiment files after creation"""
+        pass

--- a/var/ramble/repos/builtin/workflow_managers/slurm/slurm_experiment_sbatch.tpl
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/slurm_experiment_sbatch.tpl
@@ -7,4 +7,4 @@ cd {experiment_run_dir}
 
 {workflow_hostfile_cmd}
 
-. {execute_experiment}
+. "{execute_experiment}"

--- a/var/ramble/repos/builtin/workflow_managers/slurm/slurm_experiment_sbatch.tpl
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/slurm_experiment_sbatch.tpl
@@ -7,4 +7,4 @@ cd {experiment_run_dir}
 
 {workflow_hostfile_cmd}
 
-{command}
+. {execute_experiment}

--- a/var/ramble/repos/builtin/workflow_managers/slurm/test/slurm.py
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/test/slurm.py
@@ -176,7 +176,9 @@ ramble:
             assert "#SBATCH --gpus-per-task=1" in content
             assert "#SBATCH -p" not in content
             assert "#SBATCH --time" not in content
-        with open(os.path.join(path, "execute_experiment"), encoding="utf-8") as f:
+        with open(
+            os.path.join(path, "execute_experiment"), encoding="utf-8"
+        ) as f:
             exec_content = f.read()
             assert "scontrol show config" in exec_content
             assert "#SBATCH" not in exec_content

--- a/var/ramble/repos/builtin/workflow_managers/slurm/test/slurm.py
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/test/slurm.py
@@ -156,6 +156,7 @@ ramble:
         assert "batch_query" in files
         assert "batch_cancel" in files
         assert "batch_wait" in files
+        assert "slurm_experiment_sbatch" in files
         with open(os.path.join(path, "batch_submit"), encoding="utf-8") as f:
             content = f.read()
             # Assert the user-defined `batch_submit` is included
@@ -168,7 +169,6 @@ ramble:
         ) as f:
             content = f.read()
             assert "scontrol show hostnames" in content
-            assert "scontrol show config" in content
             assert "#SBATCH -N 1" in content
             assert "#SBATCH -J hostname_local_test_slurm" in content
             assert "#SBATCH --ntasks-per-node 1" in content
@@ -176,6 +176,10 @@ ramble:
             assert "#SBATCH --gpus-per-task=1" in content
             assert "#SBATCH -p" not in content
             assert "#SBATCH --time" not in content
+        with open(os.path.join(path, "execute_experiment"), encoding="utf-8") as f:
+            exec_content = f.read()
+            assert "scontrol show config" in exec_content
+            assert "#SBATCH" not in exec_content
         with open(os.path.join(path, "batch_query"), encoding="utf-8") as f:
             content = f.read()
             assert "squeue" in content

--- a/var/ramble/repos/builtin/workflow_managers/slurm/test/slurm.py
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/test/slurm.py
@@ -60,6 +60,7 @@ ramble:
         assert "batch_query" in files
         assert "batch_cancel" in files
         assert "batch_wait" in files
+        assert "slurm_experiment_sbatch" in files
         with open(os.path.join(path, "batch_submit"), encoding="utf-8") as f:
             content = f.read()
             assert "slurm_experiment_sbatch" in content
@@ -67,6 +68,11 @@ ramble:
             assert ".slurm_job" in content
             assert "sbatch" in content
             assert "batch_submit" not in content
+        with open(
+            os.path.join(path, "slurm_experiment_sbatch"), encoding="utf-8"
+        ) as f:
+            content = f.read()
+            assert "execute_experiment" in content
 
 
 def test_slurm_workflow():
@@ -176,6 +182,7 @@ ramble:
             assert "#SBATCH --gpus-per-task=1" in content
             assert "#SBATCH -p" not in content
             assert "#SBATCH --time" not in content
+            assert "execute_experiment" in content
         with open(
             os.path.join(path, "execute_experiment"), encoding="utf-8"
         ) as f:

--- a/var/ramble/repos/builtin/workflow_managers/slurm/test/slurm.py
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/test/slurm.py
@@ -181,7 +181,8 @@ ramble:
         ) as f:
             exec_content = f.read()
             assert "scontrol show config" in exec_content
-            assert "#SBATCH" not in exec_content
+            for line in exec_content.splitlines():
+                assert not line.strip().startswith("#SBATCH")
         with open(os.path.join(path, "batch_query"), encoding="utf-8") as f:
             content = f.read()
             assert "squeue" in content
@@ -213,7 +214,8 @@ ramble:
         ) as f:
             content = f.read()
             # Since it uses the default execute_experiment tpl, no slurm content is present
-            assert "#SBATCH" not in content
+            for line in content.splitlines():
+                assert not line.strip().startswith("#SBATCH")
             assert "scontrol show hostnames" not in content
 
 

--- a/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
@@ -344,23 +344,18 @@ class Slurm(WorkflowManagerBase):
         formula="'{value}' == 'COMPLETE'",
     )
 
-    def validate_experiment(self):
-        super().validate_experiment()
-        exp_run_dir = self.app_inst.expander.experiment_run_dir
-        exec_path = os.path.join(exp_run_dir, "execute_experiment")
-        if os.path.isfile(exec_path):
-            with open(exec_path, encoding="utf-8") as f:
-                content = f.read()
-                for line in content.splitlines():
-                    if line.strip().startswith("#SBATCH"):
-                        logger.warn(
-                            f"In experiment {self.app_inst.expander.experiment_namespace}:\n"
-                            f"  `execute_experiment` contains `#SBATCH` directives, "
-                            f"which will be ignored.\n"
-                            f"  Custom headers should be added to `extra_sbatch_headers` "
-                            f"in the workspace configuration instead."
-                        )
-                        break
+    register_validator(
+        name="check_sbatch_in_execute_experiment",
+        predicate="not file_contains('{workspace_configs}/execute_experiment.tpl', '(?m)^[ \\t]*#SBATCH')",
+        message=(
+            "In experiment {experiment_namespace}:\n"
+            "  `execute_experiment` contains `#SBATCH` directives, "
+            "which will be ignored.\n"
+            "  Custom headers should be added to `extra_sbatch_headers` "
+            "in the workspace configuration instead."
+        ),
+        fail_on_invalid=False,
+    )
 
 
 class SlurmRunner:

--- a/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
@@ -55,8 +55,8 @@ class Slurm(WorkflowManagerBase):
         default="""# ****************************************************
 # * Workflow manager: slurm
 # * Execution script is: {slurm_experiment_sbatch}
-# * If this file is not the same as the above path, it is unlikely that this script
-# * is used when `ramble on` executes experiments.
+# * Note: `execute_experiment` is sourced by the execution script.
+# * Do not add `#SBATCH` headers to `execute_experiment`, as they will be ignored.
 # ****************************************************
 """,
         description="Banner to describe the workflow within execution templates",
@@ -343,6 +343,24 @@ class Slurm(WorkflowManagerBase):
         fom_name="job-status",
         formula="'{value}' == 'COMPLETE'",
     )
+
+    def validate_experiment(self):
+        super().validate_experiment()
+        exp_run_dir = self.app_inst.expander.experiment_run_dir
+        exec_path = os.path.join(exp_run_dir, "execute_experiment")
+        if os.path.isfile(exec_path):
+            with open(exec_path, encoding="utf-8") as f:
+                content = f.read()
+                for line in content.splitlines():
+                    if line.strip().startswith("#SBATCH"):
+                        logger.warn(
+                            f"In experiment {self.app_inst.expander.experiment_namespace}:\n"
+                            f"  `execute_experiment` contains `#SBATCH` directives, "
+                            f"which will be ignored.\n"
+                            f"  Custom headers should be added to `extra_sbatch_headers` "
+                            f"in the workspace configuration instead."
+                        )
+                        break
 
 
 class SlurmRunner:


### PR DESCRIPTION
Placeholder for discussion of changing slurm workflow manager to use `execute_experiment`

```
...
Processing phase make_experiments (3/6):  50%|====================>                    | Elapsed (s): 0.00==> Warning: `sbatch` is missing in the given `batch_submit` command
==> Warning: In experiment hostname.local.test_default:
  `execute_experiment` contains `#SBATCH` directives, which will be ignored.
  Custom headers should be added to `extra_sbatch_headers` in the workspace configuration instead.
```