### PR TITLE
Specify location for cloud-build triggers

### DIFF
--- a/share/ramble/cloud-build/terraform/triggers/codecov.tf
+++ b/share/ramble/cloud-build/terraform/triggers/codecov.tf
@@ -8,6 +8,7 @@ locals {
 }
 
 resource "google_cloudbuild_trigger" "codecov_pr" {
+  location    = var.region
   name        = "Codecov-PR-Unit-Tests-${local.codecov_image.base}${replace(local.codecov_image.base_ver, ".", "-")}-py${replace(local.codecov_image.python, ".", "-")}-spack${replace(local.codecov_image.spack, ".", "-")}"
   description = "Run unit tests and linting on Ramble pull requests with Codecov upload"
 
@@ -44,6 +45,7 @@ resource "google_cloudbuild_trigger" "codecov_pr" {
 }
 
 resource "google_cloudbuild_trigger" "codecov_push" {
+  location    = var.region
   name        = "Codecov-BasePush-${local.codecov_image.base}${replace(local.codecov_image.base_ver, ".", "-")}-py${replace(local.codecov_image.python, ".", "-")}-spack${replace(local.codecov_image.spack, ".", "-")}"
   description = "Collect coverage information on develop or main pushes"
 

--- a/share/ramble/cloud-build/terraform/triggers/image_builds.tf
+++ b/share/ramble/cloud-build/terraform/triggers/image_builds.tf
@@ -1,6 +1,7 @@
 resource "google_cloudbuild_trigger" "image_builders" {
   for_each = local.image_map
 
+  location    = var.region
   name        = "ramble-image-builder-${each.value.base}${replace(each.value.base_ver, ".", "-")}-py${replace(each.value.python, ".", "-")}-spack${replace(each.value.spack, ".", "-")}"
   description = "Build Ramble cloud build image for ${each.value.base} ${each.value.base_ver} with Python ${each.value.python} and Spack ${each.value.spack}"
 

--- a/share/ramble/cloud-build/terraform/triggers/perf_tests.tf
+++ b/share/ramble/cloud-build/terraform/triggers/perf_tests.tf
@@ -3,6 +3,7 @@ locals {
 }
 
 resource "google_cloudbuild_trigger" "perf_test_pr" {
+  location    = var.region
   name        = "PerfTest-PR-${local.perf_test_img.base}${local.perf_test_img.base_ver}-${replace(local.perf_test_img.spack, ".", "-")}spack-${replace(local.perf_test_img.python, ".", "-")}python"
   description = "Ramble perf tests for PR builds"
 
@@ -42,6 +43,7 @@ resource "google_cloudbuild_trigger" "perf_test_pr" {
 }
 
 resource "google_cloudbuild_trigger" "perf_test_push" {
+  location    = var.region
   name        = "PerfTest-Push-${local.perf_test_img.base}${local.perf_test_img.base_ver}-${replace(local.perf_test_img.spack, ".", "-")}spack-${replace(local.perf_test_img.python, ".", "-")}python"
   description = "Continuous monitoring of Ramble performance for develop push"
 

--- a/share/ramble/cloud-build/terraform/triggers/pr_doc_build.tf
+++ b/share/ramble/cloud-build/terraform/triggers/pr_doc_build.tf
@@ -3,6 +3,7 @@ locals {
 }
 
 resource "google_cloudbuild_trigger" "pr_doc_build_tests" {
+  location    = var.region
   name        = "PR-Doc-Build-Tests"
   description = "A presubmit check for building Ramble documentation"
 

--- a/share/ramble/cloud-build/terraform/triggers/pr_image_build.tf
+++ b/share/ramble/cloud-build/terraform/triggers/pr_image_build.tf
@@ -1,4 +1,5 @@
 resource "google_cloudbuild_trigger" "pr_image_build_tests_debian" {
+  location    = var.region
   name        = "PR-Image-Build-Tests-Debian"
   description = "A presubmit check for building Debian image used by other cloud build triggers"
 
@@ -29,6 +30,7 @@ resource "google_cloudbuild_trigger" "pr_image_build_tests_debian" {
 }
 
 resource "google_cloudbuild_trigger" "pr_image_build_tests_rocky" {
+  location    = var.region
   name        = "PR-Image-Build-Tests-Rocky"
   description = "A presubmit check for building Rocky image used by other cloud build triggers"
 

--- a/share/ramble/cloud-build/terraform/triggers/pr_software_conflicts.tf
+++ b/share/ramble/cloud-build/terraform/triggers/pr_software_conflicts.tf
@@ -3,6 +3,7 @@ locals {
 }
 
 resource "google_cloudbuild_trigger" "pr_software_conflicts" {
+  location    = var.region
   name        = "PR-Software-Conflicts-${local.pr_software_conflicts_img.base}${local.pr_software_conflicts_img.base_ver}-${replace(local.pr_software_conflicts_img.spack, ".", "-")}spack-${replace(local.pr_software_conflicts_img.python, ".", "-")}python"
   description = "Check for conflicts in application definitions on Ramble pull requests"
 

--- a/share/ramble/cloud-build/terraform/triggers/pr_style.tf
+++ b/share/ramble/cloud-build/terraform/triggers/pr_style.tf
@@ -3,6 +3,7 @@ locals {
 }
 
 resource "google_cloudbuild_trigger" "pr_style" {
+  location    = var.region
   name        = "PR-Style-${local.pr_style_img.base}${local.pr_style_img.base_ver}-${replace(local.pr_style_img.spack, ".", "-")}spack-${replace(local.pr_style_img.python, ".", "-")}python"
   description = "Run linting on Ramble pull requests"
 

--- a/share/ramble/cloud-build/terraform/triggers/pr_unit_tests.tf
+++ b/share/ramble/cloud-build/terraform/triggers/pr_unit_tests.tf
@@ -1,6 +1,7 @@
 resource "google_cloudbuild_trigger" "pr_unit_tests" {
   for_each = local.image_map
 
+  location    = var.region
   name        = "PR-Unit-Tests-${each.value.base}${replace(each.value.base_ver, ".", "-")}-${replace(each.value.spack, ".", "-")}spack-${replace(each.value.python, ".", "-")}python"
   description = "Run unit tests and linting on Ramble pull requests"
 

--- a/share/ramble/cloud-build/terraform/triggers/terraform_apply.tf
+++ b/share/ramble/cloud-build/terraform/triggers/terraform_apply.tf
@@ -1,4 +1,5 @@
 resource "google_cloudbuild_trigger" "terraform_apply" {
+  location    = var.region
   name        = "ramble-terraform-apply"
   description = "Automatically apply Cloud Build Triggers Terraform configuration when pushed to develop branch"
 


### PR DESCRIPTION
The default location is "us-central1". This setting allows the trigger runs to be routed to the default regional pool, as opposed to previously the global pool. We have higher concurrent build quota for the former.