### PR TITLE
Allow FOMs as scaling var in scaling plots

### DIFF
--- a/lib/ramble/docs/results.rst
+++ b/lib/ramble/docs/results.rst
@@ -68,9 +68,9 @@ Activated by the ``strong-scaling``, ``weak-scaling``, or ``multi-line`` subcomm
 
 These commands take two sub-arguments:
   * The y-axis metric: the FOM you want to measure the performance of
-  * The x-axis metric: the scaling variable to plot on the x axis
+  * The x-axis metric: the scaling variable or FOM to plot on the x axis
 
-And example call may look something like:
+An example call may look something like:
 
 .. code-block:: console
 
@@ -78,11 +78,12 @@ And example call may look something like:
 
 (a very similar command should also work for ``--weak-scaling`` and ``--multi-line``)
 
-Another common use case might be to plot data by context (such as in OMB), which can be done by simply changing the y-axis metric:
+Another common use case might be to plot data by context (such as in OMB), which can be done by simply changing the y-axis metric, or to plot an FOM against another FOM (e.g. latency vs array size):
 
 .. code-block:: console
 
     ramble results report --weak-scaling 'Bandwidth' context -f ~/ramble-results.json
+    ramble results report --multi-line "Multichase Best Latency" "Array Size" --logx --logy -f ~/ramble-results.json
 
 Other compelling options include ``-n`` to normalize the plot y values, or ``--logx``/``--logy`` for log axes.
 

--- a/lib/ramble/ramble/reports.py
+++ b/lib/ramble/ramble/reports.py
@@ -736,14 +736,25 @@ class PlotGenerator:
 
         ax.set_xticks(series_data.index.unique().tolist())
         ax.set_title(title, wrap=True)
-        if y_label:
-            ax.set_ylabel(y_label)
-        ax.set_xlabel(scale_var)
+        if not y_label:
+            if getattr(self, "perf_unit", "") and not self.normalize:
+                y_label = f"{perf_measure} ({self.perf_unit})"
+            elif self.normalize:
+                y_label = f"{perf_measure} (Normalized)"
+            else:
+                y_label = perf_measure
+        ax.set_ylabel(y_label)
+
+        if getattr(self, "scale_unit", ""):
+            scale_var_label = f"{scale_var} ({self.scale_unit})"
+        else:
+            scale_var_label = scale_var
+        ax.set_xlabel(scale_var_label)
 
         # Rotate to prevent long x-axis labels overlapping. There's probably a better way
         if series_data.index.astype(str).str.len().max() > 4:
             ax.tick_params(axis="x", labelrotation=45)
-            fig.tight_layout()
+        fig.tight_layout()
 
         chart_filename = f"strong-scaling_{perf_measure}_vs_{scale_var}_{series}.png"
         self.write(fig, chart_filename, pdf_report)
@@ -784,28 +795,94 @@ class PlotGenerator:
 
     def write(self, fig, filename, pdf_report):
         filename = filename.replace(" ", "-")
-        plt.savefig(os.path.join(self.report_dir_path, filename))
+        plt.savefig(os.path.join(self.report_dir_path, filename), bbox_inches="tight")
         self.add_to_inventory(filename)
-        pdf_report.savefig(fig)
+        pdf_report.savefig(fig, bbox_inches="tight")
         plt.close(fig)
 
 
 class ScalingPlotGenerator(PlotGenerator):
     def generate_plot_data(self, pdf_report):
-        """Creates a dataframe for plotting line charts with scaling var on x axis,
-        and performance variable on y axis."""
+        """Creates a dataframe for plotting line charts with scaling var or FOM on x axis,
+        and performance metric on y axis."""
         pd = import_pandas()
         self.validate_spec(self.spec, self.result_index)
 
         perf_measure, scale_var, *additional_vars = self.spec
 
-        # FOMs are by row, so select only rows with the perf_measure FOM
+        all_foms = get_all_foms(self.result_index)
+
+        foms = [perf_measure]
+        variables = []
+
+        if scale_var in all_foms:
+            foms.append(scale_var)
+        else:
+            variables.append(scale_var)
+
+        for var in additional_vars + [self.split_by]:
+            if var not in variables and var not in foms:
+                variables.append(var)
+
         results = extract_data(
             self.exp_results,
-            [perf_measure],
-            [scale_var] + additional_vars + [self.split_by],
+            foms,
+            variables,
             where_query=self.where,
         )
+
+        if results.empty:
+            logger.warn(f"No results found matching spec {self.spec}")
+            return
+
+        self.perf_unit = ""
+        self.scale_unit = ""
+
+        if ReportVars.FOM_UNITS.value in results.columns:
+            perf_rows = results[results[ReportVars.FOM_NAME.value] == perf_measure]
+            if not perf_rows.empty and pd.notna(perf_rows[ReportVars.FOM_UNITS.value].iloc[0]):
+                unit_val = str(perf_rows[ReportVars.FOM_UNITS.value].iloc[0]).strip()
+                if unit_val:
+                    self.perf_unit = unit_val
+
+            if scale_var in all_foms:
+                scale_rows = results[results[ReportVars.FOM_NAME.value] == scale_var]
+                if not scale_rows.empty and pd.notna(
+                    scale_rows[ReportVars.FOM_UNITS.value].iloc[0]
+                ):
+                    unit_val = str(scale_rows[ReportVars.FOM_UNITS.value].iloc[0]).strip()
+                    if unit_val:
+                        self.scale_unit = unit_val
+
+        if scale_var in all_foms:
+            if ReportVars.FOM_ORIGIN_TYPE.value in results.columns:
+                results["_merge_origin_type"] = results[ReportVars.FOM_ORIGIN_TYPE.value].apply(
+                    lambda x: x if isinstance(x, str) and x.startswith("summary::") else "raw"
+                )
+                origin_key = "_merge_origin_type"
+            else:
+                origin_key = ReportVars.FOM_ORIGIN_TYPE.value
+
+            merge_keys = [
+                k
+                for k in [
+                    ReportVars.EXP_NAME.value,
+                    ReportVars.CONTEXT_NAME.value,
+                    origin_key,
+                ]
+                if k in results.columns
+            ]
+            scale_df = (
+                results[results[ReportVars.FOM_NAME.value] == scale_var][
+                    merge_keys + [ReportVars.FOM_VALUE.value]
+                ]
+                .rename(columns={ReportVars.FOM_VALUE.value: scale_var})
+                .drop_duplicates(subset=merge_keys)
+            )
+            results = results[results[ReportVars.FOM_NAME.value] == perf_measure].copy()
+            results = results.merge(scale_df, on=merge_keys, how="left")
+            if "_merge_origin_type" in results.columns:
+                results.drop(columns=["_merge_origin_type"], inplace=True)
 
         # Determine which direction is 'better', or 'INDETERMINATE' if missing or ambiguous data
         if len(results.loc[:, ReportVars.BETTER_DIRECTION.value].unique()) == 1:
@@ -1229,12 +1306,22 @@ class MultiLinePlot(ScalingPlotGenerator):
 
         ax.set_xticks(self.output_df.index.unique().tolist())
         ax.set_title(title, wrap=True)
-        # This is to prevent x-axis labels overlapping but there's probably a better way
-        if series_data.index.astype(str).str.len().max() > 4:
-            ax.tick_params(axis="x", labelrotation=45)
-            fig.tight_layout()
+        if getattr(self, "perf_unit", "") and not self.normalize:
+            y_label = f"{perf_measure} ({self.perf_unit})"
+        elif self.normalize:
+            y_label = f"{perf_measure} (Normalized)"
         ax.set_ylabel(y_label)
-        ax.set_xlabel(scale_var)
+
+        if getattr(self, "scale_unit", ""):
+            scale_var_label = f"{scale_var} ({self.scale_unit})"
+        else:
+            scale_var_label = scale_var
+        ax.set_xlabel(scale_var_label)
+
+        # This is to prevent x-axis labels overlapping but there's probably a better way
+        if self.output_df.index.astype(str).str.len().max() > 4:
+            ax.tick_params(axis="x", labelrotation=45)
+        fig.tight_layout()
 
         chart_filename = f"multi_line_{perf_measure}_vs_{scale_var}_all-series.png"
         self.write(fig, chart_filename, pdf_report)

--- a/lib/ramble/ramble/reports.py
+++ b/lib/ramble/ramble/reports.py
@@ -736,7 +736,7 @@ class PlotGenerator:
 
         ax.set_xticks(series_data.index.unique().tolist())
         ax.set_title(title, wrap=True)
-        if not y_label:
+        if not y_label or y_label == perf_measure:
             if getattr(self, "perf_unit", "") and not self.normalize:
                 y_label = f"{perf_measure} ({self.perf_unit})"
             elif self.normalize:
@@ -880,9 +880,13 @@ class ScalingPlotGenerator(PlotGenerator):
                 .drop_duplicates(subset=merge_keys)
             )
             results = results[results[ReportVars.FOM_NAME.value] == perf_measure].copy()
-            results = results.merge(scale_df, on=merge_keys, how="left")
+            results = results.merge(scale_df, on=merge_keys, how="inner")
             if "_merge_origin_type" in results.columns:
                 results.drop(columns=["_merge_origin_type"], inplace=True)
+
+        if results.empty:
+            logger.warn(f"No results found matching spec {self.spec}")
+            return
 
         # Determine which direction is 'better', or 'INDETERMINATE' if missing or ambiguous data
         if len(results.loc[:, ReportVars.BETTER_DIRECTION.value].unique()) == 1:
@@ -1328,6 +1332,9 @@ class MultiLinePlot(ScalingPlotGenerator):
 
     def generate_plot_data(self, pdf_report):
         super().generate_plot_data(pdf_report)
+
+        if getattr(self, "output_df", None) is None or self.output_df.empty:
+            return
 
         perf_measure, scale_var, *_ = self.spec
         y_label = perf_measure

--- a/lib/ramble/ramble/test/reports.py
+++ b/lib/ramble/ramble/test/reports.py
@@ -499,6 +499,71 @@ def test_multiple_groupby(mutable_mock_workspace_path, tmpdir_factory, capsys):
     )
 
 
+def test_scaling_fom_as_scale_var(tmpdir_factory):
+    report_name = "unit_test_fom_scale_var"
+    report_dir_path = tmpdir_factory.mktemp(report_name)
+    pdf_path = os.path.join(report_dir_path, f"{report_name}.pdf")
+
+    in_data = [
+        ("exp_1", "100", "1.0"),
+        ("exp_2", "200", "2.0"),
+        ("exp_3", "300", "3.0"),
+    ]
+    experiments = []
+    for exp in in_data:
+        name, fom_scale_val, fom_perf_val = exp
+
+        experiment = create_test_exp_result(
+            ramble_status="SUCCESS",
+            experiment_name=name,
+            application_name="app_v1",
+            workload_name="test_wl_1",
+            foms=[
+                (
+                    "null",
+                    (
+                        "fom_perf",
+                        fom_perf_val,
+                        "GFLOPs",
+                        "app_v1",
+                        "application",
+                        foms.FomType.MEASURE,
+                    ),
+                ),
+                (
+                    "null",
+                    (
+                        "fom_scale",
+                        fom_scale_val,
+                        "MB",
+                        "app_v1",
+                        "application",
+                        foms.FomType.MEASURE,
+                    ),
+                ),
+            ],
+            ramble_vars={},
+            ramble_raw_vars={},
+        )
+        experiments.append(experiment)
+
+    test_spec = ["fom_perf", "fom_scale"]
+    logx = False
+    logy = False
+    split_by = "workload_name"
+    plot = ramble.reports.MultiLinePlot(
+        test_spec, False, report_dir_path, experiments, logx, logy, split_by
+    )
+
+    with PdfPages(pdf_path) as pdf_report:
+        plot.generate_plot_data(pdf_report)
+
+    assert os.path.isfile(pdf_path)
+    assert os.path.isfile(
+        os.path.join(report_dir_path, "multi_line_fom_perf_vs_fom_scale_all-series.png")
+    )
+
+
 @pytest.mark.parametrize("format", ["json", "yaml"])
 def test_index_printing(mutable_mock_workspace_path, tmpdir_factory, format):
     test_exps = copy.deepcopy(all_experiments)

--- a/lib/ramble/ramble/test/reports.py
+++ b/lib/ramble/ramble/test/reports.py
@@ -505,9 +505,9 @@ def test_scaling_fom_as_scale_var(tmpdir_factory):
     pdf_path = os.path.join(report_dir_path, f"{report_name}.pdf")
 
     in_data = [
-        ("exp_1", "100", "1.0"),
-        ("exp_2", "200", "2.0"),
-        ("exp_3", "300", "3.0"),
+        ("exp_1", "100000", "1.0"),
+        ("exp_2", "200000", "2.0"),
+        ("exp_3", "300000", "3.0"),
     ]
     experiments = []
     for exp in in_data:
@@ -562,6 +562,100 @@ def test_scaling_fom_as_scale_var(tmpdir_factory):
     assert os.path.isfile(
         os.path.join(report_dir_path, "multi_line_fom_perf_vs_fom_scale_all-series.png")
     )
+
+    # Test normalized plot (covers normalize=True y_label)
+    plot_norm = ramble.reports.MultiLinePlot(
+        test_spec, True, report_dir_path, experiments, logx, logy, split_by
+    )
+    with PdfPages(pdf_path) as pdf_report:
+        plot_norm.generate_plot_data(pdf_report)
+
+
+def test_scaling_plot_empty_results(tmpdir_factory):
+    report_name = "unit_test_empty_results"
+    report_dir_path = tmpdir_factory.mktemp(report_name)
+    pdf_path = os.path.join(report_dir_path, f"{report_name}.pdf")
+
+    exp_1 = create_test_exp_result(
+        ramble_status="SUCCESS",
+        experiment_name="exp_1",
+        application_name="app_v1",
+        workload_name="test_wl_1",
+        foms=[
+            (
+                "null",
+                (
+                    "fom_perf",
+                    "1.0",
+                    "GFLOPs",
+                    "app_v1",
+                    "application",
+                    foms.FomType.MEASURE,
+                ),
+            ),
+            (
+                "null",
+                (
+                    "fom_scale",
+                    "100",
+                    "MB",
+                    "app_v1",
+                    "application",
+                    foms.FomType.MEASURE,
+                ),
+            ),
+        ],
+        ramble_vars={},
+        ramble_raw_vars={},
+    )
+    exp_alt = create_test_exp_result(
+        ramble_status="SUCCESS",
+        experiment_name="exp_alt",
+        application_name="app_v1",
+        workload_name="test_wl_1",
+        foms=[
+            (
+                "null",
+                (
+                    "fom_other",
+                    "10",
+                    "MB",
+                    "app_v1",
+                    "application",
+                    foms.FomType.MEASURE,
+                ),
+            ),
+        ],
+        ramble_vars={},
+        ramble_raw_vars={},
+    )
+
+    test_spec = ["fom_perf", "fom_scale"]
+    logx = False
+    logy = False
+    split_by = "workload_name"
+
+    # Test empty results when extract_data returns empty via where clause
+    plot_empty_where = ramble.reports.MultiLinePlot(
+        test_spec,
+        False,
+        report_dir_path,
+        [exp_1],
+        logx,
+        logy,
+        split_by,
+        where='experiment_name == "non_existent"',
+    )
+    with PdfPages(pdf_path) as pdf_report:
+        plot_empty_where.generate_plot_data(pdf_report)
+
+    # Test empty results when scale_df merge produces no matching scale FOM
+    empty_spec_scale = ["fom_perf", "fom_other"]
+    plot_empty_merge = ramble.reports.MultiLinePlot(
+        empty_spec_scale, False, report_dir_path, [exp_1, exp_alt], logx, logy, split_by
+    )
+    with PdfPages(pdf_path) as pdf_report:
+        plot_empty_merge.generate_plot_data(pdf_report)
 
 
 @pytest.mark.parametrize("format", ["json", "yaml"])


### PR DESCRIPTION
Updates `ramble results report` to allow FOMs to be used as a scaling variable in scaling plots. Also fixes issues with axis labels falling off the chart in certain scenarios.