### PR TITLE
Update spack utility availability check

### DIFF
--- a/lib/ramble/ramble/test/test_base_classes_extra.py
+++ b/lib/ramble/ramble/test/test_base_classes_extra.py
@@ -230,14 +230,14 @@ def test_application_base_bootstrap_utilities_is_bootstrappable_false(
         setup_pipeline = ramble.pipeline.SetupPipeline(ws, filters)
         app_inst = next(iter(setup_pipeline.experiment_set.experiments.values()))
         app_inst.required_utilities = {frozenset([]): {"spack": {"git": "mygit"}}}
-        UtilityBase = ramble.repository.get_base_class("utility-base")
-        monkeypatch.setattr(UtilityBase, "is_available", lambda *a, **k: False)
+        SpackClass = type(ramble.repository.get("spack", ramble.repository.ObjectTypes.utilities))
+        monkeypatch.setattr(SpackClass, "is_available", lambda *a, **k: False)
         # Mock bootstrappable to False
+        monkeypatch.setattr(SpackClass, "bootstrappable", {"True": [{"is_bootstrappable": False}]})
         monkeypatch.setattr(
-            UtilityBase, "bootstrappable", {"True": [{"is_bootstrappable": False}]}
-        )
-        monkeypatch.setattr(
-            UtilityBase, "missing_error_messages", {"True": [{"message": "Custom Error"}]}
+            SpackClass,
+            "missing_error_messages",
+            {"True": [{"message": "Custom Error"}]},
         )
 
         with pytest.raises(SystemExit):
@@ -302,3 +302,45 @@ def test_application_base_bootstrap_utilities_success(
         setup_pipeline.run()
     assert hasattr(app_inst, "_bootstrapped_utility_paths")
     assert "spack" in app_inst._bootstrapped_utility_paths
+
+
+def test_spack_utility_is_available_version_checking(
+    mutable_config, mutable_mock_workspace_path, monkeypatch
+):
+    ws = ramble.workspace.create("test_spack_ver")
+    os.makedirs(os.path.dirname(ws.config_file_path), exist_ok=True)
+    with open(ws.config_file_path, "w", encoding="utf-8") as f:
+        f.write("""ramble:
+  variables:
+    use_system_spack: True
+""")
+    ws._re_read()
+    spack = Spack("/tmp/dummy")
+    monkeypatch.setattr(
+        shutil, "which", lambda cmd, **kwargs: "/path/to/spack" if cmd == "spack" else None
+    )
+
+    class MockResult:
+        stdout = "0.22.0\n"
+        stderr = ""
+        returncode = 0
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: MockResult())
+
+    # When use_system_spack is True, regardless of version, do not bootstrap
+    # a new spack (return True if installed)
+    assert spack.is_available(ws, min_version="0.20.0", max_version="0.25.0") is True
+    assert spack.is_available(ws, min_version="0.23.0") is True
+    assert spack.is_available(ws, max_version="0.21.0") is True
+
+    # When use_system_spack is False, only return True (avoid bootstrap) if
+    # already-installed spack has right version
+    with open(ws.config_file_path, "w", encoding="utf-8") as f:
+        f.write("""ramble:
+  variables:
+    use_system_spack: False
+""")
+    ws._re_read()
+    assert spack.is_available(ws, min_version="0.20.0", max_version="0.25.0") is True
+    assert spack.is_available(ws, min_version="0.23.0") is False
+    assert spack.is_available(ws, max_version="0.21.0") is False

--- a/var/ramble/repos/builtin/utilities/spack/utility.py
+++ b/var/ramble/repos/builtin/utilities/spack/utility.py
@@ -6,7 +6,6 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-import shutil
 
 # flake8: noqa: F403
 from ramble.toolkit import *
@@ -69,6 +68,7 @@ class Spack(UtilityBase):
             .get("variables", {})
         )
         if ws_vars.get("use_system_spack", False):
-            if shutil.which("spack"):
-                return True
-        return False
+            return super().is_available(workspace)
+        return super().is_available(
+            workspace, min_version=min_version, max_version=max_version
+        )


### PR DESCRIPTION
Update logic around whether to bootstrap spack or not
    
With the change, the current behavior is:
    
* If the use_system_spack is set to True, then as long as the system spack is found, regardless of its version, do not bootstrap a new spack
* If the use_system_spack is set to False, then only bootstrap a new spack if the already-installed spack does not have the right version
    
Incidentally, also update a test case for properly mocking out the spack utility behavior.