### PR TITLE
Avoid keeping reference of generated experiments

### DIFF
--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -1995,7 +1995,7 @@ ramble:
         logger.debug(str(self.software_environments))
 
         for _, app_inst in experiment_set.template_experiments():
-            if app_inst.is_template and not app_inst.generated_experiments:
+            if app_inst.is_template and not app_inst.has_generated_experiments:
                 app = app_inst.expander.application_name
                 wl = app_inst.expander.workload_name
                 exp = app_inst.expander.experiment_name

--- a/var/ramble/repos/builtin/base_classes/application-base/base_class.py
+++ b/var/ramble/repos/builtin/base_classes/application-base/base_class.py
@@ -226,7 +226,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
         self.workspace = None
         self.internals = {}
         self.is_template = False
-        self.generated_experiments = []
+        self.has_generated_experiments = False
         self.repeats = ramble.repeats.Repeats()
         self._command_list = []
         self._command_list_without_logs = []
@@ -302,7 +302,7 @@ class ApplicationBase(ObjectMixin, metaclass=ApplicationMeta):
     def clone(self):
         """Deep clone an application instance"""
         new_clone = type(self)(self._file_path)
-        self.generated_experiments.append(new_clone)
+        self.has_generated_experiments = True
 
         if self.known_versions:
             new_clone.known_versions = self.known_versions.copy()


### PR DESCRIPTION
Keeping the reference of experiments make it hard to GC these objects.

Instead simply use a boolean to check if a template has been used or not.