### PR TITLE
Add a multichase application

### DIFF
--- a/var/ramble/repos/builtin/applications/multichase/application.py
+++ b/var/ramble/repos/builtin/applications/multichase/application.py
@@ -1,0 +1,118 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.appkit import *
+
+_LATENCY_REGEX = r"^\s*(?P<latency>[0-9\.]+)\s*$"
+
+
+class Multichase(ExecutableApplication):
+    """Multichase pointer chaser benchmark.
+
+    Includes a latency workload that benchmarks latency for a given array size.
+    """
+
+    name = "multichase"
+
+    maintainers("linsword")
+
+    tags("benchmark", "memory", "latency", "bandwidth")
+
+    with when("package_manager_family=spack"):
+        define_compiler("gcc", pkg_spec="gcc")
+        software_spec(
+            "multichase",
+            pkg_spec="multichase",
+            compiler="gcc",
+        )
+        required_package("multichase")
+
+    executable(
+        "execute",
+        "{multichase_bin} -m {array_size} {additional_args}",
+        use_mpi=False,
+    )
+
+    # Workloads
+    workload("latency", executable="execute")
+
+    # Workload variables for latency
+    workload_variable(
+        "multichase_bin",
+        default="multichase",
+        description="Path or binary name for multichase",
+        workloads=["latency"],
+    )
+    workload_variable(
+        "array_size",
+        default="1g",
+        description="Array size for pointer chasing",
+        workloads=["latency"],
+    )
+    workload_variable(
+        "stride",
+        default="256",
+        description="Stride size in bytes",
+        workloads=["latency"],
+    )
+    workload_variable(
+        "threads",
+        default="1",
+        description="Number of threads",
+        workloads=["latency"],
+    )
+    workload_variable(
+        "samples",
+        default="5",
+        description="Number of 0.5 second samples",
+        workloads=["latency"],
+    )
+    workload_variable(
+        "additional_args",
+        default="-s {stride} -t {threads} -n {samples}",
+        description="Additional arguments for multichase",
+        workloads=["latency"],
+    )
+
+    register_validator(
+        name="single_node",
+        predicate="{n_nodes} == 1",
+        message=(
+            "The multichase application is intended to be used on a single "
+            "node, but is configured with n_nodes = {n_nodes}"
+        ),
+        fail_on_invalid=False,
+    )
+
+    with when("workload_name=latency"):
+        figure_of_merit(
+            "Multichase Best Latency",
+            fom_regex=_LATENCY_REGEX,
+            group_name="latency",
+            units="ns",
+        )
+        figure_of_merit(
+            "Array Size",
+            fom_map_key="array_size_bytes",
+            units="bytes",
+        )
+
+    def _prepare_analysis(self, workspace, app_inst=None):
+        def _parse_size_bytes(size_str):
+            s = str(size_str).strip().lower()
+            units = {"k": 1024, "m": 1024**2, "g": 1024**3, "t": 1024**4}
+            if s and s[-1] in units:
+                return int(float(s[:-1]) * units[s[-1]])
+            return int(float(s))
+
+        array_size_str = self.expander.expand_var("{array_size}")
+        try:
+            array_size_bytes = _parse_size_bytes(array_size_str)
+            self.add_inmem_fom_value("array_size_bytes", array_size_bytes)
+        except ValueError:
+            pass


### PR DESCRIPTION
The corresponding spack package has been merged: https://github.com/spack/spack-packages/pull/5543.
    
As an example, to generate a study of memory hierarchy latency plot:
    
1. Create a workspace with the following config:
    
    ```
    ramble:
      variants:
        package_manager: spack
        workflow_manager: slurm
      variables:
        n_nodes: 1
        processes_per_node: 1
        slurm_partition: h4dhighmemlssd
        extra_sbatch_headers: |
          #SBATCH --nodelist=hpcperf-h4dnodeset-0
      applications:
        multichase:
          workloads:
            latency:
              experiments:
                size_{array_size}:
                  variables:
                    array_size: [4k, 8k, 16k, 32k, 64k, 128k, 256k, 512k, 1m, 2m, 4m, 8m, 16m, 32m, 64m, 128m, 256m, 512m, 1g]
      software:
        packages:
          gcc15:
            pkg_spec: gcc@15.2.0
          multichase:
            pkg_spec: multichase@master target=zen5
            compiler: gcc15
        environments:
          multichase:
            packages:
              - multichase
    
    ```
    
2. Run the experiments and generate the json results
    
    ```
    ramble workspace setup
    ramble on
    ramble workspace analyze -f json
    ```
    
3. Generate the report and the plot
    
    ```
    ramble results report --multi-line "Multichase Best Latency" "Array Size" --logx --logy
    ```
    
The generated plot is attached.
<img width="1200" height="800" alt="multi_line_Multichase-Best-Latency_vs_Array-Size_all-series" src="https://github.com/user-attachments/assets/8c78688c-22fa-43b4-9ecf-977b29204cca" />

