### PR TITLE
Use default machine type for lighter-weight checks

### DIFF
--- a/share/ramble/cloud-build/ramble-pr-docs.yaml
+++ b/share/ramble/cloud-build/ramble-pr-docs.yaml
@@ -65,5 +65,3 @@ substitutions:
   _BASE_VER: '8'
 timeout: 600s
 queueTtl: 7200s
-options:
-  machineType: E2_HIGHCPU_8

--- a/share/ramble/cloud-build/ramble-pr-software-conflicts.yaml
+++ b/share/ramble/cloud-build/ramble-pr-software-conflicts.yaml
@@ -71,5 +71,3 @@ substitutions:
   _BASE_VER: '8'
 timeout: 600s
 queueTtl: 7200s
-options:
-  machineType: E2_HIGHCPU_8

--- a/share/ramble/cloud-build/ramble-pr-style.yaml
+++ b/share/ramble/cloud-build/ramble-pr-style.yaml
@@ -135,5 +135,3 @@ substitutions:
   _BASE_VER: '8'
 timeout: 600s
 queueTtl: 7200s
-options:
-  machineType: E2_HIGHCPU_8


### PR DESCRIPTION
These triggers don't really need the relatively beefy E2_HIGHCPU_8 machine type. Converting them to use the default smaller shape, to reduce the CPU footprints.