### PR TITLE
Make experiment_status not show as 'SETUP' for executed exps [AI]

### DIFF
--- a/lib/ramble/ramble/experiment_result.py
+++ b/lib/ramble/ramble/experiment_result.py
@@ -126,14 +126,15 @@ class ExperimentResult:
         app_inst = self._app_inst
         self.name = app_inst.expander.experiment_namespace
 
-        self.status = app_inst.get_ramble_status()
+        self.status = app_inst.get_status()
 
         self.n_repeats = app_inst.repeats.n_repeats
         self.experiment_chain = app_inst.chain_order.copy()
         self.tags = list(app_inst.experiment_tags)
 
         # Most libs can handle this str enum, but convert it to help out
-        self.status = self.status.value
+        if hasattr(self.status, "value"):
+            self.status = self.status.value
 
         for key in app_inst.keywords.keys:
             if app_inst.keywords.is_key_level(key):

--- a/lib/ramble/ramble/test/end_to_end/analyze_fom_output.py
+++ b/lib/ramble/ramble/test/end_to_end/analyze_fom_output.py
@@ -140,6 +140,47 @@ def test_analyze_fail_with_no_fom_detected(mock_applications, workspace_name):
         assert "Status = FAILED" in content
 
 
+def test_analyze_fail_with_workflow_manager(
+    monkeypatch, mock_applications, make_workspace_from_config
+):
+    test_config = """
+ramble:
+  variants:
+    workflow_manager: user-managed
+  variables:
+    mpi_command: ''
+    batch_submit: '{execute_experiment}'
+    processes_per_node: '1'
+  applications:
+    basic:
+      workloads:
+        test_wl:
+          experiments:
+            test:
+              variables:
+                n_nodes: '1'
+"""
+    ws, ws_name = make_workspace_from_config(test_config)
+    workspace_flags = ["-w", ws_name]
+
+    workspace("setup", "--dry-run", global_args=workspace_flags)
+
+    # Inject mock workflow manager status COMPLETE but provide no valid FOM output
+    import ramble.wmkit
+
+    monkeypatch.setattr(
+        ramble.wmkit.WorkflowManagerBase,
+        "get_status",
+        lambda self, workspace: ramble.experiment_result.ExperimentStatus.COMPLETE,
+    )
+
+    workspace("analyze", global_args=workspace_flags)
+    result_file = os.path.join(ws.results_dir, "results.latest.txt")
+    with open(result_file) as f:
+        content = f.read()
+        assert "Status = FAILED" in content
+
+
 def test_analyze_fom_origin_types_filter(mock_applications, make_workspace_from_config):
     test_config = """
 ramble:

--- a/lib/ramble/ramble/test/success_criteria_functionality/success_modifiers.py
+++ b/lib/ramble/ramble/test/success_criteria_functionality/success_modifiers.py
@@ -129,3 +129,70 @@ ramble:
         assert "default (null) context figures of merit" in content
         assert "test_fom = 0.25 s" in content
         assert "test_fom = 0.35 s" in content
+
+
+def test_success_criteria_preserves_terminal_failures(mock_applications, mock_modifiers):
+    test_config = """
+ramble:
+  variables:
+    mpi_command: ''
+    batch_submit: '{execute_experiment}'
+    processes_per_node: '1'
+  applications:
+    basic:
+      workloads:
+        working_wl:
+          experiments:
+            test_cancelled:
+              variables:
+                n_nodes: '1'
+            test_timeout:
+              variables:
+                n_nodes: '1'
+  modifiers:
+  - name: success-criteria
+"""
+    workspace_name = "test-preserved-terminal-failures"
+    ws = ramble.workspace.create(workspace_name)
+    ws.write()
+
+    config_path = os.path.join(ws.config_dir, ramble.workspace.CONFIG_FILE_NAME)
+
+    with open(config_path, "w+") as f:
+        f.write(test_config)
+
+    ws._re_read()
+    workspace("setup", "--dry-run", global_args=["-w", workspace_name])
+
+    import spack.util.spack_json as sjson
+
+    # Write mock output data that fails success criteria:
+    exp1_dir = os.path.join(ws.experiment_dir, "basic", "working_wl", "test_cancelled")
+    with open(os.path.join(exp1_dir, "test_cancelled.out"), "w+") as f:
+        f.write("0.25 seconds\n")
+    with open(os.path.join(exp1_dir, "ramble_status.json"), "w+") as f:
+        sjson.dump({"experiment_status": "CANCELLED"}, f)
+
+    exp2_dir = os.path.join(ws.experiment_dir, "basic", "working_wl", "test_timeout")
+    with open(os.path.join(exp2_dir, "test_timeout.out"), "w+") as f:
+        f.write("0.35 seconds\n")
+    with open(os.path.join(exp2_dir, "ramble_status.json"), "w+") as f:
+        sjson.dump({"experiment_status": "TIMEOUT"}, f)
+
+    workspace(
+        "analyze",
+        "--formats",
+        "json",
+        global_args=["-w", workspace_name],
+    )
+    result_file = os.path.join(ws.results_dir, "results.latest.json")
+
+    with open(result_file) as f:
+        cache_dict = sjson.load(f)
+        for exp in cache_dict["experiments"]:
+            if "cancelled" in exp["name"]:
+                assert exp["EXPERIMENT_STATUS"] == "CANCELLED"
+                assert exp["RAMBLE_STATUS"] == "FAILED"
+            if "timeout" in exp["name"]:
+                assert exp["EXPERIMENT_STATUS"] == "TIMEOUT"
+                assert exp["RAMBLE_STATUS"] == "FAILED"

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -3201,11 +3201,19 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                     success = True
         success = success and criteria_list.passed()
 
-        status = self.get_status()
-        if status == ExperimentStatus.SUCCESS and not success:
-            status = ExperimentStatus.FAILED
-        elif success:
+        if success:
             status = ExperimentStatus.SUCCESS
+        else:
+            preserved_terminal = {
+                ExperimentStatus.CANCELLED,
+                ExperimentStatus.TIMEOUT,
+                ExperimentStatus.FAILED,
+            }
+            current_status = self.get_status()
+            if current_status in preserved_terminal:
+                status = current_status
+            else:
+                status = ExperimentStatus.FAILED
 
         # When workflow_manager is present, only use app_status when workflow is completed or
         # unresolved.


### PR DESCRIPTION
Fixes issues where exp status shows SETUP instead of FAILED/SUCCESS
```
ramble workspace analyze
ramble on --executor="echo {experiment_status}"
```

I think longer term we want to re-write much of this parsing so we can better reason about STATUS outside of analyze (and also parents), but it's good to fix this until then 