### PR TITLE
Replace N1 with E2 machines for cloud build

### DIFF
--- a/share/ramble/cloud-build/ramble-image-builder.yaml
+++ b/share/ramble/cloud-build/ramble-image-builder.yaml
@@ -37,5 +37,5 @@ images: ['us-central1-docker.pkg.dev/$PROJECT_ID/ramble-repo/ramble-${_BASE_IMG}
 timeout: 6000s
 queueTtl: 7200s
 options:
-  machineType: N1_HIGHCPU_8
+  machineType: E2_HIGHCPU_8
 

--- a/share/ramble/cloud-build/ramble-perf-tests.yaml
+++ b/share/ramble/cloud-build/ramble-perf-tests.yaml
@@ -123,7 +123,7 @@ timeout: 3600s
 queueTtl: 7200s
 options:
   # TODO: Maybe use a higher SKU for more consistent performance?
-  machineType: N1_HIGHCPU_8
+  machineType: E2_HIGHCPU_8
 
 availableSecrets:
   secretManager:

--- a/share/ramble/cloud-build/ramble-pr-docs.yaml
+++ b/share/ramble/cloud-build/ramble-pr-docs.yaml
@@ -66,4 +66,4 @@ substitutions:
 timeout: 600s
 queueTtl: 7200s
 options:
-  machineType: N1_HIGHCPU_8
+  machineType: E2_HIGHCPU_8

--- a/share/ramble/cloud-build/ramble-pr-image-builds.yaml
+++ b/share/ramble/cloud-build/ramble-pr-image-builds.yaml
@@ -46,4 +46,4 @@ substitutions:
 timeout: 3600s
 queueTtl: 7200s
 options:
-  machineType: N1_HIGHCPU_8
+  machineType: E2_HIGHCPU_8

--- a/share/ramble/cloud-build/ramble-pr-software-conflicts.yaml
+++ b/share/ramble/cloud-build/ramble-pr-software-conflicts.yaml
@@ -72,4 +72,4 @@ substitutions:
 timeout: 600s
 queueTtl: 7200s
 options:
-  machineType: N1_HIGHCPU_8
+  machineType: E2_HIGHCPU_8

--- a/share/ramble/cloud-build/ramble-pr-style.yaml
+++ b/share/ramble/cloud-build/ramble-pr-style.yaml
@@ -136,4 +136,4 @@ substitutions:
 timeout: 600s
 queueTtl: 7200s
 options:
-  machineType: N1_HIGHCPU_8
+  machineType: E2_HIGHCPU_8

--- a/share/ramble/cloud-build/ramble-pr-unit-tests.yaml
+++ b/share/ramble/cloud-build/ramble-pr-unit-tests.yaml
@@ -105,4 +105,4 @@ substitutions:
 timeout: 3600s
 queueTtl: 7200s
 options:
-  machineType: N1_HIGHCPU_8
+  machineType: E2_HIGHCPU_8

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-1.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-1.yaml
@@ -72,4 +72,4 @@ substitutions:
   _CI_CACHE: gs://spack/latest
 timeout: 1500s
 options:
-  machineType: N1_HIGHCPU_8
+  machineType: E2_HIGHCPU_8

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-10.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-10.yaml
@@ -87,4 +87,4 @@ substitutions:
   _CI_CACHE: gs://spack/latest
 timeout: 1500s
 options:
-  machineType: N1_HIGHCPU_8
+  machineType: E2_HIGHCPU_8

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-11.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-11.yaml
@@ -70,4 +70,4 @@ substitutions:
   _CI_CACHE: gs://spack/latest
 timeout: 1500s
 options:
-  machineType: N1_HIGHCPU_8
+  machineType: E2_HIGHCPU_8

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-2.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-2.yaml
@@ -56,4 +56,4 @@ substitutions:
   _CI_CACHE: gs://spack/latest
 timeout: 1500s
 options:
-  machineType: N1_HIGHCPU_8
+  machineType: E2_HIGHCPU_8

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-3.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-3.yaml
@@ -60,4 +60,4 @@ substitutions:
   _CI_CACHE: gs://spack/latest
 timeout: 1500s
 options:
-  machineType: N1_HIGHCPU_8
+  machineType: E2_HIGHCPU_8

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-4.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-4.yaml
@@ -65,4 +65,4 @@ substitutions:
   _CI_CACHE: gs://spack/latest
 timeout: 7200s
 options:
-  machineType: N1_HIGHCPU_8
+  machineType: E2_HIGHCPU_8

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-5.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-5.yaml
@@ -67,4 +67,4 @@ substitutions:
   _CI_CACHE: gs://spack/latest
 timeout: 7200s
 options:
-  machineType: N1_HIGHCPU_8
+  machineType: E2_HIGHCPU_8

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-6.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-6.yaml
@@ -78,4 +78,4 @@ substitutions:
   _CI_CACHE: gs://spack/latest
 timeout: 7200s
 options:
-  machineType: N1_HIGHCPU_8
+  machineType: E2_HIGHCPU_8

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-7.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-7.yaml
@@ -80,4 +80,4 @@ substitutions:
   _CI_CACHE: gs://spack/latest
 timeout: 1500s
 options:
-  machineType: N1_HIGHCPU_8
+  machineType: E2_HIGHCPU_8

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-8.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-8.yaml
@@ -74,4 +74,4 @@ substitutions:
   _CI_CACHE: gs://spack/latest
 timeout: 1500s
 options:
-  machineType: N1_HIGHCPU_8
+  machineType: E2_HIGHCPU_8

--- a/share/ramble/cloud-build/tutorials/ramble-tutorial-9.yaml
+++ b/share/ramble/cloud-build/tutorials/ramble-tutorial-9.yaml
@@ -67,4 +67,4 @@ substitutions:
   _CI_CACHE: gs://spack/latest
 timeout: 7200s
 options:
-  machineType: N1_HIGHCPU_8
+  machineType: E2_HIGHCPU_8


### PR DESCRIPTION
Now that we are using regional pool for cloud build, N1 machine is no longer available.