### PR TITLE
Use a private n2d pool for running perf tests

### DIFF
--- a/share/ramble/cloud-build/ramble-perf-tests.yaml
+++ b/share/ramble/cloud-build/ramble-perf-tests.yaml
@@ -118,12 +118,13 @@ substitutions:
   # client_id is recommended over app id.
   # client_id is not a secret.
   _GITHUB_CLIENT_ID: 'Iv23limpijbNRXQzHurG'
+  _WORKER_POOL: ''
 
 timeout: 3600s
 queueTtl: 7200s
 options:
-  # TODO: Maybe use a higher SKU for more consistent performance?
-  machineType: E2_HIGHCPU_8
+  pool:
+    name: '$_WORKER_POOL'
 
 availableSecrets:
   secretManager:

--- a/share/ramble/cloud-build/terraform/triggers/perf_tests.tf
+++ b/share/ramble/cloud-build/terraform/triggers/perf_tests.tf
@@ -2,6 +2,17 @@ locals {
   perf_test_img = local.image_map["rocky8-py3-13-5-spack-v1-0-0"]
 }
 
+resource "google_cloudbuild_worker_pool" "perf_test_pool" {
+  name         = "n2d-perf-test-pool"
+  location     = var.region
+  display_name = "Private N2D worker pool for Ramble performance tests"
+
+  worker_config {
+    machine_type = "n2d-standard-16"
+    disk_size_gb = 100
+  }
+}
+
 resource "google_cloudbuild_trigger" "perf_test_pr" {
   location    = var.region
   name        = "PerfTest-PR-${local.perf_test_img.base}${local.perf_test_img.base_ver}-${replace(local.perf_test_img.spack, ".", "-")}spack-${replace(local.perf_test_img.python, ".", "-")}python"
@@ -39,6 +50,7 @@ resource "google_cloudbuild_trigger" "perf_test_pr" {
     _PROJECT_ID   = var.project_id
     _TABLE_ID     = "perf_test_durations"
     _UPLOAD_TO_BQ = "false"
+    _WORKER_POOL  = google_cloudbuild_worker_pool.perf_test_pool.id
   }
 }
 
@@ -66,5 +78,6 @@ resource "google_cloudbuild_trigger" "perf_test_push" {
     _PROJECT_ID   = var.project_id
     _TABLE_ID     = "perf_test_durations"
     _UPLOAD_TO_BQ = "true"
+    _WORKER_POOL  = google_cloudbuild_worker_pool.perf_test_pool.id
   }
 }


### PR DESCRIPTION
This aims to improve on the perf test result consistency.