### PR TITLE
fix issue where bootstaped spack was not used during workspace setup

### DIFF
--- a/lib/ramble/ramble/test/mock_spack_runner.py
+++ b/lib/ramble/ramble/test/mock_spack_runner.py
@@ -26,6 +26,7 @@ class MockPackageInfo:
 
 class MockSpackRunner:
     def __init__(self, **kwargs):
+        self.env = kwargs.get("env", None)
         self.env_path = None
         self.concretized = False
         self.dry_run = False

--- a/lib/ramble/ramble/util/command_runner.py
+++ b/lib/ramble/ramble/util/command_runner.py
@@ -44,11 +44,12 @@ class CommandRunner:
         if command is None:
             self.command = None
         else:
+            search_path = path if path is not None else (env.get("PATH") if env else None)
             try:
-                if path is None:
-                    self.command = which(command, required=required)
+                if search_path is not None:
+                    self.command = which(command, required=required, path=search_path)
                 else:
-                    self.command = which(command, required=required, path=path)
+                    self.command = which(command, required=required)
             except CommandNotFoundError:
                 raise RunnerError(f"Command {name} is not found in path") from None
 

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
@@ -59,11 +59,12 @@ class SpackLightweight(PackageManagerBase):
 
     @property
     def runner(self):
-        if self._runner is None:
-            env = None
-            app_inst = self._get_app_inst()
-            if hasattr(app_inst, "experiment_runner_env"):
-                env = app_inst.experiment_runner_env
+        env = None
+        app_inst = self._get_app_inst()
+        if hasattr(app_inst, "experiment_runner_env"):
+            env = app_inst.experiment_runner_env
+
+        if self._runner is None or self._runner.env != env:
             self._runner = SpackRunner(env=env)
         return self._runner
 


### PR DESCRIPTION
Resolves conflicts between Ramble's bootstrapped Spack (v0.22.0) and the user's home Spack
  installation:

(main fix)
  1. Fix Executable Path Resolution (command_runner.py): Updated CommandRunner to search for
  executables using the PATH provided in the env argument, rather than always falling back to the
  system PATH.

(caching issue)
  2. Invalidate Runner Cache (package_manager.py): Updated the runner property to invalidate and
  recreate the cached Spack runner when the execution environment changes (ensuring it switches to the
  bootstrapped path after the bootstrap phase).