### PR TITLE
Resolve false spack deprecation warning

### DIFF
--- a/lib/ramble/ramble/caches.py
+++ b/lib/ramble/ramble/caches.py
@@ -11,8 +11,7 @@
 import os
 
 import llnl.util.lang
-from llnl.util.filesystem import mkdirp
-from llnl.util.symlink import symlink
+from llnl.util.filesystem import mkdirp, symlink
 
 import ramble.config
 import ramble.fetch_strategy

--- a/lib/ramble/spack/build_environment.py
+++ b/lib/ramble/spack/build_environment.py
@@ -42,9 +42,8 @@ import traceback
 import types
 
 import llnl.util.tty as tty
-from llnl.util.filesystem import install, install_tree, mkdirp
+from llnl.util.filesystem import install, install_tree, mkdirp, symlink
 from llnl.util.lang import dedupe
-from llnl.util.symlink import symlink
 from llnl.util.tty.color import cescape, colorize
 from llnl.util.tty.log import MultiProcessFd
 

--- a/lib/ramble/spack/caches.py
+++ b/lib/ramble/spack/caches.py
@@ -7,8 +7,7 @@
 import os
 
 import llnl.util.lang
-from llnl.util.filesystem import mkdirp
-from llnl.util.symlink import symlink
+from llnl.util.filesystem import mkdirp, symlink
 
 import spack.config
 import spack.error

--- a/lib/ramble/spack/compilers/apple_clang.py
+++ b/lib/ramble/spack/compilers/apple_clang.py
@@ -8,7 +8,7 @@ import shutil
 
 import llnl.util.lang
 import llnl.util.tty as tty
-from llnl.util.symlink import symlink
+from llnl.util.filesystem import symlink
 
 import spack.compiler
 import spack.compilers.clang

--- a/lib/ramble/spack/environment/environment.py
+++ b/lib/ramble/spack/environment/environment.py
@@ -16,9 +16,8 @@ import ruamel.yaml as yaml
 
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
-from llnl.util.filesystem import rename
+from llnl.util.filesystem import rename, symlink
 from llnl.util.lang import dedupe
-from llnl.util.symlink import symlink
 
 import spack.bootstrap
 import spack.compilers

--- a/lib/ramble/spack/fetch_strategy.py
+++ b/lib/ramble/spack/fetch_strategy.py
@@ -41,8 +41,8 @@ from llnl.util.filesystem import (
     temp_cwd,
     temp_rename,
     working_dir,
+    symlink,
 )
-from llnl.util.symlink import symlink
 
 import spack.config
 import spack.error

--- a/lib/ramble/spack/filesystem_view.py
+++ b/lib/ramble/spack/filesystem_view.py
@@ -18,6 +18,7 @@ from llnl.util.filesystem import (
     remove_dead_links,
     remove_empty_directories,
     visit_directory_tree,
+    symlink,
 )
 from llnl.util.lang import index_by, match_predicate
 from llnl.util.link_tree import (
@@ -27,7 +28,6 @@ from llnl.util.link_tree import (
     SingleMergeConflictError,
     SourceMergeVisitor,
 )
-from llnl.util.symlink import symlink
 from llnl.util.tty.color import colorize
 
 import spack.config


### PR DESCRIPTION
We are getting this warning, which doesn't make much sense for us:

```
 /workspace/lib/ramble/spack/caches.py:11: UserWarning: The `llnl.util.symlink` module will be removed in Spack v1.1
```

Changing the import to be more direct and avoid the checking 