### PR TITLE
Fix py3.6 compatibility for subprocess.run calls

### DIFF
--- a/lib/ramble/ramble/test/cmd/unit_test.py
+++ b/lib/ramble/ramble/test/cmd/unit_test.py
@@ -82,8 +82,9 @@ def test_external_repo_valid(tmpdir):
     ramble_bin = os.path.join(ramble.paths.ramble_root, "bin", "ramble")
     result = subprocess.run(
         [ramble_bin, "unit-test", "--repo-path", str(tmpdir), "-k", "test_dummy"],
-        capture_output=True,
-        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
         check=False,
     )
     assert result.returncode == 0

--- a/lib/ramble/ramble/test/end_to_end/shell_wrappers.py
+++ b/lib/ramble/ramble/test/end_to_end/shell_wrappers.py
@@ -45,7 +45,13 @@ ramble workspace activate non_existent_workspace
 
     cmd = [shell, test_script_path]
     process = subprocess.run(
-        cmd, capture_output=True, text=True, cwd=str(tmpdir), env=os.environ.copy(), check=False
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+        cwd=str(tmpdir),
+        env=os.environ.copy(),
+        check=False,
     )
 
     assert process.returncode == 1
@@ -110,8 +116,9 @@ exit 0
         cmd = [shell, test_script_path]
         process = subprocess.run(
             cmd,
-            capture_output=True,
-            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
             cwd=str(tmpdir),
             env=os.environ.copy(),
             check=False,
@@ -124,7 +131,8 @@ exit 0
         ramble_exe = os.path.join(paths.ramble_root, "bin", "ramble")
         subprocess.run(
             [ramble_exe, "workspace", "rm", "-y", ws_name],
-            capture_output=True,
-            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
             check=False,
         )

--- a/share/ramble/qa/upload_perf_metrics.py
+++ b/share/ramble/qa/upload_perf_metrics.py
@@ -28,8 +28,9 @@ def get_commit_timestamp(commit_sha=None):
     try:
         result = subprocess.run(
             cmd,
-            capture_output=True,
-            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
             check=True
         )
         return result.stdout.strip()


### PR DESCRIPTION
Both the `capture_output` and `text` options are only available for python 3.7+.