### PR TITLE
Add `dry-run` option to all workspace commands

### DIFF
--- a/lib/ramble/ramble/cmd/__init__.py
+++ b/lib/ramble/ramble/cmd/__init__.py
@@ -155,7 +155,7 @@ class CommandNameError(ramble.error.RambleError):
         super().__init__(f"{name} is not a permissible Ramble command name.")
 
 
-def require_active_workspace(cmd_name):
+def require_active_workspace(cmd_name, dry_run: bool = False):
     """Used by commands to get the active workspace
 
     If a workspace is not found, print an error message that says the calling
@@ -163,6 +163,7 @@ def require_active_workspace(cmd_name):
 
     Arguments:
         cmd_name (str): name of calling command
+        dry_run (bool): whether this is a dry run
 
     Returns:
         (ramble.workspace.Workspace): the active workspace
@@ -170,6 +171,8 @@ def require_active_workspace(cmd_name):
     ws = ramble.workspace.active_workspace()
 
     if ws:
+        if dry_run:
+            ws.dry_run = True
         return ws
     else:
         logger.die(

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -460,7 +460,7 @@ def workspace_concretize_setup_parser(subparser):
 
 
 def workspace_concretize(args):
-    ws = ramble.cmd.require_active_workspace(cmd_name="workspace concretize")
+    ws = ramble.cmd.require_active_workspace("workspace concretize", args.dry_run)
 
     if args.simplify:
         logger.debug("Simplifying workspace config")
@@ -528,10 +528,7 @@ def workspace_setup_setup_parser(subparser):
 
 def workspace_setup(args):
     current_pipeline = ramble.pipeline.pipelines.setup
-    ws = ramble.cmd.require_active_workspace(cmd_name="workspace setup")
-
-    if args.dry_run:
-        ws.dry_run = True
+    ws = ramble.cmd.require_active_workspace("workspace setup", args.dry_run)
 
     filters = ramble.filters.Filters(
         phase_filters=args.phases,
@@ -612,7 +609,7 @@ def workspace_analyze_setup_parser(subparser):
 
 def workspace_analyze(args):
     current_pipeline = ramble.pipeline.pipelines.analyze
-    ws = ramble.cmd.require_active_workspace(cmd_name="workspace analyze")
+    ws = ramble.cmd.require_active_workspace("workspace analyze", args.dry_run)
     ws.repeat_success_strict = ramble.config.get("config:repeat_success_strict")
 
     filters = ramble.filters.Filters(
@@ -646,10 +643,7 @@ def workspace_analyze(args):
 
 def workspace_push_to_cache(args):
     current_pipeline = ramble.pipeline.pipelines.pushtocache
-    ws = ramble.cmd.require_active_workspace(cmd_name="workspace pushtocache")
-
-    if args.dry_run:
-        ws.dry_run = True
+    ws = ramble.cmd.require_active_workspace("workspace pushtocache", args.dry_run)
 
     filters = ramble.filters.Filters(
         phase_filters="*",
@@ -736,7 +730,7 @@ def workspace_config_setup_parser(subparser):
 
 
 def workspace_config(args):
-    ws = ramble.cmd.require_active_workspace(cmd_name="workspace squashed-config")
+    ws = ramble.cmd.require_active_workspace("workspace squashed-config", args.dry_run)
 
     if args.print_squash:
         ws.squash_and_print_config(args.included_section, args.excluded_section)
@@ -800,7 +794,7 @@ def workspace_info_setup_parser(subparser):
 
 
 def workspace_info(args):
-    ws = ramble.cmd.require_active_workspace(cmd_name="workspace info")
+    ws = ramble.cmd.require_active_workspace("workspace info", args.dry_run)
 
     # Enable verbose mode
     if args.verbose >= 1:
@@ -1258,7 +1252,7 @@ def workspace_archive_setup_parser(subparser):
 
 def workspace_archive(args):
     current_pipeline = ramble.pipeline.pipelines.archive
-    ws = ramble.cmd.require_active_workspace(cmd_name="workspace archive")
+    ws = ramble.cmd.require_active_workspace("workspace archive", args.dry_run)
 
     filters = ramble.filters.Filters(
         phase_filters=args.phases,
@@ -1314,10 +1308,7 @@ def workspace_mirror_setup_parser(subparser):
 
 def workspace_mirror(args):
     current_pipeline = ramble.pipeline.pipelines.mirror
-    ws = ramble.cmd.require_active_workspace(cmd_name="workspace archive")
-
-    if args.dry_run:
-        ws.dry_run = True
+    ws = ramble.cmd.require_active_workspace("workspace archive", args.dry_run)
 
     filters = ramble.filters.Filters(
         phase_filters=args.phases,
@@ -1867,7 +1858,7 @@ def workspace_experiment_logs_setup_parser(subparser):
 def workspace_experiment_logs(args):
     """Print log information for workspace"""
     current_pipeline = ramble.pipeline.pipelines.logs
-    ws = ramble.cmd.require_active_workspace(cmd_name="workspace concretize")
+    ws = ramble.cmd.require_active_workspace("workspace experiment-logs", args.dry_run)
 
     first_only = args.limit_one or args.first_failed
     where_filter = args.where.copy() if args.where else []
@@ -1926,6 +1917,15 @@ def setup_parser(subparser):
             description=setup_parser_cmd.__doc__,
         )
         setup_parser_cmd(subsubparser)
+
+        # inject --dry-run into subcommands
+        if "--dry-run" not in subsubparser._option_string_actions:
+            subsubparser.add_argument(
+                "--dry-run",
+                dest="dry_run",
+                action="store_true",
+                help=f"perform a dry run of the {name} command",
+            )
 
 
 def workspace(parser, args, unknown_args):

--- a/lib/ramble/ramble/test/systems_and_platforms/system_platform_general.py
+++ b/lib/ramble/ramble/test/systems_and_platforms/system_platform_general.py
@@ -48,11 +48,8 @@ def test_system_platform_works(workspace_name, mock_platforms, mock_systems):
         global_args=global_args,
     )
 
-    ws._re_read()
-    ws.dry_run = True
-
     try:
-        workspace("concretize", global_args=global_args)
+        workspace("concretize", "--dry-run", global_args=global_args)
 
         # Verify there is spack info in the workspace
         with open(ws.config_file_path) as f:
@@ -98,7 +95,7 @@ def test_system_platform_works(workspace_name, mock_platforms, mock_systems):
 
 
 def test_platform_validator_threads_per_core(workspace_name, mock_platforms, mock_systems):
-    ws = ramble.workspace.create(workspace_name)
+    ramble.workspace.create(workspace_name)
     global_args = ["-w", workspace_name]
     workspace(
         "manage",
@@ -119,21 +116,19 @@ def test_platform_validator_threads_per_core(workspace_name, mock_platforms, moc
         global_args=global_args,
     )
 
-    ws._re_read()
-
     err_regex = re.escape(
         "Validator 'threads_per_node_platform_validation' (defined in 'mock-platform1') "
         "fails with message: 'Number of threads per node (2 * 3) exceeds max cores per node (4)'"
     )
 
     with pytest.raises(ramble.error.ObjectValidationError, match=err_regex):
-        workspace("info", global_args=global_args)
+        workspace("info", "--dry-run", global_args=global_args)
 
 
 def test_skipping_platform_validator_threads_per_core(
     workspace_name, mock_platforms, mock_systems
 ):
-    ws = ramble.workspace.create(workspace_name)
+    ramble.workspace.create(workspace_name)
     global_args = ["-w", workspace_name]
     workspace(
         "manage",
@@ -156,14 +151,12 @@ def test_skipping_platform_validator_threads_per_core(
         global_args=global_args,
     )
 
-    ws._re_read()
-
-    workspace("concretize", global_args=global_args)
-    workspace("info", global_args=global_args)
+    workspace("concretize", "--dry-run", global_args=global_args)
+    workspace("info", "--dry-run", global_args=global_args)
 
 
 def test_platform_validator_accelerators_per_node(workspace_name, mock_platforms, mock_systems):
-    ws = ramble.workspace.create(workspace_name)
+    ramble.workspace.create(workspace_name)
     global_args = ["-w", workspace_name]
     workspace(
         "manage",
@@ -186,21 +179,19 @@ def test_platform_validator_accelerators_per_node(workspace_name, mock_platforms
         global_args=global_args,
     )
 
-    ws._re_read()
-
     err_regex = re.escape(
         "Validator 'accelerators_per_node_platform_validation' (defined in 'mock-platform1') "
         "fails with message: 'Number of accelerators per node (2) exceeds max accelerators "
         "on node (0)'"
     )
 
-    workspace("concretize", global_args=global_args)
+    workspace("concretize", "--dry-run", global_args=global_args)
     with pytest.raises(ramble.error.ObjectValidationError, match=err_regex):
-        workspace("info", global_args=global_args)
+        workspace("info", "--dry-run", global_args=global_args)
 
 
 def test_system_validator_n_nodes(workspace_name, mock_platforms, mock_systems):
-    ws = ramble.workspace.create(workspace_name)
+    ramble.workspace.create(workspace_name)
     global_args = ["-w", workspace_name]
     workspace(
         "manage",
@@ -219,19 +210,17 @@ def test_system_validator_n_nodes(workspace_name, mock_platforms, mock_systems):
         global_args=global_args,
     )
 
-    ws._re_read()
-
     err_regex = re.escape(
         "Validator 'n_nodes_system_validation' (defined in 'spack-slurm-sys') fails with message: "
         "'Number of nodes requested (10) exceeds max nodes (4)'"
     )
 
     with pytest.raises(ramble.error.ObjectValidationError, match=err_regex):
-        workspace("info", global_args=global_args)
+        workspace("info", "--dry-run", global_args=global_args)
 
 
 def test_system_validator_n_ranks(workspace_name, mock_platforms, mock_systems):
-    ws = ramble.workspace.create(workspace_name)
+    ramble.workspace.create(workspace_name)
     global_args = ["-w", workspace_name]
     workspace(
         "manage",
@@ -250,12 +239,10 @@ def test_system_validator_n_ranks(workspace_name, mock_platforms, mock_systems):
         global_args=global_args,
     )
 
-    ws._re_read()
-
     err_regex = re.escape(
         "Validator 'n_ranks_system_validation' (defined in 'spack-slurm-sys') fails with "
         "message: 'Total number of ranks (10) exceeds max cores (4 * 2)'"
     )
 
     with pytest.raises(ramble.error.ObjectValidationError, match=err_regex):
-        workspace("info", global_args=global_args)
+        workspace("info", "--dry-run", global_args=global_args)

--- a/share/ramble/ramble-completion.bash
+++ b/share/ramble/ramble-completion.bash
@@ -631,35 +631,35 @@ _ramble_workspace() {
 _ramble_workspace_activate() {
     if $list_options
     then
-        RAMBLE_COMPREPLY="-h --help --sh --csh --fish --bat -p --prompt --temp -d --dir --parent-dir"
+        RAMBLE_COMPREPLY="-h --help --sh --csh --fish --bat -p --prompt --temp -d --dir --parent-dir --dry-run"
     else
         _workspaces
     fi
 }
 
 _ramble_workspace_archive() {
-    RAMBLE_COMPREPLY="-h --help --tar-archive -t --prefix -p --upload-url -u --include-secrets --archive-pattern --phases --include-phase-dependencies --where --exclude-where --profile-phase --profile-phase-output"
+    RAMBLE_COMPREPLY="-h --help --tar-archive -t --prefix -p --upload-url -u --include-secrets --archive-pattern --phases --include-phase-dependencies --where --exclude-where --profile-phase --profile-phase-output --dry-run"
 }
 
 _ramble_workspace_deactivate() {
-    RAMBLE_COMPREPLY="-h --help --sh --csh --fish --bat"
+    RAMBLE_COMPREPLY="-h --help --sh --csh --fish --bat --dry-run"
 }
 
 _ramble_workspace_create() {
     if $list_options
     then
-        RAMBLE_COMPREPLY="-h --help -c --config -t --template_execute -d --dir --software-dir --inputs-dir --parent-dir -a --activate"
+        RAMBLE_COMPREPLY="-h --help -c --config -t --template_execute -d --dir --software-dir --inputs-dir --parent-dir -a --activate --dry-run"
     else
         RAMBLE_COMREPLY=""
     fi
 }
 
 _ramble_workspace_concretize() {
-    RAMBLE_COMPREPLY="-h --help -f --force-concretize --simplify --quiet -q"
+    RAMBLE_COMPREPLY="-h --help -f --force-concretize --simplify --quiet -q --dry-run"
 }
 
 _ramble_workspace_config() {
-    RAMBLE_COMPREPLY="-h --help --print-squash -p --simplify-software --ss --simplify-variables --sv --include-section -i --exclude-section -e"
+    RAMBLE_COMPREPLY="-h --help --print-squash -p --simplify-software --ss --simplify-variables --sv --include-section -i --exclude-section -e --dry-run"
 }
 
 _ramble_workspace_setup() {
@@ -667,7 +667,7 @@ _ramble_workspace_setup() {
 }
 
 _ramble_workspace_analyze() {
-    RAMBLE_COMPREPLY="-h --help -f --formats -u --upload -p --print-results --fom-origin-types -s --summary-only --phases --include-phase-dependencies --where --exclude-where --filter-tags --profile-phase --profile-phase-output"
+    RAMBLE_COMPREPLY="-h --help -f --formats -u --upload -p --print-results --fom-origin-types -s --summary-only --phases --include-phase-dependencies --where --exclude-where --filter-tags --profile-phase --profile-phase-output --dry-run"
 }
 
 _ramble_workspace_push_to_cache() {
@@ -675,13 +675,13 @@ _ramble_workspace_push_to_cache() {
 }
 
 _ramble_workspace_info() {
-    RAMBLE_COMPREPLY="-h --help --software --all-software --templates --expansions --tags --phases --variants --executables --where --exclude-where --filter-tags -v --verbose"
+    RAMBLE_COMPREPLY="-h --help --software --all-software --templates --expansions --tags --phases --variants --executables --where --exclude-where --filter-tags -v --verbose --dry-run"
 }
 
 _ramble_workspace_edit() {
     if $list_options
     then
-        RAMBLE_COMPREPLY="-h --help -f --file -c --config-only -t --template-only -l --license-only --all -p --print-file"
+        RAMBLE_COMPREPLY="-h --help -f --file -c --config-only -t --template-only -l --license-only --all -p --print-file --dry-run"
     else
         RAMBLE_COMREPLY=""
     fi
@@ -692,17 +692,17 @@ _ramble_workspace_mirror() {
 }
 
 _ramble_workspace_experiment_logs() {
-    RAMBLE_COMPREPLY="-h --help --limit-one --first-failed --failed --where --exclude-where --filter-tags"
+    RAMBLE_COMPREPLY="-h --help --limit-one --first-failed --failed --where --exclude-where --filter-tags --dry-run"
 }
 
 _ramble_workspace_list() {
-    RAMBLE_COMPREPLY="-h --help --parent-dir --merged"
+    RAMBLE_COMPREPLY="-h --help --parent-dir --merged --dry-run"
 }
 
 _ramble_workspace_remove() {
     if $list_options
     then
-        RAMBLE_COMPREPLY="-h --help -y --yes-to-all"
+        RAMBLE_COMPREPLY="-h --help -y --yes-to-all --dry-run"
     else
         _workspaces
     fi
@@ -720,7 +720,7 @@ _ramble_workspace_generate_config() {
 _ramble_workspace_manage() {
     if $list_options
     then
-        RAMBLE_COMPREPLY="-h --help"
+        RAMBLE_COMPREPLY="-h --help --dry-run"
     else
         RAMBLE_COMPREPLY="experiments software includes modifiers"
     fi


### PR DESCRIPTION
Also use the option to fix up some flaky tests, where the tests may fail if `sinfo` is available:

```
$ mkdir -p /tmp/mock_bin
$ echo -e '#!/bin/bash\necho "hello"' > /tmp/mock_bin/sinfo
$ chmod +x /tmp/mock_bin/sinfo
$ PATH="/tmp/mock_bin:$PATH" ramble unit-test -k system_platform_general
```