### PR TITLE
Use python to implement the `cleanup` directive

### DIFF
--- a/lib/ramble/ramble/test/end_to_end/cleanup_directive.py
+++ b/lib/ramble/ramble/test/end_to_end/cleanup_directive.py
@@ -7,8 +7,6 @@
 # except according to those terms.
 
 import os
-import shutil
-import sys
 
 import pytest
 
@@ -21,8 +19,6 @@ workspace = ramble.main.RambleCommand("workspace")
 on = ramble.main.RambleCommand("on")
 
 
-@pytest.mark.skipif(sys.platform != "linux", reason="linux only given the find command usage")
-@pytest.mark.skipif(shutil.which("find") is None, reason="skip if `find` is not in the path")
 @pytest.mark.maybeslow
 def test_cleanup_directive(mock_applications, workspace_name):
     global_args = ["-w", workspace_name]

--- a/lib/ramble/ramble/util/cleaner.py
+++ b/lib/ramble/ramble/util/cleaner.py
@@ -1,0 +1,95 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+
+def get_cleaner_exec_path():
+    """Returns the path to the cleaner script to use"""
+    return f"{{workspace_shared}}/utilities/{HELPER_SCRIPT_NAME}"
+
+
+def get_cleaner_script():
+    """Returns the content of the standalone cleaner script"""
+
+    return r"""# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+import re
+import shutil
+import sys
+import argparse
+
+def matches_whole_path(regex, path):
+    return regex.fullmatch(path) is not None
+
+def perform_cleanup(args):
+    directory = args.directory
+    pattern = args.regex
+    recurse = args.recurse
+
+    if not os.path.isdir(directory):
+        print(f"Directory {directory} does not exist. Skipping cleanup.", file=sys.stderr)
+        return 0
+
+    try:
+        regex = re.compile(pattern)
+    except re.error as e:
+        print(f"Invalid regex pattern '{pattern}': {e}", file=sys.stderr)
+        return 1
+
+    paths_to_delete = []
+    if recurse:
+        for root, dirs, files in os.walk(directory, topdown=True):
+            for d in list(dirs):
+                d_path = os.path.join(root, d)
+                if matches_whole_path(regex, d_path):
+                    paths_to_delete.append(d_path)
+                    dirs.remove(d)
+            for f in files:
+                f_path = os.path.join(root, f)
+                if matches_whole_path(regex, f_path):
+                    paths_to_delete.append(f_path)
+    else:
+        try:
+            for entry in os.scandir(directory):
+                if matches_whole_path(regex, entry.path):
+                    paths_to_delete.append(entry.path)
+        except Exception as e:
+            print(f"Error scanning directory {directory}: {e}", file=sys.stderr)
+            return 1
+
+    for path in paths_to_delete:
+        try:
+            if os.path.islink(path):
+                os.remove(path)
+            elif os.path.isdir(path):
+                shutil.rmtree(path)
+            else:
+                os.remove(path)
+        except Exception as e:
+            print(f"Error removing {path}: {e}", file=sys.stderr)
+
+    return 0
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Ramble Directory Cleaner')
+    parser.add_argument('--directory', required=True, help='Directory to clean')
+    parser.add_argument('--regex', required=True, help='Regex pattern to match paths')
+    parser.add_argument('--recurse', action='store_true', help='Search recursively')
+
+    args = parser.parse_args()
+    sys.exit(perform_cleanup(args))
+"""
+
+
+HELPER_SCRIPT_NAME = "_ramble_cleaner.py"

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -820,6 +820,7 @@ ramble:
 
     def write_utilities(self):
         """Write workspace utilities out to the shared directory"""
+        import ramble.util.cleaner
         import ramble.util.file_editor
 
         if ramble.config.get("config:generate_file_editing_scripts", True):
@@ -832,6 +833,16 @@ ramble:
             )
             with open(base_script_path, "w+", encoding="utf-8") as f:
                 f.write(base_script_content)
+
+            # Write cleaner utility script
+            # TODO: Currently this is guarded by the generate_file_editing_scripts
+            # config. Should it use its own config setting?
+            cleaner_script_content = ramble.util.cleaner.get_cleaner_script()
+            cleaner_script_path = os.path.join(
+                self.shared_utilities_dir, ramble.util.cleaner.HELPER_SCRIPT_NAME
+            )
+            with open(cleaner_script_path, "w+", encoding="utf-8") as f:
+                f.write(cleaner_script_content)
 
     def write_auxiliary_software_files(self):
         """Write all auxiliary software files out to workspace"""

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -13,6 +13,7 @@ import importlib.util
 import operator
 import os
 import re
+import shlex
 import shutil
 import stat
 import string
@@ -59,7 +60,7 @@ from ramble.language.shared_language import (
     register_builtin,
     register_phase,
 )
-from ramble.util import conversions
+from ramble.util import cleaner, conversions
 from ramble.util.foms import FomType, SummaryFoms, get_literal_from_regex
 from ramble.util.logger import logger
 from ramble.util.naming import NS_SEPARATOR
@@ -1696,16 +1697,17 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             else:
                 dir = self.expander.experiment_run_dir
             regex = self.expander.expand_var(cleanup_props["regex"])
-            if cleanup_props["recurse"]:
-                recurse_opt = ""
-            else:
-                recurse_opt = "-maxdepth 1"
-            regex_opts = f"-regextype posix-extended -regex '{regex}'"
-            delete_opts = "-exec rm -rf {} +"
-            find_cmd = f"find '{dir}' -mindepth 1 {recurse_opt} {regex_opts} {delete_opts}"
+            cleaner_script = cleaner.get_cleaner_exec_path()
+            recurse_flag = " --recurse" if cleanup_props["recurse"] else ""
+            cleaner_cmd = (
+                f'python3 "{cleaner_script}" '
+                f"--directory {shlex.quote(dir)} "
+                f"--regex {shlex.quote(regex)}"
+                f"{recurse_flag}"
+            )
 
             commands.append(f"# {key}-cleanup: {name}")
-            commands.append(find_cmd)
+            commands.append(cleaner_cmd)
 
         return commands
 


### PR DESCRIPTION
Previously the `cleanup` directive was implemented using `find` with the `posix-extended` support. This makes it not very portable for various platforms. Piggybacking on the work done in https://github.com/GoogleCloudPlatform/ramble/pull/1559, it now uses python to implement the cleanup.

This assumes that `python3` is more widely available, for the platforms we aim to support.