### PR TITLE
Improve on version compatibility check

### DIFF
--- a/lib/ramble/ramble/language/language_helpers.py
+++ b/lib/ramble/ramble/language/language_helpers.py
@@ -11,6 +11,9 @@ import functools
 from collections import OrderedDict
 from typing import Any, List, Optional, Union
 
+from packaging.specifiers import SpecifierSet
+from packaging.version import InvalidVersion, Version
+
 from ramble.error import DirectiveError
 
 
@@ -318,11 +321,102 @@ def build_when_list(
     return when_list
 
 
+def _parse_version_spec(value):
+    if not value:
+        return SpecifierSet()
+
+    # Fallback translation: replace underscores with dots for PEP 440 compatibility
+    value = value.replace("_", ".")
+
+    sep_index = value.find(":")
+    if sep_index == -1:
+        return SpecifierSet(f"=={value}", prereleases=True)
+    elif sep_index == 0:
+        return SpecifierSet(f"<={value.lstrip(':')}", prereleases=True)
+    elif sep_index == len(value) - 1:
+        return SpecifierSet(f">={value.rstrip(':')}", prereleases=True)
+    else:
+        start = value[:sep_index]
+        end = value[sep_index + 1 :]
+        return SpecifierSet(f">={start},<={end}", prereleases=True)
+
+
+def is_specifier_set_compatible(spec_set):
+    if not spec_set:
+        return True
+
+    eq_versions = []
+    lower_bounds = []
+    upper_bounds = []
+    for spec in spec_set:
+        try:
+            val = Version(spec.version)
+        except InvalidVersion:
+            return False
+        if spec.operator == "==":
+            eq_versions.append(val)
+        elif spec.operator == ">=":
+            lower_bounds.append((val, True))
+        elif spec.operator == ">":
+            lower_bounds.append((val, False))
+        elif spec.operator == "<=":
+            upper_bounds.append((val, True))
+        elif spec.operator == "<":
+            upper_bounds.append((val, False))
+
+    if eq_versions:
+        target = eq_versions[0]
+        for eq_val in eq_versions[1:]:
+            if eq_val != target:
+                return False
+        for lb, inclusive in lower_bounds:
+            if inclusive:
+                if not (target >= lb):
+                    return False
+            else:
+                if not (target > lb):
+                    return False
+        for ub, inclusive in upper_bounds:
+            if inclusive:
+                if not (target <= ub):
+                    return False
+            else:
+                if not (target < ub):
+                    return False
+        return True
+
+    max_lb = None
+    max_lb_inclusive = True
+    for lb, inclusive in lower_bounds:
+        if max_lb is None or lb > max_lb:
+            max_lb = lb
+            max_lb_inclusive = inclusive
+        elif lb == max_lb:
+            if not inclusive:
+                max_lb_inclusive = False
+
+    min_ub = None
+    min_ub_inclusive = True
+    for ub, inclusive in upper_bounds:
+        if min_ub is None or ub < min_ub:
+            min_ub = ub
+            min_ub_inclusive = inclusive
+        elif ub == min_ub:
+            if not inclusive:
+                min_ub_inclusive = False
+
+    if max_lb is not None and min_ub is not None:
+        if max_lb > min_ub:
+            return False
+        if max_lb == min_ub:
+            return max_lb_inclusive and min_ub_inclusive
+
+    return True
+
+
 @functools.lru_cache(maxsize=None)
 def _parse_when(w_set):
     from ramble.util.format import when_order
-
-    from spack import version
 
     variants = {}
     versions = {}
@@ -350,7 +444,7 @@ def _parse_when(w_set):
             elif "@" in w:
                 name, ver = w.split("@", 1)
                 try:
-                    ver_obj = version.ver(ver)
+                    spec_set = _parse_version_spec(ver)
                 except Exception as e:
                     return (
                         None,
@@ -358,16 +452,16 @@ def _parse_when(w_set):
                         f"version '{name}' has invalid spec '{ver}': {e}",
                     )
                 if name in versions:
-                    intersection = versions[name].intersection(ver_obj)
-                    if not intersection:
+                    combined = versions[name] & spec_set
+                    if not is_specifier_set_compatible(combined):
                         msg = (
                             f"version '{name}' has conflicting values: "
                             f"'{versions[name]}' and '{ver}'"
                         )
                         return (None, None, msg)
-                    versions[name] = intersection
+                    versions[name] = combined
                 else:
-                    versions[name] = ver_obj
+                    versions[name] = spec_set
     return variants, versions, None
 
 
@@ -400,7 +494,8 @@ def are_when_compatible(when_set1, when_set2):
 
     for name in ver1:
         if name in ver2:
-            if not ver1[name].intersection(ver2[name]):
+            combined = ver1[name] & ver2[name]
+            if not is_specifier_set_compatible(combined):
                 return False
     return True
 

--- a/lib/ramble/ramble/language/language_helpers.py
+++ b/lib/ramble/ramble/language/language_helpers.py
@@ -322,6 +322,8 @@ def build_when_list(
 def _parse_when(w_set):
     from ramble.util.format import when_order
 
+    from spack import version
+
     variants = {}
     versions = {}
     for w_entry in sorted(w_set, key=when_order):
@@ -347,13 +349,25 @@ def _parse_when(w_set):
                 variants[name] = val
             elif "@" in w:
                 name, ver = w.split("@", 1)
-                if name in versions and versions[name] != ver:
+                try:
+                    ver_obj = version.ver(ver)
+                except Exception as e:
                     return (
                         None,
                         None,
-                        f"version '{name}' has conflicting values: '{versions[name]}' and '{ver}'",
+                        f"version '{name}' has invalid spec '{ver}': {e}",
                     )
-                versions[name] = ver
+                if name in versions:
+                    intersection = versions[name].intersection(ver_obj)
+                    if not intersection:
+                        msg = (
+                            f"version '{name}' has conflicting values: "
+                            f"'{versions[name]}' and '{ver}'"
+                        )
+                        return (None, None, msg)
+                    versions[name] = intersection
+                else:
+                    versions[name] = ver_obj
     return variants, versions, None
 
 
@@ -386,7 +400,7 @@ def are_when_compatible(when_set1, when_set2):
 
     for name in ver1:
         if name in ver2:
-            if ver1[name] != ver2[name]:
+            if not ver1[name].intersection(ver2[name]):
                 return False
     return True
 

--- a/lib/ramble/ramble/test/impossible_when.py
+++ b/lib/ramble/ramble/test/impossible_when.py
@@ -74,3 +74,12 @@ def test_info_value_conflict_impossible(mock_applications):
 
     parts = out.split("Workload: wl1")
     assert "var1" not in parts[1]
+
+
+def test_info_nested_compatible_when(mock_applications):
+    out = info("-v", "nested-when-test")
+    assert "impossible when condition" not in out
+    assert "When: application_version@1.0 AND application_version@1.0:" in out
+    assert "Default: val1" in out
+    assert "When: application_version@1.0: AND application_version@2.0" in out
+    assert "Default: val2" in out

--- a/lib/ramble/ramble/test/impossible_when.py
+++ b/lib/ramble/ramble/test/impossible_when.py
@@ -88,4 +88,4 @@ def test_info_nested_compatible_when(mock_applications):
 def test_info_nested_version_conflict(mock_applications):
     out = info("-v", "nested-version-conflict")
     assert "has an impossible when condition" in out
-    assert "version 'application_version' has conflicting values: '1.0' and '1.1:'" in out
+    assert "version 'application_version' has conflicting values: '==1.0' and '1.1:'" in out

--- a/lib/ramble/ramble/test/impossible_when.py
+++ b/lib/ramble/ramble/test/impossible_when.py
@@ -83,3 +83,9 @@ def test_info_nested_compatible_when(mock_applications):
     assert "Default: val1" in out
     assert "When: application_version@1.0: AND application_version@2.0" in out
     assert "Default: val2" in out
+
+
+def test_info_nested_version_conflict(mock_applications):
+    out = info("-v", "nested-version-conflict")
+    assert "has an impossible when condition" in out
+    assert "version 'application_version' has conflicting values: '1.0' and '1.1:'" in out

--- a/lib/ramble/ramble/test/language_helpers.py
+++ b/lib/ramble/ramble/test/language_helpers.py
@@ -1,0 +1,69 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import pytest
+from packaging.specifiers import SpecifierSet
+
+from ramble.language.language_helpers import _parse_version_spec, is_specifier_set_compatible
+
+
+@pytest.mark.parametrize(
+    "val,expected",
+    [
+        ("1.0", SpecifierSet("==1.0")),
+        ("1.0:", SpecifierSet(">=1.0")),
+        (":2.0", SpecifierSet("<=2.0")),
+        ("1.0:2.0", SpecifierSet(">=1.0,<=2.0")),
+        ("1_0", SpecifierSet("==1.0")),
+        ("1_0_1:", SpecifierSet(">=1.0.1")),
+        (":2_0_0a1", SpecifierSet("<=2.0.0a1")),
+        ("1_0:2_0", SpecifierSet(">=1.0,<=2.0")),
+        ("", SpecifierSet()),
+    ],
+)
+def test_parse_version_spec(val, expected):
+    assert _parse_version_spec(val) == expected
+
+
+@pytest.mark.parametrize(
+    "specs,expected",
+    [
+        # Empty
+        ([], True),
+        # Single bounds
+        ([">=1.0"], True),
+        (["<=2.0"], True),
+        (["==1.5"], True),
+        # Multiple ==
+        (["==1.0", "==1.0"], True),
+        (["==1.0", "==2.0"], False),
+        # == and ranges (compatible)
+        (["==1.5", ">=1.0"], True),
+        (["==1.5", "<=2.0"], True),
+        (["==1.5", ">=1.0", "<=2.0"], True),
+        # == and ranges (incompatible)
+        (["==1.5", ">=2.0"], False),
+        (["==1.5", "<=1.0"], False),
+        (["==1.5", ">1.5"], False),
+        (["==1.5", "<1.5"], False),
+        # Ranges overlapping
+        ([">=1.0", "<=2.0"], True),
+        ([">=2.0", "<=2.0"], True),
+        # Ranges non-overlapping
+        ([">=2.0", "<=1.0"], False),
+        # Exclusive boundary overlap
+        ([">2.0", "<=2.0"], False),
+        ([">=2.0", "<2.0"], False),
+        ([">2.0", "<2.0"], False),
+    ],
+)
+def test_is_specifier_set_compatible(specs, expected):
+    spec_set = SpecifierSet()
+    for s in specs:
+        spec_set &= SpecifierSet(s)
+    assert is_specifier_set_compatible(spec_set) is expected

--- a/lib/ramble/ramble/test/util/object_utils.py
+++ b/lib/ramble/ramble/test/util/object_utils.py
@@ -27,6 +27,7 @@ from ramble.util import object_utils
                 "conflict-test",
                 "import-test",
                 "input-test",
+                "nested-when-test",
                 "unused-compiler-test",
             ],
         ),

--- a/var/ramble/repos/builtin.mock/applications/nested-version-conflict/application.py
+++ b/var/ramble/repos/builtin.mock/applications/nested-version-conflict/application.py
@@ -1,0 +1,30 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.appkit import *
+
+
+class NestedVersionConflict(ExecutableApplication):
+    name = "nested-version-conflict"
+
+    executable("base_exec", "echo 'base'", use_mpi=False)
+
+    version("1.0", description="version 1.0")
+    version("1.1", description="version 1.1")
+    version("2.0", description="version 2.0")
+
+    workload("wl1", executable="base_exec")
+
+    with when("application_version@1.1:"):
+        workload_variable(
+            "conflict_var",
+            default="val",
+            description="conflicting nested var",
+            workloads=["wl1"],
+            when="application_version@1.0",
+        )

--- a/var/ramble/repos/builtin.mock/applications/nested-when-test/application.py
+++ b/var/ramble/repos/builtin.mock/applications/nested-when-test/application.py
@@ -1,0 +1,37 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.appkit import *
+
+
+class NestedWhenTest(ExecutableApplication):
+    name = "nested-when-test"
+
+    executable("base_exec", "echo 'base'", use_mpi=False)
+
+    version("1.0", description="version 1.0")
+    version("2.0", description="version 2.0")
+
+    workload("wl1", executable="base_exec")
+
+    with when("application_version@1.0:"):
+        workload_variable(
+            "test_var",
+            default="val1",
+            description="Compatible variable 1",
+            workloads=["wl1"],
+            when="application_version@1.0",
+        )
+
+        workload_variable(
+            "test_var",
+            default="val2",
+            description="Compatible variable 2",
+            workloads=["wl1"],
+            when="application_version@2.0",
+        )


### PR DESCRIPTION
This is to support more complex when clauses that involve versions, such as a nested when.