### PR TITLE
mirror/repo removal should default to default_list_scope()

### DIFF
--- a/lib/ramble/ramble/cmd/mirror.py
+++ b/lib/ramble/ramble/cmd/mirror.py
@@ -65,7 +65,7 @@ def setup_parser(subparser):
         "--scope",
         choices=scopes,
         metavar=scopes_metavar,
-        default=ramble.config.default_modify_scope(),
+        default=ramble.config.default_list_scope(),
         help="configuration scope to modify",
     )
 

--- a/lib/ramble/ramble/cmd/repo.py
+++ b/lib/ramble/ramble/cmd/repo.py
@@ -90,7 +90,7 @@ def setup_parser(subparser):
         "--scope",
         choices=scopes,
         metavar=scopes_metavar,
-        default=ramble.config.default_modify_scope(),
+        default=ramble.config.default_list_scope(),
         help="configuration scope to modify",
     )
     ramble.cmd.common.arguments.add_common_arguments(remove_parser, ["repo_type"])


### PR DESCRIPTION
This fixes a bug where a repo or mirror added at a low scope (e.g., user) is then tried to be removed when a higher scope (e.g., workspace) is then active. Listing the repos/mirros would show the corresponding elements but trying to remove them would fail. Instead of the removal parser defaulting to the current modify scope, it now defaults to the list scope (i.e., `None`).