### PR TITLE
Ensure submodules are exported explicitly

### DIFF
--- a/lib/ramble/ramble/caches.py
+++ b/lib/ramble/ramble/caches.py
@@ -15,6 +15,7 @@ from llnl.util.filesystem import mkdirp
 from llnl.util.symlink import symlink
 
 import ramble.config
+import ramble.fetch_strategy
 import ramble.paths
 import ramble.util.file_cache
 import ramble.util.path

--- a/lib/ramble/ramble/cmd/debug.py
+++ b/lib/ramble/ramble/cmd/debug.py
@@ -12,6 +12,7 @@ import platform
 import ramble.util.version
 
 import spack.platforms
+import spack.spec
 
 description = "debugging commands for troubleshooting Ramble"
 section = "developer"

--- a/lib/ramble/ramble/cmd/on.py
+++ b/lib/ramble/ramble/cmd/on.py
@@ -6,6 +6,7 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+import ramble.cmd
 import ramble.config
 import ramble.filters
 import ramble.pipeline


### PR DESCRIPTION
This detects cases where for instance only `import a` is present, while the code accesses `a.b.func`, where `b` is a submodule that's not automatically imported when only importing module `a`.