### PR TITLE
Add bootstrapped / required utilities objects [AI]

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -580,7 +580,7 @@ def mutable_mock_workspace_path(tmpdir_factory, mutable_config):
         yield mock_path
 
 
-@pytest.fixture()
+@pytest.fixture(autouse=True)
 def workspace_deactivate():
     """Deactivates any active workspace after a test."""
     ramble.workspace.deactivate()

--- a/etc/ramble/defaults/base_utility_repos.yaml
+++ b/etc/ramble/defaults/base_utility_repos.yaml
@@ -1,0 +1,3 @@
+base_utility_repos:
+  - $ramble/var/ramble/repos/builtin
+

--- a/etc/ramble/defaults/config.yaml
+++ b/etc/ramble/defaults/config.yaml
@@ -19,6 +19,7 @@ config:
   verify_ssl: true
   connect_timeout: 10
   checksum: true
+  bootstrap_utilities: true
   shell: bash
   input_cache: $ramble/var/ramble/cache
   workspace_dirs:

--- a/etc/ramble/defaults/utility_repos.yaml
+++ b/etc/ramble/defaults/utility_repos.yaml
@@ -1,0 +1,3 @@
+utility_repos:
+  - $ramble/var/ramble/repos/builtin
+

--- a/lib/ramble/docs/base_utility_list.rst
+++ b/lib/ramble/docs/base_utility_list.rst
@@ -1,0 +1,20 @@
+.. Copyright 2022-2026 The Ramble Authors
+
+   Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+   https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+   <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+   option. This file may not be copied, modified, or distributed
+   except according to those terms.
+
+.. _base-utility-list:
+
+=================
+Base Utility List
+=================
+
+This is a list of base utilities available within Ramble, which can be
+inherited from when creating new utility definitions. It is automatically
+generated based on the base utilities in this Ramble version.
+
+.. raw:: html
+   :file: base_utility_list.html

--- a/lib/ramble/docs/conf.py
+++ b/lib/ramble/docs/conf.py
@@ -43,10 +43,12 @@ object_types = [
     ("applications", "application"),
     ("modifiers", "modifier"),
     ("package_managers", "package_manager"),
+    ("utilities", "utility"),
     ("workflow_managers", "workflow_manager"),
     ("base_applications", "base_application"),
     ("base_modifiers", "base_modifier"),
     ("base_package_managers", "base_package_manager"),
+    ("base_utilities", "base_utility"),
     ("base_workflow_managers", "base_workflow_manager"),
 ]
 

--- a/lib/ramble/docs/dev_guides.rst
+++ b/lib/ramble/docs/dev_guides.rst
@@ -21,4 +21,5 @@ Below is a list of developer guides for various aspects of Ramble.
     dev_guides/application_dev_guide
     dev_guides/modifier_dev_guide
     dev_guides/package_manager_dev_guide
+    dev_guides/utility_dev_guide
     dev_guides/advanced_topics

--- a/lib/ramble/docs/dev_guides/3_utility_definition_tutorial.rst
+++ b/lib/ramble/docs/dev_guides/3_utility_definition_tutorial.rst
@@ -1,0 +1,167 @@
+.. Copyright 2022-2026 The Ramble Authors
+
+   Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+   https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+   <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+   option. This file may not be copied, modified, or distributed
+   except according to those terms.
+
+.. _utility-definition-tutorial:
+
+===========================
+Utility Definition Tutorial
+===========================
+
+This tutorial will guide you through creating a simple utility definition in Ramble. We will create a mock utility called `my_tool` that provides an executable and modifies the environment.
+
+Installation
+============
+
+To install Ramble, see the :doc:`../getting_started` guide.
+
+**NOTE**: This tutorial does not require a package manager to be installed or configured.
+
+.. include:: shared/repository_create.rst
+
+Step 1: Setting up the file structure
+=====================================
+
+First, we need to create a directory for our utility within the ``tutorial-repo`` repository we created above.
+
+Navigate to the utilities directory:
+
+.. code-block:: console
+
+    $ mkdir -p tutorial-repo/utilities/my-tool
+    $ cd tutorial-repo/utilities/my-tool
+
+Create a file named ``utility.py`` using your editor of choice.
+
+Step 2: Defining the Class
+==========================
+
+Open `utility.py` and start by importing the necessary base classes and language directives.
+
+.. code-block:: python
+
+    from ramble.utility import UtilityBase
+    from ramble.language.utility_language import *
+
+    class MyTool(UtilityBase):
+        """MyTool is a mock utility for this tutorial."""
+
+        name = "my-tool"
+        maintainers("your_username")
+
+Step 3: Defining Variables and Bootstrapping
+============================================
+
+We want our utility to be able to be downloaded and installed by Ramble if the user doesn't already have it.
+
+.. code-block:: python
+
+        bootstrappable(True)
+
+Next, we define a variable to hold the path to where the utility is installed. We use `scoped=True` so that the variable name is automatically namespaced to `{utility::my_tool::path}`.
+
+.. code-block:: python
+
+        variable(
+            name="path",
+            default="system",
+            description="Path to MyTool",
+            scoped=True,
+        )
+
+Step 4: Providing Executables
+=============================
+
+Let's tell Ramble that this utility provides the `my_tool_bin` executable, and how Ramble can check the system to see if a valid version is already installed.
+
+.. code-block:: python
+
+        provides_executable(
+            "my_tool_bin",
+            version_cmd="my_tool_bin --version",
+            version_regex=r"MyTool Version (\d+\.\d+\.\d+)"
+        )
+
+If a user requests this utility, Ramble will run `my_tool_bin --version`. If the output matches the regex, Ramble can check the version against any `min_version` or `max_version` constraints requested by other objects.
+
+Step 5: Modifying the Environment
+=================================
+
+Finally, we need to ensure that the experiments can actually use `my_tool_bin`. We do this by prepending the utility's `bin` directory to the `PATH` environment variable.
+
+.. code-block:: python
+
+        env_prepend("PATH", "{utility::my-tool::path}/bin")
+
+Step 6: Applying Utilities in Other Objects
+===========================================
+
+Now that we have defined a utility, other objects (like applications or modifiers) can apply it. To do this, the object definition uses the ``requires_utility`` directive.
+
+For example, an application definition could apply our new utility like this:
+
+.. code-block:: python
+
+    from ramble.appkit import *
+
+    class MyApplication(ExecutableApplication):
+        name = "my-application"
+
+        requires_utility("my-tool", min_version="2.0.0", max_version="3.0.0")
+
+        executable(
+            "run",
+            "my-tool run {arguments}",
+            use_mpi=False,
+        )
+
+When an experiment uses this application, the variables and environment modifications defined in ``MyTool`` will be applied to the experiment, and Ramble will ensure the utility is either found on the system or bootstrapped.
+
+Putting it all together
+=======================
+
+Your complete ``utility.py`` should look like this:
+
+.. code-block:: python
+
+    from ramble.utility import UtilityBase
+    from ramble.language.utility_language import *
+
+    class MyTool(UtilityBase):
+        """MyTool is a mock utility for this tutorial."""
+
+        name = "my-tool"
+        maintainers("your_username")
+
+        bootstrappable(True)
+
+        variable(
+            name="path",
+            default="system",
+            description="Path to MyTool",
+            scoped=True,
+        )
+
+        provides_executable(
+            "my_tool_bin",
+            version_cmd="my_tool_bin --version",
+            version_regex=r"MyTool Version (\d+\.\d+\.\d+)"
+        )
+
+        env_prepend("PATH", "{utility::my-tool::path}/bin")
+
+You've successfully created your first utility definition! You can now reference ``my-tool`` in your workspace configuration under the ``utilities:`` section.
+
+Cleanup
+=======
+
+If you are done with this tutorial and want to clean up the repository you created, you can execute the following:
+
+.. code-block:: console
+
+    $ ramble repo rm tutorial-repo
+    $ rm -rf tutorial-repo

--- a/lib/ramble/docs/dev_guides/utility_dev_guide.rst
+++ b/lib/ramble/docs/dev_guides/utility_dev_guide.rst
@@ -1,0 +1,162 @@
+.. Copyright 2022-2026 The Ramble Authors
+
+   Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+   https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+   <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+   option. This file may not be copied, modified, or distributed
+   except according to those terms.
+
+.. _utility-dev-guide:
+
+=======================
+Utility Developer Guide
+=======================
+
+This guide details how to create and manage utility definitions in Ramble.
+
+What is a Utility?
+==================
+
+Utilities in Ramble are external dependencies or tools that are required by experiments or applications to function correctly. This could include package managers (like Spack), system monitoring tools, or job execution frameworks.
+
+Utilities are defined as Python classes that inherit from `UtilityBase`.
+
+Creating a New Utility
+======================
+
+To create a new utility, you must define a class that inherits from `UtilityBase`. This definition must be placed in a file named `utility.py` within a directory named after your utility, inside a valid repository's `utilities/` folder.
+
+For example, a utility named `my_util` would be located at `var/ramble/repos/builtin/utilities/my_util/utility.py`.
+
+Basic Structure
+---------------
+
+.. code-block:: python
+
+    from ramble.utility import UtilityBase
+    from ramble.language.utility_language import *
+
+    class MyUtil(UtilityBase):
+        """MyUtil provides system information capabilities."""
+
+        name = "my_util"
+        maintainers("your_username")
+
+        bootstrappable(True)
+
+        variable(
+            name="path",
+            default="system",
+            description="Path to MyUtil",
+            scoped=True,
+        )
+
+        provides_executable(
+            "my_util_bin",
+            version_cmd="my_util_bin --version",
+            version_regex=r"my_util version (\d+\.\d+\.\d+)"
+        )
+
+        env_prepend("PATH", "{utility::my_util::path}/bin")
+
+Utility Directives
+==================
+
+Utilities have access to a specific set of declarative directives to define their behavior.
+
+``bootstrappable``
+------------------
+
+Indicates whether Ramble is capable of downloading and installing this utility if it is not found on the system.
+
+.. code-block:: python
+
+    bootstrappable(True)
+
+``variable`` and Scoping
+------------------------
+
+Utilities can define variables just like applications. However, to prevent namespace collisions, utility variables are strongly encouraged to use `scoped=True`.
+
+.. code-block:: python
+
+    variable(
+        name="path",
+        default="system",
+        description="Path to the utility",
+        scoped=True,
+    )
+
+When `scoped=True` is used, Ramble automatically prefixes the variable name with the utility's namespace. In the example above, the `path` variable becomes `{utility::my_util::path}`. This allows other parts of Ramble, or other utilities, to reference this variable safely.
+
+``provides_executable``
+-----------------------
+
+This directive declares an executable that the utility provides, and optionally, how Ramble should check the system to see if the utility is already installed and meets version requirements.
+
+.. code-block:: python
+
+    provides_executable(
+        "cmake",
+        version_cmd="cmake --version",
+        version_regex=r"cmake version (\d+\.\d+\.\d+)"
+    )
+
+If an object requiring this utility provides a `min_version` or `max_version`, Ramble will verify the system's executable meets the constraints using this regex. If it does, Ramble will skip the bootstrapping phase and use the system's version.
+
+``requires_utility``
+--------------------
+
+Other objects (like Applications or Modifiers) can require a utility and optionally specify a minimum or maximum version using the ``requires_utility`` directive.
+
+.. code-block:: python
+
+    requires_utility("cmake", min_version="3.20.0", max_version="3.30.0")
+
+Environment Modifications
+=========================
+
+Utilities often need to modify the environment (e.g., setting paths, exporting variables) for the experiments that use them. Ramble provides a unified set of directives to handle this. These modifications are automatically applied to both the Ramble runner's environment and the generated experiment bash scripts.
+
+``env_source``
+--------------
+
+Sources a bash script.
+
+.. code-block:: python
+
+    env_source("{utility::my_util::path}/setup.sh")
+
+``env_set``
+-----------
+
+Sets an environment variable to a specific value.
+
+.. code-block:: python
+
+    env_set("MY_UTIL_DIR", "{utility::my_util::path}")
+
+``env_prepend`` and ``env_append``
+----------------------------------
+
+Prepends or appends a value to a colon-separated environment variable (like `PATH`).
+
+.. code-block:: python
+
+    env_prepend("PATH", "{utility::my_util::path}/bin")
+    env_append("LD_LIBRARY_PATH", "{utility::my_util::path}/lib")
+
+Lifecycle Hooks
+===============
+
+If a utility requires complex setup logic that cannot be captured declaratively, you can override lifecycle hooks provided by `UtilityBase`.
+
+``install(self, workspace)``
+----------------------------
+
+Executed when Ramble bootstraps the utility. This is where you place the logic to compile or configure the utility after it has been downloaded.
+
+``modify_bootstrap(self, workspace, app_inst)``
+-----------------------------------------------
+
+Executed after the utility has been installed. This allows the utility to modify its own installation (e.g., altering default configuration files). The `app_inst` argument is the application instance that triggered the bootstrap. You can retrieve scoped variables from `app_inst.variables`.

--- a/lib/ramble/docs/developer_tutorials.rst
+++ b/lib/ramble/docs/developer_tutorials.rst
@@ -21,4 +21,5 @@ started writing various objects in Ramble.
 
    dev_guides/1_basic_application_definition_tutorial
    dev_guides/2_hpl_application_definition_tutorial
+   dev_guides/3_utility_definition_tutorial
    dev_guides/system_and_platform_definition_tutorial

--- a/lib/ramble/docs/index.rst
+++ b/lib/ramble/docs/index.rst
@@ -32,6 +32,7 @@ If you're new to Ramble and want to start using it, see :doc:`getting_started`.
    configuration_files
    workspace
    workspace_config
+   utilities
    package_managers
    workflow_managers
    systems
@@ -54,10 +55,12 @@ If you're new to Ramble and want to start using it, see :doc:`getting_started`.
    application_list
    modifier_list
    package_manager_list
+   utility_list
    workflow_manager_list
    base_application_list
    base_modifier_list
    base_package_manager_list
+   base_utility_list
    base_workflow_manager_list
 
 .. toctree::

--- a/lib/ramble/docs/utilities.rst
+++ b/lib/ramble/docs/utilities.rst
@@ -1,0 +1,66 @@
+.. Copyright 2022-2026 The Ramble Authors
+
+   Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+   https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+   <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+   option. This file may not be copied, modified, or distributed
+   except according to those terms.
+
+
+.. _utilities:
+
+=========
+Utilities
+=========
+
+Utilities in Ramble represent external dependencies or tools that experiments rely on to function correctly. This can range from software package managers like `spack`, to cluster execution tools like `pdsh`. 
+
+Utilities differ from Ramble's internal `software` definitions in that they are often required *before* the primary software stack can even be installed or configured, or they provide fundamental system-level capabilities that aren't strictly part of the experiment's scientific payload.
+
+---------------------
+Configuring Utilities
+---------------------
+
+Utilities can be requested and configured within the `ramble.yaml` configuration file using the `utilities:` dictionary.
+
+When a utility is specified, Ramble will attempt to bootstrap it (if configured to do so) or locate it on the system before setting up the experiment's environment.
+
+.. code-block:: yaml
+
+  ramble:
+    utilities:
+      spack:
+        version: "0.22.0"
+
+In this example, the `spack` utility is requested at version `0.22.0`. If Spack is not already available on the system matching this requirement, Ramble can fetch and bootstrap it automatically into the workspace's shared directory (`$workspace/shared/bootstrapped_utilities/spack/0.22.0/source`).
+
+---------------------------
+Utility Variables & Scoping
+---------------------------
+
+When a utility is active for an experiment, it often injects variables into the experiment's context. To prevent namespace collisions, utility variables can be strongly scoped using the `utility::` prefix, followed by the utility's name. This is accomplished by setting ``scoped=True`` when defining the variable in the utility class.
+
+For instance, the installation path of the `spack` utility can be accessed via:
+
+.. code-block:: text
+
+  {utility::spack::path}
+
+These variables can be used in your workspace configurations or application definitions just like any other standard Ramble variable.
+
+---------------------------------
+Bootstrapping vs System Utilities
+---------------------------------
+
+By default, Ramble attempts to use an existing installation of a utility if it meets the requirements (e.g., if a matching version of `spack` is already in your `PATH` and satisfies the minimum version constraints).
+
+If a suitable version is not found, and the utility is marked as `bootstrappable(True)`, Ramble will download and set it up automatically.
+
+You can globally disable the bootstrapping of all utilities by modifying your Ramble configuration:
+
+.. code-block:: yaml
+
+  config:
+    bootstrap_utilities: False
+
+If bootstrapping is disabled, and the required utility is not found on the system, Ramble will halt with an error indicating the missing dependency.

--- a/lib/ramble/docs/utility_list.rst
+++ b/lib/ramble/docs/utility_list.rst
@@ -1,0 +1,20 @@
+.. Copyright 2022-2026 The Ramble Authors
+
+   Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+   https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+   <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+   option. This file may not be copied, modified, or distributed
+   except according to those terms.
+
+.. _utility-list:
+
+============
+Utility List
+============
+
+This is a list of utilities available within Ramble, for managing
+external dependencies. It is automatically generated based on the
+utilities in this Ramble version.
+
+.. raw:: html
+   :file: utility_list.html

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -56,6 +56,7 @@ def _deprecated_manage_experiments_arguments():
 subcommands = [
     "activate",
     "archive",
+    "bootstrap",
     "deactivate",
     "create",
     "concretize",
@@ -479,6 +480,35 @@ def workspace_concretize(args):
         ws.concretize(force=args.force_concretize, quiet=args.quiet)
 
 
+def workspace_bootstrap_setup_parser(subparser):
+    """Bootstrap external utilities for a workspace"""
+    arguments.add_common_arguments(
+        subparser,
+        [
+            "where",
+            "exclude_where",
+            "filter_tags",
+        ],
+    )
+
+
+def workspace_bootstrap(args):
+    current_pipeline = ramble.pipeline.pipelines.bootstrap
+    ws = ramble.cmd.require_active_workspace(cmd_name="workspace bootstrap")
+
+    filters = ramble.filters.Filters(
+        phase_filters=["bootstrap_utilities"],
+        include_where_filters=getattr(args, "where", None),
+        exclude_where_filters=getattr(args, "exclude_where", None),
+        tags=getattr(args, "filter_tags", None),
+    )
+
+    pipeline_cls = ramble.pipeline.pipeline_class(current_pipeline)
+    pipeline = pipeline_cls(ws, filters)
+    with ws.write_transaction():
+        workspace_run_pipeline(args, pipeline)
+
+
 def workspace_run_pipeline(args, pipeline):
     profile_phases = getattr(args, "profile_phases", None)
     profile_phase_output = getattr(args, "profile_phase_output", None)
@@ -796,6 +826,10 @@ def workspace_info_setup_parser(subparser):
         "--executables", action="store_true", help="If set, experiment executables will be printed"
     )
 
+    subparser.add_argument(
+        "--utilities", action="store_true", help="If set, bootstrapped utilities will be printed"
+    )
+
     arguments.add_common_arguments(
         subparser,
         ["where", "exclude_where", "filter_tags", "filter_group", "exclude_filter_group"],
@@ -829,6 +863,7 @@ def workspace_info(args):
         args.expansions = True
         args.phases = True
         args.executables = True
+        args.utilities = True
 
     color.cprint(f'{color.section_title("Workspace: ")}{ws.name}')
     color.cprint("")
@@ -1041,6 +1076,65 @@ def workspace_info(args):
                 verbosity=args.verbose, indent=4, color_level=1, only_used=only_used_software
             )
         )
+
+    if args.utilities:
+        color.cprint("")
+        color.cprint(color.section_title("Bootstrapped Utilities:"))
+
+        all_utilities = {}
+        for workloads, _application_context in ws.all_applications():
+            for experiments, _workload_context in ws.all_workloads(workloads):
+                for _exp_contents, _experiment_context in ws.all_experiments(experiments):
+                    app_ctx = _application_context.context_name
+                    wl_ctx = _workload_context.context_name
+                    exp_ctx = _experiment_context.context_name
+                    full_exp_name = f"{app_ctx}.{wl_ctx}.{exp_ctx}"
+                    app_inst = experiment_set.get_experiment(full_exp_name)
+
+                    objects_to_check = [app_inst]
+                    if hasattr(app_inst, "package_manager") and app_inst.package_manager:
+                        objects_to_check.append(app_inst.package_manager)
+                    if hasattr(app_inst, "system") and app_inst.system:
+                        objects_to_check.append(app_inst.system)
+                    if hasattr(app_inst, "platform") and app_inst.platform:
+                        objects_to_check.append(app_inst.platform)
+                    if hasattr(app_inst, "workflow_manager") and app_inst.workflow_manager:
+                        objects_to_check.append(app_inst.workflow_manager)
+                    if hasattr(app_inst, "_modifiers") and app_inst._modifiers:
+                        objects_to_check.extend(app_inst._modifiers)
+
+                    for obj in objects_to_check:
+                        if hasattr(obj, "required_utilities"):
+                            for when_key, utilities in obj.required_utilities.items():
+                                if obj.satisfy_when(when_key):
+                                    for utility_name, utility_conf in utilities.items():
+                                        if utility_name not in all_utilities:
+                                            all_utilities[utility_name] = set()
+                                        conf_tuple = tuple(
+                                            sorted(
+                                                (k, tuple(v) if isinstance(v, list) else v)
+                                                for k, v in utility_conf.items()
+                                                if k != "when"
+                                            )
+                                        )
+                                        all_utilities[utility_name].add(conf_tuple)
+
+        if not all_utilities:
+            color.cprint("    None")
+        else:
+            ws_utilities = ws.get_workspace_utilities() or {}
+            for utility_name, confs in sorted(all_utilities.items()):
+                color.cprint(color.nested_1(f"    {utility_name}:"))
+
+                # Check for workspace override
+                if utility_name in ws_utilities:
+                    override_conf = dict(ws_utilities[utility_name])
+                    color.cprint(f"      Configuration: {override_conf} (Workspace Override)")
+                    continue
+
+                for conf in sorted(confs):
+                    conf_dict = dict(conf)
+                    color.cprint(f"      Configuration: {conf_dict}")
 
 
 #

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -1091,19 +1091,10 @@ def workspace_info(args):
                     full_exp_name = f"{app_ctx}.{wl_ctx}.{exp_ctx}"
                     app_inst = experiment_set.get_experiment(full_exp_name)
 
-                    objects_to_check = [app_inst]
-                    if hasattr(app_inst, "package_manager") and app_inst.package_manager:
-                        objects_to_check.append(app_inst.package_manager)
-                    if hasattr(app_inst, "system") and app_inst.system:
-                        objects_to_check.append(app_inst.system)
-                    if hasattr(app_inst, "platform") and app_inst.platform:
-                        objects_to_check.append(app_inst.platform)
-                    if hasattr(app_inst, "workflow_manager") and app_inst.workflow_manager:
-                        objects_to_check.append(app_inst.workflow_manager)
-                    if hasattr(app_inst, "_modifiers") and app_inst._modifiers:
-                        objects_to_check.extend(app_inst._modifiers)
+                    if not app_inst:
+                        continue
 
-                    for obj in objects_to_check:
+                    for _, obj in app_inst.objects():
                         if hasattr(obj, "required_utilities"):
                             for when_key, utilities in obj.required_utilities.items():
                                 if obj.satisfy_when(when_key):

--- a/lib/ramble/ramble/config.py
+++ b/lib/ramble/ramble/config.py
@@ -57,6 +57,7 @@ import ramble.schema.base_modifier_repos
 import ramble.schema.base_package_manager_repos
 import ramble.schema.base_platform_repos
 import ramble.schema.base_system_repos
+import ramble.schema.base_utility_repos
 import ramble.schema.base_workflow_manager_repos
 import ramble.schema.config
 import ramble.schema.env_vars
@@ -76,6 +77,7 @@ import ramble.schema.software
 import ramble.schema.success_criteria
 import ramble.schema.system_repos
 import ramble.schema.tables
+import ramble.schema.utility_repos
 import ramble.schema.variables
 import ramble.schema.variants
 import ramble.schema.workflow_manager_repos
@@ -107,6 +109,7 @@ section_schemas: Dict[str, Dict[str, Any]] = {
     "variables": ramble.schema.variables.schema,
     "variants": ramble.schema.variants.schema,
     "zips": ramble.schema.zips.schema,
+    "utilities": ramble.schema.utilities.schema,
     "repos": ramble.schema.repos.schema,
     "modifier_repos": ramble.schema.modifier_repos.schema,
     "package_manager_repos": ramble.schema.package_manager_repos.schema,
@@ -120,6 +123,8 @@ section_schemas: Dict[str, Dict[str, Any]] = {
     "base_workflow_manager_repos": ramble.schema.base_workflow_manager_repos.schema,
     "base_system_repos": ramble.schema.base_system_repos.schema,
     "base_platform_repos": ramble.schema.base_platform_repos.schema,
+    "utility_repos": ramble.schema.utility_repos.schema,
+    "base_utility_repos": ramble.schema.base_utility_repos.schema,
 }
 
 # Same as above, but including keys for workspaces

--- a/lib/ramble/ramble/language/language_base.py
+++ b/lib/ramble/ramble/language/language_base.py
@@ -64,6 +64,8 @@ namespaces = [
     "ramble.platform",
     "ramble.base_cls",
     "ramble.modifier",
+    "ramble.ext_dep",
+    "ramble.utility",
 ]
 
 

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -1025,6 +1025,36 @@ def register_validator(
     return _define_validator
 
 
+@shared_directive("required_utilities")
+def requires_utility(
+    name: str,
+    when=None,
+    **kwargs,
+):
+    """Directive to declare an external dependency.
+
+    Args:
+        name: Name of the external dependency required (e.g. spack)
+        when: List of when conditions to apply to directive
+        **kwargs: Optional configuration overrides for the dependency (e.g. version). Also
+            supports ``min_version`` and ``max_version`` to constrain the required version.
+    """
+
+    def _define_requires_utility(obj):
+        when_list = ramble.language.language_helpers.build_when_list(
+            when, obj, name, "requires_utility"
+        )
+        when_key = frozenset(when_list)
+
+        if when_key not in obj.required_utilities:
+            obj.required_utilities[when_key] = {}
+
+        obj.required_utilities[when_key][name] = kwargs.copy()
+        obj.required_utilities[when_key][name]["when"] = when_list
+
+    return _define_requires_utility
+
+
 @shared_directive("conflicts")
 def conflict(
     conflict_spec: str,
@@ -1072,6 +1102,7 @@ def variable(
     when=None,
     error_context="variable",
     environment_variable_name: Optional[str] = None,
+    scoped: bool = False,
     **kwargs,
 ):
     """Define a variable for this modifier
@@ -1095,8 +1126,12 @@ def variable(
     def _define_variable(obj):
         import ramble.definitions.variables
 
+        var_name = name
+        if scoped:
+            var_name = f"{obj.origin_type}::{obj.name}::{name}"
+
         when_list = ramble.language.language_helpers.build_when_list(
-            when, obj, name, error_context
+            when, obj, var_name, error_context
         )
 
         when_set = frozenset(when_list)
@@ -1106,7 +1141,7 @@ def variable(
 
         obj.object_variables[when_set].append(
             ramble.definitions.variables.Variable(
-                name,
+                var_name,
                 default=default,
                 description=description,
                 values=values,
@@ -1117,7 +1152,9 @@ def variable(
         )
 
         if strict and values is not None:
-            ramble.language.language_helpers.add_variable_validator(obj, name, values, when_list)
+            ramble.language.language_helpers.add_variable_validator(
+                obj, var_name, values, when_list
+            )
 
         if environment_variable_name is not None:
             if when_set not in obj.object_environment_variables:
@@ -1126,7 +1163,7 @@ def variable(
             obj.object_environment_variables[when_set].append(
                 ramble.definitions.variables.EnvironmentVariable(
                     environment_variable_name,
-                    value=f"{{{name}}}",
+                    value=f"{{{var_name}}}",
                     description=description,
                     method="set",
                     when=when_list,
@@ -1284,6 +1321,28 @@ def variant(
         obj.class_variants[name] = args_dict
 
     return _define_variant
+
+
+@shared_directive("scripts_to_source")
+def source_script(
+    script_path: str,
+    when=None,
+    **kwargs,
+):
+    """Add a script that should be sourced before executing
+
+    Args:
+        script_path (str): Path to the script to source
+        when (list | None): List of when conditions to apply to directive
+    """
+
+    def _execute_source_script(obj):
+        when_list = ramble.language.language_helpers.build_when_list(
+            when, obj, script_path, "source_script"
+        )
+        obj.scripts_to_source.append({"path": script_path, "when": when_list})
+
+    return _execute_source_script
 
 
 @shared_directive("known_versions")

--- a/lib/ramble/ramble/language/utility_language.py
+++ b/lib/ramble/ramble/language/utility_language.py
@@ -1,0 +1,179 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from typing import Optional
+
+import ramble.language.language_helpers
+import ramble.language.shared_language
+
+
+class UtilityMeta(ramble.language.shared_language.SharedMeta):
+    _directive_names = set()
+    _directives_to_be_executed = []
+
+
+utility_directive = UtilityMeta.directive
+
+
+@utility_directive("env_sources")
+def env_source(script_path: str, when=None, **kwargs):
+    def _execute_env_source(obj):
+        when_list = ramble.language.language_helpers.build_when_list(
+            when, obj, script_path, "env_source"
+        )
+        when_key = frozenset(when_list)
+        if when_key not in obj.env_sources:
+            obj.env_sources[when_key] = []
+        obj.env_sources[when_key].append(
+            {
+                "script_path": script_path,
+                "when": when_list,
+            }
+        )
+
+    return _execute_env_source
+
+
+@utility_directive("env_sets")
+def env_set(var: str, value: str, when=None, **kwargs):
+    def _execute_env_set(obj):
+        when_list = ramble.language.language_helpers.build_when_list(when, obj, var, "env_set")
+        when_key = frozenset(when_list)
+        if when_key not in obj.env_sets:
+            obj.env_sets[when_key] = []
+        obj.env_sets[when_key].append(
+            {
+                "var": var,
+                "value": value,
+                "when": when_list,
+            }
+        )
+
+    return _execute_env_set
+
+
+@utility_directive("env_prepends")
+def env_prepend(var: str, value: str, when=None, **kwargs):
+    def _execute_env_prepend(obj):
+        when_list = ramble.language.language_helpers.build_when_list(when, obj, var, "env_prepend")
+        when_key = frozenset(when_list)
+        if when_key not in obj.env_prepends:
+            obj.env_prepends[when_key] = []
+        obj.env_prepends[when_key].append(
+            {
+                "var": var,
+                "value": value,
+                "when": when_list,
+            }
+        )
+
+    return _execute_env_prepend
+
+
+@utility_directive("env_appends")
+def env_append(var: str, value: str, when=None, **kwargs):
+    def _execute_env_append(obj):
+        when_list = ramble.language.language_helpers.build_when_list(when, obj, var, "env_append")
+        when_key = frozenset(when_list)
+        if when_key not in obj.env_appends:
+            obj.env_appends[when_key] = []
+        obj.env_appends[when_key].append(
+            {
+                "var": var,
+                "value": value,
+                "when": when_list,
+            }
+        )
+
+    return _execute_env_append
+
+
+@utility_directive("fetch_mappings")
+def fetch_mapping(utility_var: str, fetch_var: str, fallback_for=None, when=None, **kwargs):
+    def _execute_fetch_mapping(obj):
+        when_list = ramble.language.language_helpers.build_when_list(
+            when, obj, utility_var, "fetch_mapping"
+        )
+        when_key = frozenset(when_list)
+        if when_key not in obj.fetch_mappings:
+            obj.fetch_mappings[when_key] = []
+        obj.fetch_mappings[when_key].append(
+            {
+                "utility_var": utility_var,
+                "fetch_var": fetch_var,
+                "fallback_for": fallback_for if fallback_for is not None else [],
+                "when": when_list,
+            }
+        )
+
+    return _execute_fetch_mapping
+
+
+@utility_directive("bootstrappable")
+def bootstrappable(is_bootstrappable: bool, when=None, **kwargs):
+    def _execute_bootstrappable(obj):
+        when_list = ramble.language.language_helpers.build_when_list(
+            when, obj, str(is_bootstrappable), "bootstrappable"
+        )
+        when_key = frozenset(when_list)
+        if when_key not in obj.bootstrappable:
+            obj.bootstrappable[when_key] = []
+        obj.bootstrappable[when_key].append(
+            {
+                "is_bootstrappable": is_bootstrappable,
+                "when": when_list,
+            }
+        )
+
+    return _execute_bootstrappable
+
+
+@utility_directive("missing_error_messages")
+def missing_error_message(message: str, when=None, **kwargs):
+    def _execute_missing_error_message(obj):
+        when_list = ramble.language.language_helpers.build_when_list(
+            when, obj, message, "missing_error_message"
+        )
+        when_key = frozenset(when_list)
+        if when_key not in obj.missing_error_messages:
+            obj.missing_error_messages[when_key] = []
+        obj.missing_error_messages[when_key].append(
+            {
+                "message": message,
+                "when": when_list,
+            }
+        )
+
+    return _execute_missing_error_message
+
+
+@utility_directive("provided_executables")
+def provides_executable(
+    executable: str,
+    version_cmd: "Optional[str]" = None,
+    version_regex: "Optional[str]" = None,
+    when=None,
+    **kwargs,
+):
+    def _execute_provides_executable(obj):
+        when_list = ramble.language.language_helpers.build_when_list(
+            when, obj, executable, "provides_executable"
+        )
+        when_key = frozenset(when_list)
+        if when_key not in obj.provided_executables:
+            obj.provided_executables[when_key] = []
+        obj.provided_executables[when_key].append(
+            {
+                "executable": executable,
+                "version_cmd": version_cmd,
+                "version_regex": version_regex,
+                "when": when_list,
+            }
+        )
+
+    return _execute_provides_executable

--- a/lib/ramble/ramble/namespace.py
+++ b/lib/ramble/ramble/namespace.py
@@ -47,6 +47,7 @@ class namespace:
     # For software definitions
     software = "software"
     external_env = "external_env"
+    utilities = "utilities"
 
     # v2 configs
     pkg_spec = "pkg_spec"

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -398,7 +398,9 @@ class ArchivePipeline(Pipeline):
             excluded_secrets.add(ramble.workspace.LICENSE_INC_NAME)
 
         fs.mkdirp(archive_shared)
-        for root, _, files in os.walk(self.workspace.shared_dir):
+        for root, dirs, files in os.walk(self.workspace.shared_dir):
+            if "bootstrapped_utilities" in dirs:
+                dirs.remove("bootstrapped_utilities")
             for name in files:
                 if name not in excluded_secrets:
                     src_dir = os.path.join(self.workspace.shared_dir, root)
@@ -420,6 +422,16 @@ class ArchivePipeline(Pipeline):
                     dest = src.replace(self.workspace.log_dir, archive_logs)
                     fs.mkdirp(os.path.dirname(dest))
                     shutil.copyfile(src, dest)
+
+        # Copy tools directory
+        tools_dir = os.path.join(self.workspace.shared_dir, "bootstrapped_utilities")
+        if os.path.exists(tools_dir):
+            archive_tools = os.path.join(
+                self.workspace.latest_archive_path,
+                ramble.workspace.WORKSPACE_SHARED_PATH,
+                "bootstrapped_utilities",
+            )
+            _copy_tree(tools_dir, archive_tools)
 
         for pattern in itertools.chain(
             self.archive_patterns,
@@ -509,6 +521,16 @@ class MirrorPipeline(Pipeline):
                 output=logger.active_stream(),
             )
             logger.die("Mirroring has errors.")
+
+
+class BootstrapPipeline(Pipeline):
+    """Class for the bootstrap pipeline"""
+
+    name = "bootstrap"
+
+    def __init__(self, workspace, filters):
+        super().__init__(workspace, filters)
+        self.action_string = "Bootstrapping"
 
 
 class SetupPipeline(Pipeline):
@@ -768,6 +790,15 @@ class PushDeploymentPipeline(Pipeline):
         aux_software_dir = os.path.join(configs_dir, ramble.workspace.AUXILIARY_SOFTWARE_DIR_NAME)
         fs.mkdirp(aux_software_dir)
 
+        tools_dir = os.path.join(self.workspace.shared_dir, "bootstrapped_utilities")
+        if os.path.exists(tools_dir):
+            deployment_tools = os.path.join(
+                self.workspace.named_deployment,
+                ramble.workspace.WORKSPACE_SHARED_PATH,
+                "bootstrapped_utilities",
+            )
+            _copy_tree(tools_dir, deployment_tools)
+
         super()._execute()
 
     def _deployment_files(self):
@@ -844,6 +875,7 @@ pipelines = Enum(
     [
         "analyze",
         "archive",
+        "bootstrap",
         "mirror",
         "setup",
         "pushtocache",
@@ -856,6 +888,7 @@ pipelines = Enum(
 _pipeline_map = {
     pipelines.analyze: AnalyzePipeline,
     pipelines.archive: ArchivePipeline,
+    pipelines.bootstrap: BootstrapPipeline,
     pipelines.mirror: MirrorPipeline,
     pipelines.setup: SetupPipeline,
     pipelines.pushtocache: PushToCachePipeline,

--- a/lib/ramble/ramble/repository.py
+++ b/lib/ramble/ramble/repository.py
@@ -65,6 +65,8 @@ ObjectTypes = Enum(
         "base_workflow_managers",
         "base_systems",
         "base_platforms",
+        "utilities",
+        "base_utilities",
     ],
 )
 
@@ -179,6 +181,22 @@ type_definitions = {
         "accepted_configs": ["base_platform_repo.yaml", unified_config],
         "singular": "base platform",
     },
+    ObjectTypes.utilities: {
+        "file_name": "utility.py",
+        "dir_name": "utilities",
+        "abbrev": "utility",
+        "config_section": "utility_repos",
+        "accepted_configs": ["utility_repo.yaml", unified_config],
+        "singular": "external dependency",
+    },
+    ObjectTypes.base_utilities: {
+        "file_name": "base_utility.py",
+        "dir_name": "base_utilities",
+        "abbrev": "base_utility",
+        "config_section": "base_utility_repos",
+        "accepted_configs": ["base_utility_repo.yaml", unified_config],
+        "singular": "base external dependency",
+    },
 }
 
 
@@ -247,6 +265,16 @@ def _base_platforms(repo_dirs=None):
     return _gen_path(repo_dirs=repo_dirs, obj_type=ObjectTypes.base_platforms)
 
 
+def _utilities(repo_dirs=None):
+    """Get the external dependencies singleton RepoPath instance for Ramble."""
+    return _gen_path(repo_dirs=repo_dirs, obj_type=ObjectTypes.utilities)
+
+
+def _base_utilities(repo_dirs=None):
+    """Get the base external dependencies singleton RepoPath instance for Ramble."""
+    return _gen_path(repo_dirs=repo_dirs, obj_type=ObjectTypes.base_utilities)
+
+
 paths = {
     ObjectTypes.applications: llnl.util.lang.Singleton(_apps),
     ObjectTypes.modifiers: llnl.util.lang.Singleton(_mods),
@@ -261,6 +289,8 @@ paths = {
     ObjectTypes.base_workflow_managers: llnl.util.lang.Singleton(_base_workflow_managers),
     ObjectTypes.base_systems: llnl.util.lang.Singleton(_base_systems),
     ObjectTypes.base_platforms: llnl.util.lang.Singleton(_base_platforms),
+    ObjectTypes.utilities: llnl.util.lang.Singleton(_utilities),
+    ObjectTypes.base_utilities: llnl.util.lang.Singleton(_base_utilities),
 }
 
 

--- a/lib/ramble/ramble/schema/base_utility_repos.py
+++ b/lib/ramble/ramble/schema/base_utility_repos.py
@@ -1,0 +1,32 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+"""Schema for repos.yaml configuration file.
+
+.. literalinclude:: _ramble_root/lib/ramble/ramble/schema/repos.py
+   :lines: 13-
+"""
+
+#: Properties for inclusion in other schemas
+properties = {
+    "base_utility_repos": {
+        "type": "array",
+        "default": [],
+        "items": {"type": "string"},
+    },
+}
+
+
+#: Full schema with metadata
+schema = {
+    "$schema": "http://json-schema.org/schema#",
+    "title": "Ramble repository configuration file schema",
+    "type": "object",
+    "additionalProperties": False,
+    "properties": properties,
+}

--- a/lib/ramble/ramble/schema/config.py
+++ b/lib/ramble/ramble/schema/config.py
@@ -200,6 +200,8 @@ properties["config"]["overwrite_inventories"] = {"type": "boolean", "default": F
 
 properties["config"]["generate_file_editing_scripts"] = {"type": "boolean", "default": True}
 
+properties["config"]["bootstrap_utilities"] = {"type": "boolean", "default": True}
+
 properties["config"]["stage_method"] = {
     "type": "string",
     "enum": ["cp", "rsync", "symbolic_link", "hard_link"],

--- a/lib/ramble/ramble/schema/merged.py
+++ b/lib/ramble/ramble/schema/merged.py
@@ -38,6 +38,7 @@ import ramble.schema.software
 import ramble.schema.success_criteria
 import ramble.schema.system_repos
 import ramble.schema.tables
+import ramble.schema.utilities
 import ramble.schema.variables
 import ramble.schema.variants
 import ramble.schema.workflow_manager_repos
@@ -73,6 +74,7 @@ properties = union_dicts(
     ramble.schema.modifiers.properties,
     ramble.schema.workflow_manager_repos.properties,
     ramble.schema.zips.properties,
+    ramble.schema.utilities.properties,
 )
 
 #: Full schema with metadata

--- a/lib/ramble/ramble/schema/utilities.py
+++ b/lib/ramble/ramble/schema/utilities.py
@@ -1,0 +1,38 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+"""Schema for utilities.yaml configuration file.
+
+.. literalinclude:: _ramble_root/lib/ramble/ramble/schema/utilities.py
+   :lines: 12-
+"""
+
+#: Properties for inclusion in other schemas
+properties = {
+    "utilities": {
+        "type": "object",
+        "default": {},
+        "patternProperties": {
+            r"[\w\d\-_\.]+": {
+                "type": "object",
+                "default": {},
+                "additionalProperties": True,
+            }
+        },
+    }
+}
+
+
+#: Full schema with metadata
+schema = {
+    "$schema": "http://json-schema.org/schema#",
+    "title": "Ramble external dependencies configuration file schema",
+    "type": "object",
+    "additionalProperties": False,
+    "properties": properties,
+}

--- a/lib/ramble/ramble/schema/utility_repos.py
+++ b/lib/ramble/ramble/schema/utility_repos.py
@@ -1,0 +1,32 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+"""Schema for repos.yaml configuration file.
+
+.. literalinclude:: _ramble_root/lib/ramble/ramble/schema/repos.py
+   :lines: 13-
+"""
+
+#: Properties for inclusion in other schemas
+properties = {
+    "utility_repos": {
+        "type": "array",
+        "default": [],
+        "items": {"type": "string"},
+    },
+}
+
+
+#: Full schema with metadata
+schema = {
+    "$schema": "http://json-schema.org/schema#",
+    "title": "Ramble repository configuration file schema",
+    "type": "object",
+    "additionalProperties": False,
+    "properties": properties,
+}

--- a/lib/ramble/ramble/test/cmd/filter_groups.py
+++ b/lib/ramble/ramble/test/cmd/filter_groups.py
@@ -131,34 +131,38 @@ def test_global_filter_groups(workspace_name):
 
     # 3. Add a group with --scope workspace (requires active workspace)
     ws = ramble.workspace.create(workspace_name)
+    ramble.workspace.activate(ws)
     global_args = ["-w", workspace_name]
 
-    filter_groups_cmd(
-        "--scope",
-        "workspace",
-        "add",
-        "-n",
-        "ws-group",
-        "--where",
-        "{n_nodes} == 4",
-        global_args=global_args,
-    )
+    try:
+        filter_groups_cmd(
+            "--scope",
+            "workspace",
+            "add",
+            "-n",
+            "ws-group",
+            "--where",
+            "{n_nodes} == 4",
+            global_args=global_args,
+        )
 
-    # Verify it went to workspace config, not user config
-    with open(ws.config_file_path, encoding="utf-8") as f:
-        ws_content = f.read()
-        assert "ws-group:" in ws_content
-        assert "{n_nodes} == 4" in ws_content
+        # Verify it went to workspace config, not user config
+        with open(ws.config_file_path, encoding="utf-8") as f:
+            ws_content = f.read()
+            assert "ws-group:" in ws_content
+            assert "{n_nodes} == 4" in ws_content
 
-    with open(user_config_file, encoding="utf-8") as f:
-        user_content = f.read()
-        assert "ws-group:" not in user_content
+        with open(user_config_file, encoding="utf-8") as f:
+            user_content = f.read()
+            assert "ws-group:" not in user_content
 
-    # 4. Blame from top-level command
-    out = filter_groups_cmd("blame", global_args=global_args)
-    assert ws.config_file_path in out
-    assert "global-small" in out
-    assert "ws-group" in out
+        # 4. Blame from top-level command
+        out = filter_groups_cmd("blame", global_args=global_args)
+        assert ws.config_file_path in out
+        assert "global-small" in out
+        assert "ws-group" in out
+    finally:
+        ramble.workspace.deactivate()
 
     # 5. Remove global group
     filter_groups_cmd(
@@ -266,15 +270,21 @@ def test_global_filter_groups_errors(workspace_name):
     out = filter_groups_cmd("blame")
     assert "exclude_where:" in out
 
-    filter_groups_cmd("--scope", "workspace", "list", fail_on_error=False)
-    assert filter_groups_cmd.returncode != 0
+    with pytest.raises(SystemExit):
+        filter_groups_cmd("--scope", "workspace", "list", fail_on_error=False)
 
-    ramble.workspace.create(workspace_name)
+    ws = ramble.workspace.create(workspace_name)
     global_args = ["-w", workspace_name]
-    filter_groups_cmd(
-        "--scope", "workspace", "add", "-n", "ws-foo", "--where", "x", global_args=global_args
-    )
-    filter_groups_cmd("--scope", "workspace", "remove", "-n", "ws-foo", global_args=global_args)
+    ramble.workspace.activate(ws)
+    try:
+        filter_groups_cmd(
+            "--scope", "workspace", "add", "-n", "ws-foo", "--where", "x", global_args=global_args
+        )
+        filter_groups_cmd(
+            "--scope", "workspace", "remove", "-n", "ws-foo", global_args=global_args
+        )
+    finally:
+        ramble.workspace.deactivate()
 
 
 def test_global_filter_groups_no_subcommand(capsys):

--- a/lib/ramble/ramble/test/cmd/list.py
+++ b/lib/ramble/ramble/test/cmd/list.py
@@ -10,6 +10,8 @@ import pytest
 
 from ramble.main import RambleCommand
 
+pytestmark = pytest.mark.usefixtures("mutable_config")
+
 list = RambleCommand("list")
 
 

--- a/lib/ramble/ramble/test/data/config/base_utility_repos.yaml
+++ b/lib/ramble/ramble/test/data/config/base_utility_repos.yaml
@@ -1,0 +1,3 @@
+base_utility_repos:
+  - $ramble/var/ramble/repos/builtin
+

--- a/lib/ramble/ramble/test/data/config/utility_repos.yaml
+++ b/lib/ramble/ramble/test/data/config/utility_repos.yaml
@@ -1,0 +1,3 @@
+utility_repos:
+  - $ramble/var/ramble/repos/builtin
+

--- a/lib/ramble/ramble/test/end_to_end/test_variable_precedence.py
+++ b/lib/ramble/ramble/test/end_to_end/test_variable_precedence.py
@@ -48,7 +48,7 @@ def test_variable_cross_pass_precedence(workspace_name):
 
         # Edit workspace config directly
         with open(ws.config_file_path, encoding="utf-8") as f:
-            import yaml
+            import yaml  # type: ignore
 
             data = yaml.safe_load(f)
 

--- a/lib/ramble/ramble/test/language/test_requires_utility.py
+++ b/lib/ramble/ramble/test/language/test_requires_utility.py
@@ -11,20 +11,20 @@ from ramble.language.language_base import DirectiveMeta
 
 
 class MockObject(metaclass=DirectiveMeta):
-    __module__ = "ramble.app.mock"
+    __module__ = "ramble.app"
     required_utilities: dict = {}
 
     ramble.language.shared_language.requires_utility(
         name="my_ext_dep",
         git="https://github.com/my/ext_dep.git",
         commit="v1.0",
-        when="@mock_when",
+        when="mock_when=True",
     )
 
 
 def test_requires_utility_directive_parsing():
     obj = MockObject()
-    when_list = ["@mock_when"]
+    when_list = ["mock_when=True"]
     when_key = frozenset(when_list)
     assert hasattr(obj, "required_utilities")
     assert when_key in obj.required_utilities

--- a/lib/ramble/ramble/test/language/test_requires_utility.py
+++ b/lib/ramble/ramble/test/language/test_requires_utility.py
@@ -1,0 +1,35 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import ramble.language.shared_language
+from ramble.language.language_base import DirectiveMeta
+
+
+class MockObject(metaclass=DirectiveMeta):
+    __module__ = "ramble.app.mock"
+    required_utilities: dict = {}
+
+    ramble.language.shared_language.requires_utility(
+        name="my_ext_dep",
+        git="https://github.com/my/ext_dep.git",
+        commit="v1.0",
+        when="@mock_when",
+    )
+
+
+def test_requires_utility_directive_parsing():
+    obj = MockObject()
+    when_list = ["@mock_when"]
+    when_key = frozenset(when_list)
+    assert hasattr(obj, "required_utilities")
+    assert when_key in obj.required_utilities
+
+    ext_dep = obj.required_utilities[when_key]["my_ext_dep"]
+    assert ext_dep["git"] == "https://github.com/my/ext_dep.git"
+    assert ext_dep["commit"] == "v1.0"
+    assert ext_dep["when"] == when_list

--- a/lib/ramble/ramble/test/mock_spack_runner.py
+++ b/lib/ramble/ramble/test/mock_spack_runner.py
@@ -25,7 +25,7 @@ class MockPackageInfo:
 
 
 class MockSpackRunner:
-    def __init__(self):
+    def __init__(self, **kwargs):
         self.env_path = None
         self.concretized = False
         self.dry_run = False

--- a/lib/ramble/ramble/test/test_application_base_fixes.py
+++ b/lib/ramble/ramble/test/test_application_base_fixes.py
@@ -1,0 +1,136 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import ramble.fetch_strategy
+import ramble.filters
+import ramble.pipeline
+import ramble.workspace
+from ramble.utility.builtin.spack.utility import Spack
+
+
+def test_application_base_bootstrap_utilities_opt_out(mutable_config, mutable_mock_workspace_path):
+    ws_name = "test_opt_out"
+    ws = ramble.workspace.create(ws_name)
+
+    os.makedirs(os.path.dirname(ws.config_file_path), exist_ok=True)
+    with open(ws.config_file_path, "w", encoding="utf-8") as f:
+        f.write(
+            """ramble:
+  config:
+    bootstrap_utilities: False
+  variables:
+    mpi_command: mpirun
+    batch_submit: '{execute_experiment}'
+    processes_per_node: '1'
+    n_threads: '1'
+  applications:
+    hostname:
+      workloads:
+        serial:
+          experiments:
+            test_exp:
+              variables:
+                n_ranks: '1'
+                n_nodes: '1'
+  utilities:
+    spack:
+      git: https://github.com/my/ext_dep.git
+      commit: v2.0
+"""
+        )
+    ws._re_read()
+    filters = ramble.filters.Filters()
+
+    with ws:
+        setup_pipeline = ramble.pipeline.SetupPipeline(ws, filters)
+        app_inst = next(iter(setup_pipeline.experiment_set.experiments.values()))
+        app_inst.required_utilities = {frozenset([]): {"spack": {"git": "git", "commit": "v1.0"}}}
+
+        ws.dry_run = True
+        setup_pipeline.run()
+
+    assert (
+        not hasattr(app_inst, "_bootstrapped_utility_paths")
+        or not app_inst._bootstrapped_utility_paths
+    )
+
+
+def test_application_base_validate_versions_die(
+    mutable_config, mutable_mock_workspace_path, monkeypatch
+):
+    ws_name = "test_die"
+    ws = ramble.workspace.create(ws_name)
+
+    os.makedirs(os.path.dirname(ws.config_file_path), exist_ok=True)
+    with open(ws.config_file_path, "w", encoding="utf-8") as f:
+        f.write(
+            """ramble:
+  config:
+    bootstrap_utilities: True
+  variables:
+    mpi_command: mpirun
+    batch_submit: '{execute_experiment}'
+    processes_per_node: '1'
+    n_threads: '1'
+  applications:
+    hostname:
+      workloads:
+        serial:
+          experiments:
+            test_exp:
+              variables:
+                n_ranks: '1'
+                n_nodes: '1'
+  utilities:
+    spack:
+      git: https://github.com/my/ext_dep.git
+      commit: v2.0
+"""
+        )
+    ws._re_read()
+    filters = ramble.filters.Filters()
+
+    with ws:
+        setup_pipeline = ramble.pipeline.SetupPipeline(ws, filters)
+        app_inst = next(iter(setup_pipeline.experiment_set.experiments.values()))
+        app_inst.required_utilities = {frozenset([]): {"spack": {"git": "git", "commit": "v1.0"}}}
+
+        # We need to bypass the fetch logic to just test validate_versions
+        def mock_bootstrap(*args, **kwargs):
+            return
+
+        def mock_validate(*args, **kwargs):
+            return False
+
+        monkeypatch.setattr(app_inst, "bootstrap_utility", mock_bootstrap, raising=False)
+        monkeypatch.setattr(Spack, "validate_versions", mock_validate)
+
+        # mock fetching
+        class MockFetcher:
+            def fetch(self):
+                pass
+
+            def expand(self):
+                pass
+
+            def archive(self, path):
+                pass
+
+        def mock_from_kwargs(*args, **kwargs):
+            return MockFetcher()
+
+        monkeypatch.setattr(ramble.fetch_strategy, "from_kwargs", mock_from_kwargs)
+
+        ws.dry_run = False
+
+        import pytest
+
+        with pytest.raises(SystemExit):
+            setup_pipeline.run()

--- a/lib/ramble/ramble/test/test_application_base_happy.py
+++ b/lib/ramble/ramble/test/test_application_base_happy.py
@@ -1,0 +1,80 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+import os
+
+import ramble.filters
+import ramble.pipeline
+import ramble.workspace
+
+
+def test_application_base_bootstrap_utilities_happy(
+    mutable_config, mutable_mock_workspace_path, monkeypatch
+):
+    ws = ramble.workspace.create("test_succ_happy")
+    os.makedirs(os.path.dirname(ws.config_file_path), exist_ok=True)
+    with open(ws.config_file_path, "w", encoding="utf-8") as f:
+        f.write(
+            """ramble:
+  config:
+    bootstrap_utilities: True
+  applications:
+    hostname:
+      workloads:
+        serial:
+          experiments:
+            test_exp:
+              variables:
+                n_ranks: '1'
+  utilities:
+    spack:
+      git: mygit
+"""
+        )
+    ws._re_read()
+    filters = ramble.filters.Filters()
+    with ws:
+        setup_pipeline = ramble.pipeline.SetupPipeline(ws, filters)
+        app_inst = next(iter(setup_pipeline.experiment_set.experiments.values()))
+        app_inst.required_utilities = {frozenset([]): {"spack": {"git": "mygit"}}}
+
+        from ramble.utility.builtin.spack.utility import Spack
+
+        is_avail_calls = [0]
+
+        def mock_is_available(*args, **kwargs):
+            is_avail_calls[0] += 1
+            return is_avail_calls[0] > 1
+
+        monkeypatch.setattr(Spack, "is_available", mock_is_available)
+        monkeypatch.setattr(Spack, "bootstrappable", {"True": [{"is_bootstrappable": True}]})
+
+        class MockStage:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+            def set_subdir(self, subdir):
+                pass
+
+            def fetch(self):
+                pass
+
+            def expand_archive(self):
+                pass
+
+        monkeypatch.setattr(ramble.stage, "InputStage", MockStage)
+
+        app_inst._bootstrap_utilities(ws)
+
+        assert hasattr(app_inst, "_bootstrapped_utility_paths")
+        assert "spack" in app_inst._bootstrapped_utility_paths

--- a/lib/ramble/ramble/test/test_base_classes_extra.py
+++ b/lib/ramble/ramble/test/test_base_classes_extra.py
@@ -1,0 +1,310 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+import shutil
+import subprocess
+
+import pytest
+
+import ramble.filters
+import ramble.pipeline
+import ramble.workspace
+from ramble.utility.builtin.spack.utility import Spack
+
+
+def test_utility_base_validate_versions_regex_fails(
+    mutable_config, mutable_mock_workspace_path, monkeypatch
+):
+    spack = Spack("/tmp/dummy")
+    spack.provided_executables = {
+        "spack": [
+            {"executable": "spack", "version_cmd": "echo bad", "version_regex": r"(\d+\.\d+\.\d+)"}
+        ]
+    }
+    monkeypatch.setattr(shutil, "which", lambda cmd, **kwargs: "/path/to/spack")
+
+    class MockResult:
+        stdout = "bad\n"
+        stderr = ""
+        returncode = 0
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: MockResult())
+    assert spack.validate_versions(min_version="1.0.0") is False
+    assert "Could not determine version" in spack.availability_error
+
+
+def test_utility_base_validate_versions_less_than_min(
+    mutable_config, mutable_mock_workspace_path, monkeypatch
+):
+    spack = Spack("/tmp/dummy")
+    spack.provided_executables = {
+        "spack": [
+            {
+                "executable": "spack",
+                "version_cmd": "echo 1.0.0",
+                "version_regex": r"(\d+\.\d+\.\d+)",
+            }
+        ]
+    }
+    monkeypatch.setattr(shutil, "which", lambda cmd, **kwargs: "/path/to/spack")
+
+    class MockResult:
+        stdout = "1.0.0\n"
+        stderr = ""
+        returncode = 0
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: MockResult())
+    assert spack.validate_versions(min_version="1.5.0") is False
+    assert "is less than required minimum" in spack.availability_error
+
+
+def test_utility_base_validate_versions_greater_than_max(
+    mutable_config, mutable_mock_workspace_path, monkeypatch
+):
+    spack = Spack("/tmp/dummy")
+    spack.provided_executables = {
+        "spack": [
+            {
+                "executable": "spack",
+                "version_cmd": "echo 2.0.0",
+                "version_regex": r"(\d+\.\d+\.\d+)",
+            }
+        ]
+    }
+    monkeypatch.setattr(shutil, "which", lambda cmd, **kwargs: "/path/to/spack")
+
+    class MockResult:
+        stdout = "2.0.0\n"
+        stderr = ""
+        returncode = 0
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: MockResult())
+    assert spack.validate_versions(max_version="1.5.0") is False
+    assert "is greater than required maximum" in spack.availability_error
+
+
+def test_utility_base_validate_versions_shutil_fails(
+    mutable_config, mutable_mock_workspace_path, monkeypatch
+):
+    spack = Spack("/tmp/dummy")
+    spack.provided_executables = {"spack": [{"executable": "spack"}]}
+    monkeypatch.setattr(shutil, "which", lambda cmd, **kwargs: None)
+    assert spack.validate_versions() is False
+    assert "not found in PATH" in spack.availability_error
+
+
+def test_utility_base_validate_versions_no_executables(
+    mutable_config, mutable_mock_workspace_path
+):
+    spack = Spack("/tmp/dummy")
+    spack.provided_executables = {}
+    assert spack.validate_versions() is False
+    assert "No provided executables defined" in spack.availability_error
+
+
+def test_utility_base_validate_versions_run_fails(
+    mutable_config, mutable_mock_workspace_path, monkeypatch
+):
+    spack = Spack("/tmp/dummy")
+    spack.provided_executables = {
+        "spack": [{"executable": "spack", "version_cmd": "fail", "version_regex": ".*"}]
+    }
+    monkeypatch.setattr(shutil, "which", lambda cmd, **kwargs: "/path")
+
+    def mock_run_fail(*args, **kwargs):
+        raise Exception("Run failed")
+
+    monkeypatch.setattr(subprocess, "run", mock_run_fail)
+    assert spack.validate_versions(min_version="1.0") is False
+    assert "Error checking version" in spack.availability_error
+
+
+def test_utility_base_setup_runner_environment_system(mutable_config, mutable_mock_workspace_path):
+    ws = ramble.workspace.create("test_sys")
+
+    class MockAppInst:
+        variables = {"utility::spack::path": "system"}
+
+        def satisfy_when(self, when_key):
+            return True
+
+    app_inst = MockAppInst()
+    spack = Spack("/tmp/dummy")
+    env_mod = spack.setup_runner_environment(ws, app_inst)
+    assert len(env_mod) == 0
+    assert spack.get_experiment_activation_command(ws, app_inst) == ""
+
+
+def test_utility_base_setup_runner_environment_missing_script(
+    mutable_config, mutable_mock_workspace_path
+):
+    ws = ramble.workspace.create("test_miss")
+    ws.dry_run = False
+
+    class MockAppInst:
+        variables = {"utility::spack::path": "/path/to/spack"}
+
+        def satisfy_when(self, when_key):
+            return True
+
+    app_inst = MockAppInst()
+    spack = Spack("/tmp/dummy")
+    spack.env_sources = {"True": [{"script_path": "/missing/script.sh", "when": []}]}
+    # This should log a warning but not fail
+    spack.setup_runner_environment(ws, app_inst)
+
+
+def test_utility_base_map_fetch_kwargs(mutable_config, mutable_mock_workspace_path):
+    spack = Spack("/tmp/dummy")
+    spack.fetch_mappings = {None: [{"utility_var": "git", "fetch_var": "url", "fallback_for": []}]}
+    mapped = spack.map_fetch_kwargs({"git": "my_git_url"})
+    assert mapped == {"url": "my_git_url"}
+
+
+def test_application_base_bootstrap_utilities_is_available_true(
+    mutable_config, mutable_mock_workspace_path, monkeypatch
+):
+    ws = ramble.workspace.create("test_avail")
+    os.makedirs(os.path.dirname(ws.config_file_path), exist_ok=True)
+    with open(ws.config_file_path, "w", encoding="utf-8") as f:
+        f.write(
+            """ramble:
+  config:
+    bootstrap_utilities: True
+  variables:
+    use_system_spack: True
+  applications:
+    hostname:
+      workloads:
+        serial:
+          experiments:
+            test_exp:
+              variables:
+                n_ranks: '1'
+  utilities:
+    spack:
+      git: mygit
+"""
+        )
+    ws._re_read()
+    filters = ramble.filters.Filters()
+    with ws:
+        setup_pipeline = ramble.pipeline.SetupPipeline(ws, filters)
+        app_inst = next(iter(setup_pipeline.experiment_set.experiments.values()))
+        app_inst.required_utilities = {frozenset([]): {"spack": {"git": "mygit"}}}
+        monkeypatch.setattr(
+            shutil, "which", lambda cmd, **kwargs: "/path/to/spack" if cmd == "spack" else None
+        )
+        setup_pipeline.run()
+    assert app_inst.variables.get("utility::spack::path") == "system"
+
+
+def test_application_base_bootstrap_utilities_is_bootstrappable_false(
+    mutable_config, mutable_mock_workspace_path, monkeypatch
+):
+    ws = ramble.workspace.create("test_boot")
+    os.makedirs(os.path.dirname(ws.config_file_path), exist_ok=True)
+    with open(ws.config_file_path, "w", encoding="utf-8") as f:
+        f.write(
+            """ramble:
+  config:
+    bootstrap_utilities: True
+  applications:
+    hostname:
+      workloads:
+        serial:
+          experiments:
+            test_exp:
+              variables:
+                n_ranks: '1'
+  utilities:
+    spack:
+      git: mygit
+"""
+        )
+    ws._re_read()
+    filters = ramble.filters.Filters()
+    with ws:
+        setup_pipeline = ramble.pipeline.SetupPipeline(ws, filters)
+        app_inst = next(iter(setup_pipeline.experiment_set.experiments.values()))
+        app_inst.required_utilities = {frozenset([]): {"spack": {"git": "mygit"}}}
+        UtilityBase = ramble.repository.get_base_class("utility-base")
+        monkeypatch.setattr(UtilityBase, "is_available", lambda *a, **k: False)
+        # Mock bootstrappable to False
+        monkeypatch.setattr(
+            UtilityBase, "bootstrappable", {"True": [{"is_bootstrappable": False}]}
+        )
+        monkeypatch.setattr(
+            UtilityBase, "missing_error_messages", {"True": [{"message": "Custom Error"}]}
+        )
+
+        with pytest.raises(SystemExit):
+            setup_pipeline.run()
+        # Custom Error should have been logged
+
+
+def test_application_base_bootstrap_utilities_success(
+    mutable_config, mutable_mock_workspace_path, monkeypatch
+):
+    ws = ramble.workspace.create("test_succ")
+    os.makedirs(os.path.dirname(ws.config_file_path), exist_ok=True)
+    with open(ws.config_file_path, "w", encoding="utf-8") as f:
+        f.write(
+            """ramble:
+  config:
+    bootstrap_utilities: True
+  applications:
+    hostname:
+      workloads:
+        serial:
+          experiments:
+            test_exp:
+              variables:
+                n_ranks: '1'
+  utilities:
+    spack:
+      git: mygit
+"""
+        )
+    ws._re_read()
+    filters = ramble.filters.Filters()
+    with ws:
+        setup_pipeline = ramble.pipeline.SetupPipeline(ws, filters)
+        app_inst = next(iter(setup_pipeline.experiment_set.experiments.values()))
+        app_inst.required_utilities = {frozenset([]): {"spack": {"git": "mygit"}}}
+        UtilityBase = ramble.repository.get_base_class("utility-base")
+        monkeypatch.setattr(UtilityBase, "is_available", lambda *a, **k: False)
+        # Force fetch
+        ws.dry_run = False
+
+        class MockStage:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+            def set_subdir(self, subdir):
+                pass
+
+            def fetch(self):
+                pass
+
+            def expand_archive(self):
+                pass
+
+        monkeypatch.setattr(ramble.stage, "InputStage", MockStage)
+        monkeypatch.setattr(UtilityBase, "validate_versions", lambda *a, **k: True)
+
+        setup_pipeline.run()
+    assert hasattr(app_inst, "_bootstrapped_utility_paths")
+    assert "spack" in app_inst._bootstrapped_utility_paths

--- a/lib/ramble/ramble/test/test_utility_base_fixes.py
+++ b/lib/ramble/ramble/test/test_utility_base_fixes.py
@@ -1,0 +1,99 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+
+def test_utility_base_environment_modifications(mutable_config, mutable_mock_workspace_path):
+    import ramble.workspace
+    from ramble.utility.builtin.spack.utility import Spack
+
+    ws = ramble.workspace.create("test_env")
+    ws.dry_run = True
+
+    class MockAppInst:
+        def __init__(self):
+            self.variables = {"utility::spack::path": "/path/to/spack"}
+
+        def satisfy_when(self, when_key):
+            return when_key == "True" or when_key is True
+
+    app_inst = MockAppInst()
+    spack = Spack("/tmp/dummy")
+
+    # Manually insert env modifications with when keys
+    spack.env_sources = {
+        "True": [{"script_path": "source.sh", "when": []}],
+        "False": [{"script_path": "no.sh", "when": []}],
+    }
+    spack.env_sets = {
+        "True": [{"var": "A", "value": "1", "when": []}],
+        "False": [{"var": "B", "value": "2", "when": []}],
+    }
+    spack.env_prepends = {
+        "True": [{"var": "C", "value": "1", "when": []}],
+        "False": [{"var": "D", "value": "2", "when": []}],
+    }
+    spack.env_appends = {
+        "True": [{"var": "E", "value": "1", "when": []}],
+        "False": [{"var": "F", "value": "2", "when": []}],
+    }
+
+    spack.setup_runner_environment(ws, app_inst)
+
+    act_cmd = spack.get_experiment_activation_command(ws, app_inst)
+
+    assert "source.sh" in act_cmd
+    assert "no.sh" not in act_cmd
+    assert "export A=1" in act_cmd
+    assert "export B=2" not in act_cmd
+    assert "export C=1:$C" in act_cmd
+    assert "export D=2:$D" not in act_cmd
+    assert "export E=$E:1" in act_cmd
+    assert "export F=$F:2" not in act_cmd
+
+
+def test_utility_base_validate_versions(mutable_config, mutable_mock_workspace_path, monkeypatch):
+    import ramble.workspace
+    from ramble.utility.builtin.spack.utility import Spack
+
+    ramble.workspace.create("test_validate")
+
+    spack = Spack("/tmp/dummy")
+    spack.provided_executables = {
+        "spack": [
+            {
+                "executable": "spack",
+                "version_cmd": "echo 1.2.3",
+                "version_regex": r"(\d+\.\d+\.\d+)",
+            }
+        ]
+    }
+
+    import shutil
+    import subprocess
+
+    original_which = shutil.which
+
+    def mock_which(cmd, **kwargs):
+        if cmd == "spack":
+            return "/path/to/spack/bin/spack"
+        return original_which(cmd, **kwargs)
+
+    def mock_run(cmd_args, **kwargs):
+        class MockResult:
+            stdout = "1.2.3\n"
+            stderr = ""
+            returncode = 0
+
+        return MockResult()
+
+    monkeypatch.setattr(shutil, "which", mock_which)
+    monkeypatch.setattr(subprocess, "run", mock_run)
+
+    res = spack.validate_versions(min_version="1.0.0", max_version="2.0.0")
+    print(spack.availability_error)
+    assert res is True

--- a/lib/ramble/ramble/test/test_utility_base_happy.py
+++ b/lib/ramble/ramble/test/test_utility_base_happy.py
@@ -1,0 +1,82 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+import os
+import shutil
+import subprocess
+
+import ramble.workspace
+from ramble.utility.builtin.spack.utility import Spack
+
+
+def test_utility_base_setup_runner_environment_exists(
+    mutable_config, mutable_mock_workspace_path, monkeypatch, tmpdir
+):
+    ws = ramble.workspace.create("test_env_exists")
+    ws.dry_run = False
+
+    class MockAppInst:
+        def __init__(self):
+            self.variables = {"utility::spack::path": "/path/to/spack"}
+
+        def satisfy_when(self, when_key):
+            return True
+
+    app_inst = MockAppInst()
+    spack = Spack("/tmp/dummy")
+
+    script_path = os.path.join(str(tmpdir), "source.sh")
+    with open(script_path, "w", encoding="utf-8") as f:
+        f.write("export MY_TEST_VAR=1\n")
+
+    spack.env_sources = {"True": [{"script_path": script_path, "when": []}]}
+
+    env_mod = spack.setup_runner_environment(ws, app_inst)
+    assert len(env_mod) > 0
+
+
+def test_utility_base_validate_versions_happy(
+    mutable_config, mutable_mock_workspace_path, monkeypatch
+):
+    spack = Spack("/tmp/dummy")
+    spack.provided_executables = {
+        "spack": [
+            {
+                "executable": "spack",
+                "version_cmd": "echo 1.5.0",
+                "version_regex": r"(\d+\.\d+\.\d+)",
+            }
+        ]
+    }
+
+    def mock_which(cmd, **kwargs):
+        if cmd == "spack":
+            return "/path/to/spack/bin/spack"
+        return None
+
+    def mock_run(cmd_args, **kwargs):
+        class MockResult:
+            stdout = "1.5.0\n"
+            stderr = ""
+            returncode = 0
+
+        return MockResult()
+
+    monkeypatch.setattr(shutil, "which", mock_which)
+    monkeypatch.setattr(subprocess, "run", mock_run)
+
+    # Test happy path with both min and max
+    res = spack.validate_versions(min_version="1.0.0", max_version="2.0.0")
+    assert res is True
+
+    # Test happy path with only min
+    res = spack.validate_versions(min_version="1.0.0")
+    assert res is True
+
+    # Test happy path with only max
+    res = spack.validate_versions(max_version="2.0.0")
+    assert res is True

--- a/lib/ramble/ramble/test/test_workspace_bootstrap.py
+++ b/lib/ramble/ramble/test/test_workspace_bootstrap.py
@@ -1,0 +1,83 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import ramble.filters
+import ramble.pipeline
+import ramble.workspace
+
+
+def test_workspace_bootstrap_utilities(mutable_config, mutable_mock_workspace_path, monkeypatch):
+    import shutil
+
+    monkeypatch.setattr(shutil, "which", lambda x, **kwargs: None)
+
+    ws_name = "test_bootstrap"
+    ws = ramble.workspace.create(ws_name)
+
+    os.makedirs(os.path.dirname(ws.config_file_path), exist_ok=True)
+    with open(ws.config_file_path, "w", encoding="utf-8") as f:
+        f.write(
+            """ramble:
+  variables:
+    mpi_command: mpirun
+    batch_submit: '{execute_experiment}'
+    processes_per_node: '1'
+    n_threads: '1'
+  applications:
+    hostname:
+      workloads:
+        serial:
+          experiments:
+            test_exp:
+              variables:
+                n_ranks: '1'
+                n_nodes: '1'
+  utilities:
+    spack:
+      git: https://github.com/my/ext_dep.git
+      commit: v2.0
+"""
+        )
+    ws._re_read()
+
+    # In order to test bootstrap, we need an object with required_utilities
+    filters = ramble.filters.Filters()
+
+    with ws:
+        setup_pipeline = ramble.pipeline.SetupPipeline(ws, filters)
+
+        # Retrieve the app instance to mock the external dependency definition
+        app_inst = next(iter(setup_pipeline.experiment_set.experiments.values()))
+
+        # Manually attach required_utilities to the instance
+        app_inst.required_utilities = {
+            frozenset([]): {
+                "spack": {
+                    "git": "https://github.com/spack/spack.git",
+                    "commit": "v1.0",
+                }
+            }
+        }
+
+        ws.dry_run = True
+        setup_pipeline.run()
+
+    print(
+        "app_inst.required_utilities:",
+        getattr(app_inst, "required_utilities", "MISSING"),
+    )
+    print("ws_ext_deps:", ws._get_workspace_dict().get("ramble", {}).get("utilities", {}))
+    assert hasattr(app_inst, "_bootstrapped_utility_paths")
+    assert "spack" in app_inst._bootstrapped_utility_paths
+    # Verify the external dependency directory is correct
+    ext_dep_dir = app_inst._bootstrapped_utility_paths["spack"]
+    assert ext_dep_dir.endswith(os.path.join("bootstrapped_utilities", "spack", "v2.0", "source"))
+    assert "utility::spack::activation_command" in app_inst.variables
+    assert "source" in app_inst.variables["utility::spack::activation_command"]

--- a/lib/ramble/ramble/toolkit.py
+++ b/lib/ramble/ramble/toolkit.py
@@ -1,0 +1,33 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+# flake8: noqa: F401
+"""toolkit is a set of useful build tools and directives for external dependencies.
+
+Everything in this module is automatically imported into Ramble external dependency files.
+"""
+
+import llnl.util.filesystem
+from llnl.util.filesystem import *
+
+import ramble.language.utility_language
+from ramble.language.shared_language import *
+from ramble.language.utility_language import *
+from ramble.repository import get_base_class
+from ramble.spec import Spec
+from ramble.util.command_runner import (
+    CommandRunner,
+    NoPathRunnerError,
+    RunnerError,
+    ValidationFailedError,
+)
+from ramble.util.file_util import get_file_path
+from ramble.util.logger import logger
+from ramble.util.output_capture import OUTPUT_CAPTURE
+
+UtilityBase = get_base_class("utility-base")

--- a/lib/ramble/ramble/util/command_runner.py
+++ b/lib/ramble/ramble/util/command_runner.py
@@ -6,7 +6,7 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 import time
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from ramble.util.executable import which
 from ramble.util.logger import logger
@@ -30,6 +30,7 @@ class CommandRunner:
         shell: str = "bash",
         dry_run: bool = False,
         path: Optional[str] = None,
+        env: Optional[Dict[str, str]] = None,
     ):
         """
         Ensure required command is found in the path
@@ -37,6 +38,7 @@ class CommandRunner:
         self.name = name
         self.dry_run = dry_run
         self.shell = shell
+        self.env = env
         self.elapsed_time: float = 0.0
         required = not self.dry_run
         if command is None:
@@ -164,14 +166,14 @@ class CommandRunner:
         try:
             if active_stream is None:
                 if return_output:
-                    out_str = executable(*args, output=str)
+                    out_str = executable(*args, output=str, env=self.env)
                 else:
-                    executable(*args)
+                    executable(*args, env=self.env)
             else:
                 if return_output:
-                    out_str = executable(*args, output=str, error=active_stream)
+                    out_str = executable(*args, output=str, error=active_stream, env=self.env)
                 else:
-                    executable(*args, output=active_stream, error=active_stream)
+                    executable(*args, output=active_stream, error=active_stream, env=self.env)
         except ProcessError as e:
             if not allow_failure:
                 logger.error(e)

--- a/lib/ramble/ramble/util/command_runner.py
+++ b/lib/ramble/ramble/util/command_runner.py
@@ -199,5 +199,9 @@ class RunnerError(Exception):
     """Raised when a problem occurs with a spack environment"""
 
 
+class NoPathRunnerError(RunnerError):
+    """Raised when an executable is not found in the path"""
+
+
 class ValidationFailedError(RunnerError):
     """Raised when a package manager requirement was not met"""

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -2702,6 +2702,10 @@ ramble:
         """Return a dict of workspace tables"""
         return ramble.config.config.get_config(namespace.tables)
 
+    def get_workspace_utilities(self):
+        """Return a dict of workspace utilities"""
+        return ramble.config.config.get_config(namespace.utilities)
+
     def get_applications(self):
         """Get the dictionary of applications"""
         logger.debug("Getting app dict.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,9 +141,10 @@ omit = [
 directory = "htmlcov"
 
 [tool.mypy]
-# Use a common version (3.12 since it starts supporting type aliases)
+# Use a common version (3.10 is the lowest supported version)
 # Otherwise mypy uses the running python's version
-python_version = "3.12"
+python_version = "3.10"
+no_site_packages = true
 # TODO: Add in more files for type-checking
 # For now, only type-check the util directory
 files = [
@@ -157,6 +158,11 @@ allow_redefinition = true
 # Only enable ramble modules
 module = "ramble.*"
 ignore_errors = false
+
+[[tool.mypy.overrides]]
+# Ignore numpy type stubs since they use 3.12 syntax
+module = "numpy.*"
+follow_imports = "skip"
 
 [[tool.mypy.overrides]]
 # TODO: Add more modules here for exhaustive type-checking

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -266,7 +266,7 @@ complete -o bashdefault -o default -F _bash_completion_ramble ramble
 _ramble() {
     if $list_options
     then
-        RAMBLE_COMPREPLY="-h --help -H --all-help --color -c --config -C --config-scope -d --debug --disable-passthrough -N --disable-logger -A --aggregate-warnings -S --suppress-warnings -P --disable-progress-bar --timestamp --pdb -w --workspace -D --workspace-dir -W --no-workspace --use-workspace-repo --resolve-variables-in-subprocesses -k --insecure -l --enable-locks -L --disable-locks -m --mock --overwrite-inventories --mock-applications --mock-modifiers --mock-package-managers --mock-workflow-managers --mock-systems --mock-platforms --mock-base-classes --mock-base-applications --mock-base-modifiers --mock-base-package-managers --mock-base-workflow-managers --mock-base-systems --mock-base-platforms -p --profile --sorted-profile --lines --profile-restrictions -v --verbose --stacktrace -V --version"
+        RAMBLE_COMPREPLY="-h --help -H --all-help --color -c --config -C --config-scope -d --debug --disable-passthrough -N --disable-logger -A --aggregate-warnings -S --suppress-warnings -P --disable-progress-bar --timestamp --pdb -w --workspace -D --workspace-dir -W --no-workspace --use-workspace-repo --resolve-variables-in-subprocesses -k --insecure -l --enable-locks -L --disable-locks -m --mock --overwrite-inventories --mock-applications --mock-modifiers --mock-package-managers --mock-workflow-managers --mock-systems --mock-platforms --mock-base-classes --mock-base-applications --mock-base-modifiers --mock-base-package-managers --mock-base-workflow-managers --mock-base-systems --mock-base-platforms --mock-utilities --mock-base-utilities -p --profile --sorted-profile --lines --profile-restrictions -v --verbose --stacktrace -V --version"
     else
         RAMBLE_COMPREPLY="attributes clean commands config create data debug deployment docs edit filter-groups help info license list mirror on python repo results software-definitions style unit-test workspace"
     fi
@@ -275,7 +275,7 @@ _ramble() {
 _ramble_attributes() {
     if $list_options
     then
-        RAMBLE_COMPREPLY="-h --help --defined --undefined -a --all --by-attribute --applications --modifiers --package_managers --workflow_managers --systems --platforms --base_classes --base_applications --base_modifiers --base_package_managers --base_workflow_managers --base_systems --base_platforms --maintainers --tags"
+        RAMBLE_COMPREPLY="-h --help --defined --undefined -a --all --by-attribute --applications --modifiers --package_managers --workflow_managers --systems --platforms --base_classes --base_applications --base_modifiers --base_package_managers --base_workflow_managers --base_systems --base_platforms --utilities --base_utilities --maintainers --tags"
     else
         RAMBLE_COMPREPLY=""
     fi
@@ -658,7 +658,7 @@ _ramble_workspace() {
     then
         RAMBLE_COMPREPLY="-h --help"
     else
-        RAMBLE_COMPREPLY="activate archive deactivate create concretize config setup analyze push-to-cache info edit mirror experiment-logs list remove generate-config manage"
+        RAMBLE_COMPREPLY="activate archive bootstrap deactivate create concretize config setup analyze push-to-cache info edit mirror experiment-logs list remove generate-config manage"
     fi
 }
 
@@ -673,6 +673,10 @@ _ramble_workspace_activate() {
 
 _ramble_workspace_archive() {
     RAMBLE_COMPREPLY="-h --help --tar-archive -t --prefix -p --upload-url -u --include-secrets --archive-pattern --phases --include-phase-dependencies --where --exclude-where --profile-phase --profile-phase-output --dry-run"
+}
+
+_ramble_workspace_bootstrap() {
+    RAMBLE_COMPREPLY="-h --help --where --exclude-where --filter-tags --dry-run"
 }
 
 _ramble_workspace_deactivate() {
@@ -709,7 +713,7 @@ _ramble_workspace_push_to_cache() {
 }
 
 _ramble_workspace_info() {
-    RAMBLE_COMPREPLY="-h --help --software --all-software --templates --expansions --tags --phases --variants --executables --where --exclude-where --filter-tags --fg --filter-group --efg --exclude-filter-group -v --verbose --dry-run"
+    RAMBLE_COMPREPLY="-h --help --software --all-software --templates --expansions --tags --phases --variants --executables --utilities --where --exclude-where --filter-tags --fg --filter-group --efg --exclude-filter-group -v --verbose --dry-run"
 }
 
 _ramble_workspace_edit() {

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -70,6 +70,7 @@ from ramble.util.shell_utils import source_str
 from ramble.workspace import LICENSE_INC_NAME, TEMPLATE_EXTENSION, namespace
 
 import spack.util.compression
+import spack.util.environment
 import spack.util.executable
 import spack.util.spack_json
 
@@ -163,6 +164,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
     pipelines = [
         "analyze",
         "archive",
+        "bootstrap",
         "mirror",
         "setup",
         "pushdeployment",
@@ -2512,6 +2514,333 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                 stage.cache_mirror(
                     workspace.input_mirror_cache, workspace.input_mirror_stats
                 )
+
+    register_phase("bootstrap_utilities", pipeline="bootstrap")
+    register_phase(
+        "bootstrap_utilities",
+        pipeline="setup",
+        run_before=["get_inputs"],
+    )
+
+    def _bootstrap_utilities(self, workspace, app_inst=None):
+        """Bootstrap external dependencies for this experiment"""
+        if not ramble.config.get("config:bootstrap_utilities", True):
+            logger.debug(
+                "Bootstrapping external dependencies is disabled by config."
+            )
+            return
+
+        ext_dep_paths = {}
+        ext_dep_instances = {}
+        ext_dep_versions = {}
+        objects_to_check = [self]
+        if hasattr(self, "package_manager") and self.package_manager:
+            objects_to_check.append(self.package_manager)
+        if hasattr(self, "system") and self.system:
+            objects_to_check.append(self.system)
+        if hasattr(self, "platform") and self.platform:
+            objects_to_check.append(self.platform)
+        if hasattr(self, "workflow_manager") and self.workflow_manager:
+            objects_to_check.append(self.workflow_manager)
+        if hasattr(self, "_modifiers") and self._modifiers:
+            objects_to_check.extend(self._modifiers)
+
+        ws_ext_deps = (
+            workspace._get_workspace_dict()
+            .get("ramble", {})
+            .get("utilities", {})
+        )
+
+        for obj in objects_to_check:
+            if not hasattr(obj, "required_utilities"):
+                continue
+
+            for (
+                when_key,
+                ext_deps,
+            ) in obj.required_utilities.items():
+                if obj.satisfy_when(when_key):
+                    for ext_dep_name, ext_dep_conf in ext_deps.items():
+                        try:
+                            # Instantiate the external dependency
+                            ext_dep_inst = ramble.repository.paths[
+                                ramble.repository.ObjectTypes.utilities
+                            ].get(ext_dep_name)
+                            ext_dep_instances[ext_dep_name] = ext_dep_inst
+                        except Exception as e:
+                            logger.warn(
+                                f"Failed to find external dependency {ext_dep_name}: {e}"
+                            )
+                            continue
+
+                        # Variables merging logic: object -> workspace
+                        fetch_kwargs = {}
+
+                        for (
+                            when_cond,
+                            vars_list,
+                        ) in ext_dep_inst.object_variables.items():
+                            if obj.satisfy_when(when_cond):
+                                for var_info in vars_list:
+                                    var_name = var_info.name
+                                    if hasattr(self, "expander"):
+                                        expanded_val = (
+                                            self.expander.expand_var(
+                                                f"{{{var_name}}}"
+                                            )
+                                        )
+                                        if expanded_val != f"{{{var_name}}}":
+                                            fetch_kwargs[var_name] = (
+                                                expanded_val
+                                            )
+                                            continue
+
+                                    fetch_kwargs[var_name] = var_info.default
+
+                        if ext_dep_name in ws_ext_deps:
+                            fetch_kwargs.update(ws_ext_deps[ext_dep_name])
+                        else:
+                            fetch_kwargs.update(ext_dep_conf)
+
+                        if hasattr(ext_dep_inst, "map_fetch_kwargs"):
+                            fetch_kwargs = ext_dep_inst.map_fetch_kwargs(
+                                fetch_kwargs
+                            )
+
+                        if "when" in fetch_kwargs:
+                            del fetch_kwargs["when"]
+
+                        min_version = fetch_kwargs.pop("min_version", None)
+                        max_version = fetch_kwargs.pop("max_version", None)
+
+                        origin_name = obj.name
+                        origin_type = getattr(obj, "origin_type", "object")
+
+                        ext_dep_versions[ext_dep_name] = {
+                            "min_version": min_version,
+                            "max_version": max_version,
+                            "origin_name": origin_name,
+                            "origin_type": origin_type,
+                        }
+
+                        for k, v in fetch_kwargs.items():
+                            if isinstance(v, str):
+                                fetch_kwargs[k] = self.expander.expand_var(v)
+
+                        version_str = (
+                            fetch_kwargs.get("commit")
+                            or fetch_kwargs.get("version")
+                            or fetch_kwargs.get("tag")
+                            or fetch_kwargs.get("branch")
+                            or fetch_kwargs.get("revision")
+                            or "latest"
+                        )
+                        ext_dep_dir = os.path.join(
+                            workspace.shared_dir,
+                            "bootstrapped_utilities",
+                            ext_dep_name,
+                            version_str,
+                        )
+                        ext_dep_paths[ext_dep_name] = os.path.join(
+                            ext_dep_dir, "source"
+                        )
+
+                        sorted_kwargs_str = str(sorted(fetch_kwargs.items()))
+                        cache_tuple = (
+                            f"utility-bootstrap-{ext_dep_name}",
+                            sorted_kwargs_str,
+                        )
+
+                        if not hasattr(obj, "variables"):
+                            obj.variables = {}
+                        obj.variables[f"utility::{ext_dep_name}::path"] = (
+                            ext_dep_paths[ext_dep_name]
+                        )
+
+                        if not ramble.config.get(
+                            "config:bootstrap_utilities",
+                            True,
+                        ):
+                            logger.debug(
+                                f"External dependency bootstrapping is disabled globally. Using system {ext_dep_name}."
+                            )
+                            ext_dep_paths[ext_dep_name] = "system"
+                            continue
+
+                        if hasattr(
+                            ext_dep_inst, "is_available"
+                        ) and ext_dep_inst.is_available(
+                            workspace,
+                            min_version=min_version,
+                            max_version=max_version,
+                        ):
+                            logger.debug(
+                                f"External dependency {ext_dep_name} is already available in the environment, skipping fetch."
+                            )
+                            ext_dep_paths[ext_dep_name] = "system"
+                            continue
+
+                        is_bootstrappable = True
+                        if hasattr(ext_dep_inst, "bootstrappable"):
+                            for (
+                                when_cond,
+                                b_list,
+                            ) in ext_dep_inst.bootstrappable.items():
+                                if obj.satisfy_when(when_cond):
+                                    for b_info in b_list:
+                                        is_bootstrappable = b_info[
+                                            "is_bootstrappable"
+                                        ]
+
+                        if not is_bootstrappable:
+                            error_message = f"External dependency '{ext_dep_name}' is not available on the system and is marked as non-bootstrappable."
+                            custom_message = None
+                            if hasattr(ext_dep_inst, "missing_error_messages"):
+                                for (
+                                    when_cond,
+                                    m_list,
+                                ) in (
+                                    ext_dep_inst.missing_error_messages.items()
+                                ):
+                                    if obj.satisfy_when(when_cond):
+                                        for m_info in m_list:
+                                            custom_message = m_info["message"]
+
+                            if custom_message:
+                                error_message = custom_message
+                            elif (
+                                hasattr(ext_dep_inst, "availability_error")
+                                and ext_dep_inst.availability_error
+                            ):
+                                error_message += f"\nReason: {ext_dep_inst.availability_error}"
+                            logger.die(error_message)
+
+                        if not workspace.check_cache(cache_tuple):
+                            if not workspace.dry_run:
+                                try:
+                                    if hasattr(ext_dep_inst, "install"):
+                                        ext_dep_inst.install(workspace)
+
+                                    fetcher_kwargs = {
+                                        k: v
+                                        for k, v in fetch_kwargs.items()
+                                        if k
+                                        in [
+                                            "git",
+                                            "url",
+                                            "commit",
+                                            "tag",
+                                            "branch",
+                                            "revision",
+                                            "version",
+                                            "checksum",
+                                            "sha256",
+                                            "svn",
+                                            "hg",
+                                        ]
+                                    }
+                                    fetcher = (
+                                        ramble.fetch_strategy.from_kwargs(
+                                            **fetcher_kwargs
+                                        )
+                                    )
+                                    stage = ramble.stage.InputStage(
+                                        fetcher,
+                                        name=ext_dep_name,
+                                        path=ext_dep_dir,
+                                    )
+                                    with stage:
+                                        stage.set_subdir("source")
+                                        stage.fetch()
+                                        stage.expand_archive()
+
+                                    if hasattr(
+                                        ext_dep_inst, "modify_bootstrap"
+                                    ):
+                                        ext_dep_inst.modify_bootstrap(
+                                            workspace,
+                                            obj,
+                                        )
+                                except Exception as e:
+                                    logger.die(
+                                        f"Failed to bootstrap external dependency {ext_dep_name}: {e}"
+                                    )
+
+                            workspace.add_to_cache(cache_tuple)
+
+        self._bootstrapped_utility_paths = ext_dep_paths
+
+        for obj in objects_to_check:
+            exp_env_mod = spack.util.environment.EnvironmentModifications()
+            source_scripts_commands = []
+
+            if hasattr(obj, "scripts_to_source"):
+                for script_info in obj.scripts_to_source:
+                    when_cond = script_info.get("when", [])
+                    if obj.satisfy_when(when_cond):
+                        script_path = script_info["path"]
+                        source_scripts_commands.append(f"source {script_path}")
+                        exp_env_mod.extend(
+                            spack.util.environment.EnvironmentModifications.from_sourcing_file(
+                                script_path
+                            )
+                        )
+
+            if not hasattr(obj, "variables"):
+                obj.variables = {}
+            if source_scripts_commands:
+                obj.variables["source_scripts_command"] = "\n".join(
+                    source_scripts_commands
+                )
+            else:
+                obj.variables["source_scripts_command"] = ""
+
+            for ext_dep_name, ext_dep_path in ext_dep_paths.items():
+                ext_dep_inst = ext_dep_instances[ext_dep_name]
+
+                obj.variables[f"utility::{ext_dep_name}::path"] = ext_dep_path
+
+                if hasattr(ext_dep_inst, "get_experiment_activation_command"):
+                    act_cmd = ext_dep_inst.get_experiment_activation_command(
+                        workspace, obj
+                    )
+                    obj.variables[
+                        f"utility::{ext_dep_name}::activation_command"
+                    ] = act_cmd
+
+                if hasattr(ext_dep_inst, "setup_runner_environment"):
+                    env_mod = ext_dep_inst.setup_runner_environment(
+                        workspace, obj
+                    )
+                    if env_mod:
+                        exp_env_mod.extend(env_mod)
+
+            exp_env = os.environ.copy()
+            exp_env_mod.apply_modifications(exp_env)
+            obj.experiment_runner_env = exp_env
+
+            for ext_dep_name, ext_dep_inst in ext_dep_instances.items():
+                if hasattr(ext_dep_inst, "validate_versions"):
+                    versions = ext_dep_versions.get(ext_dep_name, {})
+                    min_v = versions.get("min_version")
+                    max_v = versions.get("max_version")
+                    origin_name = versions.get("origin_name")
+                    origin_type = versions.get("origin_type")
+
+                    if not workspace.dry_run:
+                        if not ext_dep_inst.validate_versions(
+                            min_version=min_v,
+                            max_version=max_v,
+                            env=exp_env,
+                            origin_name=origin_name,
+                            origin_type=origin_type,
+                        ):
+                            logger.die(
+                                f"Version validation failed for {ext_dep_name} after bootstrap:\n{ext_dep_inst.availability_error}"
+                            )
+
+            if hasattr(obj, "bootstrap_utility"):
+                obj.bootstrap_utility(workspace, ext_dep_paths)
 
     register_phase("get_inputs", pipeline="setup")
 

--- a/var/ramble/repos/builtin/base_classes/utility-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/utility-base/base_class.py
@@ -71,12 +71,11 @@ class UtilityBase(ObjectMixin, metaclass=UtilityMeta):
         """Check if the provided executables are available and satisfy version constraints.
         Uses the provided environment or the system environment if None.
         """
-        import os
         import re
         import shutil
         import subprocess
 
-        from spack.version import Version
+        from ramble.definitions.versions import Version
 
         self.availability_error = None
         check_env = env if env is not None else os.environ.copy()

--- a/var/ramble/repos/builtin/base_classes/utility-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/utility-base/base_class.py
@@ -1,0 +1,297 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import ramble.repository
+import ramble.util.class_attributes
+import ramble.variants
+from ramble.language.shared_language import SharedMeta
+from ramble.language.utility_language import UtilityMeta
+from ramble.util.logger import logger
+from ramble.util.naming import NS_SEPARATOR
+
+ObjectMixin = ramble.repository.get_base_class("object-mixin")
+
+
+class UtilityBase(ObjectMixin, metaclass=UtilityMeta):
+    origin_type = "utility"
+    _builtin_name = NS_SEPARATOR.join(
+        ("utility_builtin", "{obj_name}", "{name}")
+    )
+    _language_classes = [UtilityMeta, SharedMeta]
+    pipelines = [
+        "setup",
+    ]
+
+    utility_class = "UtilityBase"
+
+    def __init__(self, file_path):
+        super().__init__()
+
+        self.object_variants = ramble.variants.VariantSet()
+        for var_args in self.class_variants.values():
+            self.object_variants.default_variant(**var_args)
+
+        self.env_sources = getattr(self, "env_sources", {})
+        self.env_sets = getattr(self, "env_sets", {})
+        self.env_prepends = getattr(self, "env_prepends", {})
+        self.env_appends = getattr(self, "env_appends", {})
+        self.fetch_mappings = getattr(self, "fetch_mappings", {})
+        self.bootstrappable = getattr(self, "bootstrappable", {})
+        self.missing_error_messages = getattr(
+            self, "missing_error_messages", {}
+        )
+        self.provided_executables = getattr(self, "provided_executables", {})
+
+        ramble.util.class_attributes.convert_class_attributes(self)
+
+        self._file_path = file_path
+        self.keywords = None
+
+        self.object_variants.default_variant(
+            self.origin_type,
+            default=self.name,
+            description="Name of external dependency for an experiment",
+        )
+
+    def validate_versions(
+        self,
+        min_version=None,
+        max_version=None,
+        env=None,
+        origin_name=None,
+        origin_type=None,
+    ):
+        """Check if the provided executables are available and satisfy version constraints.
+        Uses the provided environment or the system environment if None.
+        """
+        import os
+        import re
+        import shutil
+        import subprocess
+
+        from spack.version import Version
+
+        self.availability_error = None
+        check_env = env if env is not None else os.environ.copy()
+
+        # When using a custom environment, we need to extract its PATH for shutil.which
+        # Default to the current process PATH if not in the custom environment
+        search_path = check_env.get("PATH", os.environ.get("PATH", ""))
+
+        # If the utility provides executables, check if they are in PATH
+        if hasattr(self, "provided_executables") and self.provided_executables:
+            for exec_list in self.provided_executables.values():
+                # We could evaluate satisfy_when here, but for simple presence checks
+                # we just check all provided executables. In the future this could be conditionally checked.
+                for exec_info in exec_list:
+                    exec_name = exec_info["executable"]
+                    if not shutil.which(exec_name, path=search_path):
+                        self.availability_error = (
+                            f"Executable '{exec_name}' not found in PATH."
+                        )
+                        return False
+
+                    version_cmd = exec_info.get("version_cmd")
+                    version_regex = exec_info.get("version_regex")
+
+                    if (
+                        version_cmd
+                        and version_regex
+                        and (min_version or max_version)
+                    ):
+                        try:
+                            import shlex
+
+                            # Run the version command
+                            result = subprocess.run(
+                                shlex.split(version_cmd),
+                                env=check_env,
+                                capture_output=True,
+                                text=True,
+                                check=True,
+                            )
+                            output = result.stdout + result.stderr
+
+                            # Extract the version using the regex
+                            match = re.search(version_regex, output)
+                            if not match:
+                                self.availability_error = f"Could not determine version for '{exec_name}' using regex '{version_regex}'."
+                                return False
+
+                            current_version = match.group(1)
+
+                            origin_str = (
+                                f" (required by {origin_type} '{origin_name}')"
+                                if origin_name and origin_type
+                                else ""
+                            )
+
+                            # Compare versions
+                            if min_version and Version(
+                                current_version
+                            ) < Version(min_version):
+                                self.availability_error = f"Version {current_version} for '{exec_name}' is less than required minimum {min_version}{origin_str}."
+                                return False
+                            if max_version and Version(
+                                current_version
+                            ) > Version(max_version):
+                                self.availability_error = f"Version {current_version} for '{exec_name}' is greater than required maximum {max_version}{origin_str}."
+                                return False
+                        except Exception as e:
+                            # If anything fails (command fails, regex fails, version parse fails)
+                            self.availability_error = f"Error checking version for '{exec_name}': {e}"
+                            return False
+            # If there are provided executables and we didn't return False, they are all present
+            return True
+
+        self.availability_error = (
+            "No provided executables defined to check availability."
+        )
+        return False
+
+    def is_available(self, workspace, min_version=None, max_version=None):
+        """Check if the external dependency is already available on the system.
+        If this returns True, Ramble will skip bootstrapping the external dependency.
+        """
+        return self.validate_versions(
+            min_version=min_version, max_version=max_version
+        )
+
+    def setup_runner_environment(self, workspace, app_inst):
+        """Return an EnvironmentModifications object to set when running commands within Ramble."""
+        import spack.util.environment
+
+        env_mod = spack.util.environment.EnvironmentModifications()
+        utility_path = app_inst.variables.get(f"utility::{self.name}::path")
+        if utility_path == "system":
+            return env_mod
+
+        expander = getattr(app_inst, "expander", None)
+        if not expander and hasattr(app_inst, "app_inst"):
+            expander = getattr(app_inst.app_inst, "expander", None)
+        if not expander:
+            import ramble.expander
+
+            expander = ramble.expander.Expander(app_inst.variables, None)
+
+        for when_key, configs in self.env_sources.items():
+            if app_inst.satisfy_when(when_key):
+                for config in configs:
+                    script_path = expander.expand_var(config["script_path"])
+                    if os.path.exists(script_path):
+                        env_mod.extend(
+                            spack.util.environment.EnvironmentModifications.from_sourcing_file(
+                                script_path
+                            )
+                        )
+                    elif not workspace.dry_run:
+                        logger.warn(
+                            f"External dependency setup script not found at {script_path}"
+                        )
+
+        for when_key, configs in self.env_sets.items():
+            if app_inst.satisfy_when(when_key):
+                for config in configs:
+                    var = expander.expand_var(config["var"])
+                    value = expander.expand_var(config["value"])
+                    env_mod.set(var, value)
+
+        for when_key, configs in self.env_prepends.items():
+            if app_inst.satisfy_when(when_key):
+                for config in configs:
+                    var = expander.expand_var(config["var"])
+                    value = expander.expand_var(config["value"])
+                    env_mod.prepend_path(var, value)
+
+        for when_key, configs in self.env_appends.items():
+            if app_inst.satisfy_when(when_key):
+                for config in configs:
+                    var = expander.expand_var(config["var"])
+                    value = expander.expand_var(config["value"])
+                    env_mod.append_path(var, value)
+
+        return env_mod
+
+    def get_experiment_activation_command(self, workspace, app_inst):
+        """Return a bash command string that activates this external dependency in the experiment's execution environment."""
+        import ramble.config
+        from ramble.util.shell_utils import source_str
+
+        shell = ramble.config.get("config:shell")
+        src_cmd = source_str(shell)
+
+        commands = []
+        utility_path = app_inst.variables.get(f"utility::{self.name}::path")
+        if utility_path == "system":
+            return ""
+
+        expander = getattr(app_inst, "expander", None)
+        if not expander and hasattr(app_inst, "app_inst"):
+            expander = getattr(app_inst.app_inst, "expander", None)
+        if not expander:
+            import ramble.expander
+
+            expander = ramble.expander.Expander(app_inst.variables, None)
+
+        for when_key, configs in self.env_sources.items():
+            if app_inst.satisfy_when(when_key):
+                for config in configs:
+                    script_path = expander.expand_var(config["script_path"])
+                    cmd = f"{{source_cmd}} {script_path}"
+                    cmd = cmd.replace("{source_cmd}", src_cmd)
+                    commands.append(cmd)
+
+        for when_key, configs in self.env_sets.items():
+            if app_inst.satisfy_when(when_key):
+                for config in configs:
+                    var = expander.expand_var(config["var"])
+                    value = expander.expand_var(config["value"])
+                    commands.append(f"export {var}={value}")
+
+        for when_key, configs in self.env_prepends.items():
+            if app_inst.satisfy_when(when_key):
+                for config in configs:
+                    var = expander.expand_var(config["var"])
+                    value = expander.expand_var(config["value"])
+                    commands.append(f"export {var}={value}:${var}")
+
+        for when_key, configs in self.env_appends.items():
+            if app_inst.satisfy_when(when_key):
+                for config in configs:
+                    var = expander.expand_var(config["var"])
+                    value = expander.expand_var(config["value"])
+                    commands.append(f"export {var}=${var}:{value}")
+
+        return "\n".join(commands)
+
+    def map_fetch_kwargs(self, fetch_kwargs):
+        """Hook to map custom external dependency variables to standard Ramble fetcher kwargs."""
+        mapped = fetch_kwargs.copy()
+        for when_key, configs in self.fetch_mappings.items():
+            if not when_key:
+                for config in configs:
+                    utility_var = config["utility_var"]
+                    fetch_var = config["fetch_var"]
+                    fallback_for = config["fallback_for"]
+
+                    if utility_var in mapped:
+                        val = mapped.pop(utility_var)
+                        if not any(k in mapped for k in fallback_for):
+                            mapped[fetch_var] = val
+        return mapped
+
+    def modify_bootstrap(self, workspace, app_inst):
+        """Hook to allow external dependency to modify its own bootstrap installation.
+
+        Args:
+            workspace: The current workspace object
+            app_inst: The application instance that triggered the bootstrap
+        """
+        pass

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
@@ -24,6 +24,7 @@ from spack.util.executable import ProcessError, which
 
 
 class SpackLightweight(PackageManagerBase):
+    requires_utility("spack")
     """Lightweight version of Spack package manager class definition
 
     This implements most of the logic for the spack package manager. The
@@ -59,7 +60,11 @@ class SpackLightweight(PackageManagerBase):
     @property
     def runner(self):
         if self._runner is None:
-            self._runner = SpackRunner()
+            env = None
+            app_inst = self._get_app_inst()
+            if hasattr(app_inst, "experiment_runner_env"):
+                env = app_inst.experiment_runner_env
+            self._runner = SpackRunner(env=env)
         return self._runner
 
     variant(
@@ -559,6 +564,12 @@ class SpackLightweight(PackageManagerBase):
     )
 
     def spack_source(self):
+        if (
+            hasattr(self.app_inst, "variables")
+            and "utility::spack::activation_command" in self.app_inst.variables
+        ):
+            if self.app_inst.variables["utility::spack::activation_command"]:
+                return ["{utility::spack::activation_command}"]
         return self.runner.generate_source_command()
 
     def spack_activate(self):
@@ -747,13 +758,17 @@ class SpackRunner(CommandRunner):
         "spack_includes.yaml",
     ]
 
-    def __init__(self, shell="bash", dry_run=False):
+    def __init__(self, shell="bash", dry_run=False, env=None):
         """
         Ensure spack is found in the path, and setup some default variables.
         """
 
         super().__init__(
-            name="spack", command="spack", shell=shell, dry_run=dry_run
+            name="spack",
+            command="spack",
+            shell=shell,
+            dry_run=dry_run,
+            env=env,
         )
         self.spack = self.command
 
@@ -778,7 +793,7 @@ class SpackRunner(CommandRunner):
         )
 
         self.bs_python = CommandRunner(
-            "python", command=sys.executable, dry_run=dry_run
+            "python", command=sys.executable, dry_run=dry_run, env=env
         )
         self.concretized = False
         self.hash = None

--- a/var/ramble/repos/builtin/utilities/pdsh/utility.py
+++ b/var/ramble/repos/builtin/utilities/pdsh/utility.py
@@ -1,0 +1,29 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+# flake8: noqa: F403
+from ramble.toolkit import *
+
+
+class Pdsh(UtilityBase):
+    """pdsh utility"""
+
+    bootstrappable(False)
+    missing_error_message(
+        "pdsh is required but was not found in your environment. Please install it to proceed."
+    )
+
+    provides_executable(
+        "pdsh",
+        version_cmd="pdsh -V",
+        version_regex=r"pdsh-(\d+\.\d+).*",
+    )
+
+    name = "pdsh"
+
+    maintainers("douglasjacobsen")

--- a/var/ramble/repos/builtin/utilities/spack/utility.py
+++ b/var/ramble/repos/builtin/utilities/spack/utility.py
@@ -1,0 +1,75 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import shutil
+
+# flake8: noqa: F403
+from ramble.toolkit import *
+
+
+class Spack(UtilityBase):
+    """Spack package manager external utility: https://spack.io"""
+
+    bootstrappable(True)
+
+    variable(
+        name="path",
+        default="system",
+        description="Path to Spack",
+        scoped=True,
+    )
+
+    name = "spack"
+
+    maintainers("douglasjacobsen")
+
+    # For testing we only require version
+    variable(
+        "spack_url",
+        default="https://github.com/spack/spack.git",
+        description="Git repository for Spack",
+    )
+    variable(
+        "spack_version",
+        default="v0.22.0",
+        description="Version of spack to fetch",
+    )
+
+    fetch_mapping("spack_url", "git", fallback_for=["git", "url"])
+    fetch_mapping(
+        "spack_version", "commit", fallback_for=["commit", "branch", "tag"]
+    )
+
+    provides_executable(
+        "spack",
+        version_cmd="spack --version",
+        version_regex=r"(\d+.\d+.\d+).*",
+    )
+
+    env_source("{utility::spack::path}/share/spack/setup-env.sh")
+    env_set("SPACK_USER_CONFIG_PATH", "{utility::spack::path}/../.spack")
+
+    # Future proofing: tools can define their own setup phases!
+    def install(self, workspace):
+        # E.g., make, configure, etc.
+        logger.debug(f"Executing install phase for {self.name}")
+        pass
+
+    def is_available(self, workspace, min_version=None, max_version=None):
+        """Check if spack is available in the user's environment."""
+        # Only return True if the user explicitly opted into using the system spack
+        # via a workspace variable, otherwise we should bootstrap the requested version.
+        ws_vars = (
+            workspace._get_workspace_dict()
+            .get("ramble", {})
+            .get("variables", {})
+        )
+        if ws_vars.get("use_system_spack", False):
+            if shutil.which("spack"):
+                return True
+        return False


### PR DESCRIPTION
This merge adds utilities as a new object type. Utilities represent external dependencies that experiments (or other objects) can require. These can include things like spack (package managers) or pdsh. A language, documentation, and tests are added to help developers create new utilities.