### PR TITLE
Respect archive_patterns for workflow manager

### DIFF
--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -3008,13 +3008,9 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
                     shutil.copy(file, archive_experiment_dir)
 
             # Copy all archive patterns
-            archive_patterns = set(self.archive_patterns.keys())
-            if self.package_manager:
-                for pattern in self.package_manager.archive_patterns:
-                    archive_patterns.add(pattern)
-
-            for mod in self._modifier_instances:
-                for pattern in mod.archive_patterns:
+            archive_patterns = set()
+            for _, obj_inst in self.objects():
+                for pattern in getattr(obj_inst, "archive_patterns", {}):
                     archive_patterns.add(pattern)
 
             for pattern in archive_patterns:

--- a/var/ramble/repos/builtin/workflow_managers/slurm/test/slurm.py
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/test/slurm.py
@@ -246,3 +246,56 @@ ramble:
         assert "#SBATCH --exclusive" not in content
         assert "#SBATCH --gpus-per-task" not in content
         assert "#SBATCH -N 1" in content
+
+
+def test_slurm_archive_patterns(make_workspace_from_config):
+    test_config = """
+ramble:
+  variants:
+    workflow_manager: slurm
+  variables:
+    processes_per_node: 1
+    n_nodes: 1
+  applications:
+    hostname:
+      workloads:
+        local:
+          experiments:
+            test: {}
+"""
+    ws, _ = make_workspace_from_config(test_config)
+
+    workspace("setup", "--dry-run", global_args=["-D", ws.root])
+
+    experiment_dir = os.path.join(
+        ws.experiment_dir, "hostname", "local", "test"
+    )
+    assert os.path.exists(
+        os.path.join(experiment_dir, "slurm_experiment_sbatch")
+    )
+
+    slurm_files = [
+        ".slurm_job",
+        ".slurm_job_info",
+        ".slurm_config",
+        ".slurm_script_end_time",
+    ]
+    for filename in slurm_files:
+        filepath = os.path.join(experiment_dir, filename)
+        with open(filepath, "w", encoding="utf-8") as f:
+            f.write(f"Content of {filename}")
+
+    workspace("archive", global_args=["-D", ws.root])
+
+    assert os.path.exists(ws.latest_archive_path)
+
+    for filename in slurm_files:
+        archived_path = os.path.join(
+            ws.latest_archive_path,
+            "experiments",
+            "hostname",
+            "local",
+            "test",
+            filename,
+        )
+        assert os.path.isfile(archived_path)

--- a/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
+++ b/var/ramble/repos/builtin/workflow_managers/slurm/workflow_manager.py
@@ -176,6 +176,8 @@ class Slurm(WorkflowManagerBase):
         dest_path="batch_helpers",
     )
 
+    archive_pattern("{experiment_run_dir}/.slurm_*")
+
     @property
     def template_render_vars(self):
         vars = {}


### PR DESCRIPTION
Also add in an archive_pattern for the slurm workflow manager, to capture some useful dot files.