### PR TITLE
Allow archive untarred workspace

### DIFF
--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -1327,7 +1327,10 @@ def workspace_archive_setup_parser(subparser):
         "-u",
         dest="upload_url",
         default=None,
-        help="URL to upload tar archive into. Does nothing if `-t` is not specified.",
+        help=(
+            "URL to upload workspace archive into "
+            "(uploads tarball if -t is set, or uncompressed folder if omitted)."
+        ),
     )
 
     subparser.add_argument(

--- a/lib/ramble/ramble/config.py
+++ b/lib/ramble/ramble/config.py
@@ -216,6 +216,7 @@ config_defaults = {
         "input_cache": "$ramble/var/ramble/cache",
         "workspace_dirs": ["$ramble/var/ramble/workspaces"],
         "upload": {"push_failed": True},
+        "upload_threads": cpus.cpus_available(),
         "report_dirs": "~/.ramble/reports",
         "enable_strict_versions": True,
     }

--- a/lib/ramble/ramble/pipeline.py
+++ b/lib/ramble/ramble/pipeline.py
@@ -361,11 +361,6 @@ class ArchivePipeline(Pipeline):
         self.archive_name = None
         self.archive_patterns = archive_patterns.copy() if archive_patterns else []
 
-        if self.upload_url and not self.create_tar:
-            logger.warn("Upload URL is currently only supported when using tar format (-t)")
-            logger.warn("Forcing `-t` on to enable archive upload.\n")
-            self.create_tar = True
-
     def _prepare(self):
         super()._prepare()
         date_str = self.workspace.date_string()
@@ -452,17 +447,17 @@ class ArchivePipeline(Pipeline):
 
     def _complete(self):
         super()._complete()
+        archive_url = (
+            self.upload_url if self.upload_url else ramble.config.get("config:archive_url")
+        )
+        archive_url = archive_url.rstrip("/") if archive_url else None
+
         if self.create_tar:
             tar_extension = ".tar.gz"
             tar = which("tar", required=True)
             tar_path = self.archive_name + tar_extension
             with fs.working_dir(self.workspace.archive_dir):
                 tar("-czf", tar_path, self.archive_name)
-
-            archive_url = (
-                self.upload_url if self.upload_url else ramble.config.get("config:archive_url")
-            )
-            archive_url = archive_url.rstrip("/") if archive_url else None
 
             tar_path_latest = os.path.join(
                 self.workspace.archive_dir, "archive.latest" + tar_extension
@@ -481,6 +476,19 @@ class ArchivePipeline(Pipeline):
 
                 # Record upload URL to workspace metadata
                 self.workspace.update_metadata("archive_url", remote_tar_path)
+                self.workspace.write_metadata()
+        else:
+            logger.debug(f"Archive url: {archive_url}")
+
+            if archive_url:
+                import ramble.util.web as web_util
+
+                remote_dir_path = archive_url + "/" + self.workspace.latest_archive
+                web_util.push_dir_to_url(self.workspace.latest_archive_path, remote_dir_path)
+                logger.all_msg(f"Uncompressed Archive Uploaded to {remote_dir_path}")
+
+                # Record upload URL to workspace metadata
+                self.workspace.update_metadata("archive_url", remote_dir_path)
                 self.workspace.write_metadata()
 
 

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -1967,6 +1967,46 @@ ramble:
     assert os.path.exists(os.path.join(remote_archive_path, ws1.latest_archive + ".tar.gz"))
 
 
+def test_workspace_uncompressed_upload_archive(make_workspace_from_config):
+    test_config = """
+ramble:
+  variables:
+    mpi_command: 'mpirun -n {n_ranks} -ppn {processes_per_node}'
+    batch_submit: 'batch_submit {execute_experiment}'
+    processes_per_node: 5
+  applications:
+    basic:
+      workloads:
+        test_wl:
+          experiments:
+            test_experiment:
+              variables:
+                n_nodes: 2
+  software:
+    packages: {}
+    environments: {}
+"""
+
+    ws1, workspace_name = make_workspace_from_config(test_config)
+
+    workspace("setup", "--dry-run", global_args=["-w", workspace_name])
+
+    remote_archive_path = os.path.join(ws1.root, "uncompressed_archive_backup")
+    fs.mkdirp(remote_archive_path)
+
+    workspace("archive", "-u", "file://" + remote_archive_path, global_args=["-w", workspace_name])
+
+    assert ws1.latest_archive
+    assert os.path.exists(ws1.latest_archive_path)
+    assert not os.path.exists(ws1.latest_archive_path + ".tar.gz")
+
+    remote_latest_dir = os.path.join(remote_archive_path, ws1.latest_archive)
+    assert os.path.exists(remote_latest_dir)
+    assert os.path.exists(
+        os.path.join(remote_latest_dir, "configs", ramble.workspace.CONFIG_FILE_NAME)
+    )
+
+
 def test_workspace_tar_upload_archive_config_url(workspace_name):
     test_config = """
 ramble:

--- a/lib/ramble/ramble/test/util/web.py
+++ b/lib/ramble/ramble/test/util/web.py
@@ -186,3 +186,29 @@ def test_push_dir_to_url_gcs(monkeypatch, tmpdir):
     assert "file1.txt" in uploaded_args["filenames"]
     assert uploaded_args["source_directory"] == str(local_dir)
     assert uploaded_args["blob_name_prefix"] == "prefix/path/"
+
+
+def test_check_push_scheme():
+    url_file = web.check_push_scheme("file:///path/to/file")
+    assert url_file.scheme == "file"
+
+    url_s3 = web.check_push_scheme("s3://bucket/key")
+    assert url_s3.scheme == "s3"
+
+    url_gs = web.check_push_scheme("gs://bucket/key")
+    assert url_gs.scheme == "gs"
+
+    with pytest.raises(NotImplementedError, match="Unrecognized URL scheme: http"):
+        web.check_push_scheme("http://example.com/file")
+
+    with pytest.raises(NotImplementedError, match="Unrecognized URL scheme: ftp"):
+        web.check_push_scheme("ftp://example.com/file")
+
+
+def test_push_dir_to_url_unsupported_scheme(tmpdir):
+    local_dir = tmpdir.mkdir("src_dir")
+    f1 = local_dir.join("file1.txt")
+    f1.write("content")
+
+    with pytest.raises(NotImplementedError, match="Unrecognized URL scheme: http"):
+        web.push_dir_to_url(str(local_dir), "http://example.com/remote_dir")

--- a/lib/ramble/ramble/test/util/web.py
+++ b/lib/ramble/ramble/test/util/web.py
@@ -128,3 +128,61 @@ def test_remove_url_file(tmpdir):
     f.write("content")
     web.remove_url(f"file://{str(d)}", recursive=True)
     assert not d.exists()
+
+
+def test_push_dir_to_url_file(tmpdir):
+    local_dir = tmpdir.mkdir("src_dir")
+    f1 = local_dir.join("file1.txt")
+    f1.write("data1")
+    sub_dir = local_dir.mkdir("subdir")
+    f2 = sub_dir.join("file2.txt")
+    f2.write("data2")
+
+    remote_dir = tmpdir.mkdir("dest_dir")
+    dest_url = f"file://{str(remote_dir)}"
+
+    web.push_dir_to_url(str(local_dir), dest_url)
+
+    assert remote_dir.join("file1.txt").exists()
+    assert remote_dir.join("file1.txt").read() == "data1"
+    assert remote_dir.join("subdir").join("file2.txt").exists()
+    assert remote_dir.join("subdir").join("file2.txt").read() == "data2"
+
+
+def test_push_dir_to_url_gcs(monkeypatch, tmpdir):
+    local_dir = tmpdir.mkdir("src_gcs_dir")
+    f1 = local_dir.join("file1.txt")
+    f1.write("data1")
+
+    uploaded_args = {}
+
+    class MockGCSBucket:
+        def __init__(self, url):
+            self.bucket = "mock_bucket_obj"
+
+        def exists(self):
+            return True
+
+        def create(self):
+            pass
+
+    def mock_upload_many(bucket, filenames, source_directory, blob_name_prefix, **kwargs):
+        uploaded_args["bucket"] = bucket
+        uploaded_args["filenames"] = filenames
+        uploaded_args["source_directory"] = source_directory
+        uploaded_args["blob_name_prefix"] = blob_name_prefix
+        uploaded_args.update(kwargs)
+
+    import google.cloud.storage.transfer_manager as tm
+
+    import spack.util.gcs as gcs_util
+
+    monkeypatch.setattr(gcs_util, "GCSBucket", MockGCSBucket)
+    monkeypatch.setattr(tm, "upload_many_from_filenames", mock_upload_many)
+
+    web.push_dir_to_url(str(local_dir), "gs://mock-bucket/prefix/path")
+
+    assert uploaded_args["bucket"] == "mock_bucket_obj"
+    assert "file1.txt" in uploaded_args["filenames"]
+    assert uploaded_args["source_directory"] == str(local_dir)
+    assert uploaded_args["blob_name_prefix"] == "prefix/path/"

--- a/lib/ramble/ramble/util/web.py
+++ b/lib/ramble/ramble/util/web.py
@@ -6,6 +6,7 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+import concurrent.futures
 import errno
 import os
 import os.path
@@ -165,6 +166,65 @@ def push_to_url(local_file_path, remote_path, keep_original=True, extra_args=Non
 
     else:
         raise NotImplementedError(f"Unrecognized URL scheme: {remote_url.scheme}")
+
+
+def push_dir_to_url(local_dir_path, remote_dir_path, max_workers=None):
+    """Upload an entire directory tree recursively to a remote URL in parallel."""
+    if max_workers is None:
+        max_workers = ramble.config.get("config:upload_threads")
+
+    remote_url = url_util.parse(remote_dir_path)
+
+    if remote_url.scheme == "gs":
+        from google.cloud.storage import transfer_manager
+
+        gcs_bucket = gcs_util.GCSBucket(remote_url)
+        if not gcs_bucket.exists():
+            gcs_bucket.create()
+
+        rel_files = []
+        for root, _, files in os.walk(local_dir_path):
+            for file in files:
+                src_file = os.path.join(root, file)
+                rel_path = os.path.relpath(src_file, local_dir_path)
+                rel_files.append(rel_path)
+
+        if not rel_files:
+            return
+
+        prefix = remote_url.path.lstrip("/")
+        if prefix and not prefix.endswith("/"):
+            prefix += "/"
+
+        transfer_manager.upload_many_from_filenames(
+            gcs_bucket.bucket,
+            rel_files,
+            source_directory=local_dir_path,
+            blob_name_prefix=prefix,
+            worker_type="thread",
+            max_workers=max_workers,
+            raise_exception=True,
+        )
+        return
+
+    files_to_upload = []
+    for root, _, files in os.walk(local_dir_path):
+        for file in files:
+            src_file = os.path.join(root, file)
+            rel_path = os.path.relpath(src_file, local_dir_path)
+            dest_file = os.path.join(remote_dir_path, rel_path).replace("\\", "/")
+            files_to_upload.append((src_file, dest_file))
+
+    if not files_to_upload:
+        return
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = [
+            executor.submit(push_to_url, src, dest, keep_original=True)
+            for src, dest in files_to_upload
+        ]
+        for future in concurrent.futures.as_completed(futures):
+            future.result()
 
 
 def url_exists(url):

--- a/lib/ramble/ramble/util/web.py
+++ b/lib/ramble/ramble/util/web.py
@@ -117,11 +117,33 @@ def read_from_url(url, accept_content_type=None):
     return response.geturl(), response.headers, response
 
 
+def check_push_scheme(url):
+    """Validate that a URL scheme is supported for push operations.
+
+    Args:
+        url (str or urllib.parse.ParseResult): URL to check
+
+    Returns:
+        urllib.parse.ParseResult: Parsed URL object
+
+    Raises:
+        NotImplementedError: If the URL scheme is not supported for push operations
+    """
+    remote_url = url_util.parse(url)
+    if url_util.local_file_path(remote_url) is not None:
+        return remote_url
+
+    if remote_url.scheme in ("s3", "gs"):
+        return remote_url
+
+    raise NotImplementedError(f"Unrecognized URL scheme: {remote_url.scheme}")
+
+
 def push_to_url(local_file_path, remote_path, keep_original=True, extra_args=None):
     if sys.platform == "win32":
         if remote_path[1] == ":":
             remote_path = "file://" + remote_path
-    remote_url = url_util.parse(remote_path)
+    remote_url = check_push_scheme(remote_path)
     remote_file_path = url_util.local_file_path(remote_url)
     logger.debug(f"Trying to backup file to: {remote_file_path}")
     if remote_file_path is not None:
@@ -170,10 +192,10 @@ def push_to_url(local_file_path, remote_path, keep_original=True, extra_args=Non
 
 def push_dir_to_url(local_dir_path, remote_dir_path, max_workers=None):
     """Upload an entire directory tree recursively to a remote URL in parallel."""
+    remote_url = check_push_scheme(remote_dir_path)
+
     if max_workers is None:
         max_workers = ramble.config.get("config:upload_threads")
-
-    remote_url = url_util.parse(remote_dir_path)
 
     if remote_url.scheme == "gs":
         from google.cloud.storage import transfer_manager

--- a/lib/ramble/spack/schema/config.py
+++ b/lib/ramble/spack/schema/config.py
@@ -68,6 +68,7 @@ properties = {
             'dirty': {'type': 'boolean'},
             'build_language': {'type': 'string'},
             'build_jobs': {'type': 'integer', 'minimum': 1},
+            'upload_threads': {'type': 'integer', 'minimum': 1},
             'ccache': {'type': 'boolean'},
             'concretizer': {
                 'type': 'string',


### PR DESCRIPTION
When uploading to a GCS bucket, sometimes uploading an uncompressed directory is faster than uploading tar file, since the former can upload large objects in parallel.