### PR TITLE
Define variants for repeats

### DIFF
--- a/lib/ramble/ramble/test/variant.py
+++ b/lib/ramble/ramble/test/variant.py
@@ -446,3 +446,41 @@ def test_variant_expansion(workspace_name, variant_scope, expected_bool, expecte
         captured = workspace("info", "-v", global_args=global_args)
 
         assert spack_spec in captured
+
+
+def test_repeat_variants_in_analyze(request):
+    ws_name = request.node.name
+
+    global_args = ["-w", ws_name]
+
+    with ramble.workspace.create(ws_name) as ws:
+        workspace(
+            "manage",
+            "experiments",
+            "when-variants",
+            "--wf",
+            "test_wl",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "processes_per_node=1",
+            "-p",
+            "spack",
+            "--default-variable-value",
+            "1",
+            global_args=global_args,
+        )
+
+        ws._re_read()
+        workspace("concretize", global_args=global_args)
+        workspace("setup", "--dry-run", global_args=global_args)
+        workspace("analyze", global_args=global_args)
+
+        with open(os.path.join(ws.root, "results.latest.txt"), encoding="utf-8") as f:
+            data = f.read()
+
+            assert "is_repeat_parent" in data
+            assert "is_repeat_child" in data
+            assert "repeat_index" in data

--- a/lib/ramble/ramble/variants.py
+++ b/lib/ramble/ramble/variants.py
@@ -22,6 +22,9 @@ reserved_variants = {
     "platform",
     "version",
     "workflow_manager",
+    "is_repeat_child",
+    "is_repeat_parent",
+    "repeat_index",
 }
 
 variant_types = Enum("variant_types", ["default", "experiment", "version"])

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -191,6 +191,21 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             self.object_variants.default_variant(**var_args)
 
         self.keywords = ramble.keywords.keywords.copy()
+        self.object_variants.default_variant(
+            name=self.keywords.is_repeat_parent,
+            default=False,
+            description="Whether this is the parent of a set of repeats or not",
+        )
+        self.object_variants.default_variant(
+            name=self.keywords.is_repeat_child,
+            default=False,
+            description="Whether this is a child in a set of repeats or not",
+        )
+        self.object_variants.default_variant(
+            name=self.keywords.repeat_index,
+            default=0,
+            description="Index of this experiment, in repeat space",
+        )
 
         self._vars_are_expanded = False
         self.expander = None
@@ -706,12 +721,25 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                 description=self.expander.application_spec,
             )
 
+        # Define variants from repeats
+        for keyword in [
+            self.keywords.is_repeat_parent,
+            self.keywords.is_repeat_child,
+            self.keywords.repeat_index,
+        ]:
+            if keyword in variables:
+                self.object_variants.experiment_variant(
+                    keyword,
+                    self.expander.expand_var(variables[keyword], typed=True),
+                )
+
         # Define experiment variants
         if variants:
             for name, value in variants.items():
                 expanded_value = self.expander.expand_var(value, typed=True)
                 self.object_variants.experiment_variant(name, expanded_value)
-            self.clear_variant_cache()
+
+        self.clear_variant_cache()
 
         # Set up remaining variants
         self._set_system()


### PR DESCRIPTION
This merge adds definitions for three new variants related to repeats.
 - is_repeat_parent
 - is_repeat_child
 - repeat_index

These can then be used by objects to conditionally apply definitions based on if the experiment is a repeat or not.