### PR TITLE
Turn off build_utilities by default for tests

### DIFF
--- a/lib/ramble/ramble/test/data/config/config.yaml
+++ b/lib/ramble/ramble/test/data/config/config.yaml
@@ -1,5 +1,6 @@
 config:
     test_stage: ~/.ramble/test
+    bootstrap_utilities: false
     overwrite_inventories: false
     spack:
       install:

--- a/lib/ramble/ramble/test/test_workspace_bootstrap.py
+++ b/lib/ramble/ramble/test/test_workspace_bootstrap.py
@@ -8,6 +8,7 @@
 
 import os
 
+import ramble.config
 import ramble.filters
 import ramble.pipeline
 import ramble.workspace
@@ -67,7 +68,8 @@ def test_workspace_bootstrap_utilities(mutable_config, mutable_mock_workspace_pa
         }
 
         ws.dry_run = True
-        setup_pipeline.run()
+        with ramble.config.override("config:bootstrap_utilities", True):
+            setup_pipeline.run()
 
     print(
         "app_inst.required_utilities:",


### PR DESCRIPTION
Otherwise some tests may be long-running when they try to bootstrap (git clone) spack during the workspace setup phase.