### PR TITLE
Reduce Ramble's dependency on spack.util

### DIFF
--- a/lib/ramble/ramble/config.py
+++ b/lib/ramble/ramble/config.py
@@ -80,6 +80,7 @@ import ramble.schema.variants
 import ramble.schema.workflow_manager_repos
 import ramble.schema.workspace
 from ramble.error import RambleError
+from ramble.util import cpus
 from ramble.util.logger import logger
 
 import spack.compilers
@@ -87,7 +88,6 @@ import spack.platforms
 
 # Hacked yaml for configuration files preserves line numbers.
 import spack.util.spack_yaml as syaml
-from spack.util.cpus import cpus_available
 
 #: Dict from section names -> schema for that section
 section_schemas: Dict[str, Dict[str, Any]] = {
@@ -199,7 +199,7 @@ config_defaults = {
         "verify_ssl": True,
         "checksum": True,
         "dirty": False,
-        "build_jobs": min(16, cpus_available()),
+        "build_jobs": min(16, cpus.cpus_available()),
         "build_stage": "$tempdir/ramble-stage",
         "concretizer": "clingo",
         "license_dir": spack.paths.default_license_dir,

--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -23,10 +23,9 @@ from typing import Dict, FrozenSet, List, Optional, Union
 import ramble.config
 import ramble.error
 import ramble.keywords
+from ramble.util import naming
 from ramble.util.logger import logger
 from ramble.util.path import substitute_config_variables
-
-import spack.util.naming
 
 _ast_cache: Dict[str, str] = {}
 # Regex for detecting math operators or keywords
@@ -193,7 +192,7 @@ supported_scalar_function_pointers = {
     "sqrt": math.sqrt,
     "randrange": random.randrange,
     "randint": random.randint,
-    "simplify_str": spack.util.naming.simplify_name,
+    "simplify_str": naming.simplify_name,
     "join_str": _join_str,
     "re_search": _re_search,
     "replace": _str_replace,

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -22,10 +22,8 @@ import ramble.renderer
 import ramble.repository
 from ramble.expander import Expander
 from ramble.namespace import namespace
+from ramble.util import cpus, naming
 from ramble.util.logger import logger
-
-import spack.util.naming
-from spack.util import cpus
 
 
 class ExperimentSet:
@@ -308,20 +306,20 @@ class ExperimentSet:
         app_inst.define_variable(
             self.keywords.simplified_application_namespace,
             (
-                spack.util.naming.simplify_name(
+                naming.simplify_name(
                     app_inst.expander.expand_var_name(self.keywords.application_namespace)
                 )
             ),
         )
         app_inst.define_variable(
             self.keywords.simplified_workload_namespace,
-            spack.util.naming.simplify_name(
+            naming.simplify_name(
                 app_inst.expander.expand_var_name(self.keywords.workload_namespace)
             ),
         )
         app_inst.define_variable(
             self.keywords.simplified_experiment_namespace,
-            spack.util.naming.simplify_name(
+            naming.simplify_name(
                 app_inst.expander.expand_var_name(self.keywords.experiment_namespace)
             ),
         )
@@ -624,8 +622,12 @@ class ExperimentSet:
             max_workers = min(2, cpus.cpus_available())
         else:
             max_workers = 1
-        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
-            results = list(executor.map(worker_func, render_list))
+
+        if max_workers == 1:
+            results = [worker_func(item) for item in render_list]
+        else:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+                results = list(executor.map(worker_func, render_list))
 
         for processed_experiments in results:
             all_processed_experiments.extend(processed_experiments)

--- a/lib/ramble/ramble/test/util/cpus.py
+++ b/lib/ramble/ramble/test/util/cpus.py
@@ -1,0 +1,32 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+
+import os
+
+from ramble.util import cpus
+
+
+def test_cpus_available(monkeypatch):
+    monkeypatch.setattr(os, "sched_getaffinity", lambda pid: {0, 1, 2}, raising=False)
+
+    assert cpus.cpus_available() == 3
+
+
+def test_cpus_available_fallback_no_sched_get_affinity(monkeypatch):
+    monkeypatch.delattr(os, "sched_getaffinity", raising=False)
+    monkeypatch.setattr(os, "cpu_count", lambda: 8)
+
+    assert cpus.cpus_available() == 8
+
+
+def test_cpus_available_last_fallback(monkeypatch):
+    monkeypatch.delattr(os, "sched_getaffinity", raising=False)
+    monkeypatch.setattr(os, "cpu_count", lambda: None)
+
+    assert cpus.cpus_available() == 1

--- a/lib/ramble/ramble/util/cpus.py
+++ b/lib/ramble/ramble/util/cpus.py
@@ -1,0 +1,15 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+
+def cpus_available() -> int:
+    if hasattr(os, "sched_getaffinity"):
+        return len(os.sched_getaffinity(0))
+    return os.cpu_count() or 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,8 +204,10 @@ select = [
 # Even though `py` is neither vendored nor listed in the deps, `pytest` has a dependency
 # on it. Use linter to ban its usage.
 "py" = { msg = "The legacy `py` library is deprecated and should not be used." }
+# These are used to enforce the gradual moving away from vendored Spack dependencies
+"spack.util.naming" = { msg = "Core Ramble code should not rely on spack.util.naming." }
+"spack.util.cpus" = { msg = "Core Ramble code should not rely on spack.util.cpus." }
 
 [tool.ruff.lint.per-file-ignores]
 "lib/ramble/ramble/*kit.py" = ["F403"]
 "var/ramble/repos/**/*.py" = ["F403", "F405"]
-

--- a/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/package-manager-base/base_class.py
@@ -25,8 +25,6 @@ from ramble.software_environments import (
 from ramble.util.logger import logger
 from ramble.util.naming import NS_SEPARATOR
 
-import spack.util.naming
-
 ObjectMixin = ramble.repository.get_base_class("object-mixin")
 
 
@@ -150,7 +148,7 @@ class PackageManagerBase(ObjectMixin, metaclass=PackageManagerMeta):
             (str): Prefix for this package manager's specs
         """
         prefix = self._spec_prefix or self.name
-        return spack.util.naming.spack_module_to_python_module(prefix)
+        return prefix.replace("-", "_")
 
     def set_application(self, app_inst):
         """Add an internal reference to the application instance this package


### PR DESCRIPTION
Remove the several usage within Ramble for the `spack.util.naming` and the `spack.util.cpu` modules.

Also add in linter rule to ensure no future imports from this module.