### PR TITLE
Remove Ramble code that supports python2

### DIFF
--- a/bin/ramble
+++ b/bin/ramble
@@ -14,9 +14,9 @@
 # Following line is a shell no-op, and starts a multi-line Python comment.
 # See https://stackoverflow.com/a/47886254
 """:"
-# prefer python3, then python, then python2
-## prefer RAMBLE_PYTHON environment variable, python3, python, then python2
-RAMBLE_PREFERRED_PYTHONS="python3 python python2 /usr/libexec/platform-python"
+# prefer python3, then python
+## prefer RAMBLE_PYTHON environment variable, python3, python
+RAMBLE_PREFERRED_PYTHONS="python3 python /usr/libexec/platform-python"
 for cmd in "${_RAMBLE_PYTHON}" "${RAMBLE_PYTHON:-}" ${RAMBLE_PREFERRED_PYTHONS}; do
     if command -v > /dev/null "$cmd"; then
         export _RAMBLE_PYTHON="$(command -v "$cmd")"
@@ -31,7 +31,6 @@ exit 1
 # Line above is a shell no-op, and ends a python multi-line comment.
 # The code above runs this file with our preferred python interpreter.
 
-from __future__ import print_function
 
 import os
 import sys

--- a/lib/ramble/docs/conf.py
+++ b/lib/ramble/docs/conf.py
@@ -210,7 +210,6 @@ nitpick_ignore = [
     ("py:class", "func"),
     ("py:class", "module"),
     ("py:class", "_io.BufferedReader"),
-    ("py:class", "ramble.repository._PrependFileLoader"),
     ("py:class", "unittest.case.TestCase"),
     ("py:class", "_frozen_importlib_external.SourceFileLoader"),
     ("py:class", "clingo.Control"),

--- a/lib/ramble/ramble/main.py
+++ b/lib/ramble/ramble/main.py
@@ -262,9 +262,9 @@ class RambleArgumentParser(argparse.ArgumentParser):
             kwargs.setdefault("required", True)
 
         sp = super().add_subparsers(**kwargs)
-        # This monkey patching is needed for Python 3.5 and 3.6, which support
-        # having a required subparser but don't expose the API used above
-        if sys.version_info[:2] == (3, 5) or sys.version_info[:2] == (3, 6):
+        # This monkey patching is needed for Python 3.6, which supports
+        # having a required subparser but doesn't expose the API used above
+        if sys.version_info[:2] == (3, 6):
             sp.required = True
 
         old_add_parser = sp.add_parser

--- a/lib/ramble/ramble/repository.py
+++ b/lib/ramble/ramble/repository.py
@@ -1523,37 +1523,15 @@ class RepositoryNamespace(types.ModuleType):
         return getattr(self, name)
 
 
-class _PrependFileLoader(importlib.machinery.SourceFileLoader):
-    def __init__(self, fullname, path, prepend=None):
-        super().__init__(fullname, path)
-        self.prepend = prepend
-
-    def path_stats(self, path):
-        stats = super().path_stats(path)
-        if self.prepend:
-            stats["size"] += len(self.prepend) + 1
-        return stats
-
-    def get_data(self, path):
-        data = super().get_data(path)
-        if path != self.path or self.prepend is None:
-            return data
-        else:
-            return self.prepend.encode() + b"\n" + data
-
-
-class RepoLoader(_PrependFileLoader):
+class RepoLoader(importlib.machinery.SourceFileLoader):
     """Loads a Python module associated with a object in specific repository"""
-
-    #: Code in ``_object_prepend`` is prepended to imported objects.
-    _object_prepend = "from __future__ import absolute_import;"
 
     def __init__(self, fullname, repo, object_name):
         self.repo = repo
         self.object_name = object_name
         self.object_py = repo.filename_for_object_name(object_name)
         self.fullname = fullname
-        super().__init__(self.fullname, self.object_py, prepend=self._object_prepend)
+        super().__init__(self.fullname, self.object_py)
 
     def is_package(self, fullname):
         # Since every Ramble object already has a containing directory,

--- a/share/ramble/setup-env.csh
+++ b/share/ramble/setup-env.csh
@@ -76,7 +76,7 @@ if ($?_RAMBLE_PYTHON && "$RAMBLE_PYTHON" != "$_RAMBLE_PYTHON") then
     echo "         in RAMBLE_PYTHON and re-source this file"
 endif
 
-foreach cmd ("$RAMBLE_PYTHON" python3 python python2)
+foreach cmd ("$RAMBLE_PYTHON" python3 python)
     command -v "$cmd" >& /dev/null
     if ($status == 0) then
         setenv _RAMBLE_PYTHON `command -v "$cmd"`

--- a/share/ramble/setup-env.fish
+++ b/share/ramble/setup-env.fish
@@ -673,7 +673,7 @@ if test -n "$RAMBLE_PYTHON"
     echo "         in RAMBLE_PYTHON and re-source this file"
   end
 end
-for cmd in "$RAMBLE_PYTHON" python3 python python2
+for cmd in "$RAMBLE_PYTHON" python3 python
     set -l _rmb_python (command -v "$cmd")
     if test $status -eq 0
         set -x _RAMBLE_PYTHON $_rmb_python

--- a/share/ramble/setup-env.sh
+++ b/share/ramble/setup-env.sh
@@ -348,7 +348,7 @@ if [ -n "${RAMBLE_PYTHON:-}" ]; then
   fi
 fi
 
-for cmd in "${RAMBLE_PYTHON:-}" python3 python python2; do
+for cmd in "${RAMBLE_PYTHON:-}" python3 python; do
     if command -v > /dev/null "$cmd"; then
         export _RAMBLE_PYTHON="$(command -v "$cmd")"
         break


### PR DESCRIPTION
Since now Ramble only supports python3.6 and up.

* Get rid of mentions of py2
* Remove a couple future imports that were for py2 compatibility. As a result the `_PrependFileLoader` is not needed any more.