### PR TITLE
Get rid of Ramble's dependency on spack_json

### DIFF
--- a/lib/ramble/ramble/cmd/deployment.py
+++ b/lib/ramble/ramble/cmd/deployment.py
@@ -20,9 +20,9 @@ import ramble.stage
 import ramble.util.path
 from ramble.cmd.common import arguments
 from ramble.main import RambleCommand
+from ramble.util import json_util
 from ramble.util.logger import logger
 
-import spack.util.spack_json as sjson
 import spack.util.url as surl
 
 description = "manage workspace deployments"
@@ -146,7 +146,7 @@ def deployment_pull(args):
             )
 
         with open(local_index_path, encoding="utf-8") as f:
-            index_data = sjson.load(f)
+            index_data = json_util.load(f)
 
         for file in index_data[push_cls.index_namespace]:
             src = surl.join(deployment_path, file)

--- a/lib/ramble/ramble/experiment_result.py
+++ b/lib/ramble/ramble/experiment_result.py
@@ -11,10 +11,9 @@ from enum import Enum
 
 from ramble.namespace import namespace
 from ramble.software_info import SoftwareInfo
+from ramble.util import json_util
 from ramble.util.file_util import get_newest_experiment_file
 from ramble.util.logger import logger
-
-import spack.util.spack_json as sjson
 
 
 # Can use auto() once we're at >= python 3.11
@@ -90,7 +89,7 @@ class ExperimentResult:
             return False
 
         with open(cache_file, encoding="utf-8") as f:
-            cache_dict = sjson.load(f)
+            cache_dict = json_util.load(f)
 
         if (
             "experiment_hash" not in cache_dict
@@ -120,7 +119,7 @@ class ExperimentResult:
             out_dict[software_key][key] = [pkg.to_dict() for pkg in pkg_list]
 
         with open(cache_file, "w+", encoding="utf-8") as f:
-            sjson.dump(out_dict, f)
+            json_util.dump(out_dict, f)
 
     def finalize(self, workspace):
         app_inst = self._app_inst

--- a/lib/ramble/ramble/mirror.py
+++ b/lib/ramble/ramble/mirror.py
@@ -27,10 +27,10 @@ from llnl.util.compat import Mapping
 import ramble.config
 import ramble.error
 import ramble.fetch_strategy as fs
+from ramble.util import json_util
 from ramble.util.logger import logger
 
 import spack.url
-import spack.util.spack_json
 import spack.util.spack_yaml
 from spack.util.spack_yaml import syaml_dict
 
@@ -65,7 +65,7 @@ class Mirror:
         return self._fetch_url == other._fetch_url and self._push_url == other._push_url
 
     def to_json(self, stream=None):
-        return spack.util.spack_json.dump(self.to_dict(), stream)
+        return json_util.dump(self.to_dict(), stream)
 
     def to_yaml(self, stream=None):
         return spack.util.spack_yaml.dump(self.to_dict(), stream)
@@ -81,10 +81,10 @@ class Mirror:
     @staticmethod
     def from_json(stream, name=None):
         try:
-            d = spack.util.spack_json.load(stream)
+            d = json_util.load(stream)
             return Mirror.from_dict(d, name)
         except Exception as e:
-            raise spack.util.spack_json.SpackJSONError("error parsing JSON mirror:", str(e)) from e
+            raise MirrorError(f"error parsing JSON mirror: {e}") from e
 
     def to_dict(self):
         return syaml_dict(
@@ -180,7 +180,7 @@ class MirrorCollection(Mapping):
         return self._mirrors == other._mirrors
 
     def to_json(self, stream=None):
-        return spack.util.spack_json.dump(self.to_dict(True), stream)
+        return json_util.dump(self.to_dict(True), stream)
 
     def to_yaml(self, stream=None):
         return spack.util.spack_yaml.dump(self.to_dict(True), stream)

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -27,11 +27,11 @@ import ramble.uploader
 import ramble.util.hashing
 import ramble.util.path
 import ramble.workspace
+from ramble.util import json_util
 from ramble.util.colors import cprint
 from ramble.util.file_util import create_symlink
 from ramble.util.logger import logger
 
-import spack.util.spack_json as sjson
 from spack.util.executable import Executable, which
 
 if not ramble.config.get("config:disable_progress_bar", False):
@@ -97,7 +97,7 @@ class Pipeline:
 
         if not self.force_inventory and files_exist:
             with open(workspace_inventory, encoding="utf-8") as f:
-                self.workspace.hash_inventory = sjson.load(f)
+                self.workspace.hash_inventory = json_util.load(f)
 
             self.workspace.workspace_hash = ramble.util.hashing.hash_json(
                 self.workspace.hash_inventory
@@ -121,7 +121,7 @@ class Pipeline:
                 "w+",
                 encoding="utf-8",
             ) as f:
-                sjson.dump(self.workspace.hash_inventory, f)
+                json_util.dump(self.workspace.hash_inventory, f)
 
             with open(
                 os.path.join(self.workspace.root, self.workspace.hash_file_name),
@@ -166,7 +166,8 @@ class Pipeline:
                 logger.all_msg(f"    log file: {exp_log_path}")
 
             with logger.add_log_context(exp_log_path):
-                logger.msg(f"Experiment inventory:\n{sjson.dump(app_inst.hash_inventory)}")
+                inv_str = json_util.dumps(app_inst.hash_inventory)
+                logger.msg(f"Experiment inventory:\n{inv_str}")
                 phase_list = list(
                     app_inst.get_pipeline_phases(self.name, phase_filters=self.filters.phases)
                 )
@@ -790,7 +791,7 @@ class PushDeploymentPipeline(Pipeline):
             )
         index_file = os.path.join(self.workspace.named_deployment, self.index_filename)
         with open(index_file, "w+", encoding="utf-8") as f:
-            f.write(sjson.dump(deployment_index))
+            f.write(json_util.dumps(deployment_index))
 
         tar_path = os.path.join(
             self.workspace.deployments_dir, self.deployment_name + self.tar_extension

--- a/lib/ramble/ramble/repository.py
+++ b/lib/ramble/ramble/repository.py
@@ -35,9 +35,8 @@ import ramble.spec
 import ramble.util.imp
 import ramble.util.naming as nm
 import ramble.util.path
+from ramble.util import json_util
 from ramble.util.logger import logger
-
-import spack.util.spack_json as sjson
 
 global_namespace = "ramble"
 
@@ -529,11 +528,11 @@ class TagIndex(Mapping):
         self._tag_dict = collections.defaultdict(list)
 
     def to_json(self, stream):
-        sjson.dump({"tags": self._tag_dict}, stream)
+        json_util.dump({"tags": self._tag_dict}, stream)
 
     @staticmethod
     def from_json(stream, object_type):
-        d = sjson.load(stream)
+        d = json_util.load(stream)
 
         r = TagIndex(object_type=object_type)
 

--- a/lib/ramble/ramble/test/end_to_end/dryrun_chained_experiments.py
+++ b/lib/ramble/ramble/test/end_to_end/dryrun_chained_experiments.py
@@ -15,8 +15,8 @@ import ramble.filters
 import ramble.pipeline
 import ramble.workspace
 from ramble.main import RambleCommand
+from ramble.util import json_util
 
-import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
 
 # everything here uses the mock_workspace_path
@@ -204,7 +204,7 @@ ramble:
         ]
 
         names = ["results.latest.json", "results.latest.yaml"]
-        loaders = [sjson.load, syaml.load]
+        loaders = [json_util.load, syaml.load]
         for name, loader in zip(names, loaders):
             with open(os.path.join(ws.root, name), encoding="utf-8") as f:
                 data = loader(f)

--- a/lib/ramble/ramble/test/end_to_end/experiment_hashes.py
+++ b/lib/ramble/ramble/test/end_to_end/experiment_hashes.py
@@ -11,8 +11,7 @@ import os
 import ramble.repository
 import ramble.workspace
 from ramble.main import RambleCommand
-
-import spack.util.spack_json as sjson
+from ramble.util import json_util
 
 ApplicationBase = ramble.repository.get_obj_class(
     "application-base", object_type=ramble.repository.ObjectTypes.base_classes
@@ -59,7 +58,7 @@ def test_experiment_hashes(mutable_config, mutable_mock_workspace_path, workspac
     # Test experiment inventory
     assert os.path.isfile(experiment_inventory)
     with open(experiment_inventory, encoding="utf-8") as f:
-        data = sjson.load(f)
+        data = json_util.load(f)
 
     assert "object_configuration" in data
     assert data["object_configuration"] != []
@@ -123,7 +122,7 @@ def test_experiment_hashes(mutable_config, mutable_mock_workspace_path, workspac
     # Test workspace inventory
     assert os.path.isfile(workspace_inventory)
     with open(workspace_inventory, encoding="utf-8") as f:
-        data = sjson.load(f)
+        data = json_util.load(f)
 
     # Test experiments
     expected_experiments = {"gromacs.water_bare.unit_test"}

--- a/lib/ramble/ramble/test/reports.py
+++ b/lib/ramble/ramble/test/reports.py
@@ -29,9 +29,8 @@ from matplotlib.backends.backend_pdf import PdfPages
 
 import ramble.reports
 from ramble.main import RambleCommand
-from ramble.util import foms
+from ramble.util import foms, json_util
 
-import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
 
 config = RambleCommand("config")
@@ -394,7 +393,7 @@ def test_multiline_plot(mutable_mock_workspace_path, mutable_config, tmpdir_fact
     test_exp_results = {"experiments": all_experiments}
 
     with open(results_file, "w+", encoding="utf-8") as f:
-        sjson.dump(test_exp_results, f)
+        json_util.dump(test_exp_results, f)
 
     with ramble.config.override("config:report_dirs", results_dir_path):
         output = results(
@@ -559,7 +558,7 @@ def test_index_printing(mutable_mock_workspace_path, tmpdir_factory, format):
 
     with open(results_file, "w+", encoding="utf-8") as f:
         if format == "json":
-            sjson.dump(test_exp_results, f)
+            json_util.dump(test_exp_results, f)
         elif format == "yaml":
             syaml.dump(test_exp_results, stream=f)
 

--- a/lib/ramble/ramble/test/success_criteria_functionality/success_modifiers.py
+++ b/lib/ramble/ramble/test/success_criteria_functionality/success_modifiers.py
@@ -13,6 +13,7 @@ import pytest
 import ramble.workspace
 from ramble.main import RambleCommand
 from ramble.test.dry_run_helpers import SCOPES, dry_run_config
+from ramble.util import json_util
 
 # everything here uses the mock_workspace_path
 pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_path")
@@ -164,20 +165,18 @@ ramble:
     ws._re_read()
     workspace("setup", "--dry-run", global_args=["-w", workspace_name])
 
-    import spack.util.spack_json as sjson
-
     # Write mock output data that fails success criteria:
     exp1_dir = os.path.join(ws.experiment_dir, "basic", "working_wl", "test_cancelled")
     with open(os.path.join(exp1_dir, "test_cancelled.out"), "w+", encoding="utf-8") as f:
         f.write("0.25 seconds\n")
     with open(os.path.join(exp1_dir, "ramble_status.json"), "w+", encoding="utf-8") as f:
-        sjson.dump({"experiment_status": "CANCELLED"}, f)
+        json_util.dump({"experiment_status": "CANCELLED"}, f)
 
     exp2_dir = os.path.join(ws.experiment_dir, "basic", "working_wl", "test_timeout")
     with open(os.path.join(exp2_dir, "test_timeout.out"), "w+", encoding="utf-8") as f:
         f.write("0.35 seconds\n")
     with open(os.path.join(exp2_dir, "ramble_status.json"), "w+", encoding="utf-8") as f:
-        sjson.dump({"experiment_status": "TIMEOUT"}, f)
+        json_util.dump({"experiment_status": "TIMEOUT"}, f)
 
     workspace(
         "analyze",
@@ -188,7 +187,7 @@ ramble:
     result_file = os.path.join(ws.results_dir, "results.latest.json")
 
     with open(result_file, encoding="utf-8") as f:
-        cache_dict = sjson.load(f)
+        cache_dict = json_util.load(f)
         for exp in cache_dict["experiments"]:
             if "cancelled" in exp["name"]:
                 assert exp["EXPERIMENT_STATUS"] == "CANCELLED"

--- a/lib/ramble/ramble/test/util/json_util.py
+++ b/lib/ramble/ramble/test/util/json_util.py
@@ -1,0 +1,41 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import io
+
+from ramble.util import json_util
+
+
+def test_dumps():
+    data = {"b": 2, "a": 1}
+    expected_default = '{\n  "b": 2,\n  "a": 1\n}'
+    assert json_util.dumps(data) == expected_default
+
+    expected_sorted = '{\n  "a": 1,\n  "b": 2\n}'
+    assert json_util.dumps(data, sort_keys=True) == expected_sorted
+
+
+def test_dump_to_stream():
+    data = {"a": 1}
+    stream = io.StringIO()
+    json_util.dump(data, stream)
+    assert stream.getvalue() == '{\n  "a": 1\n}'
+
+
+def test_dump_to_string():
+    data = {"a": 1}
+    assert json_util.dump(data) == '{\n  "a": 1\n}'
+
+
+def test_load():
+    stream = io.StringIO('{\n  "a": 1\n}')
+    assert json_util.load(stream) == {"a": 1}
+
+
+def test_loads():
+    assert json_util.loads('{"a": 1}') == {"a": 1}

--- a/lib/ramble/ramble/util/hashing.py
+++ b/lib/ramble/ramble/util/hashing.py
@@ -7,10 +7,9 @@
 # except according to those terms.
 
 import hashlib
-import json
-from typing import Any, Dict
+from typing import Any
 
-import spack.util.spack_json as sjson
+from ramble.util import json_util
 
 BLOCK_SIZE = 1024 * 1024
 
@@ -31,9 +30,6 @@ def hash_string(string):
 
 
 def hash_json(in_json: Any) -> str:
-    _json_dump_args: Dict[str, Any] = {"indent": 2, "separators": (",", ": "), "sort_keys": True}
-
-    data = sjson._strify(in_json)
-    json_data = json.dumps(data, **_json_dump_args)
+    json_data = json_util.dumps(in_json, sort_keys=True)
 
     return hashlib.sha256(json_data.encode("UTF-8")).hexdigest()

--- a/lib/ramble/ramble/util/json_util.py
+++ b/lib/ramble/ramble/util/json_util.py
@@ -1,0 +1,38 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import json
+from typing import IO, Any, Dict, Optional
+
+# This matches the spack_json format
+dump_args: Dict[str, Any] = {"indent": 2, "separators": (",", ": ")}
+
+
+def dump(obj: Any, fp: Optional[IO[str]] = None, **kwargs: Any) -> Optional[str]:
+    """Wrapper around json.dump. If fp is None, returns the JSON as a string."""
+    args = {**dump_args, **kwargs}
+    if fp is None:
+        return json.dumps(obj, **args)
+    json.dump(obj, fp, **args)
+    return None
+
+
+def dumps(obj: Any, **kwargs: Any) -> str:
+    """Wrapper around json.dumps using Ramble's default formatting arguments"""
+    args = {**dump_args, **kwargs}
+    return json.dumps(obj, **args)
+
+
+def load(fp: IO[str], **kwargs: Any) -> Any:
+    """Wrapper around json.load"""
+    return json.load(fp, **kwargs)
+
+
+def loads(s: str, **kwargs: Any) -> Any:
+    """Wrapper around json.loads"""
+    return json.loads(s, **kwargs)

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -40,11 +40,11 @@ import ramble.util.path
 import ramble.util.version
 from ramble.mirror import MirrorStats
 from ramble.namespace import namespace
+from ramble.util import json_util
 from ramble.util.conversions import list_str_to_list, strip_quotes
 from ramble.util.logger import logger
 from ramble.util.path import substitute_path_variables
 
-import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
 import spack.util.url as url_util
 import spack.util.web as web_util
@@ -1822,7 +1822,7 @@ ramble:
             out_file = os.path.join(self.results_dir, filename_base + file_extension)
             results_written.append(out_file)
             with open(out_file, "w+", encoding="utf-8") as f:
-                sjson.dump(results, f)
+                json_util.dump(results, f)
             self._create_result_symlinks(out_file, latest_base, file_extension, symlinks_updated)
 
         if "yaml" in output_formats:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,6 +208,7 @@ select = [
 # These are used to enforce the gradual moving away from vendored Spack dependencies
 "spack.util.naming" = { msg = "Core Ramble code should not rely on spack.util.naming." }
 "spack.util.cpus" = { msg = "Core Ramble code should not rely on spack.util.cpus." }
+"spack.util.spack_json" = { msg = "Core Ramble code should not rely on spack.util.spack_json." }
 
 [tool.ruff.lint.per-file-ignores]
 "lib/ramble/ramble/*kit.py" = ["F403"]

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -61,7 +61,7 @@ from ramble.language.shared_language import (
     register_phase,
     variant,
 )
-from ramble.util import cleaner, conversions
+from ramble.util import cleaner, conversions, json_util
 from ramble.util.foms import FomType, SummaryFoms, get_literal_from_regex
 from ramble.util.logger import logger
 from ramble.util.naming import NS_SEPARATOR
@@ -71,7 +71,6 @@ from ramble.workspace import LICENSE_INC_NAME, TEMPLATE_EXTENSION, namespace
 
 import spack.util.compression
 import spack.util.executable
-import spack.util.spack_json
 
 ObjectMixin = ramble.repository.get_base_class("object-mixin")
 
@@ -2801,7 +2800,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         existing_hash = None
         if os.path.exists(inventory_file) and not force:
             with open(inventory_file, encoding="utf-8") as f:
-                existing_inventory = spack.util.spack_json.load(f)
+                existing_inventory = json_util.load(f)
             existing_hash = ramble.util.hashing.hash_json(existing_inventory)
 
         # Clean up variables before hashing
@@ -2934,7 +2933,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         if changed and writable:
             with lk.WriteTransaction(self.experiment_lock):
                 with open(inventory_file, "w+", encoding="utf-8") as f:
-                    spack.util.spack_json.dump(self.hash_inventory, f)
+                    json_util.dump(self.hash_inventory, f)
 
         return changed
 
@@ -3921,7 +3920,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             exp_lock = self.experiment_lock
             with lk.ReadTransaction(exp_lock):
                 with open(status_path, encoding="utf-8") as f:
-                    status_data = spack.util.spack_json.load(f)
+                    status_data = json_util.load(f)
                     self.set_status(
                         ExperimentStatus(
                             status_data[self.keywords.experiment_status]
@@ -3980,7 +3979,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
             exp_lock = self.experiment_lock
             with lk.ReadTransaction(exp_lock):
                 with open(status_path, "w+", encoding="utf-8") as f:
-                    spack.util.spack_json.dump(status_data, f)
+                    json_util.dump(status_data, f)
 
     register_phase(
         "write_results_cache",


### PR DESCRIPTION
Instead, implement thin helpers under ramble.util.