### PR TITLE
Fix precedence ordering with complex when statements

### DIFF
--- a/lib/ramble/ramble/test/end_to_end/test_variable_precedence.py
+++ b/lib/ramble/ramble/test/end_to_end/test_variable_precedence.py
@@ -1,0 +1,76 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.workspace
+from ramble.main import RambleCommand
+
+pytestmark = pytest.mark.usefixtures(
+    "mutable_config",
+    "mutable_mock_workspace_path",
+    "mutable_mock_apps_repo",
+    "mock_modifiers",
+)
+
+config = RambleCommand("config")
+workspace = RambleCommand("workspace")
+
+
+def test_variable_cross_pass_precedence(workspace_name):
+    """Test that a specific when block overrides a generic one across evaluation passes."""
+    global_args = ["-w", workspace_name]
+
+    with ramble.workspace.create(workspace_name) as ws:
+        workspace(
+            "manage",
+            "experiments",
+            "when-variants",
+            "--wf",
+            "test_wl",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "processes_per_node=1",
+            "--default-variable-value",
+            "1",
+            global_args=global_args,
+        )
+
+        # Edit workspace config directly
+        with open(ws.config_file_path, encoding="utf-8") as f:
+            import yaml
+
+            data = yaml.safe_load(f)
+
+        data["ramble"]["modifiers"] = [{"name": "precedence-test", "mode": "test_mode"}]
+        data["ramble"]["variants"] = {"trigger": "True"}
+
+        with open(ws.config_file_path, "w", encoding="utf-8") as f:
+            yaml.dump(data, f)
+
+        ws._re_read()
+
+        workspace("setup", "--dry-run", global_args=global_args)
+
+        exec_file = os.path.join(
+            ws.experiment_dir,
+            "when-variants",
+            "test_wl",
+            "generated",
+            "execute_experiment",
+        )
+
+        with open(exec_file, encoding="utf-8") as f:
+            exec_data = f.read()
+
+        assert "echo 'specific'" in exec_data

--- a/var/ramble/repos/builtin.mock/modifiers/precedence-test/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/precedence-test/modifier.py
@@ -1,0 +1,60 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.modkit import *
+
+
+class PrecedenceTest(BasicModifier):
+    """Modifier to test cross-pass variable precedence logic"""
+
+    name = "precedence-test"
+
+    variant("trigger", default=False, description="Trigger variant")
+
+    modifier_variable(
+        name="dep_var",
+        default="trigger",
+        description="Dependent var",
+        mode="test_mode",
+    )
+
+    # Generic block
+    with when("trigger=True"):
+        modifier_variable(
+            name="override_var",
+            default="generic",
+            description="Fallback",
+            mode="test_mode",
+        )
+
+    # Specific block
+    with when("{dep_var}=True"):
+        modifier_variable(
+            name="override_var",
+            default="specific",
+            description="Override",
+            mode="test_mode",
+        )
+
+    mode("test_mode", description="A test mode")
+
+    executable_modifier("test_exec_modifier")
+
+    def test_exec_modifier(self, exec_name, executable, app_inst=None):
+        import ramble.util.executable
+
+        prepend_execs = []
+        append_execs = [
+            ramble.util.executable.CommandExecutable(
+                name="test_exec",
+                template="echo '{override_var}'",
+                redirect=None,
+                output_capture=None,
+            )
+        ]
+        return prepend_execs, append_execs

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -929,17 +929,27 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                 for obj, when_keys in when_map.items():
                     to_remove = set()
                     obj_prec = obj_precedence[obj]
-                    for when_key in when_keys:
+                    for when_idx, when_key in enumerate(reversed(when_keys)):
                         if obj.satisfy_when(when_key):
                             to_remove.add(when_key)
                             variable_dict = getattr(obj, variable_set_attr, {})
                             if when_key in variable_dict:
                                 for var in reversed(variable_dict[when_key]):
                                     if var.name not in original_variables:
+                                        # Use a tuple for precedence: (obj_prec, when_idx)
+                                        # Lower tuple means higher precedence.
+                                        current_prec = (obj_prec, when_idx)
+                                        best_prec = var_precedence.get(
+                                            var.name, (999, 999)
+                                        )
+
+                                        # Convert existing scalar precedence to tuple if necessary
+                                        if not isinstance(best_prec, tuple):
+                                            best_prec = (best_prec, 999)
+
                                         if (
                                             var.name not in to_define
-                                            and obj_prec
-                                            < var_precedence.get(var.name, 999)
+                                            and current_prec < best_prec
                                         ):
                                             if isinstance(
                                                 var, CommandVariable
@@ -954,7 +964,9 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                                                     var.default
                                                 )
 
-                                            var_precedence[var.name] = obj_prec
+                                            var_precedence[var.name] = (
+                                                current_prec
+                                            )
                                             changed_definitions = True
 
                     # Remove any satisfied when_keys, as we won't need to check


### PR DESCRIPTION
This merge fixes an issue where precedence of variable definitions was not being applied correctly. Specifically when a variable is defined multiple times with varying levels of complexity in their when arguments.

Tests are also added, to help ensure this doesn't regress in the future.