### PR TITLE
Fix potential deadlock in tty.log writer_daemon [AI]

### DIFF
--- a/lib/ramble/llnl/util/tty/log.py
+++ b/lib/ramble/llnl/util/tty/log.py
@@ -628,8 +628,15 @@ class nixlog(object):
             os.dup2(self._saved_stderr, sys.stderr.fileno())
             os.close(self._saved_stderr)
         else:
-            sys.stdout = self._saved_stdout
-            sys.stderr = self._saved_stderr
+            try:
+                for stream in (sys.stdout, sys.stderr):
+                    try:
+                        stream.close()
+                    except Exception:
+                        pass
+            finally:
+                sys.stdout = self._saved_stdout
+                sys.stderr = self._saved_stderr
 
         # print log contents in parent if needed.
         if self.log_file.write_in_parent:


### PR DESCRIPTION
When `use_fds` falls back to `False` (which occurs when pytest replaces standard file descriptors with its  StringIO  streams for capture via  capsys ),  sys.stdout  was not being correctly closed upon context exit. This caused the pipe to leak and the main process to wait indefinitely on the daemon to exit.