### PR TITLE
Avoid redundant calls in workspace concretization

### DIFF
--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1517,8 +1517,6 @@ ramble:
         force_prefix = force_prefix or len(pkgman_prefixes) > 1
 
         for _, app_inst, _ in experiment_set.all_experiments():
-            app_inst.build_modifier_instances()
-            app_inst.define_variables_for_template_path()
             env_name_str = app_inst.expander.expansion_str(ramble.keywords.keywords.env_name)
             env_name = app_inst.expander.expand_var(env_name_str)
 

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -231,6 +231,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         # A dict storing fom values, currently it only stores inmem FOMs
         self._fom_map = {}
         self._template_paths_defined = False
+        self._modifiers_built = False
 
         # Ensure we always have the application name, and this is never empty
         self._file_path = file_path
@@ -987,6 +988,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         """Set modifiers for this instance"""
         if modifiers:
             self.modifiers = modifiers.copy()
+            self._modifiers_built = False
             self.build_modifier_instances()
 
     def set_tags(self, tags):
@@ -1458,7 +1460,11 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         """Built a map of modifier names to modifier instances needed for this
         application instance
         """
+        if self._modifiers_built:
+            return
+
         if not self.modifiers:
+            self._modifiers_built = True
             return
 
         self._modifier_instances = []
@@ -1514,6 +1520,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         self.define_missing_variables()
         if self.modifiers:
             self.clear_variant_cache()
+        self._modifiers_built = True
 
     @property
     def inventory_file(self):


### PR DESCRIPTION
Incidentally, add a guard against unnecessary modifier building