### PR TITLE
Fix up unit test that fails when run serially

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -871,3 +871,32 @@ def pytest_generate_tests(metafunc):
                             test_ids.append(f"{prefix}_{test_case_path.name}_{id}")
                             id += 1
         metafunc.parametrize("test_case_path", test_case_paths, ids=test_ids)
+
+
+@pytest.fixture()
+def default_showwarning():
+    """Fixture to restore original warnings.showwarning handler.
+
+    The main Ramble process overrides warnings.showwarning, which can cause
+    assertions (such as `pytest.deprecated_call`) to fail if they assume the
+    warnings are written to stderr.
+    """
+    import warnings
+
+    prev_showwarning = warnings.showwarning
+    orig_showwarning = getattr(warnings, "_showwarning_orig", None)
+    if orig_showwarning is not None:
+        warnings.showwarning = orig_showwarning
+    try:
+        yield
+    finally:
+        warnings.showwarning = prev_showwarning
+
+
+@pytest.fixture()
+def deprecated_call(default_showwarning):
+    """Fixture that provides a context manager to assert deprecation warnings.
+
+    Relies on default_showwarning fixture to ensure standard warnings propagation.
+    """
+    return pytest.deprecated_call

--- a/lib/ramble/ramble/test/definitions/test_versions.py
+++ b/lib/ramble/ramble/test/definitions/test_versions.py
@@ -55,7 +55,7 @@ class TestObjectVersion:
         assert str(obj_ver) == "1.2.3"
 
     @deprecation.fail_if_not_removed
-    def test_version_properties(self):
+    def test_version_properties(self, deprecated_call):
         """Test that properties and deprecated getter methods work correctly."""
         obj_ver = ObjectVersion(version_number="1.2.3")
 
@@ -70,11 +70,11 @@ class TestObjectVersion:
         assert obj_ver_lazy.version_num == "1.2.3"
 
         # Test deprecated get_version method triggers warning
-        with pytest.deprecated_call():
+        with deprecated_call():
             assert str(obj_ver.get_version()) == "1.2.3"
 
         # Test deprecated get_version_num method triggers warning
-        with pytest.deprecated_call():
+        with deprecated_call():
             assert obj_ver.get_version_num() == "1.2.3"
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
The `pytest.deprecated_call` fixture assumes warnings are written to stderr. This is however not always the case as the main Ramble overrides `showwarnings` to log warning to files.

Add in a fixture to revert `showwarning` to its original behavior.