### PR TITLE
Simplify confidence interval classes

### DIFF
--- a/lib/ramble/ramble/test/util/stats.py
+++ b/lib/ramble/ramble/test/util/stats.py
@@ -10,110 +10,110 @@ import math
 
 import pytest
 
-import ramble.util.stats
+from ramble.util import stats
 
 
 @pytest.mark.parametrize(
     "statistic,input_values,input_units,output",
     [
-        (ramble.util.stats.StatsMin(), [-2, 0, 2, 5.5], "s", (-2, "s", "summary::min")),
-        (ramble.util.stats.StatsMax(), [-2, 0, 2, 5.5], "s", (5.5, "s", "summary::max")),
+        (stats.StatsMin(), [-2, 0, 2, 5.5], "s", (-2, "s", "summary::min")),
+        (stats.StatsMax(), [-2, 0, 2, 5.5], "s", (5.5, "s", "summary::max")),
         # Test for scientific notation support
-        (ramble.util.stats.StatsMean(), [-2, 0, 2, 5.5, 1.45e1], "s", (4, "s", "summary::mean")),
+        (stats.StatsMean(), [-2, 0, 2, 5.5, 1.45e1], "s", (4, "s", "summary::mean")),
         (
-            ramble.util.stats.StatsHarmonicMean(),
+            stats.StatsHarmonicMean(),
             [2, 3, 5],
             "s",
             (3.0, "s", "summary::harmonic_mean"),
         ),
         (
-            ramble.util.stats.StatsHarmonicMean(),
+            stats.StatsHarmonicMean(),
             [2, 3, 5, -1],
             "s",
             ("NA", "s", "summary::harmonic_mean"),
         ),
-        (ramble.util.stats.StatsMedian(), [-2, 0, 2, 5.5], "s", (1.0, "s", "summary::median")),
-        (ramble.util.stats.StatsVar(), [-2, 0, 2, 5.5], "s", (10.2, "s^2", "summary::variance")),
-        (ramble.util.stats.StatsVar(), [3], "s", ("NA", "", "summary::variance")),
-        (ramble.util.stats.StatsStdev(), [-2, 0, 2, 5.5], "s", (3.2, "s", "summary::stdev")),
-        (ramble.util.stats.StatsStdev(), [3], "s", ("NA", "", "summary::stdev")),
-        (ramble.util.stats.StatsCoefficientOfVariation(), [3], "s", ("NA", "", "summary::cv")),
-        (ramble.util.stats.StatsCoefficientOfVariation(), [3, -3], "s", ("NA", "", "summary::cv")),
+        (stats.StatsMedian(), [-2, 0, 2, 5.5], "s", (1.0, "s", "summary::median")),
+        (stats.StatsVar(), [-2, 0, 2, 5.5], "s", (10.2, "s^2", "summary::variance")),
+        (stats.StatsVar(), [3], "s", ("NA", "", "summary::variance")),
+        (stats.StatsStdev(), [-2, 0, 2, 5.5], "s", (3.2, "s", "summary::stdev")),
+        (stats.StatsStdev(), [3], "s", ("NA", "", "summary::stdev")),
+        (stats.StatsCoefficientOfVariation(), [3], "s", ("NA", "", "summary::cv")),
+        (stats.StatsCoefficientOfVariation(), [3, -3], "s", ("NA", "", "summary::cv")),
         (
-            ramble.util.stats.StatsCoefficientOfVariation(),
+            stats.StatsCoefficientOfVariation(),
             [6.79, 5.6, 4.31, 5.5],
             "s",
             (0.18, "", "summary::cv"),
         ),
         (
-            ramble.util.stats.StatsConfidenceIntervalLower95(),
+            stats.StatsConfidenceIntervalLower95(),
             [1, 2, 3, 4, 5],
             "s",
             (1.0, "s", "summary::ci_95_lower"),
         ),
         (
-            ramble.util.stats.StatsConfidenceIntervalUpper95(),
+            stats.StatsConfidenceIntervalUpper95(),
             [1, 2, 3, 4, 5],
             "s",
             (5.0, "s", "summary::ci_95_upper"),
         ),
         (
-            ramble.util.stats.StatsConfidenceIntervalLower95(),
+            stats.StatsConfidenceIntervalLower95(),
             [1],
             "s",
             ("NA", "", "summary::ci_95_lower"),
         ),
         (
-            ramble.util.stats.StatsConfidenceIntervalUpper95(),
+            stats.StatsConfidenceIntervalUpper95(),
             [1],
             "s",
             ("NA", "", "summary::ci_95_upper"),
         ),
         # Test case with a larger sample size to verify z-score approximation
         (
-            ramble.util.stats.StatsConfidenceIntervalLower95(),
+            stats.StatsConfidenceIntervalLower95(),
             list(range(1, 31)),
             "s",
             (12.0, "s", "summary::ci_95_lower"),
         ),
         (
-            ramble.util.stats.StatsConfidenceIntervalUpper95(),
+            stats.StatsConfidenceIntervalUpper95(),
             list(range(1, 31)),
             "s",
             (19.0, "s", "summary::ci_95_upper"),
         ),
         (
-            ramble.util.stats.StatsConfidenceIntervalLower99(),
+            stats.StatsConfidenceIntervalLower99(),
             list(range(1, 31)),
             "s",
             (11.0, "s", "summary::ci_99_lower"),
         ),
         (
-            ramble.util.stats.StatsConfidenceIntervalUpper99(),
+            stats.StatsConfidenceIntervalUpper99(),
             list(range(1, 31)),
             "s",
             (20.0, "s", "summary::ci_99_upper"),
         ),
         (
-            ramble.util.stats.StatsConfidenceIntervalLower90(),
+            stats.StatsConfidenceIntervalLower90(),
             list(range(1, 31)),
             "s",
             (13.0, "s", "summary::ci_90_lower"),
         ),
         (
-            ramble.util.stats.StatsConfidenceIntervalUpper90(),
+            stats.StatsConfidenceIntervalUpper90(),
             list(range(1, 31)),
             "s",
             (18.0, "s", "summary::ci_90_upper"),
         ),
         (
-            ramble.util.stats.StatsConfidenceIntervalLower50(),
+            stats.StatsConfidenceIntervalLower50(),
             list(range(1, 31)),
             "s",
             (14.0, "s", "summary::ci_50_lower"),
         ),
         (
-            ramble.util.stats.StatsConfidenceIntervalUpper50(),
+            stats.StatsConfidenceIntervalUpper50(),
             list(range(1, 31)),
             "s",
             (17.0, "s", "summary::ci_50_upper"),
@@ -159,16 +159,16 @@ def test_calculate_margin_of_error():
     ]
 
     assert math.isclose(
-        ramble.util.stats._calculate_margin_of_error(data, 0.99), 0.531, abs_tol=1e-3
+        stats._calculate_margin_of_error(data, stats.ConfidenceLevel.CL_99), 0.531, abs_tol=1e-3
     )
     assert math.isclose(
-        ramble.util.stats._calculate_margin_of_error(data, 0.95), 0.404, abs_tol=1e-3
+        stats._calculate_margin_of_error(data, stats.ConfidenceLevel.CL_95), 0.404, abs_tol=1e-3
     )
     assert math.isclose(
-        ramble.util.stats._calculate_margin_of_error(data, 0.90), 0.339, abs_tol=1e-3
+        stats._calculate_margin_of_error(data, stats.ConfidenceLevel.CL_90), 0.339, abs_tol=1e-3
     )
     assert math.isclose(
-        ramble.util.stats._calculate_margin_of_error(data, 0.50), 0.139, abs_tol=1e-3
+        stats._calculate_margin_of_error(data, stats.ConfidenceLevel.CL_50), 0.139, abs_tol=1e-3
     )
     with pytest.raises(ValueError, match="Unsupported confidence level"):
-        ramble.util.stats._calculate_margin_of_error(data, 0.1)
+        stats._calculate_margin_of_error(data, 0.1)

--- a/lib/ramble/ramble/util/stats.py
+++ b/lib/ramble/ramble/util/stats.py
@@ -7,6 +7,7 @@
 # except according to those terms.
 
 import decimal
+import enum
 import math
 import statistics
 from typing import List, Tuple, Union
@@ -28,6 +29,13 @@ def _decimal_places(value: float) -> int:
 def _max_decimal_places(values: List[float]) -> int:
     """Returns the max decimal places of a list of values"""
     return max(_decimal_places(v) for v in values)
+
+
+class ConfidenceLevel(enum.Enum):
+    CL_99 = 0.99
+    CL_95 = 0.95
+    CL_90 = 0.90
+    CL_50 = 0.50
 
 
 class StatsBase:
@@ -125,7 +133,7 @@ class StatsCoefficientOfVariation(StatsBase):
         return ""
 
 
-def _calculate_margin_of_error(values: List[float], confidence_level: float) -> float:
+def _calculate_margin_of_error(values: List[float], cl: ConfidenceLevel) -> float:
     """Calculates the margin of error for a given confidence interval."""
     n = len(values)
     stdev = statistics.stdev(values)
@@ -134,101 +142,81 @@ def _calculate_margin_of_error(values: List[float], confidence_level: float) -> 
     # For larger samples, the z-score is a good approximation.
     if n < 30:
         degrees_freedom = n - 1
-        t_score = float(t.ppf(1 - (1 - confidence_level) / 2, degrees_freedom))
+        t_score = float(t.ppf(1 - (1 - cl.value) / 2, degrees_freedom))
         return t_score * (stdev / math.sqrt(n))
     else:
         # Using z-score for confidence.
-        if confidence_level == 0.99:
+        if cl == ConfidenceLevel.CL_99:
             z_score = 2.576
-        elif confidence_level == 0.95:
+        elif cl == ConfidenceLevel.CL_95:
             z_score = 1.96
-        elif confidence_level == 0.90:
+        elif cl == ConfidenceLevel.CL_90:
             z_score = 1.645
-        elif confidence_level == 0.50:
+        elif cl == ConfidenceLevel.CL_50:
             z_score = 0.674
         else:
             raise ValueError("Unsupported confidence level")
         return z_score * (stdev / math.sqrt(n))
 
 
-class StatsConfidenceIntervalLower99(StatsBase):
+class StatsConfidenceIntervalBase(StatsBase):
+    min_count = 2
+    confidence_level: ConfidenceLevel
+    is_upper: bool
+
+    def compute(self, values: List[float]) -> float:
+        mean = statistics.mean(values)
+        margin_of_error = _calculate_margin_of_error(values, self.confidence_level)
+        res = mean + margin_of_error if self.is_upper else mean - margin_of_error
+        return round(res, _max_decimal_places(values))
+
+
+class StatsConfidenceIntervalLower99(StatsConfidenceIntervalBase):
     name = "ci_99_lower"
-    min_count = 2
-
-    def compute(self, values: List[float]) -> float:
-        mean = statistics.mean(values)
-        margin_of_error = _calculate_margin_of_error(values, 0.99)
-        return round(mean - margin_of_error, _max_decimal_places(values))
+    confidence_level = ConfidenceLevel.CL_99
+    is_upper = False
 
 
-class StatsConfidenceIntervalUpper99(StatsBase):
+class StatsConfidenceIntervalUpper99(StatsConfidenceIntervalBase):
     name = "ci_99_upper"
-    min_count = 2
-
-    def compute(self, values: List[float]) -> float:
-        mean = statistics.mean(values)
-        margin_of_error = _calculate_margin_of_error(values, 0.99)
-        return round(mean + margin_of_error, _max_decimal_places(values))
+    confidence_level = ConfidenceLevel.CL_99
+    is_upper = True
 
 
-class StatsConfidenceIntervalLower95(StatsBase):
+class StatsConfidenceIntervalLower95(StatsConfidenceIntervalBase):
     name = "ci_95_lower"
-    min_count = 2
-
-    def compute(self, values: List[float]) -> float:
-        mean = statistics.mean(values)
-        margin_of_error = _calculate_margin_of_error(values, 0.95)
-        return round(mean - margin_of_error, _max_decimal_places(values))
+    confidence_level = ConfidenceLevel.CL_95
+    is_upper = False
 
 
-class StatsConfidenceIntervalUpper95(StatsBase):
+class StatsConfidenceIntervalUpper95(StatsConfidenceIntervalBase):
     name = "ci_95_upper"
-    min_count = 2
-
-    def compute(self, values: List[float]) -> float:
-        mean = statistics.mean(values)
-        margin_of_error = _calculate_margin_of_error(values, 0.95)
-        return round(mean + margin_of_error, _max_decimal_places(values))
+    confidence_level = ConfidenceLevel.CL_95
+    is_upper = True
 
 
-class StatsConfidenceIntervalLower90(StatsBase):
+class StatsConfidenceIntervalLower90(StatsConfidenceIntervalBase):
     name = "ci_90_lower"
-    min_count = 2
-
-    def compute(self, values: List[float]) -> float:
-        mean = statistics.mean(values)
-        margin_of_error = _calculate_margin_of_error(values, 0.90)
-        return round(mean - margin_of_error, _max_decimal_places(values))
+    confidence_level = ConfidenceLevel.CL_90
+    is_upper = False
 
 
-class StatsConfidenceIntervalUpper90(StatsBase):
+class StatsConfidenceIntervalUpper90(StatsConfidenceIntervalBase):
     name = "ci_90_upper"
-    min_count = 2
-
-    def compute(self, values: List[float]) -> float:
-        mean = statistics.mean(values)
-        margin_of_error = _calculate_margin_of_error(values, 0.90)
-        return round(mean + margin_of_error, _max_decimal_places(values))
+    confidence_level = ConfidenceLevel.CL_90
+    is_upper = True
 
 
-class StatsConfidenceIntervalLower50(StatsBase):
+class StatsConfidenceIntervalLower50(StatsConfidenceIntervalBase):
     name = "ci_50_lower"
-    min_count = 2
-
-    def compute(self, values: List[float]) -> float:
-        mean = statistics.mean(values)
-        margin_of_error = _calculate_margin_of_error(values, 0.50)
-        return round(mean - margin_of_error, _max_decimal_places(values))
+    confidence_level = ConfidenceLevel.CL_50
+    is_upper = False
 
 
-class StatsConfidenceIntervalUpper50(StatsBase):
+class StatsConfidenceIntervalUpper50(StatsConfidenceIntervalBase):
     name = "ci_50_upper"
-    min_count = 2
-
-    def compute(self, values: List[float]) -> float:
-        mean = statistics.mean(values)
-        margin_of_error = _calculate_margin_of_error(values, 0.50)
-        return round(mean + margin_of_error, _max_decimal_places(values))
+    confidence_level = ConfidenceLevel.CL_50
+    is_upper = True
 
 
 all_stats = [


### PR DESCRIPTION
* Use a base class to simplify subclasses implementations
* Introduce an enum class to avoid using float directly