### PR TITLE
Fix issues with variable validation

### DIFF
--- a/lib/ramble/ramble/language/language_helpers.py
+++ b/lib/ramble/ramble/language/language_helpers.py
@@ -246,7 +246,8 @@ def add_variable_validator(obj, var_name, var_values, when_list, wl_name=None):
     """Adds a validator to an object to ensure a variable's value is in a list of values."""
     validator_name = f"validate_values_for_{var_name}_obj_{obj.name}"
 
-    predicate = f"'{{{var_name}}}' in {var_values!r}"
+    str_values = [str(v) for v in var_values]
+    predicate = f"'{{{var_name}}}' in {str_values!r}"
     message = (
         f"Value of variable '{var_name}' ('{{{var_name}}}') is not one of the allowed values: "
         f"{var_values}"

--- a/lib/ramble/ramble/test/application_language.py
+++ b/lib/ramble/ramble/test/application_language.py
@@ -12,6 +12,8 @@ from typing import FrozenSet
 import deprecation
 import pytest
 
+import ramble.expander
+import ramble.language.language_helpers
 from ramble.appkit import *  # noqa
 from ramble.error import DirectiveError
 
@@ -613,3 +615,45 @@ def test_non_reserved_variables(app_class):
     assert "user_var1" not in non_reserved
     assert "user_var2" in non_reserved
     assert len(non_reserved) == 2
+
+
+class MockObject:
+    def __init__(self, name):
+        self.name = name
+        self.validators = {}
+
+
+@pytest.mark.parametrize(
+    "var_value,expected_result",
+    [
+        ("1", True),
+        (1, True),
+        ("4", False),
+        (4, False),
+    ],
+)
+def test_add_variable_validator_numeric_conversion(var_value, expected_result):
+    obj = MockObject("test_obj")
+    var_name = "test_var"
+    var_values = [0, 1, 2, 3]  # Integers in allowed values
+    when_list = []
+
+    ramble.language.language_helpers.add_variable_validator(obj, var_name, var_values, when_list)
+
+    assert len(obj.validators) == 1
+    when_set = next(iter(obj.validators.keys()))
+    assert when_set == frozenset()
+
+    validators = obj.validators[when_set]
+    assert len(validators) == 1
+    val_name = next(iter(validators.keys()))
+    assert val_name == "validate_values_for_test_var_obj_test_obj"
+
+    val_def = validators[val_name]
+    predicate = val_def["predicate"]
+
+    # The predicate should compare string representations
+    assert predicate == "'{test_var}' in ['0', '1', '2', '3']"
+
+    expander = ramble.expander.Expander({"test_var": var_value}, None)
+    assert expander.evaluate_predicate(predicate) == expected_result

--- a/lib/ramble/ramble/test/variant.py
+++ b/lib/ramble/ramble/test/variant.py
@@ -538,3 +538,25 @@ def test_templated_variant_validation(workspace_name, var_value, should_fail):
                 workspace("concretize", global_args=global_args)
         else:
             workspace("concretize", global_args=global_args)
+
+
+def test_variant_set_callable_validation():
+    v_set = ramble.variants.VariantSet()
+
+    def my_validator(val):
+        return val in [1, 3, 5]
+
+    v_set.default_variant("my_var", default=1, description="odd numbers", values=my_validator)
+
+    # Check that it validates valid values
+    v_set.experiment_variant("my_var", 3)
+    defs = v_set.as_set()
+    assert "my_var=3" in defs
+
+    # Check invalid value raises error
+    v_set2 = ramble.variants.VariantSet()
+    v_set2.default_variant("my_var", default=1, description="odd numbers", values=my_validator)
+    v_set2.experiment_variant("my_var", 2)
+
+    with pytest.raises(ramble.variants.RambleVariantError):
+        v_set2.as_set()

--- a/lib/ramble/ramble/test/variant.py
+++ b/lib/ramble/ramble/test/variant.py
@@ -484,3 +484,57 @@ def test_repeat_variants_in_analyze(request):
             assert "is_repeat_parent" in data
             assert "is_repeat_child" in data
             assert "repeat_index" in data
+
+
+@pytest.mark.parametrize(
+    "var_value,should_fail",
+    [
+        (None, False),
+        ("valid_val", False),
+        ("invalid_val", True),
+    ],
+)
+def test_templated_variant_validation(workspace_name, var_value, should_fail):
+    ws_name = workspace_name
+    global_args = ["-w", ws_name]
+
+    with ramble.workspace.create(ws_name) as ws:
+        workspace(
+            "manage",
+            "experiments",
+            "when-variants",
+            "--wf",
+            "test_wl",
+            "-v",
+            "n_ranks=1",
+            "-v",
+            "n_nodes=1",
+            "-v",
+            "processes_per_node=1",
+            "-p",
+            "spack",
+            "--default-variable-value",
+            "1",
+            global_args=global_args,
+        )
+
+        config(
+            "add",
+            "variants:templated_validation:'{templated_validation_var}'",
+            global_args=global_args,
+        )
+
+        if var_value is not None:
+            config(
+                "add",
+                f"variables:templated_validation_var:{var_value}",
+                global_args=global_args,
+            )
+
+        ws._re_read()
+
+        if should_fail:
+            with pytest.raises(ramble.variants.RambleVariantError):
+                workspace("concretize", global_args=global_args)
+        else:
+            workspace("concretize", global_args=global_args)

--- a/lib/ramble/ramble/variants.py
+++ b/lib/ramble/ramble/variants.py
@@ -358,12 +358,20 @@ class VariantSet:
                     name in self.default_variants
                     and name not in reserved_variants
                     and self.default_variants[name].values
-                    and variant.default not in self.default_variants[name].values
                 ):
-                    raise RambleVariantError(
-                        f"When defining variant {name} the value {variant.default} is not valid.\n"
-                        f"   Valid values include: {self.default_variants[name].values}"
-                    )
+                    val = variant.default
+                    if expander and isinstance(val, str) and "{" in val:
+                        try:
+                            val = expander.expand_var(val)
+                        except Exception:
+                            pass
+                    if isinstance(val, str) and "{" in val:
+                        pass
+                    elif val not in self.default_variants[name].values:
+                        raise RambleVariantError(
+                            f"When defining variant {name} the value {val} is not valid.\n"
+                            f"   Valid values include: {self.default_variants[name].values}"
+                        )
 
                 out_set.update(variant.as_definitions())
                 defined_variants.add(name)

--- a/lib/ramble/ramble/variants.py
+++ b/lib/ramble/ramble/variants.py
@@ -367,11 +367,17 @@ class VariantSet:
                             pass
                     if isinstance(val, str) and "{" in val:
                         pass
-                    elif val not in self.default_variants[name].values:
-                        raise RambleVariantError(
-                            f"When defining variant {name} the value {val} is not valid.\n"
-                            f"   Valid values include: {self.default_variants[name].values}"
-                        )
+                    else:
+                        values = self.default_variants[name].values
+                        if callable(values):
+                            is_valid = values(val)
+                        else:
+                            is_valid = str(val) in [str(v) for v in values]
+                        if not is_valid:
+                            raise RambleVariantError(
+                                f"When defining variant {name} the value {val} is not valid.\n"
+                                f"   Valid values include: {values}"
+                            )
 
                 out_set.update(variant.as_definitions())
                 defined_variants.add(name)

--- a/var/ramble/repos/builtin.mock/applications/when-variants/application.py
+++ b/var/ramble/repos/builtin.mock/applications/when-variants/application.py
@@ -75,6 +75,20 @@ class WhenVariants(ExecutableApplication):
         workloads=["*"],
     )
 
+    variant(
+        "templated_validation",
+        default="{templated_validation_var}",
+        values=["valid_val", "other_valid_val"],
+        description="Test template variant validation",
+    )
+
+    workload_variable(
+        "templated_validation_var",
+        default="valid_val",
+        description="Variable for templated_validation",
+        workloads=["*"],
+    )
+
     with when("+validation"):
         register_validator(
             "fixed_n_nodes",


### PR DESCRIPTION
Fixes two issues with variant validation:
1) Unexpanded variable is passed to validator
2) Validator compares string representation from yaml (e.g., "1") against values
   that are not strings (e.g., [1, 2, 3]) and fails validation

Now, before validating a variant, Ramble checks variant values for expansion variables ("{") and attempts to expand them before validating. If a value remains unexpanded, instead of failing validation it will fail later as an undefined variable. Ramble will now convert validation inputs into strings to ensure that quoting an integer in yaml or an object definition does not cause it to fail validation against a set of integer values.