### PR TITLE
Update ruff to the latest v0.16.0

### DIFF
--- a/lib/ramble/ramble/expander.py
+++ b/lib/ramble/ramble/expander.py
@@ -965,7 +965,7 @@ class Expander:
 
         """
         # Fast path for things that are likely paths
-        if in_str.startswith("/") or in_str.startswith("./"):
+        if in_str.startswith(("/", "./")):
             return in_str
 
         # Heuristic: if no math operators/keywords, it's probably a string. Skip parsing.

--- a/lib/ramble/ramble/test/test_deployment.py
+++ b/lib/ramble/ramble/test/test_deployment.py
@@ -49,7 +49,7 @@ class TestPushDeploymentPipeline(unittest.TestCase):
             deployment_name=self.deployment_name,
             create_tar=False,
         )
-        pipeline._deployment_files = lambda: []
+        pipeline._deployment_files = list
         pipeline._construct_experiment_hashes = lambda: False
         with mock.patch("ramble.expander.Expander.expand_var", return_value=self.deployment_name):
             pipeline._execute()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,7 +184,6 @@ extend-exclude = [
 
 [tool.ruff.lint]
 preview = true
-explicit-preview-rules = true
 # B905 requires Python 3.9 or up.
 ignore = ["B905", "PERF203"]
 select = [
@@ -193,10 +192,9 @@ select = [
     "B043",   # del-attr-with-constant
     "PLW1510",# subprocess-run-without-check
     "PLW1514",# unspecified-encoding
-    "PIE794", # duplicate-class-field-definition
-    "PIE796", # non-unique-enums
+    "PIE",    # flake8-pie
     "PT014",  # pytest-duplicate-parametrize-test-cases
-    "T100",   # debugger
+    "T10",    # flake8-debugger
     "RUF019", # unnecessary-key-check
     "PLC0206",# dict-index-missing-items
     "SIM118", # in-dict-keys
@@ -204,7 +202,7 @@ select = [
     "RUF015", # unnecessary-iterable-allocation
     "FURB192",# sorted-min-max
     "FURB118",# reimplemented-operator
-    "TID251", # banned imports
+    "TID",    # flake8-tidy-imports
 ]
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]

--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -6,4 +6,4 @@ mypy==2.3.0;python_version>="3.9"
 coverage==7.13.5;python_version>="3.9"
 codecov-cli==11.2.5;python_version>="3.9"
 line_profiler==5.0.2;python_version>="3.9"
-ruff==0.15.12
+ruff==0.16.0;python_version>="3.7"

--- a/share/ramble/qa/check_external_copyright.py
+++ b/share/ramble/qa/check_external_copyright.py
@@ -58,7 +58,7 @@ def main():
             actual_relative_paths.add(rel_path)
 
     for entry in os.listdir(external_dir):
-        if entry.startswith("__") or entry.startswith("."):
+        if entry.startswith(("__", ".")):
             continue
         full_path = os.path.join(external_dir, entry)
         rel_path = os.path.relpath(full_path, ramble_root)

--- a/var/ramble/repos/builtin/base_classes/object-mixin/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/object-mixin/base_class.py
@@ -165,7 +165,6 @@ class ObjectMixin:
 
     def set_required_variables(self, app_inst=None):
         """Stub that allows objects to update required variables"""
-        pass
 
     @staticmethod
     def version_to_pep440(version_str):

--- a/var/ramble/repos/builtin/base_classes/utility-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/utility-base/base_class.py
@@ -293,4 +293,3 @@ class UtilityBase(ObjectMixin, metaclass=UtilityMeta):
             workspace: The current workspace object
             app_inst: The application instance that triggered the bootstrap
         """
-        pass

--- a/var/ramble/repos/builtin/utilities/spack/utility.py
+++ b/var/ramble/repos/builtin/utilities/spack/utility.py
@@ -58,7 +58,6 @@ class Spack(UtilityBase):
     def install(self, workspace):
         # E.g., make, configure, etc.
         logger.debug(f"Executing install phase for {self.name}")
-        pass
 
     def is_available(self, workspace, min_version=None, max_version=None):
         """Check if spack is available in the user's environment."""


### PR DESCRIPTION
Also expand to enable more ruff rule sets. Make changes to the code accordingly to accommodate these new rule sets.