### PR TITLE
Bug: Fix success_criteria to track when clause precedence

### DIFF
--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -602,8 +602,12 @@ def success_criteria(
         when_list = ramble.language.language_helpers.build_when_list(
             when, obj, name, "success_criteria"
         )
+        when_set = frozenset(when_list)
 
-        obj.success_criteria[name] = {
+        if when_set not in obj.success_criteria:
+            obj.success_criteria[when_set] = {}
+
+        obj.success_criteria[when_set][name] = {
             "mode": mode,
             "match": match,
             "anti_match": anti_match,

--- a/lib/ramble/ramble/test/success_criteria_functionality/success_precedence.py
+++ b/lib/ramble/ramble/test/success_criteria_functionality/success_precedence.py
@@ -10,11 +10,19 @@ import os
 
 import pytest
 
+import ramble.workspace
+from ramble.error import RambleCommandError
 from ramble.main import RambleCommand
 
 # everything here uses the mock_workspace_path
-pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_path")
+pytestmark = pytest.mark.usefixtures(
+    "mutable_config",
+    "mutable_mock_workspace_path",
+    "mutable_mock_apps_repo",
+    "workspace_deactivate",
+)
 
+config = RambleCommand("config")
 workspace = RambleCommand("workspace")
 ramble_on = RambleCommand("on")
 
@@ -24,6 +32,7 @@ def test_success_criteria_precedence(mock_applications, make_workspace_from_conf
     Tests that YAML success_criteria takes precedence over
     object-defined criteria
     """
+    # TODO: Update once success_criteria has manage experiments command
     test_config = """
 ramble:
   variables:
@@ -61,33 +70,28 @@ ramble:
         assert "config::experiment::test_success = PASSED" in data
 
 
-def test_success_criteria_mutex_versions(mock_applications, make_workspace_from_config):
+def test_success_criteria_mutex_versions(workspace_name):
     """
     Tests that same named success_criteria defined in mutually exclusive
     when clauses are handled appropriately.
     """
-    test_config = """
-ramble:
-  variables:
-    processes_per_node: '1'
-    n_threads: '1'
-  applications:
-    success-criteria-conflicts@1.0.0:
-      workloads:
-        version_wl:
-          experiments:
-            pass-experiment:
-              variables:
-                n_nodes: 1
-  software:
-    packages: {}
-    environments: {}
-"""
-    ws, ws_name = make_workspace_from_config(test_config)
+    global_args = ["-w", workspace_name]
 
-    workspace("setup", global_args=["-w", ws_name])
-    ramble_on(global_args=["-w", ws_name])
-    workspace("analyze", "-f", "text", "json", "yaml", global_args=["-w", ws_name])
+    with ramble.workspace.create(workspace_name) as ws:
+        workspace(
+            "manage",
+            "experiments",
+            "success-criteria-conflicts@1.0.0",
+            "--wf",
+            "version_wl",
+            "--default-variable-value",
+            "1",
+            global_args=global_args,
+        )
+
+    workspace("setup", global_args=global_args)
+    ramble_on(global_args=global_args)
+    workspace("analyze", "-f", "text", "json", "yaml", global_args=global_args)
 
     for ext in ["txt", "json", "yaml"]:
         assert os.path.exists(os.path.join(ws.results_dir, f"results.latest.{ext}"))
@@ -99,33 +103,25 @@ ramble:
         assert "application::success-criteria-conflicts::test_version = PASSED" in data
 
 
-def test_success_criteria_multiple_satisfies(mock_applications, make_workspace_from_config):
+def test_success_criteria_multiple_satisfies(workspace_name):
     """
     Tests that an object, Application in this case, defining the same named
     success_criteria in multiple satisfying when conditions, will error out.
     """
-    test_config = """
-ramble:
-  variables:
-    processes_per_node: '1'
-    n_threads: '1'
-  applications:
-    success-criteria-conflicts:
-      variants:
-        force_pass: True
-      workloads:
-        success_str_wl:
-          experiments:
-            pass-experiment:
-              variables:
-                n_nodes: 1
-  software:
-    packages: {}
-    environments: {}
-"""
-    ws, ws_name = make_workspace_from_config(test_config)
+    global_args = ["-w", workspace_name]
 
-    from ramble.error import RambleCommandError
+    with ramble.workspace.create(workspace_name):
+        workspace(
+            "manage",
+            "experiments",
+            "success-criteria-conflicts",
+            "--wf",
+            "success_str_wl",
+            "--default-variable-value",
+            "1",
+            global_args=global_args,
+        )
+    config("add", "variants:force_pass:true", global_args=global_args)
 
     expected_err = (
         r"Success criteria '.*' in object '.*' is defined "
@@ -133,36 +129,31 @@ ramble:
     )
 
     with pytest.raises(RambleCommandError, match=expected_err):
-        workspace("setup", global_args=["-w", ws_name])
+        workspace("setup", global_args=global_args)
 
 
-def test_success_criteria_inheritance(mock_applications, make_workspace_from_config):
+def test_success_criteria_inheritance(workspace_name):
     """
     Tests that same named success_criteria defined in multiple objects (using
     inheritance) is handled appropriately.
     """
-    test_config = """
-ramble:
-  variables:
-    processes_per_node: '1'
-    n_threads: '1'
-  applications:
-    success-criteria-conflicts:
-      workloads:
-        inheritance_wl:
-          experiments:
-            pass-experiment:
-              variables:
-                n_nodes: 1
-  software:
-    packages: {}
-    environments: {}
-"""
-    ws, ws_name = make_workspace_from_config(test_config)
+    global_args = ["-w", workspace_name]
 
-    workspace("setup", global_args=["-w", ws_name])
-    ramble_on(global_args=["-w", ws_name])
-    workspace("analyze", "-f", "text", "json", "yaml", global_args=["-w", ws_name])
+    with ramble.workspace.create(workspace_name) as ws:
+        workspace(
+            "manage",
+            "experiments",
+            "success-criteria-conflicts",
+            "--wf",
+            "inheritance_wl",
+            "--default-variable-value",
+            "1",
+            global_args=global_args,
+        )
+
+    workspace("setup", global_args=global_args)
+    ramble_on(global_args=global_args)
+    workspace("analyze", "-f", "text", "json", "yaml", global_args=global_args)
 
     for ext in ["txt", "json", "yaml"]:
         assert os.path.exists(os.path.join(ws.results_dir, f"results.latest.{ext}"))

--- a/lib/ramble/ramble/test/success_criteria_functionality/success_precedence.py
+++ b/lib/ramble/ramble/test/success_criteria_functionality/success_precedence.py
@@ -1,0 +1,191 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import os
+
+import pytest
+
+import ramble.workspace
+from ramble.main import RambleCommand
+
+# everything here uses the mock_workspace_path
+pytestmark = pytest.mark.usefixtures("mutable_config", "mutable_mock_workspace_path")
+
+workspace = RambleCommand("workspace")
+ramble_on = RambleCommand("on")
+
+
+def test_success_criteria_precedence(mock_applications, workspace_name):
+    """
+    Tests that YAML success_criteria takes precedence over
+    object-defined criteria
+    """
+    test_config = """
+ramble:
+  variables:
+    processes_per_node: '1'
+    n_threads: '1'
+  applications:
+    success-criteria-conflicts:
+      workloads:
+        success_str_wl:
+          experiments:
+            pass-experiment:
+              variables:
+                n_nodes: 1
+              success_criteria:
+              - name: test_success
+                mode: string
+                match: 'SUCCESS'
+  software:
+    packages: {}
+    environments: {}
+"""
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+
+        config_path = os.path.join(ws.config_dir, ramble.workspace.CONFIG_FILE_NAME)
+
+        with open(config_path, "w+", encoding="utf-8") as f:
+            f.write(test_config)
+        ws._re_read()
+
+        workspace("setup", global_args=["-w", workspace_name])
+        ramble_on(global_args=["-w", workspace_name])
+        workspace("analyze", "-f", "text", "json", "yaml", global_args=["-w", workspace_name])
+
+        for _ in ["txt", "json", "yaml"]:
+            with open(os.path.join(ws.results_dir, "results.latest.txt"), encoding="utf-8") as f:
+                data = f.read()
+                assert "Success criteria summary:" in data
+                assert "application::success-criteria-conflicts::_application_function = PASSED" in data
+                assert "config::experiment::test_success = PASSED" in data
+
+def test_success_criteria_mutex_versions(mock_applications, workspace_name):
+    """
+    Tests that same named success_criteria defined in mutually exclusive
+    when clauses are handled appropriately.
+    """
+    test_config = """
+ramble:
+  variables:
+    processes_per_node: '1'
+    n_threads: '1'
+  applications:
+    success-criteria-conflicts@1.0.0:
+      workloads:
+        version_wl:
+          experiments:
+            pass-experiment:
+              variables:
+                n_nodes: 1
+  software:
+    packages: {}
+    environments: {}
+"""
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+
+        config_path = os.path.join(ws.config_dir, ramble.workspace.CONFIG_FILE_NAME)
+
+        with open(config_path, "w+", encoding="utf-8") as f:
+            f.write(test_config)
+        ws._re_read()
+
+        workspace("setup", global_args=["-w", workspace_name])
+        ramble_on(global_args=["-w", workspace_name])
+        workspace("analyze", "-f", "text", "json", "yaml", global_args=["-w", workspace_name])
+
+        for _ in ["txt", "json", "yaml"]:
+            with open(os.path.join(ws.results_dir, "results.latest.txt"), encoding="utf-8") as f:
+                data = f.read()
+                assert "Success criteria summary:" in data
+                assert "application::success-criteria-conflicts::_application_function = PASSED" in data
+                assert "application::success-criteria-conflicts::test_version = PASSED" in data
+
+def test_success_criteria_multiple_satisfies(mock_applications, workspace_name):
+    """
+    Tests that an object, Application in this case, defining the same named
+    success_criteria in multiple satisfying when conditions, will error out.
+    """
+    test_config = """
+ramble:
+  variables:
+    processes_per_node: '1'
+    n_threads: '1'
+  applications:
+    success-criteria-conflicts:
+      variants:
+        force_pass: True
+      workloads:
+        success_str_wl:
+          experiments:
+            pass-experiment:
+              variables:
+                n_nodes: 1
+  software:
+    packages: {}
+    environments: {}
+"""
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+
+        config_path = os.path.join(ws.config_dir, ramble.workspace.CONFIG_FILE_NAME)
+
+        with open(config_path, "w+", encoding="utf-8") as f:
+            f.write(test_config)
+        ws._re_read()
+
+        from ramble.error import RambleCommandError
+        
+        expected_err = r"Success criteria '.*' in object '.*' is defined multiple times under conflicting satisfied 'when' conditions"
+        
+        with pytest.raises(RambleCommandError, match=expected_err):
+            workspace("setup", global_args=["-w", workspace_name])
+
+def test_success_criteria_inheritance(mock_applications, workspace_name):
+    """
+    Tests that same named success_criteria defined in multiple objects (using
+    inheritance) is handled appropriately.
+    """
+    test_config = """
+ramble:
+  variables:
+    processes_per_node: '1'
+    n_threads: '1'
+  applications:
+    success-criteria-conflicts:
+      workloads:
+        inheritance_wl:
+          experiments:
+            pass-experiment:
+              variables:
+                n_nodes: 1
+  software:
+    packages: {}
+    environments: {}
+"""
+    with ramble.workspace.create(workspace_name) as ws:
+        ws.write()
+
+        config_path = os.path.join(ws.config_dir, ramble.workspace.CONFIG_FILE_NAME)
+
+        with open(config_path, "w+", encoding="utf-8") as f:
+            f.write(test_config)
+        ws._re_read()
+
+        workspace("setup", global_args=["-w", workspace_name])
+        ramble_on(global_args=["-w", workspace_name])
+        workspace("analyze", "-f", "text", "json", "yaml", global_args=["-w", workspace_name])
+
+        for _ in ["txt", "json", "yaml"]:
+            with open(os.path.join(ws.results_dir, "results.latest.txt"), encoding="utf-8") as f:
+                data = f.read()
+                assert "Success criteria summary:" in data
+                assert "application::success-criteria-conflicts::_application_function = PASSED" in data
+                assert "application::success-criteria-conflicts::test_inheritance = PASSED" in data

--- a/lib/ramble/ramble/test/success_criteria_functionality/success_precedence.py
+++ b/lib/ramble/ramble/test/success_criteria_functionality/success_precedence.py
@@ -66,8 +66,7 @@ ramble:
             data = f.read()
             assert "Success criteria summary:" in data
             assert (
-                "application::success-criteria-conflicts::_application_function = PASSED"
-                in data
+                "application::success-criteria-conflicts::_application_function = PASSED" in data
             )
             assert "config::experiment::test_success = PASSED" in data
 
@@ -114,8 +113,7 @@ ramble:
             data = f.read()
             assert "Success criteria summary:" in data
             assert (
-                "application::success-criteria-conflicts::_application_function = PASSED"
-                in data
+                "application::success-criteria-conflicts::_application_function = PASSED" in data
             )
             assert "application::success-criteria-conflicts::test_version = PASSED" in data
 
@@ -155,7 +153,10 @@ ramble:
 
         from ramble.error import RambleCommandError
 
-        expected_err = r"Success criteria '.*' in object '.*' is defined multiple times under conflicting satisfied 'when' conditions"
+        expected_err = (
+            r"Success criteria '.*' in object '.*' is defined "
+            r"multiple times under conflicting satisfied 'when' conditions"
+        )
 
         with pytest.raises(RambleCommandError, match=expected_err):
             workspace("setup", global_args=["-w", workspace_name])

--- a/lib/ramble/ramble/test/success_criteria_functionality/success_precedence.py
+++ b/lib/ramble/ramble/test/success_criteria_functionality/success_precedence.py
@@ -10,7 +10,6 @@ import os
 
 import pytest
 
-import ramble.workspace
 from ramble.main import RambleCommand
 
 # everything here uses the mock_workspace_path
@@ -20,7 +19,7 @@ workspace = RambleCommand("workspace")
 ramble_on = RambleCommand("on")
 
 
-def test_success_criteria_precedence(mock_applications, workspace_name):
+def test_success_criteria_precedence(mock_applications, make_workspace_from_config):
     """
     Tests that YAML success_criteria takes precedence over
     object-defined criteria
@@ -46,32 +45,23 @@ ramble:
     packages: {}
     environments: {}
 """
-    with ramble.workspace.create(workspace_name) as ws:
-        ws.write()
+    ws, ws_name = make_workspace_from_config(test_config)
 
-        config_path = os.path.join(ws.config_dir, ramble.workspace.CONFIG_FILE_NAME)
+    workspace("setup", global_args=["-w", ws_name])
+    ramble_on(global_args=["-w", ws_name])
+    workspace("analyze", "-f", "text", "json", "yaml", global_args=["-w", ws_name])
 
-        with open(config_path, "w+", encoding="utf-8") as f:
-            f.write(test_config)
-        ws._re_read()
+    for ext in ["txt", "json", "yaml"]:
+        assert os.path.exists(os.path.join(ws.results_dir, f"results.latest.{ext}"))
 
-        workspace("setup", global_args=["-w", workspace_name])
-        ramble_on(global_args=["-w", workspace_name])
-        workspace("analyze", "-f", "text", "json", "yaml", global_args=["-w", workspace_name])
-
-        for ext in ["txt", "json", "yaml"]:
-            assert os.path.exists(os.path.join(ws.results_dir, f"results.latest.{ext}"))
-
-        with open(os.path.join(ws.results_dir, "results.latest.txt"), encoding="utf-8") as f:
-            data = f.read()
-            assert "Success criteria summary:" in data
-            assert (
-                "application::success-criteria-conflicts::_application_function = PASSED" in data
-            )
-            assert "config::experiment::test_success = PASSED" in data
+    with open(os.path.join(ws.results_dir, "results.latest.txt"), encoding="utf-8") as f:
+        data = f.read()
+        assert "Success criteria summary:" in data
+        assert "application::success-criteria-conflicts::_application_function = PASSED" in data
+        assert "config::experiment::test_success = PASSED" in data
 
 
-def test_success_criteria_mutex_versions(mock_applications, workspace_name):
+def test_success_criteria_mutex_versions(mock_applications, make_workspace_from_config):
     """
     Tests that same named success_criteria defined in mutually exclusive
     when clauses are handled appropriately.
@@ -93,32 +83,23 @@ ramble:
     packages: {}
     environments: {}
 """
-    with ramble.workspace.create(workspace_name) as ws:
-        ws.write()
+    ws, ws_name = make_workspace_from_config(test_config)
 
-        config_path = os.path.join(ws.config_dir, ramble.workspace.CONFIG_FILE_NAME)
+    workspace("setup", global_args=["-w", ws_name])
+    ramble_on(global_args=["-w", ws_name])
+    workspace("analyze", "-f", "text", "json", "yaml", global_args=["-w", ws_name])
 
-        with open(config_path, "w+", encoding="utf-8") as f:
-            f.write(test_config)
-        ws._re_read()
+    for ext in ["txt", "json", "yaml"]:
+        assert os.path.exists(os.path.join(ws.results_dir, f"results.latest.{ext}"))
 
-        workspace("setup", global_args=["-w", workspace_name])
-        ramble_on(global_args=["-w", workspace_name])
-        workspace("analyze", "-f", "text", "json", "yaml", global_args=["-w", workspace_name])
-
-        for ext in ["txt", "json", "yaml"]:
-            assert os.path.exists(os.path.join(ws.results_dir, f"results.latest.{ext}"))
-
-        with open(os.path.join(ws.results_dir, "results.latest.txt"), encoding="utf-8") as f:
-            data = f.read()
-            assert "Success criteria summary:" in data
-            assert (
-                "application::success-criteria-conflicts::_application_function = PASSED" in data
-            )
-            assert "application::success-criteria-conflicts::test_version = PASSED" in data
+    with open(os.path.join(ws.results_dir, "results.latest.txt"), encoding="utf-8") as f:
+        data = f.read()
+        assert "Success criteria summary:" in data
+        assert "application::success-criteria-conflicts::_application_function = PASSED" in data
+        assert "application::success-criteria-conflicts::test_version = PASSED" in data
 
 
-def test_success_criteria_multiple_satisfies(mock_applications, workspace_name):
+def test_success_criteria_multiple_satisfies(mock_applications, make_workspace_from_config):
     """
     Tests that an object, Application in this case, defining the same named
     success_criteria in multiple satisfying when conditions, will error out.
@@ -142,27 +123,20 @@ ramble:
     packages: {}
     environments: {}
 """
-    with ramble.workspace.create(workspace_name) as ws:
-        ws.write()
+    ws, ws_name = make_workspace_from_config(test_config)
 
-        config_path = os.path.join(ws.config_dir, ramble.workspace.CONFIG_FILE_NAME)
+    from ramble.error import RambleCommandError
 
-        with open(config_path, "w+", encoding="utf-8") as f:
-            f.write(test_config)
-        ws._re_read()
+    expected_err = (
+        r"Success criteria '.*' in object '.*' is defined "
+        r"multiple times under conflicting satisfied 'when' conditions"
+    )
 
-        from ramble.error import RambleCommandError
-
-        expected_err = (
-            r"Success criteria '.*' in object '.*' is defined "
-            r"multiple times under conflicting satisfied 'when' conditions"
-        )
-
-        with pytest.raises(RambleCommandError, match=expected_err):
-            workspace("setup", global_args=["-w", workspace_name])
+    with pytest.raises(RambleCommandError, match=expected_err):
+        workspace("setup", global_args=["-w", ws_name])
 
 
-def test_success_criteria_inheritance(mock_applications, workspace_name):
+def test_success_criteria_inheritance(mock_applications, make_workspace_from_config):
     """
     Tests that same named success_criteria defined in multiple objects (using
     inheritance) is handled appropriately.
@@ -184,26 +158,17 @@ ramble:
     packages: {}
     environments: {}
 """
-    with ramble.workspace.create(workspace_name) as ws:
-        ws.write()
+    ws, ws_name = make_workspace_from_config(test_config)
 
-        config_path = os.path.join(ws.config_dir, ramble.workspace.CONFIG_FILE_NAME)
+    workspace("setup", global_args=["-w", ws_name])
+    ramble_on(global_args=["-w", ws_name])
+    workspace("analyze", "-f", "text", "json", "yaml", global_args=["-w", ws_name])
 
-        with open(config_path, "w+", encoding="utf-8") as f:
-            f.write(test_config)
-        ws._re_read()
+    for ext in ["txt", "json", "yaml"]:
+        assert os.path.exists(os.path.join(ws.results_dir, f"results.latest.{ext}"))
 
-        workspace("setup", global_args=["-w", workspace_name])
-        ramble_on(global_args=["-w", workspace_name])
-        workspace("analyze", "-f", "text", "json", "yaml", global_args=["-w", workspace_name])
-
-        for ext in ["txt", "json", "yaml"]:
-            assert os.path.exists(os.path.join(ws.results_dir, f"results.latest.{ext}"))
-
-        with open(os.path.join(ws.results_dir, "results.latest.txt"), encoding="utf-8") as f:
-            data = f.read()
-            assert "Success criteria summary:" in data
-            assert (
-                "application::success-criteria-conflicts::_application_function = PASSED" in data
-            )
-            assert "application::success-criteria-conflicts::test_inheritance = PASSED" in data
+    with open(os.path.join(ws.results_dir, "results.latest.txt"), encoding="utf-8") as f:
+        data = f.read()
+        assert "Success criteria summary:" in data
+        assert "application::success-criteria-conflicts::_application_function = PASSED" in data
+        assert "application::success-criteria-conflicts::test_inheritance = PASSED" in data

--- a/lib/ramble/ramble/test/success_criteria_functionality/success_precedence.py
+++ b/lib/ramble/ramble/test/success_criteria_functionality/success_precedence.py
@@ -59,12 +59,18 @@ ramble:
         ramble_on(global_args=["-w", workspace_name])
         workspace("analyze", "-f", "text", "json", "yaml", global_args=["-w", workspace_name])
 
-        for _ in ["txt", "json", "yaml"]:
-            with open(os.path.join(ws.results_dir, "results.latest.txt"), encoding="utf-8") as f:
-                data = f.read()
-                assert "Success criteria summary:" in data
-                assert "application::success-criteria-conflicts::_application_function = PASSED" in data
-                assert "config::experiment::test_success = PASSED" in data
+        for ext in ["txt", "json", "yaml"]:
+            assert os.path.exists(os.path.join(ws.results_dir, f"results.latest.{ext}"))
+
+        with open(os.path.join(ws.results_dir, "results.latest.txt"), encoding="utf-8") as f:
+            data = f.read()
+            assert "Success criteria summary:" in data
+            assert (
+                "application::success-criteria-conflicts::_application_function = PASSED"
+                in data
+            )
+            assert "config::experiment::test_success = PASSED" in data
+
 
 def test_success_criteria_mutex_versions(mock_applications, workspace_name):
     """
@@ -101,12 +107,18 @@ ramble:
         ramble_on(global_args=["-w", workspace_name])
         workspace("analyze", "-f", "text", "json", "yaml", global_args=["-w", workspace_name])
 
-        for _ in ["txt", "json", "yaml"]:
-            with open(os.path.join(ws.results_dir, "results.latest.txt"), encoding="utf-8") as f:
-                data = f.read()
-                assert "Success criteria summary:" in data
-                assert "application::success-criteria-conflicts::_application_function = PASSED" in data
-                assert "application::success-criteria-conflicts::test_version = PASSED" in data
+        for ext in ["txt", "json", "yaml"]:
+            assert os.path.exists(os.path.join(ws.results_dir, f"results.latest.{ext}"))
+
+        with open(os.path.join(ws.results_dir, "results.latest.txt"), encoding="utf-8") as f:
+            data = f.read()
+            assert "Success criteria summary:" in data
+            assert (
+                "application::success-criteria-conflicts::_application_function = PASSED"
+                in data
+            )
+            assert "application::success-criteria-conflicts::test_version = PASSED" in data
+
 
 def test_success_criteria_multiple_satisfies(mock_applications, workspace_name):
     """
@@ -142,11 +154,12 @@ ramble:
         ws._re_read()
 
         from ramble.error import RambleCommandError
-        
+
         expected_err = r"Success criteria '.*' in object '.*' is defined multiple times under conflicting satisfied 'when' conditions"
-        
+
         with pytest.raises(RambleCommandError, match=expected_err):
             workspace("setup", global_args=["-w", workspace_name])
+
 
 def test_success_criteria_inheritance(mock_applications, workspace_name):
     """
@@ -183,9 +196,13 @@ ramble:
         ramble_on(global_args=["-w", workspace_name])
         workspace("analyze", "-f", "text", "json", "yaml", global_args=["-w", workspace_name])
 
-        for _ in ["txt", "json", "yaml"]:
-            with open(os.path.join(ws.results_dir, "results.latest.txt"), encoding="utf-8") as f:
-                data = f.read()
-                assert "Success criteria summary:" in data
-                assert "application::success-criteria-conflicts::_application_function = PASSED" in data
-                assert "application::success-criteria-conflicts::test_inheritance = PASSED" in data
+        for ext in ["txt", "json", "yaml"]:
+            assert os.path.exists(os.path.join(ws.results_dir, f"results.latest.{ext}"))
+
+        with open(os.path.join(ws.results_dir, "results.latest.txt"), encoding="utf-8") as f:
+            data = f.read()
+            assert "Success criteria summary:" in data
+            assert (
+                "application::success-criteria-conflicts::_application_function = PASSED" in data
+            )
+            assert "application::success-criteria-conflicts::test_inheritance = PASSED" in data

--- a/var/ramble/repos/builtin.mock/applications/success-criteria-conflicts/application.py
+++ b/var/ramble/repos/builtin.mock/applications/success-criteria-conflicts/application.py
@@ -8,6 +8,7 @@
 
 from ramble.appkit import *
 
+
 class SuccessCriteriaConflictsParent(ExecutableApplication):
     name = "success-criteria-conflicts-parent"
 
@@ -22,6 +23,7 @@ class SuccessCriteriaConflictsParent(ExecutableApplication):
             mode="string",
             anti_match="PARENT",
         )
+
 
 class SuccessCriteriaConflicts(SuccessCriteriaConflictsParent):
     name = "success-criteria-conflicts"

--- a/var/ramble/repos/builtin.mock/applications/success-criteria-conflicts/application.py
+++ b/var/ramble/repos/builtin.mock/applications/success-criteria-conflicts/application.py
@@ -1,0 +1,78 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.appkit import *
+
+class SuccessCriteriaConflictsParent(ExecutableApplication):
+    name = "success-criteria-conflicts-parent"
+
+    executable("inheritance", "echo 'PARENT'", use_mpi=False)
+
+    workload("inheritance_wl", executable="inheritance")
+
+    # This will fail if inheritance precedence isn't working
+    with when("workload_name=inheritance_wl"):
+        success_criteria(
+            "test_inheritance",
+            mode="string",
+            anti_match="PARENT",
+        )
+
+class SuccessCriteriaConflicts(SuccessCriteriaConflictsParent):
+    name = "success-criteria-conflicts"
+
+    version("1.0.0")
+    version("2.0.0")
+
+    executable("version", "echo '{application_version}'", use_mpi=False)
+    executable("success_str", "echo 'SUCCESS'", use_mpi=False)
+
+    workload("version_wl", executable="version")
+    workload("success_str_wl", executable="success_str")
+
+    variant(
+        "force_pass",
+        default=False,
+        values=[True, False],
+    )
+
+    # This is meant to always fail
+    with when("workload_name=success_str_wl"):
+        success_criteria(
+            "test_success",
+            mode="string",
+            anti_match="SUCCESS",
+        )
+        with when("+force_pass"):
+            success_criteria(
+                "test_success",
+                mode="string",
+                match="SUCCESS",
+            )
+
+    with when("@1.0.0"):
+        success_criteria(
+            "test_version",
+            mode="string",
+            match="1.0.0",
+        )
+
+    with when("@2.0.0"):
+        success_criteria(
+            "test_version",
+            mode="string",
+            match="2.0.0",
+        )
+
+    # This should override the parent definition causing it to pass instead of fail
+    with when("workload_name=inheritance_wl"):
+        success_criteria(
+            "test_inheritance",
+            mode="string",
+            match="PARENT",
+        )

--- a/var/ramble/repos/builtin/applications/wrf/application.py
+++ b/var/ramble/repos/builtin/applications/wrf/application.py
@@ -418,13 +418,6 @@ class Wrf(ExecutableApplication):
         fom_type=FomType.MEASURE,
     )
 
-    success_criteria(
-        "Complete",
-        mode="string",
-        match=r".*?wrf: SUCCESS COMPLETE WRF",
-        file="{experiment_run_dir}/rsl.out.0000",
-    )
-
     def _analyze_experiments(self, workspace, app_inst=None):
         experiment_dir = self.expander.expand_var_name("experiment_run_dir")
 

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -3635,15 +3635,34 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         # Add the object defined criteria
         criteria_list.flush_scope("object_definitions")
 
-        for _, obj_inst in self.objects():
+        resolved_criteria = {crit.name: -1 for crit, _ in criteria_list.all_criteria()}
+
+        for prec, (_, obj_inst) in enumerate(self.objects()):
             if obj_inst.success_criteria:
-                for criteria, conf in obj_inst.success_criteria.items():
+                obj_satisfied_criteria = {}
+                for when_set, criteria_dict in obj_inst.success_criteria.items():
                     if not self.expander.satisfies(
-                        conf["when"],
+                        when_set,
                         variant_set=obj_inst.experiment_variants(),
                     ):
                         continue
 
+                    for name, conf in criteria_dict.items():
+                        if name in obj_satisfied_criteria:
+                            existing_when_set = obj_satisfied_criteria[name][0]
+                            logger.die(
+                                f"Success criteria '{name}' in object '{obj_inst.name}' is defined multiple times "
+                                f"under conflicting satisfied 'when' conditions:\n"
+                                f"  1) {sorted(existing_when_set)}\n"
+                                f"  2) {sorted(when_set)}"
+                            )
+                        obj_satisfied_criteria[name] = (when_set, conf)
+
+                for criteria, (_, conf) in obj_satisfied_criteria.items():
+                    if criteria in resolved_criteria:
+                        continue
+
+                    resolved_criteria[criteria] = prec
                     if conf["mode"] == "string":
                         match = (
                             self.expander.expand_var(conf["match"])
@@ -3675,12 +3694,13 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                             owning_object=obj_inst,
                         )
 
-        criteria_list.add_criteria(
-            scope="object_definitions",
-            name="_application_function",
-            mode="application_function",
-            owning_object=self,
-        )
+        if "_application_function" not in resolved_criteria:
+            criteria_list.add_criteria(
+                scope="object_definitions",
+                name="_application_function",
+                mode="application_function",
+                owning_object=self,
+            )
 
         # Extract file paths for all criteria
         for criteria, _ in criteria_list.all_criteria():

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -3679,15 +3679,34 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         # Add the object defined criteria
         criteria_list.flush_scope("object_definitions")
 
-        for _, obj_inst in self.objects():
+        resolved_criteria = {crit.name: -1 for crit, _ in criteria_list.all_criteria()}
+
+        for prec, (_, obj_inst) in enumerate(self.objects()):
             if obj_inst.success_criteria:
-                for criteria, conf in obj_inst.success_criteria.items():
+                obj_satisfied_criteria = {}
+                for when_set, criteria_dict in obj_inst.success_criteria.items():
                     if not self.expander.satisfies(
-                        conf["when"],
+                        when_set,
                         variant_set=obj_inst.experiment_variants(),
                     ):
                         continue
 
+                    for name, conf in criteria_dict.items():
+                        if name in obj_satisfied_criteria:
+                            existing_when_set = obj_satisfied_criteria[name][0]
+                            logger.die(
+                                f"Success criteria '{name}' in object '{obj_inst.name}' is defined multiple times "
+                                f"under conflicting satisfied 'when' conditions:\n"
+                                f"  1) {sorted(existing_when_set)}\n"
+                                f"  2) {sorted(when_set)}"
+                            )
+                        obj_satisfied_criteria[name] = (when_set, conf)
+
+                for criteria, (_, conf) in obj_satisfied_criteria.items():
+                    if criteria in resolved_criteria:
+                        continue
+
+                    resolved_criteria[criteria] = prec
                     if conf["mode"] == "string":
                         match = (
                             self.expander.expand_var(conf["match"])
@@ -3719,12 +3738,13 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                             owning_object=obj_inst,
                         )
 
-        criteria_list.add_criteria(
-            scope="object_definitions",
-            name="_application_function",
-            mode="application_function",
-            owning_object=self,
-        )
+        if "_application_function" not in resolved_criteria:
+            criteria_list.add_criteria(
+                scope="object_definitions",
+                name="_application_function",
+                mode="application_function",
+                owning_object=self,
+            )
 
         # Extract file paths for all criteria
         for criteria, _ in criteria_list.all_criteria():

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -3679,7 +3679,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         # Add the object defined criteria
         criteria_list.flush_scope("object_definitions")
 
-        resolved_criteria = {crit.name: -1 for crit, _ in criteria_list.all_criteria()}
+        resolved_criteria = {crit.name for crit, _ in criteria_list.all_criteria()}
 
         for prec, (_, obj_inst) in enumerate(self.objects()):
             if obj_inst.success_criteria:
@@ -3706,7 +3706,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                     if criteria in resolved_criteria:
                         continue
 
-                    resolved_criteria[criteria] = prec
+                    resolved_criteria.add(criteria)
                     if conf["mode"] == "string":
                         match = (
                             self.expander.expand_var(conf["match"])

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -3679,12 +3679,17 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         # Add the object defined criteria
         criteria_list.flush_scope("object_definitions")
 
-        resolved_criteria = {crit.name for crit, _ in criteria_list.all_criteria()}
+        resolved_criteria = {
+            crit.name for crit, _ in criteria_list.all_criteria()
+        }
 
-        for prec, (_, obj_inst) in enumerate(self.objects()):
+        for _, obj_inst in self.objects():
             if obj_inst.success_criteria:
                 obj_satisfied_criteria = {}
-                for when_set, criteria_dict in obj_inst.success_criteria.items():
+                for (
+                    when_set,
+                    criteria_dict,
+                ) in obj_inst.success_criteria.items():
                     if not self.expander.satisfies(
                         when_set,
                         variant_set=obj_inst.experiment_variants(),


### PR DESCRIPTION
Currently, `success_criteria` allows for scoping via `when` clauses, but definitions of these criteria are not properly tracked in the `success_criteria` dict. In cases where multiple `when` clauses are satisfied and define the same criteria name, this leads to the last defined criteria winning. This fix properly tracks satisfying `when` conditions selecting the highest precedence criteria.

In the case where multiple `when` conditions are satisfied at the same precedence, ramble will now throw an error. Because of this, the WRF application was also fixed as it defined both an unscoped "Complete" criteria and one for specific WRF versions. The versioned definitions are mutually exclusive, but the unscoped criteria would always be satisfied resulting in a conflict between it and the satisfied versioned criteria.