### PR TITLE
allow additional warnings for none unique experiments [AI]

### DIFF
--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -637,7 +637,7 @@ class ExperimentSet:
             logger.debug(f"   Final name: {final_exp_namespace}")
 
             if final_exp_namespace in self.rendered_experiments:
-                left_inst = self.experiments[final_exp_namespace]
+                left_inst = self.get_experiment(final_exp_namespace)
                 left_vars = left_inst.variables
                 right_vars = app_inst.variables
                 lkeys = set(left_vars.keys())
@@ -649,15 +649,14 @@ class ExperimentSet:
                 common_vars = lkeys & rkeys
 
                 independent_vars = set()
-                if "render_group" in locals():
-                    for matrix in render_group.matrices:
-                        for var_or_zip in matrix:
-                            if var_or_zip in render_group.zips:
-                                independent_vars.update(render_group.zips[var_or_zip])
-                            else:
-                                independent_vars.add(var_or_zip)
-                    for zip_vars in render_group.zips.values():
-                        independent_vars.update(zip_vars)
+                for matrix in render_group.matrices:
+                    for var_or_zip in matrix:
+                        if var_or_zip in render_group.zips:
+                            independent_vars.update(render_group.zips[var_or_zip])
+                        else:
+                            independent_vars.add(var_or_zip)
+                for zip_vars in render_group.zips.values():
+                    independent_vars.update(zip_vars)
 
                 for var, val in final_context.variables.items():
                     if isinstance(val, list):

--- a/lib/ramble/ramble/experiment_set.py
+++ b/lib/ramble/ramble/experiment_set.py
@@ -637,7 +637,8 @@ class ExperimentSet:
             logger.debug(f"   Final name: {final_exp_namespace}")
 
             if final_exp_namespace in self.rendered_experiments:
-                left_vars = self.experiments[final_exp_namespace].variables
+                left_inst = self.experiments[final_exp_namespace]
+                left_vars = left_inst.variables
                 right_vars = app_inst.variables
                 lkeys = set(left_vars.keys())
                 rkeys = set(right_vars.keys())
@@ -647,7 +648,55 @@ class ExperimentSet:
                 right_unique_vars = rkeys - lkeys
                 common_vars = lkeys & rkeys
 
+                independent_vars = set()
+                if "render_group" in locals():
+                    for matrix in render_group.matrices:
+                        for var_or_zip in matrix:
+                            if var_or_zip in render_group.zips:
+                                independent_vars.update(render_group.zips[var_or_zip])
+                            else:
+                                independent_vars.add(var_or_zip)
+                    for zip_vars in render_group.zips.values():
+                        independent_vars.update(zip_vars)
+
+                for var, val in final_context.variables.items():
+                    if isinstance(val, list):
+                        independent_vars.add(var)
+
+                differing_independent_vars = [
+                    var
+                    for var in independent_vars
+                    if var in left_vars and var in right_vars and left_vars[var] != right_vars[var]
+                ]
+
+                missing_vars = [
+                    var
+                    for var in differing_independent_vars
+                    if var not in app_inst.expander._used_variables
+                ]
+
                 logger.warn(f"Two experiments are defined with the name {final_exp_namespace}")
+
+                exp_template_var = self.keywords.experiment_template_name
+                prev_block = left_vars.get(exp_template_var, "unknown")
+                new_block = right_vars.get(exp_template_var, "unknown")
+
+                if prev_block != new_block:
+                    logger.warn(
+                        "  -> Collision Origin: Across different YAML "
+                        f"experiment blocks: '{prev_block}' vs '{new_block}'"
+                    )
+                elif independent_vars:
+                    logger.warn(
+                        "  -> Collision Origin: Within the same YAML "
+                        f"experiment block: '{prev_block}' "
+                        "(Matrix/Vector Expansion)"
+                    )
+                else:
+                    logger.warn(
+                        "  -> Collision Origin: Static definition "
+                        "(No Matrix/Vector expansion active)"
+                    )
 
                 # Print warnings about experiment differences
                 if left_unique_vars:
@@ -669,6 +718,33 @@ class ExperimentSet:
 
                         diff = {"previous": left_vars[var], "new": right_vars[var]}
                         logger.warn(f"  - {var}: {diff}")
+
+                if missing_vars:
+                    logger.warn("")
+                    logger.warn(
+                        "==> SUGGESTION: Your experiment name template "
+                        "does not distinguish between parallel expansions."
+                    )
+                    logger.warn(
+                        "    To make the namespaces unique, add one or more "
+                        "of these differing matrix variables into your "
+                        f"'{prev_block}' template:"
+                    )
+                    for var in missing_vars:
+                        logger.warn(f"    -> {{{var}}}")
+                    logger.warn("")
+                elif not independent_vars and prev_block == new_block:
+                    logger.warn("")
+                    logger.warn(
+                        "==> SUGGESTION: Multiple distinct experiment "
+                        "blocks in your YAML are using the same literal name."
+                    )
+                    logger.warn(
+                        "    Rename one of the "
+                        f"'{prev_block}' experiment blocks in your "
+                        "YAML file."
+                    )
+                    logger.warn("")
 
                 logger.die(f"Experiment {final_exp_namespace} is not unique.")
 

--- a/lib/ramble/ramble/test/experiment_set.py
+++ b/lib/ramble/ramble/test/experiment_set.py
@@ -166,6 +166,143 @@ def test_nonunique_vector_errors(workspace_name, capsys):
         assert "is not unique." in captured
 
 
+def test_collision_across_different_blocks(workspace_name, capsys):
+    workspace("create", workspace_name)
+
+    assert workspace_name in workspace("list")
+
+    with ramble.workspace.read(workspace_name) as ws:
+        exp_set = ramble.experiment_set.ExperimentSet(ws)
+
+        application_context = ramble.context.Context()
+        application_context.context_name = "basic"
+        application_context.variables = {
+            "mpi_command": "",
+            "batch_submit": "",
+        }
+
+        workload_context = ramble.context.Context()
+        workload_context.context_name = "test_wl"
+
+        experiment_context1 = ramble.context.Context()
+        experiment_context1.context_name = "collision_{my_var1}"
+        experiment_context1.variables = {"my_var1": "foo", "my_var2": "bar"}
+
+        experiment_context2 = ramble.context.Context()
+        experiment_context2.context_name = "collision_{my_var2}"
+        experiment_context2.variables = {
+            "my_var1": "baz",
+            "my_var2": "foo",
+            "unique_to_right": "yes",
+        }
+
+        exp_set.set_application_context(application_context)
+        exp_set.set_workload_context(workload_context)
+
+        # Ingest the first experiment
+        exp_set.set_experiment_context(experiment_context1)
+
+        # Ingest the second experiment, which should trigger collision
+        with pytest.raises(SystemExit):
+            exp_set.set_experiment_context(experiment_context2)
+
+        captured = capsys.readouterr().err
+        assert "is not unique." in captured
+        assert (
+            "Collision Origin: Across different YAML "
+            "experiment blocks: 'collision_{my_var1}' vs 'collision_{my_var2}'" in captured
+        )
+
+        assert "Variables unique to newly defined experiment:" in captured
+        assert "unique_to_right" in captured
+
+
+def test_collision_static_definition(workspace_name, capsys):
+    workspace("create", workspace_name)
+
+    assert workspace_name in workspace("list")
+
+    with ramble.workspace.read(workspace_name) as ws:
+        exp_set = ramble.experiment_set.ExperimentSet(ws)
+
+        application_context = ramble.context.Context()
+        application_context.context_name = "basic"
+        application_context.variables = {
+            "mpi_command": "",
+            "batch_submit": "",
+        }
+
+        workload_context = ramble.context.Context()
+        workload_context.context_name = "test_wl"
+
+        experiment_context1 = ramble.context.Context()
+        experiment_context1.context_name = "static_collision"
+
+        experiment_context2 = ramble.context.Context()
+        experiment_context2.context_name = "static_collision"
+
+        exp_set.set_application_context(application_context)
+        exp_set.set_workload_context(workload_context)
+
+        # Ingest the first experiment
+        exp_set.set_experiment_context(experiment_context1)
+
+        # Ingest the second experiment, which should trigger collision
+        with pytest.raises(SystemExit):
+            exp_set.set_experiment_context(experiment_context2)
+
+        captured = capsys.readouterr().err
+        assert "is not unique." in captured
+        assert (
+            "Collision Origin: Static definition (No Matrix/Vector expansion active)" in captured
+        )
+        assert (
+            "Multiple distinct experiment blocks in your YAML are using the same literal name."
+            in captured
+        )
+
+
+def test_collision_matrix_and_zip(workspace_name, capsys):
+    workspace("create", workspace_name)
+
+    assert workspace_name in workspace("list")
+
+    with ramble.workspace.read(workspace_name) as ws:
+        exp_set = ramble.experiment_set.ExperimentSet(ws)
+
+        application_context = ramble.context.Context()
+        application_context.context_name = "basic"
+        application_context.variables = {
+            "mpi_command": "",
+            "batch_submit": "",
+        }
+
+        workload_context = ramble.context.Context()
+        workload_context.context_name = "test_wl"
+
+        experiment_context = ramble.context.Context()
+        # Name template does not use the matrix/zip variables, so they will collide
+        experiment_context.context_name = "collision_matrix"
+        experiment_context.variables = {
+            "var_a": ["1", "2"],
+            "var_b": ["a", "b"],
+            "var_c": ["x", "y"],
+        }
+        experiment_context.zips = {"my_zip": ["var_b", "var_c"]}
+        experiment_context.matrices = [["var_a", "my_zip"]]
+
+        exp_set.set_application_context(application_context)
+        exp_set.set_workload_context(workload_context)
+
+        with pytest.raises(SystemExit):
+            exp_set.set_experiment_context(experiment_context)
+
+        captured = capsys.readouterr().err
+        assert "is not unique." in captured
+        assert "var_b" in captured
+        assert "var_c" in captured
+
+
 def test_zipped_vector_experiments(workspace_name):
     workspace("create", workspace_name)
 


### PR DESCRIPTION
This PR adds some explicit warnings that try call out what happens if you have colliding yaml defintions:


  ### 1. Matrix/Vector Expansion Collision

  This happens when you expand an experiment using vectors/matrices (e.g.  var_b  and  var_c ), but your name template does not use them, resulting in duplicate experiment namespaces.
```
              experiments:
                collision_matrix:
                  variables:
                    var_b: ['a', 'b']
                    var_c: ['x', 'y']
                  zips:
                    my_zip:
                      - var_b
                      - var_c
                  matrix:
                    - my_zip               
```
yeilds:
```
    ==> Warning: Two experiments are defined with the name basic.test_wl.collision_matrix
    ==> Warning:   -> Collision Origin: Within the same YAML experiment block: 'collision_matrix' (Matrix/Vector Expansion)
    ==> Warning: Variable differences between experiment definitions:
    ==> Warning:   - var_b: {'previous': 'a', 'new': 'b'}
    ==> Warning:   - var_c: {'previous': 'x', 'new': 'y'}
    ==> Warning:
    ==> Warning: ==> SUGGESTION: Your experiment name template does not distinguish between parallel expansions.
    ==> Warning:     To make the namespaces unique, add one or more of these differing matrix variables into your 'collision_matrix' template:
    ==> Warning:     -> {var_b}
    ==> Warning:     -> {var_c}
    ==> Warning:
    ==> Error: Experiment basic.test_wl.collision_matrix is not unique.
    ──────
```
  ### 2. Collision Across Different YAML Experiment Blocks

  This happens when you have two distinct experiment blocks in your YAML (e.g.  collision_{my_var1}  and  collision_{my_var2} ) that end up evaluating to the exact same final experiment name.

```
            test_wl:
              experiments:
                collision_{my_var1}:
    		  variables:
                    my_var1: 'foo'
                    my_var2: 'bar'
                collision_{my_var2}:
    		  variables:
                    my_var1: 'baz'
                    my_var2: 'foo'
                    unique_to_right: 'yes'
```
yeilds
```
    ==> Warning: Two experiments are defined with the name basic.test_wl.collision_foo
    ==> Warning:   -> Collision Origin: Across different YAML experiment blocks: 'collision_{my_var1}' vs 'collision_{my_var2}'
    ==> Warning: Variables unique to newly defined experiment:
    ==> Warning:   - unique_to_right
    ==> Warning: Variable differences between experiment definitions:
    ==> Warning:   - my_var1: {'previous': 'foo', 'new': 'baz'}
    ==> Warning:   - my_var2: {'previous': 'bar', 'new': 'foo'}
    ==> Warning:
    ==> Error: Experiment basic.test_wl.collision_foo is not unique.
    ──────
 ```
### 3. Static Definition Collision

  This happens when you have two static (un-expanded) experiment definitions in your YAML using the exact same literal name.

```
    # Inherited or defined via a template workspace:
    # experiments:
    #   static_collision:
    #     variables:
    #       var: 'original'

    # In your local ramble.yaml:
    ramble:
      variables:
        mpi_command: ''
        batch_submit: '{execute_experiment}'

      applications:
        basic:
          workloads:
            test_wl:
              experiments:
                static_collision:
                  variables:
                    var: 'new'
```
yields
```
    ==> Warning: Two experiments are defined with the name basic.test_wl.static_collision
    ==> Warning:   -> Collision Origin: Static definition (No Matrix/Vector expansion active)
    ==> Warning:
    ==> Warning: ==> SUGGESTION: Multiple distinct experiment blocks in your YAML are using the same literal name.
    ==> Warning:     Rename one of the 'static_collision' experiment blocks in your YAML file.
    ==> Warning:
    ==> Error: Experiment basic.test_wl.static_collision is not unique.
```