### PR TITLE
Better support for setting dry-run for workspace cmds

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -734,6 +734,13 @@ def make_workspace_from_config(workspace_name, mutable_config, mutable_mock_work
     return _create
 
 
+@pytest.fixture
+def dry_run_env(working_env):
+    """Fixture to enable dry-run for workspace cmds"""
+    os.environ["RAMBLE_WORKSPACE_DRY_RUN"] = "1"
+    yield
+
+
 def pytest_generate_tests(metafunc):
     import re
 

--- a/lib/ramble/ramble/test/systems_and_platforms/system_platform_general.py
+++ b/lib/ramble/ramble/test/systems_and_platforms/system_platform_general.py
@@ -26,7 +26,7 @@ pytestmark = pytest.mark.usefixtures(
 )
 
 
-def test_system_platform_works(workspace_name, mock_platforms, mock_systems):
+def test_system_platform_works(workspace_name, mock_platforms, mock_systems, dry_run_env):
     ws = ramble.workspace.create(workspace_name)
     global_args = ["-w", workspace_name]
     workspace(
@@ -47,9 +47,6 @@ def test_system_platform_works(workspace_name, mock_platforms, mock_systems):
         "system-variant1=bar",
         global_args=global_args,
     )
-
-    ws._re_read()
-    ws.dry_run = True
 
     try:
         workspace("concretize", global_args=global_args)
@@ -97,8 +94,10 @@ def test_system_platform_works(workspace_name, mock_platforms, mock_systems):
         pytest.skip(str(e))
 
 
-def test_platform_validator_threads_per_core(workspace_name, mock_platforms, mock_systems):
-    ws = ramble.workspace.create(workspace_name)
+def test_platform_validator_threads_per_core(
+    workspace_name, mock_platforms, mock_systems, dry_run_env
+):
+    ramble.workspace.create(workspace_name)
     global_args = ["-w", workspace_name]
     workspace(
         "manage",
@@ -119,8 +118,6 @@ def test_platform_validator_threads_per_core(workspace_name, mock_platforms, moc
         global_args=global_args,
     )
 
-    ws._re_read()
-
     err_regex = re.escape(
         "Validator 'threads_per_node_platform_validation' (defined in 'mock-platform1') "
         "fails with message: 'Number of threads per node (2 * 3) exceeds max cores per node (4)'"
@@ -131,9 +128,9 @@ def test_platform_validator_threads_per_core(workspace_name, mock_platforms, moc
 
 
 def test_skipping_platform_validator_threads_per_core(
-    workspace_name, mock_platforms, mock_systems
+    workspace_name, mock_platforms, mock_systems, dry_run_env
 ):
-    ws = ramble.workspace.create(workspace_name)
+    ramble.workspace.create(workspace_name)
     global_args = ["-w", workspace_name]
     workspace(
         "manage",
@@ -156,14 +153,14 @@ def test_skipping_platform_validator_threads_per_core(
         global_args=global_args,
     )
 
-    ws._re_read()
-
     workspace("concretize", global_args=global_args)
     workspace("info", global_args=global_args)
 
 
-def test_platform_validator_accelerators_per_node(workspace_name, mock_platforms, mock_systems):
-    ws = ramble.workspace.create(workspace_name)
+def test_platform_validator_accelerators_per_node(
+    workspace_name, mock_platforms, mock_systems, dry_run_env
+):
+    ramble.workspace.create(workspace_name)
     global_args = ["-w", workspace_name]
     workspace(
         "manage",
@@ -186,8 +183,6 @@ def test_platform_validator_accelerators_per_node(workspace_name, mock_platforms
         global_args=global_args,
     )
 
-    ws._re_read()
-
     err_regex = re.escape(
         "Validator 'accelerators_per_node_platform_validation' (defined in 'mock-platform1') "
         "fails with message: 'Number of accelerators per node (2) exceeds max accelerators "
@@ -199,8 +194,8 @@ def test_platform_validator_accelerators_per_node(workspace_name, mock_platforms
         workspace("info", global_args=global_args)
 
 
-def test_system_validator_n_nodes(workspace_name, mock_platforms, mock_systems):
-    ws = ramble.workspace.create(workspace_name)
+def test_system_validator_n_nodes(workspace_name, mock_platforms, mock_systems, dry_run_env):
+    ramble.workspace.create(workspace_name)
     global_args = ["-w", workspace_name]
     workspace(
         "manage",
@@ -219,8 +214,6 @@ def test_system_validator_n_nodes(workspace_name, mock_platforms, mock_systems):
         global_args=global_args,
     )
 
-    ws._re_read()
-
     err_regex = re.escape(
         "Validator 'n_nodes_system_validation' (defined in 'spack-slurm-sys') fails with message: "
         "'Number of nodes requested (10) exceeds max nodes (4)'"
@@ -230,8 +223,8 @@ def test_system_validator_n_nodes(workspace_name, mock_platforms, mock_systems):
         workspace("info", global_args=global_args)
 
 
-def test_system_validator_n_ranks(workspace_name, mock_platforms, mock_systems):
-    ws = ramble.workspace.create(workspace_name)
+def test_system_validator_n_ranks(workspace_name, mock_platforms, mock_systems, dry_run_env):
+    ramble.workspace.create(workspace_name)
     global_args = ["-w", workspace_name]
     workspace(
         "manage",
@@ -249,8 +242,6 @@ def test_system_validator_n_ranks(workspace_name, mock_platforms, mock_systems):
         "system=spack-slurm-sys",
         global_args=global_args,
     )
-
-    ws._re_read()
 
     err_regex = re.escape(
         "Validator 'n_ranks_system_validation' (defined in 'spack-slurm-sys') fails with "

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -442,11 +442,11 @@ class Workspace:
     inventory_file_name = "ramble_inventory.json"
     hash_file_name = "workspace_hash.sha256"
 
-    def __init__(self, root, dry_run=False, read_default_template=True):
+    def __init__(self, root, dry_run=None, read_default_template=True):
         logger.debug(f"In workspace init. Root = {root}")
         self.root = ramble.util.path.canonicalize_path(root)
         self.txlock = lk.Lock(self._transaction_lock_path)
-        self.dry_run = dry_run
+        self._dry_run = dry_run
         self.repeat_success_strict = True
 
         self.read_default_template = read_default_template
@@ -2165,6 +2165,19 @@ ramble:
     def shared_license_dir(self):
         """Path to the shared license directory"""
         return os.path.join(self.shared_dir, WORKSPACE_SHARED_LICENSE_PATH)
+
+    @property
+    def dry_run(self):
+        if self._dry_run is not None:
+            return self._dry_run
+        dry_run_env = os.environ.get("RAMBLE_WORKSPACE_DRY_RUN")
+        if dry_run_env is not None:
+            return dry_run_env.lower() in ("true", "1")
+        return False
+
+    @dry_run.setter
+    def dry_run(self, val):
+        self._dry_run = val
 
     def template_path(self, name):
         if name in self._templates:


### PR DESCRIPTION
It's often not sufficient to use `ws.dry_run = True`, given that invocations like `workspace("concretize")` do not expose the workspace handle used. To address this, this PR adds in an environment variable to configure the `dry_run` property of a workspace.

Example repro where previously not properly setting dry_run causes test failures under certain conditions (in this case, when `sinfo` is available):

```
$ mkdir -p /tmp/mock_bin
$ echo -e '#!/bin/bash\necho "hello"' > /tmp/mock_bin/sinfo
$ chmod +x /tmp/mock_bin/sinfo
$ PATH="/tmp/mock_bin:$PATH" ramble unit-test -k system_platform_general
```